### PR TITLE
Version Packages (gocd)

### DIFF
--- a/workspaces/gocd/.changeset/migrate-1713466067342.md
+++ b/workspaces/gocd/.changeset/migrate-1713466067342.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gocd': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/gocd/plugins/gocd/CHANGELOG.md
+++ b/workspaces/gocd/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gocd
 
+## 0.1.41
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.40
 
 ### Patch Changes

--- a/workspaces/gocd/plugins/gocd/package.json
+++ b/workspaces/gocd/plugins/gocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gocd",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "A Backstage plugin that integrates towards GoCD",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gocd@0.1.41

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
