### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/migrate-1713465859341.md
+++ b/workspaces/analytics/.changeset/migrate-1713465859341.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga': patch
-'@backstage-community/plugin-analytics-module-ga4': patch
-'@backstage-community/plugin-analytics-module-newrelic-browser': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga
 
+## 0.2.5
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.4
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-ga/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "backstage": {
     "role": "frontend-plugin-module"
   },

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.2.5
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.4
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "backstage": {
     "role": "frontend-plugin-module"
   },

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.1.5
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "backstage": {
     "role": "frontend-plugin-module"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga@0.2.5

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-analytics-module-ga4@0.2.5

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-analytics-module-newrelic-browser@0.1.5

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
