### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/migrate-1713466190773.md
+++ b/workspaces/rollbar/.changeset/migrate-1713466190773.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rollbar': patch
-'@backstage-community/plugin-rollbar-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.1.63
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.62
 
 ### Patch Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.1.62",
+  "version": "0.1.63",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/rollbar/plugins/rollbar/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rollbar
 
+## 0.4.35
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.4.34
 
 ### Patch Changes

--- a/workspaces/rollbar/plugins/rollbar/package.json
+++ b/workspaces/rollbar/plugins/rollbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "A Backstage plugin that integrates towards Rollbar",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar@0.4.35

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-rollbar-backend@0.1.63

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
