### PR TITLE
Version Packages (puppetdb)

### DIFF
--- a/workspaces/puppetdb/.changeset/migrate-1713466183570.md
+++ b/workspaces/puppetdb/.changeset/migrate-1713466183570.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-puppetdb': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/puppetdb/plugins/puppetdb/CHANGELOG.md
+++ b/workspaces/puppetdb/plugins/puppetdb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-puppetdb
 
+## 0.1.18
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.17
 
 ### Patch Changes

--- a/workspaces/puppetdb/plugins/puppetdb/package.json
+++ b/workspaces/puppetdb/plugins/puppetdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-puppetdb",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Backstage plugin to visualize resource information and Puppet facts from PuppetDB.",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-puppetdb@0.1.18

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
