### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/migrate-1713466242003.md
+++ b/workspaces/tech-insights/.changeset/migrate-1713466242003.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
-'@backstage-community/plugin-tech-insights-backend': patch
-'@backstage-community/plugin-tech-insights-backend-module-jsonfc': patch
-'@backstage-community/plugin-tech-insights-common': patch
-'@backstage-community/plugin-tech-insights-node': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.50
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-tech-insights-common@0.2.13
+  - @backstage-community/plugin-tech-insights-node@0.6.1
+
 ## 0.1.49
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "backstage": {
     "role": "backend-plugin-module"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 0.5.32
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-tech-insights-common@0.2.13
+  - @backstage-community/plugin-tech-insights-node@0.6.1
+
 ## 0.5.31
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "0.5.31",
+  "version": "0.5.32",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-common
 
+## 0.2.13
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.12
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-common/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-common",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "common-library"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights-node
 
+## 0.6.1
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-tech-insights-common@0.2.13
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-node",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "backstage": {
     "role": "node-library"
   },

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.3.27
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-tech-insights-common@0.2.13
+
 ## 0.3.26
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights@0.3.27

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-tech-insights-common@0.2.13

## @backstage-community/plugin-tech-insights-backend@0.5.32

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-tech-insights-common@0.2.13
    -   @backstage-community/plugin-tech-insights-node@0.6.1

## @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.50

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-tech-insights-common@0.2.13
    -   @backstage-community/plugin-tech-insights-node@0.6.1

## @backstage-community/plugin-tech-insights-common@0.2.13

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-tech-insights-node@0.6.1

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-tech-insights-common@0.2.13
