### PR TITLE
Version Packages (git-release-manager)

### DIFF
--- a/workspaces/git-release-manager/.changeset/migrate-1713466022480.md
+++ b/workspaces/git-release-manager/.changeset/migrate-1713466022480.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-git-release-manager': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
+++ b/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-git-release-manager
 
+## 0.3.47
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.46
 
 ### Patch Changes

--- a/workspaces/git-release-manager/plugins/git-release-manager/package.json
+++ b/workspaces/git-release-manager/plugins/git-release-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-git-release-manager",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "description": "A Backstage plugin that helps you manage releases in git",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-git-release-manager@0.3.47

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
