### PR TITLE
chore: add IntelliJ and VSCode files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
 # macOS
 .DS_Store
 
+# IntelliJ
+.idea/
+*.iml
+
+# Visual Studio Code
+.vscode/
+.vsls.json
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Add project files by IntelliJ IDEA and Visual Studio Code to `.gitignore` as used at `.gitignore` at backstage/backstage.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
