### PR TITLE
Version Packages (apollo-explorer)

### DIFF
--- a/workspaces/apollo-explorer/.changeset/migrate-1713465873342.md
+++ b/workspaces/apollo-explorer/.changeset/migrate-1713465873342.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-apollo-explorer': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/apollo-explorer/plugins/apollo-explorer/CHANGELOG.md
+++ b/workspaces/apollo-explorer/plugins/apollo-explorer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-apollo-explorer
 
+## 0.2.1
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/apollo-explorer/plugins/apollo-explorer/package.json
+++ b/workspaces/apollo-explorer/plugins/apollo-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apollo-explorer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-apollo-explorer@0.2.1

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
