### PR TITLE
Version Packages (cloudbuild)

### DIFF
--- a/workspaces/cloudbuild/.changeset/migrate-1713465928820.md
+++ b/workspaces/cloudbuild/.changeset/migrate-1713465928820.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cloudbuild': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/cloudbuild/plugins/cloudbuild/CHANGELOG.md
+++ b/workspaces/cloudbuild/plugins/cloudbuild/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cloudbuild
 
+## 0.5.2
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/cloudbuild/plugins/cloudbuild/package.json
+++ b/workspaces/cloudbuild/plugins/cloudbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cloudbuild",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Backstage plugin that integrates towards Google Cloud Build",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cloudbuild@0.5.2

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
