### PR TITLE
Add issue templates & update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This file registers ownership for certain parts of the backstage code.
+# Review from a member of the corresponding code owner is required to merge pull requests.
+#
+# The last matching pattern takes precedence.
+# https://help.github.com/articles/about-codeowners/
+
+*                                                 @backstage/community-plugins-maintainers
+/workspaces/example-1                             @vinzscam @tudi2d

--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -8,10 +8,10 @@ body:
     attributes:
       value: We value your time and effort to submit this bug report. 🙏
   - type: input
-    id: workspace
+    id: plugin-name
     attributes:
-      label: Plugin Workspace
-      description: "Specify the name of the workspace folder (https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      label: Plugin Name
+      description: "Specify the name of the [plugin name](https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
       placeholder: "Example: catalog"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -11,7 +11,7 @@ body:
     id: plugin-name
     attributes:
       label: Plugin Name
-      description: "Specify the name of the [plugin name](https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      description: "Specify the name of the [plugin name](https://www.npmjs.com/search?q=%40backstage-community) this issue refers to"
       placeholder: "Example: catalog"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/1-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yaml
@@ -1,0 +1,83 @@
+name: "🐛 Plugin Bug Report"
+description: "Submit a plugin bug report to help us improve"
+title: "🐛 <Plugin>: <Title>"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: We value your time and effort to submit this bug report. 🙏
+  - type: input
+    id: workspace
+    attributes:
+      label: Plugin Workspace
+      description: "Specify the name of the workspace folder (https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      placeholder: "Example: catalog"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: "📜 Description"
+      description: "A clear and concise description of what the bug is."
+      placeholder: "It bugs out when ..."
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👍 Expected behavior"
+      description: "What did you think should happen?"
+      placeholder: "It should ..."
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👎 Actual Behavior with Screenshots"
+      description: "What did actually happen? Add screenshots, if applicable."
+      placeholder: "It actually ..."
+  - type: textarea
+    id: steps-to-reproduce
+    validations:
+      required: true
+    attributes:
+      label: "👟 Reproduction steps"
+      description: "How do you trigger this bug? Please walk us through it step by step."
+      placeholder:
+        "Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code or configuration to reproduce, if relevant.\n
+        1. Go to '...'\n
+        2. Click on '....'\n
+        3. Scroll down to '....'"
+  - type: textarea
+    id: context
+    validations:
+      required: false
+    attributes:
+      label: "📃 Provide the context for the Bug."
+      description: "How has this issue affected you? What are you trying to accomplish?"
+      placeholder: "Providing context (e.g. links to configuration settings, stack trace or log data) helps us come up with a solution that is most useful in the real world."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this bug has been raised before?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/backstage/community-plugins/blob/main/CODE_OF_CONDUCT.md)"
+          required: true
+  - type: dropdown
+    attributes:
+      label: Are you willing to submit PR?
+      description: This is absolutely not required, but we are happy to guide you in the contribution process.
+      options:
+        - Yes I am willing to submit a PR!
+        - No, but I'm happy to collaborate on a PR with someone else
+        - No, I don't have time to work on this right now

--- a/.github/ISSUE_TEMPLATE/2-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yaml
@@ -1,0 +1,62 @@
+name: 🚀 Plugin Feature
+description: "Submit a proposal for a new feature in a plugin"
+title: "🚀 <Plugin>: <Title>"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We value your time and efforts to submit this Feature request form. 🙏
+  - type: input
+    id: workspace
+    attributes:
+      label: Plugin Workspace
+      description: "Specify the name of the workspace folder (https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      placeholder: "Example: catalog"
+    validations:
+      required: true
+  - type: textarea
+    id: feature-description
+    validations:
+      required: true
+    attributes:
+      label: "🔖 Feature description"
+      description: "A clear and concise description of what the feature is."
+      placeholder: "You should add ..."
+  - type: textarea
+    id: context
+    validations:
+      required: true
+    attributes:
+      label: "🎤 Context"
+      description: "Please explain why this feature should be implemented and how it would be used. Add examples, if applicable."
+      placeholder: "In my use-case, ..."
+  - type: textarea
+    id: implementation
+    attributes:
+      label: "✌️ Possible Implementation"
+      description: "A clear and concise description of what you want to happen."
+      placeholder: "Not obligatory, but ideas as to the implementation of the addition or change"
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this feature request has been raised before?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/backstage/backstage/blob/master/CODE_OF_CONDUCT.md)"
+          required: true
+  - type: dropdown
+    id: willing-to-submit-pr
+    attributes:
+      label: Are you willing to submit PR?
+      description: This is absolutely not required, but we are happy to guide you in the contribution process.
+      options:
+        - Yes I am willing to submit a PR!
+        - No, but I'm happy to collaborate on a PR with someone else
+        - No, I don't have time to work on this right now

--- a/.github/ISSUE_TEMPLATE/2-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yaml
@@ -8,10 +8,10 @@ body:
       value: |
         We value your time and efforts to submit this Feature request form. 🙏
   - type: input
-    id: workspace
+    id: plugin-name
     attributes:
-      label: Plugin Workspace
-      description: "Specify the name of the workspace folder (https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      label: Plugin Name
+      description: "Specify the name of the [plugin name](https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
       placeholder: "Example: catalog"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2-feature.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature.yaml
@@ -11,7 +11,7 @@ body:
     id: plugin-name
     attributes:
       label: Plugin Name
-      description: "Specify the name of the [plugin name](https://github.com/backstage/community-plugins/tree/main/workspaces) this issue refers to"
+      description: "Specify the name of the [plugin name](https://www.npmjs.com/search?q=%40backstage-community) this issue refers to"
       placeholder: "Example: catalog"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/3-plugin.yaml
