### PR TITLE
Version Packages (graphiql)

### DIFF
--- a/workspaces/graphiql/.changeset/migrate-1713466074732.md
+++ b/workspaces/graphiql/.changeset/migrate-1713466074732.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-graphiql': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
+++ b/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-graphiql
 
+## 0.3.8
+
+### Patch Changes
+
+- 193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.3.7
 
 ### Patch Changes

--- a/workspaces/graphiql/plugins/graphiql/package.json
+++ b/workspaces/graphiql/plugins/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-graphiql",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Backstage plugin for browsing GraphQL APIs",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-graphiql@0.3.8

### Patch Changes

-   193a2a3: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
