### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/migrate-1713465942505.md
+++ b/workspaces/code-coverage/.changeset/migrate-1713465942505.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-code-coverage': patch
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.2.32
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.31
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage
 
+## 0.2.28
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.27
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage@0.2.28

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-code-coverage-backend@0.2.32

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
