### PR TITLE
Version Packages (vault)

### DIFF
--- a/workspaces/vault/.changeset/migrate-1713466249416.md
+++ b/workspaces/vault/.changeset/migrate-1713466249416.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-vault': patch
-'@backstage-community/plugin-vault-backend': patch
-'@backstage-community/plugin-vault-node': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/vault/plugins/vault-backend/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-vault-backend
 
+## 0.4.11
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+- Updated dependencies [193a2a3]
+  - @backstage-community/plugin-vault-node@0.1.11
+
 ## 0.4.10
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault-backend/package.json
+++ b/workspaces/vault/plugins/vault-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault-backend",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "A Backstage backend plugin that integrates towards Vault",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/vault/plugins/vault-node/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-vault-node
 
+## 0.1.11
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.10
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault-node/package.json
+++ b/workspaces/vault/plugins/vault-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault-node",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Node.js library for the vault plugin",
   "backstage": {
     "role": "node-library"

--- a/workspaces/vault/plugins/vault/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-vault
 
+## 0.1.30
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.29
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault/package.json
+++ b/workspaces/vault/plugins/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "A Backstage plugin that integrates towards Vault",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-vault@0.1.30

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-vault-backend@0.4.11

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
-   Updated dependencies [193a2a3]
    -   @backstage-community/plugin-vault-node@0.1.11

## @backstage-community/plugin-vault-node@0.1.11

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
