### PR TITLE
Version Packages (lighthouse)

### DIFF
--- a/workspaces/lighthouse/.changeset/migrate-1713466110116.md
+++ b/workspaces/lighthouse/.changeset/migrate-1713466110116.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-lighthouse': patch
-'@backstage-community/plugin-lighthouse-backend': patch
-'@backstage-community/plugin-lighthouse-common': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-lighthouse-backend
 
+## 0.4.11
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-lighthouse-common@0.1.6
+
 ## 0.4.10
 
 ### Patch Changes

--- a/workspaces/lighthouse/plugins/lighthouse-backend/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-backend",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/lighthouse/plugins/lighthouse-common/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-lighthouse-common
 
+## 0.1.6
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/lighthouse/plugins/lighthouse-common/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-common",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Common functionalities for lighthouse, to be shared between lighthouse and lighthouse-backend plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/lighthouse/plugins/lighthouse/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-lighthouse
 
+## 0.4.20
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-lighthouse-common@0.1.6
+
 ## 0.4.19
 
 ### Patch Changes

--- a/workspaces/lighthouse/plugins/lighthouse/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "A Backstage plugin that integrates towards Lighthouse",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-lighthouse@0.4.20

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-lighthouse-common@0.1.6

## @backstage-community/plugin-lighthouse-backend@0.4.11

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-lighthouse-common@0.1.6

## @backstage-community/plugin-lighthouse-common@0.1.6

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
