### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/migrate-1713465971344.md
+++ b/workspaces/entity-feedback/.changeset/migrate-1713465971344.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback': patch
-'@backstage-community/plugin-entity-feedback-backend': patch
-'@backstage-community/plugin-entity-feedback-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.2.15
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-entity-feedback-common@0.1.4
+
 ## 0.2.14
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-feedback-common
 
+## 0.1.4
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-common/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Common functionalities for the entity-feedback plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-entity-feedback
 
+## 0.2.18
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-entity-feedback-common@0.1.4
+
 ## 0.2.17
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback@0.2.18

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-entity-feedback-common@0.1.4

## @backstage-community/plugin-entity-feedback-backend@0.2.15

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-entity-feedback-common@0.1.4

## @backstage-community/plugin-entity-feedback-common@0.1.4

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
