### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/migrate-1713465887317.md
+++ b/workspaces/azure-sites/.changeset/migrate-1713465887317.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-sites': patch
-'@backstage-community/plugin-azure-sites-backend': patch
-'@backstage-community/plugin-azure-sites-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.3.5
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-azure-sites-common@0.1.4
+
 ## 0.3.4
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-common
 
+## 0.1.4
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-common/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Common functionalities for the azure plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites
 
+## 0.1.24
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-azure-sites-common@0.1.4
+
 ## 0.1.23
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites@0.1.24

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-azure-sites-common@0.1.4

## @backstage-community/plugin-azure-sites-backend@0.3.5

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-azure-sites-common@0.1.4

## @backstage-community/plugin-azure-sites-common@0.1.4

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
