### PR TITLE
Version Packages (todo)

### DIFF
--- a/workspaces/todo/.changeset/migrate-1713426449436.md
+++ b/workspaces/todo/.changeset/migrate-1713426449436.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-todo': patch
-'@backstage-community/plugin-todo-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/todo/plugins/todo-backend/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-todo-backend
 
+## 0.3.17
+
+### Patch Changes
+
+- ef7522c: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.16
 
 ### Patch Changes

--- a/workspaces/todo/plugins/todo-backend/package.json
+++ b/workspaces/todo/plugins/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo-backend",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/todo/plugins/todo/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-todo
 
+## 0.2.39
+
+### Patch Changes
+
+- ef7522c: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.38
 
 ### Patch Changes

--- a/workspaces/todo/plugins/todo/package.json
+++ b/workspaces/todo/plugins/todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "A Backstage plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-todo@0.2.39

### Patch Changes

-   ef7522c: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-todo-backend@0.3.17

### Patch Changes

-   ef7522c: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
