### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/grumpy-humans-flash.md
+++ b/workspaces/adr/.changeset/grumpy-humans-flash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Allow the `tokenManager` parameter to be optional when instantiating collator

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.16
+
+### Patch Changes
+
+- 6b9305e: Allow the `tokenManager` parameter to be optional when instantiating collator
+
 ## 0.4.15
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.4.16

### Patch Changes

-   6b9305e: Allow the `tokenManager` parameter to be optional when instantiating collator
