### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/migrate-1713465957264.md
+++ b/workspaces/cost-insights/.changeset/migrate-1713465957264.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': patch
-'@backstage-community/plugin-cost-insights-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights-common
 
+## 0.1.3
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights-common/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights-common",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Common functionalities for the cost-insights plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.12.24
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-cost-insights-common@0.1.3
+
 ## 0.12.23
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.12.23",
+  "version": "0.12.24",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.12.24

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-cost-insights-common@0.1.3

## @backstage-community/plugin-cost-insights-common@0.1.3

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
