### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/giant-goats-itch.md
+++ b/workspaces/azure-devops/.changeset/giant-goats-itch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
----
-
-Fixed a bug where proper error was not thrown when the repository was not found.

--- a/workspaces/azure-devops/.changeset/renovate-727bc86.md
+++ b/workspaces/azure-devops/.changeset/renovate-727bc86.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
----
-
-Updated dependency `azure-devops-node-api` to `^13.0.0`.

--- a/workspaces/azure-devops/.changeset/rich-cycles-love.md
+++ b/workspaces/azure-devops/.changeset/rich-cycles-love.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Backstage `1.27.6` version bump

--- a/workspaces/azure-devops/.changeset/wet-planets-cough.md
+++ b/workspaces/azure-devops/.changeset/wet-planets-cough.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Updated dependencies

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,0 +1,9 @@
+# app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [0a6bae4]
+- Updated dependencies [0032b05]
+  - @backstage-community/plugin-azure-devops@0.4.5

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# backend
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [82b799b]
+- Updated dependencies [fef765e]
+- Updated dependencies [0a6bae4]
+- Updated dependencies [0032b05]
+  - @backstage-community/plugin-azure-devops-backend@0.6.6
+  - app@0.0.1

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.6.6
+
+### Patch Changes
+
+- 82b799b: Fixed a bug where proper error was not thrown when the repository was not found.
+- fef765e: Updated dependency `azure-devops-node-api` to `^13.0.0`.
+- 0a6bae4: Backstage `1.27.6` version bump
+- 0032b05: Updated dependencies
+- Updated dependencies [0a6bae4]
+- Updated dependencies [0032b05]
+  - @backstage-community/plugin-azure-devops-common@0.4.3
+
 ## 0.6.5
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.4.3
+
+### Patch Changes
+
+- 0a6bae4: Backstage `1.27.6` version bump
+- 0032b05: Updated dependencies
+
 ## 0.4.2
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "backstage": {
     "role": "common-library"
   },

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.4.5
+
+### Patch Changes
+
+- 0a6bae4: Backstage `1.27.6` version bump
+- 0032b05: Updated dependencies
+- Updated dependencies [0a6bae4]
+- Updated dependencies [0032b05]
+  - @backstage-community/plugin-azure-devops-common@0.4.3
+
 ## 0.4.4
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.4.5

### Patch Changes

-   0a6bae4: Backstage `1.27.6` version bump
-   0032b05: Updated dependencies
-   Updated dependencies [0a6bae4]
-   Updated dependencies [0032b05]
    -   @backstage-community/plugin-azure-devops-common@0.4.3

## @backstage-community/plugin-azure-devops-backend@0.6.6

### Patch Changes

-   82b799b: Fixed a bug where proper error was not thrown when the repository was not found.
-   fef765e: Updated dependency `azure-devops-node-api` to `^13.0.0`.
-   0a6bae4: Backstage `1.27.6` version bump
-   0032b05: Updated dependencies
-   Updated dependencies [0a6bae4]
-   Updated dependencies [0032b05]
    -   @backstage-community/plugin-azure-devops-common@0.4.3

## @backstage-community/plugin-azure-devops-common@0.4.3

### Patch Changes

-   0a6bae4: Backstage `1.27.6` version bump
-   0032b05: Updated dependencies

## app@0.0.1

### Patch Changes

-   Updated dependencies [0a6bae4]
-   Updated dependencies [0032b05]
    -   @backstage-community/plugin-azure-devops@0.4.5

## backend@0.0.1

### Patch Changes

-   Updated dependencies [82b799b]
-   Updated dependencies [fef765e]
-   Updated dependencies [0a6bae4]
-   Updated dependencies [0032b05]
    -   @backstage-community/plugin-azure-devops-backend@0.6.6
    -   app@0.0.1
