### PR TITLE
Version Packages (octopus-deploy)

### DIFF
--- a/workspaces/octopus-deploy/.changeset/migrate-1713466146663.md
+++ b/workspaces/octopus-deploy/.changeset/migrate-1713466146663.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-octopus-deploy': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-octopus-deploy
 
+## 0.2.17
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.16
 
 ### Patch Changes

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/package.json
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-octopus-deploy",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-octopus-deploy@0.2.17

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
