### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/migrate-1713466212007.md
+++ b/workspaces/sonarqube/.changeset/migrate-1713466212007.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
-'@backstage-community/plugin-sonarqube-backend': patch
-'@backstage-community/plugin-sonarqube-react': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.2.20
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.19
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/sonarqube/plugins/sonarqube-react/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-react
 
+## 0.1.16
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.15
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube-react/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-react",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "backstage": {
     "role": "web-library"
   },

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.7.17
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-sonarqube-react@0.1.16
+
 ## 0.7.16
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.7.17

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-sonarqube-react@0.1.16

## @backstage-community/plugin-sonarqube-backend@0.2.20

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-sonarqube-react@0.1.16

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
