### PR TITLE
add property hideChildren to GroupsDiagram and GroupsExplorerContent

### DIFF
--- a/workspaces/explore/.changeset/smooth-onions-build.md
+++ b/workspaces/explore/.changeset/smooth-onions-build.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore': patch
+---
+
+Added property hideChildren to GroupsDiagram and GroupsExplorerContent

--- a/workspaces/explore/.changeset/smooth-onions-build.md
+++ b/workspaces/explore/.changeset/smooth-onions-build.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-explore': patch
 ---
 
-Added property hideChildren to GroupsDiagram and GroupsExplorerContent
+Added property `hideChildren` to `GroupsDiagram` and `GroupsExplorerContent` components

--- a/workspaces/explore/plugins/explore/api-report.md
+++ b/workspaces/explore/plugins/explore/api-report.md
@@ -113,6 +113,7 @@ export const exploreRouteRef: RouteRef<undefined>;
 export const GroupsExplorerContent: (props: {
   title?: string | undefined;
   direction?: DependencyGraphTypes.Direction | undefined;
+  hideChildren?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -168,6 +168,7 @@ function RenderNode(props: DependencyGraphTypes.RenderNodeProps<any>) {
  */
 export function GroupsDiagram(props: {
   direction?: DependencyGraphTypes.Direction;
+  hideChildren?: boolean;
 }) {
   const nodes = new Array<{
     id: string;
@@ -209,17 +210,19 @@ export function GroupsDiagram(props: {
   for (const catalogItem of catalogResponse?.items || []) {
     const currentItemId = stringifyEntityRef(catalogItem);
 
-    nodes.push({
-      id: stringifyEntityRef(catalogItem),
-      kind: catalogItem.kind,
-      name: '',
-    });
-
     // Edge to parent
     const catalogItemRelations_childOf = getEntityRelations(
       catalogItem,
       RELATION_CHILD_OF,
     );
+
+    if (props.hideChildren && catalogItemRelations_childOf.length) continue;
+
+    nodes.push({
+      id: stringifyEntityRef(catalogItem),
+      kind: catalogItem.kind,
+      name: '',
+    });
 
     // if no parent is found, link the node to the root
     if (catalogItemRelations_childOf.length === 0) {

--- a/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.tsx
+++ b/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsExplorerContent.tsx
@@ -38,6 +38,7 @@ const useStyles = makeStyles(
 export const GroupsExplorerContent = (props: {
   title?: string;
   direction?: DependencyGraphTypes.Direction;
+  hideChildren?: boolean;
 }) => {
   const classes = useStyles();
 
@@ -46,7 +47,10 @@ export const GroupsExplorerContent = (props: {
       <ContentHeader title={props.title ?? 'Groups'}>
         <SupportButton>Explore your groups.</SupportButton>
       </ContentHeader>
-      <GroupsDiagram direction={props.direction} />
+      <GroupsDiagram
+        direction={props.direction}
+        hideChildren={props.hideChildren}
+      />
     </Content>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I've added a property `hideChildren` to the `GroupsDiagram` and `GroupsExplorerContent` components. If you have a lot of groups with a lot of children and you only care about the parent groups, this can greatly improve visibility.

An example of what a GroupsDiagram looks like with `hideChildren` set to `true`:

<img width="547" alt="Scherm­afbeelding 2024-04-25 om 13 15 58" src="https://github.com/backstage/community-plugins/assets/24613245/ab6d3c76-75ff-43a9-b4cf-50deb9c12e79">

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
