### PR TITLE
plugin-azure-devops-backend: throwing proper error message when gitRepository not found.

### DIFF
--- a/workspaces/azure-devops/.changeset/giant-goats-itch.md
+++ b/workspaces/azure-devops/.changeset/giant-goats-itch.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-azure-devops-backend': minor
 ---
 
-Fixed bug in plugin-azure-devops-backend where proper error was not thrown when gitRepository was not found.
+Fixed a bug where proper error was not thrown when the repository was not found.

--- a/workspaces/azure-devops/.changeset/giant-goats-itch.md
+++ b/workspaces/azure-devops/.changeset/giant-goats-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-backend': minor
+---
+
+Fixed bug in plugin-azure-devops-backend where proper error was not thrown when gitRepository was not found.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
@@ -465,6 +465,43 @@ describe('AzureDevOpsApi', () => {
     ]);
   });
 
+  it('should throw error when gitRepository is undefined', async () => {
+    const mockApi = {
+      getGitApi: jest.fn().mockReturnValue({}),
+      serverUrl: 'serverUrl',
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const pullRequestOptions: PullRequestOptions = {
+      top: 10,
+      status: PullRequestStatus.Active,
+    };
+
+    api.getGitRepository = jest.fn().mockResolvedValue(undefined);
+
+    const temp = async () => {
+      try {
+        await api.getPullRequests('project', 'repo', pullRequestOptions);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    };
+
+    const error = await temp();
+
+    expect(error).toHaveProperty(
+      'message',
+      'No repository found for Project "project" with Repository "repo" on host "undefined" under organization "undefined".',
+    );
+  });
+
   it('should get build definitions', async () => {
     const mockBuilds: Build[] = [
       {

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -231,6 +231,11 @@ export class AzureDevOpsApi {
       host,
       org,
     );
+    if (!gitRepository) {
+      throw new Error(
+        `No repository found for Project "${projectName}" with Repository "${repoName}" on host "${host}" under organization "${org}".`,
+      );
+    }
     const buildList = await this.getBuildList(
       projectName,
       gitRepository.id as string,
@@ -262,6 +267,11 @@ export class AzureDevOpsApi {
       host,
       org,
     );
+    if (!gitRepository) {
+      throw new Error(
+        `No repository found for Project "${projectName}" with Repository "${repoName}" on host "${host}" under organization "${org}".`,
+      );
+    }
     const webApi = await this.getWebApi(host, org);
     const client = await webApi.getGitApi();
     const tagRefs: GitRef[] = await client.getRefs(
@@ -304,6 +314,11 @@ export class AzureDevOpsApi {
       host,
       org,
     );
+    if (!gitRepository) {
+      throw new Error(
+        `No repository found for Project "${projectName}" with Repository "${repoName}" on host "${host}" under organization "${org}".`,
+      );
+    }
     const webApi = await this.getWebApi(host, org);
     const client = await webApi.getGitApi();
     const searchCriteria: GitPullRequestSearchCriteria = {
@@ -514,6 +529,11 @@ export class AzureDevOpsApi {
         host,
         org,
       );
+      if (!gitRepository) {
+        throw new Error(
+          `No repository found for Project "${projectName}" with Repository "${repoName}" on host "${host}" under organization "${org}".`,
+        );
+      }
       repoId = gitRepository.id;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR contains the changes done in `plugin-azure-devops-backend` regarding the issue https://github.com/backstage/backstage/issues/22255. Proper error message is thrown when gitRepository is not found.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