+++ b/.github/ISSUE_TEMPLATE/3-plugin.yaml
@@ -1,0 +1,59 @@
+name: 🔌 New Plugin
+description: "Submit a proposal for a new plugin"
+title: "🔌 Plugin: <Title>"
+labels: [plugin]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We value your time and efforts to submit this Plugin request form. 🙏
+  - type: textarea
+    id: plugin-summary
+    validations:
+      required: true
+    attributes:
+      label: "🔖 Summary"
+      description: "Provide a general summary of the plugin and how it should work"
+      placeholder: "You should add ..."
+  - type: textarea
+    id: website
+    attributes:
+      label: "🌐 Project website (if applicable)"
+      description: "Add a link to the open source project or product this plugin will integrate with, if existing"
+      placeholder: "Website Link is ..."
+  - type: textarea
+    id: context
+    attributes:
+      label: "✌️ Context"
+      description: "A clear and concise description about the Plugin."
+      placeholder: "Providing additional context"
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this plugin request has been raised before?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: willing-to-take-ownership
+    attributes:
+      label: "✍️ Are you willing to maintain the plugin?"
+      options:
+        - label: "I understand the responsibilities as a [Plugin Maintainer Governance](https://github.com/backstage/backstage/blob/master/GOVERNANCE.md#plugin-maintainer) & will maintain the plugin"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/backstage/community-repository/blob/master/CODE_OF_CONDUCT.md)"
+          required: true
+  - type: dropdown
+    id: willing-to-submit-pr
+    attributes:
+      label: Are you willing to submit PR?
+      description: This is absolutely not required, but we are happy to guide you in the contribution process.
+      options:
+        - Yes I am willing to submit a PR!
+        - No, but I'm happy to collaborate on a PR with someone else
+        - No, I don't have time to work on this right now

--- a/.github/ISSUE_TEMPLATE/4-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/4-issue.yaml
@@ -1,0 +1,75 @@
+name: "🔧 Plugins Repository Issue"
+description: "Submit an issue to improve the overall community repository"
+title: "🔧 Repository: <Title>"
+labels:
+  - bug, community-plugins
+body:
+  - type: markdown
+    attributes:
+      value: We value your time and effort to submit this issue. 🙏
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: "📜 Description"
+      description: "A clear and concise description of what the issue is."
+      placeholder: "It bugs out when ..."
+  - type: textarea
+    id: expected-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👍 Expected behavior"
+      description: "What did you think should happen?"
+      placeholder: "It should ..."
+  - type: textarea
+    id: actual-behavior
+    validations:
+      required: true
+    attributes:
+      label: "👎 Current Behavior"
+      description: "What did actually happen? Add screenshots, if applicable."
+      placeholder: "It actually ..."
+  - type: textarea
+    id: steps-to-reproduce
+    validations:
+      required: true
+    attributes:
+      label: "👟 Reproduction steps"
+      description: "How do you trigger this bug? Please walk us through it step by step."
+      placeholder:
+        "Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include code or configuration to reproduce, if relevant.\n
+        1. Go to '...'\n
+        2. Click on '....'\n
+        3. Scroll down to '....'"
+  - type: textarea
+    id: context
+    validations:
+      required: false
+    attributes:
+      label: "📃 Provide the context for the Bug."
+      description: "How has this issue affected you? What are you trying to accomplish?"
+      placeholder: "Providing context (e.g. links to configuration settings, stack trace or log data) helps us come up with a solution that is most useful in the real world."
+  - type: checkboxes
+    id: no-duplicate-issues
+    attributes:
+      label: "👀 Have you spent some time to check if this bug has been raised before?"
+      options:
+        - label: "I checked and didn't find similar issue"
+          required: true
+  - type: checkboxes
+    id: read-code-of-conduct
+    attributes:
+      label: "🏢 Have you read the Code of Conduct?"
+      options:
+        - label: "I have read the [Code of Conduct](https://github.com/backstage/community-plugins/blob/main/CODE_OF_CONDUCT.md)"
+          required: true
+  - type: dropdown
+    attributes:
+      label: Are you willing to submit PR?
+      description: This is absolutely not required, but we are happy to guide you in the contribution process.
+      options:
+        - Yes I am willing to submit a PR!
+        - No, but I'm happy to collaborate on a PR with someone else
+        - No, I don't have time to work on this right now

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - about: "Use the Backstage Community Discord for questions & discussions"
+    name: Questions
+    url: "https://discord.gg/backstage-687207715902193673"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Hey, I just made a Pull Request!
+
+<!-- Please describe what you added, and add a screenshot if possible.
+     That makes it easier to understand the change so we can :shipit: faster. -->
+
+#### :heavy_check_mark: Checklist
+
+<!--- Please include the following in your Pull Request when applicable: -->
+
+- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
+- [ ] Tests for new functionality and regression tests for bug fixes
+- [ ] Screenshots attached (for UI changes)
+- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


### PR DESCRIPTION
Adding issue templates to this repository. Goal is to start using them for adding plugins. Mostly the oriantate on the existing issue templates from `backstage/backstage`. Some context of changes:

- Ordering changed by numbered naming
- Adding required `input` for "bug" and "enhancement" issues to specific the affected workspace
  - **Idea:** Allow to create a GitHub action to ping the right plugin owner
- Addig checkbox to "plugin" template asking if the person is willing to take ownership
- Adding seperate "issue" template for general issues on the repository, which do not affect any plugins. I'm not sure about this one, but thought we would need some kind escape hatch for issues on CI or general setup

Happy about feedback!