### PR TITLE
Version Packages (graphql-voyager)

### DIFF
--- a/workspaces/graphql-voyager/.changeset/migrate-1713466081821.md
+++ b/workspaces/graphql-voyager/.changeset/migrate-1713466081821.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-graphql-voyager': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/graphql-voyager/plugins/graphql-voyager/CHANGELOG.md
+++ b/workspaces/graphql-voyager/plugins/graphql-voyager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-graphql-voyager
 
+## 0.1.17
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.16
 
 ### Patch Changes

--- a/workspaces/graphql-voyager/plugins/graphql-voyager/package.json
+++ b/workspaces/graphql-voyager/plugins/graphql-voyager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-graphql-voyager",
   "description": "Backstage plugin for GraphQL Voyager",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-graphql-voyager@0.1.17

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
