### PR TITLE
Version Packages (airbrake)

### DIFF
--- a/workspaces/airbrake/.changeset/migrate-1713465844081.md
+++ b/workspaces/airbrake/.changeset/migrate-1713465844081.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-airbrake': patch
-'@backstage-community/plugin-airbrake-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
+++ b/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-airbrake-backend
 
+## 0.3.15
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.14
 
 ### Patch Changes

--- a/workspaces/airbrake/plugins/airbrake-backend/package.json
+++ b/workspaces/airbrake/plugins/airbrake-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-airbrake-backend",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/airbrake/plugins/airbrake/CHANGELOG.md
+++ b/workspaces/airbrake/plugins/airbrake/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-airbrake
 
+## 0.3.35
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.34
 
 ### Patch Changes

--- a/workspaces/airbrake/plugins/airbrake/package.json
+++ b/workspaces/airbrake/plugins/airbrake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-airbrake",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-airbrake@0.3.35

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-airbrake-backend@0.3.15

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
