### PR TITLE
Version Packages (opencost)

### DIFF
--- a/workspaces/opencost/.changeset/migrate-1713466155177.md
+++ b/workspaces/opencost/.changeset/migrate-1713466155177.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-opencost': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/opencost/plugins/opencost/CHANGELOG.md
+++ b/workspaces/opencost/plugins/opencost/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-opencost
 
+## 0.2.10
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.9
 
 ### Patch Changes

--- a/workspaces/opencost/plugins/opencost/package.json
+++ b/workspaces/opencost/plugins/opencost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-opencost",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-opencost@0.2.10

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
