### PR TITLE
Version Packages (github-deployments)

### DIFF
--- a/workspaces/github-deployments/.changeset/migrate-1713466038273.md
+++ b/workspaces/github-deployments/.changeset/migrate-1713466038273.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-deployments': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
+++ b/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-deployments
 
+## 0.1.66
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.65
 
 ### Patch Changes

--- a/workspaces/github-deployments/plugins/github-deployments/package.json
+++ b/workspaces/github-deployments/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-deployments",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-deployments@0.1.66

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
