### PR TITLE
Version Packages (github-pull-requests-board)

### DIFF
--- a/workspaces/github-pull-requests-board/.changeset/migrate-1713466052584.md
+++ b/workspaces/github-pull-requests-board/.changeset/migrate-1713466052584.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-pull-requests-board
 
+## 0.2.1
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-pull-requests-board",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-pull-requests-board@0.2.1

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
