### PR TITLE
Version Packages (periskop)

### DIFF
--- a/workspaces/periskop/.changeset/migrate-1713466169253.md
+++ b/workspaces/periskop/.changeset/migrate-1713466169253.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-periskop': patch
-'@backstage-community/plugin-periskop-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
+++ b/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-periskop-backend
 
+## 0.2.16
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.15
 
 ### Patch Changes

--- a/workspaces/periskop/plugins/periskop-backend/package.json
+++ b/workspaces/periskop/plugins/periskop-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-periskop-backend",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/periskop/plugins/periskop/CHANGELOG.md
+++ b/workspaces/periskop/plugins/periskop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-periskop
 
+## 0.1.33
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.32
 
 ### Patch Changes

--- a/workspaces/periskop/plugins/periskop/package.json
+++ b/workspaces/periskop/plugins/periskop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-periskop",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-periskop@0.1.33

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-periskop-backend@0.2.16

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
