### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/migrate-1713466095836.md
+++ b/workspaces/jenkins/.changeset/migrate-1713466095836.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-jenkins': patch
-'@backstage-community/plugin-jenkins-backend': patch
-'@backstage-community/plugin-jenkins-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.4.5
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-jenkins-common@0.1.26
+
 ## 0.4.4
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-common
 
+## 0.1.26
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.25
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-common/package.json
+++ b/workspaces/jenkins/plugins/jenkins-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-common",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "backstage": {
     "role": "common-library"
   },

--- a/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-jenkins
 
+## 0.9.10
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-jenkins-common@0.1.26
+
 ## 0.9.9
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins/package.json
+++ b/workspaces/jenkins/plugins/jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "A Backstage plugin that integrates towards Jenkins",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins@0.9.10

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-jenkins-common@0.1.26

## @backstage-community/plugin-jenkins-backend@0.4.5

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-jenkins-common@0.1.26

## @backstage-community/plugin-jenkins-common@0.1.26

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
