### PR TITLE
Update renovate config to exclude pinning `devDeps`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,9 +5,9 @@
     ":rebaseStalePrs",
     "group:linters",
     "group:test",
-    ":preserveSemverRanges",
-    ":pinOnlyDevDependencies"
+    ":preserveSemverRanges"
   ],
+  "ignorePresets": [":pinDevDependencies", ":pinDigest", "docker:pinDigests"],
   "labels": ["kind/dependency upgrade"],
   "npm": {
     "minimumReleaseAge": "3 days"


### PR DESCRIPTION
This is just a little bit unfortunate I think, let's just keep the config from main repo.