### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/migrate-1713466103067.md
+++ b/workspaces/kafka/.changeset/migrate-1713466103067.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kafka': patch
-'@backstage-community/plugin-kafka-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kafka-backend
 
+## 0.3.16
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.15
 
 ### Patch Changes

--- a/workspaces/kafka/plugins/kafka-backend/package.json
+++ b/workspaces/kafka/plugins/kafka-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka-backend",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "A Backstage backend plugin that integrates towards Kafka",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/kafka/plugins/kafka/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kafka
 
+## 0.3.35
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.34
 
 ### Patch Changes

--- a/workspaces/kafka/plugins/kafka/package.json
+++ b/workspaces/kafka/plugins/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "A Backstage plugin that integrates towards Kafka",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka@0.3.35

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-kafka-backend@0.3.16

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
