### PR TITLE
Version Packages (github-issues)

### DIFF
--- a/workspaces/github-issues/.changeset/migrate-1713466045590.md
+++ b/workspaces/github-issues/.changeset/migrate-1713466045590.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-issues': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/github-issues/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github-issues/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-issues
 
+## 0.4.2
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/workspaces/github-issues/plugins/github-issues/package.json
+++ b/workspaces/github-issues/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-issues@0.4.2

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
