### PR TITLE
Version Packages (microsoft-calendar)

### DIFF
--- a/workspaces/microsoft-calendar/.changeset/migrate-1713466117435.md
+++ b/workspaces/microsoft-calendar/.changeset/migrate-1713466117435.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-microsoft-calendar': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/microsoft-calendar/plugins/microsoft-calendar/CHANGELOG.md
+++ b/workspaces/microsoft-calendar/plugins/microsoft-calendar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-microsoft-calendar
 
+## 0.1.17
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.16
 
 ### Patch Changes

--- a/workspaces/microsoft-calendar/plugins/microsoft-calendar/package.json
+++ b/workspaces/microsoft-calendar/plugins/microsoft-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-microsoft-calendar",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-microsoft-calendar@0.1.17

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
