### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/migrate-1713465834005.md
+++ b/workspaces/adr/.changeset/migrate-1713465834005.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.15
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-adr-common@0.2.23
+
 ## 0.4.14
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.2.23
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.22
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.6.18
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-adr-common@0.2.23
+
 ## 0.6.17
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.6.18

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-adr-common@0.2.23

## @backstage-community/plugin-adr-backend@0.4.15

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-adr-common@0.2.23

## @backstage-community/plugin-adr-common@0.2.23

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
