### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/witty-lobsters-complain.md
+++ b/workspaces/playlist/.changeset/witty-lobsters-complain.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-playlist': patch
----
-
-`EntityPlaylistDialog` now uses `EntityDisplayName` to display playlist owner Entity.

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist
 
+## 0.2.10
+
+### Patch Changes
+
+- 4ba14c1: `EntityPlaylistDialog` now uses `EntityDisplayName` to display playlist owner Entity.
+
 ## 0.2.9
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.2.10

### Patch Changes

-   4ba14c1: `EntityPlaylistDialog` now uses `EntityDisplayName` to display playlist owner Entity.
