### PR TITLE
Version Packages (nomad)

### DIFF
--- a/workspaces/nomad/.changeset/migrate-1713531195787.md
+++ b/workspaces/nomad/.changeset/migrate-1713531195787.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-nomad': patch
-'@backstage-community/plugin-nomad-backend': patch
----
-
-Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

--- a/workspaces/nomad/plugins/nomad-backend/CHANGELOG.md
+++ b/workspaces/nomad/plugins/nomad-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-nomad-backend
 
+## 0.1.20
+
+### Patch Changes
+
+- afff3cf: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.19
 
 ### Patch Changes

--- a/workspaces/nomad/plugins/nomad-backend/package.json
+++ b/workspaces/nomad/plugins/nomad-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nomad-backend",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/nomad/plugins/nomad/CHANGELOG.md
+++ b/workspaces/nomad/plugins/nomad/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-nomad
 
+## 0.1.16
+
+### Patch Changes
+
+- afff3cf: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
+
 ## 0.1.15
 
 ### Patch Changes

--- a/workspaces/nomad/plugins/nomad/package.json
+++ b/workspaces/nomad/plugins/nomad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nomad",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nomad@0.1.16

### Patch Changes

-   afff3cf: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.

## @backstage-community/plugin-nomad-backend@0.1.20

### Patch Changes

-   afff3cf: Migrated from the [backstage/backstage](https://github.com/backstage/backstage) monorepo.
