### PR TITLE
Version Packages (explore)

### DIFF
--- a/workspaces/explore/.changeset/migrate-1713465986035.md
+++ b/workspaces/explore/.changeset/migrate-1713465986035.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-explore': patch
-'@backstage-community/plugin-explore-backend': patch
-'@backstage-community/plugin-explore-common': patch
-'@backstage-community/plugin-explore-react': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/explore/plugins/explore-backend/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-explore-backend
 
+## 0.0.28
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-explore-common@0.0.3
+
 ## 0.0.27
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-backend/package.json
+++ b/workspaces/explore/plugins/explore-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-backend",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/explore/plugins/explore-common/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-explore-common
 
+## 0.0.3
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-common/package.json
+++ b/workspaces/explore/plugins/explore-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-common",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Common functionalities for the explore plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/explore/plugins/explore-react/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-explore-react
 
+## 0.0.39
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-explore-common@0.0.3
+
 ## 0.0.38
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-react/package.json
+++ b/workspaces/explore/plugins/explore-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-react",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "A frontend library for Backstage plugins that want to interact with the explore plugin",
   "backstage": {
     "role": "web-library"

--- a/workspaces/explore/plugins/explore/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-explore
 
+## 0.4.21
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-explore-common@0.0.3
+  - @backstage-community/plugin-explore-react@0.0.39
+
 ## 0.4.20
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore/package.json
+++ b/workspaces/explore/plugins/explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "A Backstage plugin for building an exploration page of your software ecosystem",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-explore@0.4.21

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-explore-common@0.0.3
    -   @backstage-community/plugin-explore-react@0.0.39

## @backstage-community/plugin-explore-backend@0.0.28

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-explore-common@0.0.3

## @backstage-community/plugin-explore-common@0.0.3

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-explore-react@0.0.39

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-explore-common@0.0.3
