### PR TITLE
Version Packages (stack-overflow)

### DIFF
--- a/workspaces/stack-overflow/.changeset/migrate-1713466226880.md
+++ b/workspaces/stack-overflow/.changeset/migrate-1713466226880.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-stack-overflow': patch
-'@backstage-community/plugin-stack-overflow-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-stack-overflow-backend
 
+## 0.2.22
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.2.21
 
 ### Patch Changes

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-stack-overflow-backend",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "description": "Deprecated, consider using @backstage/plugin-search-backend-module-stack-overflow-collator instead",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/stack-overflow/plugins/stack-overflow/CHANGELOG.md
+++ b/workspaces/stack-overflow/plugins/stack-overflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-stack-overflow
 
+## 0.1.30
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.29
 
 ### Patch Changes

--- a/workspaces/stack-overflow/plugins/stack-overflow/package.json
+++ b/workspaces/stack-overflow/plugins/stack-overflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-stack-overflow",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-stack-overflow@0.1.30

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-stack-overflow-backend@0.2.22

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
