### PR TITLE
Use the backstage service account to create VP PR's

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -83,9 +83,7 @@ jobs:
           versionBranch: changesets-release/${{ inputs.workspace }}
           skipRootChangelogUpdate: true
         env:
-          # TODO(vinzscam): If we use secrets.GITHUB_TOKEN here, checks won't trigger in the version packages
-          # PR. cf. https://github.community/t/push-doesnt-trigger-workflow-action-in-an-open-pr/118675
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 
 
 


### PR DESCRIPTION
We need to use a dedicated service account in order to kick off the tests for the changed workspaces.
