### PR TITLE
Version Packages (xcmetrics)

### DIFF
--- a/workspaces/xcmetrics/.changeset/migrate-1713466257285.md
+++ b/workspaces/xcmetrics/.changeset/migrate-1713466257285.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-xcmetrics': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/xcmetrics/plugins/xcmetrics/CHANGELOG.md
+++ b/workspaces/xcmetrics/plugins/xcmetrics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-xcmetrics
 
+## 0.2.53
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.52
 
 ### Patch Changes

--- a/workspaces/xcmetrics/plugins/xcmetrics/package.json
+++ b/workspaces/xcmetrics/plugins/xcmetrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-xcmetrics",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "A Backstage plugin that shows XCode build metrics for your components",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-xcmetrics@0.2.53

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
