### PR TITLE
Version Packages (explore)

### DIFF
--- a/workspaces/explore/.changeset/itchy-singers-prove.md
+++ b/workspaces/explore/.changeset/itchy-singers-prove.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-explore-backend': minor
----
-
-**BREAKING** Removed the deprecated `ToolDocument`, `ToolDocumentCollatorFactory`, and `ToolDocumentCollatorFactoryOptions`. These were deprecated with the `1.13.0` release of Backstage. They should be import from `@backstage/plugin-search-backend-module-explore` instead.

--- a/workspaces/explore/.changeset/perfect-knives-smoke.md
+++ b/workspaces/explore/.changeset/perfect-knives-smoke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-explore-backend': patch
----
-
-Add reference to search module to explore-backend installation steps.

--- a/workspaces/explore/plugins/explore-backend/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-explore-backend
 
+## 0.1.0
+
+### Minor Changes
+
+- 07f73d7: **BREAKING** Removed the deprecated `ToolDocument`, `ToolDocumentCollatorFactory`, and `ToolDocumentCollatorFactoryOptions`. These were deprecated with the `1.13.0` release of Backstage. They should be import from `@backstage/plugin-search-backend-module-explore` instead.
+
+### Patch Changes
+
+- 617f575: Add reference to search module to explore-backend installation steps.
+
 ## 0.0.28
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-backend/package.json
+++ b/workspaces/explore/plugins/explore-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-backend",
-  "version": "0.0.28",
+  "version": "0.1.0",
   "backstage": {
     "role": "backend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-explore-backend@0.1.0

### Minor Changes

-   07f73d7: **BREAKING** Removed the deprecated `ToolDocument`, `ToolDocumentCollatorFactory`, and `ToolDocumentCollatorFactoryOptions`. These were deprecated with the `1.13.0` release of Backstage. They should be import from `@backstage/plugin-search-backend-module-explore` instead.

### Patch Changes

-   617f575: Add reference to search module to explore-backend installation steps.
