### PR TITLE
add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Community Code of Conduct
+
+Backstage, and Backstage Community Plugins, follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
Adds a reference to the CNCF code of conduct to
Backstage Community Plugins.

----

Copied from https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md, I figured it made sense to explicitly state Backstage Community Plugins.