### PR TITLE
Version Packages (badges)

### DIFF
--- a/workspaces/badges/.changeset/migrate-1713465894125.md
+++ b/workspaces/badges/.changeset/migrate-1713465894125.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-badges': patch
-'@backstage-community/plugin-badges-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/badges/plugins/badges-backend/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges-backend
 
+## 0.4.1
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges-backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Backstage backend plugin that generates README badges for your entities",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/badges/plugins/badges/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges
 
+## 0.2.59
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.58
 
 ### Patch Changes

--- a/workspaces/badges/plugins/badges/package.json
+++ b/workspaces/badges/plugins/badges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "A Backstage plugin that generates README badges for your entities",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-badges@0.2.59

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-badges-backend@0.4.1

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
