### PR TITLE
Version Packages (shortcuts)

### DIFF
--- a/workspaces/shortcuts/.changeset/migrate-1713466204982.md
+++ b/workspaces/shortcuts/.changeset/migrate-1713466204982.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-shortcuts': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
+++ b/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-shortcuts
 
+## 0.3.24
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.23
 
 ### Patch Changes

--- a/workspaces/shortcuts/plugins/shortcuts/package.json
+++ b/workspaces/shortcuts/plugins/shortcuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-shortcuts",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "A Backstage plugin that provides a shortcuts feature to the sidebar",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-shortcuts@0.3.24

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
