### PR TITLE
Version Packages (badges)

### DIFF
--- a/workspaces/badges/.changeset/healthy-socks-fix.md
+++ b/workspaces/badges/.changeset/healthy-socks-fix.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-badges-backend': patch
----
-
-Fix: move test dependency `supertest` to `devDependencies`.

--- a/workspaces/badges/plugins/badges-backend/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges-backend
 
+## 0.4.2
+
+### Patch Changes
+
+- 68ab360: Fix: move test dependency `supertest` to `devDependencies`.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges-backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A Backstage backend plugin that generates README badges for your entities",
   "backstage": {
     "role": "backend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-badges-backend@0.4.2

### Patch Changes

-   68ab360: Fix: move test dependency `supertest` to `devDependencies`.
