### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/migrate-1713466176491.md
+++ b/workspaces/playlist/.changeset/migrate-1713466176491.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist': patch
-'@backstage-community/plugin-playlist-backend': patch
-'@backstage-community/plugin-playlist-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.3.22
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-playlist-common@0.1.16
+
 ## 0.3.21
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-common
 
+## 0.1.16
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.15
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-common/package.json
+++ b/workspaces/playlist/plugins/playlist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-common",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Common functionalities for the playlist plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist
 
+## 0.2.9
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-playlist-common@0.1.16
+
 ## 0.2.8
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.2.9

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-playlist-common@0.1.16

## @backstage-community/plugin-playlist-backend@0.3.22

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-playlist-common@0.1.16

## @backstage-community/plugin-playlist-common@0.1.16

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
