### PR TITLE
Vault support kubernetes login

### DIFF
--- a/workspaces/vault/.changeset/yellow-trees-worry.md
+++ b/workspaces/vault/.changeset/yellow-trees-worry.md
@@ -1,0 +1,21 @@
+---
+'@backstage-community/plugin-vault-backend': patch
+---
+
+Added support to Kubernetes authentication for Vault.
+
+The Vault backend supports now 2 types of authentication:
+
+- `static`: The one available in the past. To keep using it, update the config to something like this:
+
+  ```diff
+  vault:
+  -  token: <TOKEN>
+  +  auth:
+  +    type: static
+  +    token: <TOKEN>
+  ```
+
+- `kubernetes`: New option to login using Kubernetes roles. Check the [README.md](../plugins/vault-backend/README.md) for more details
+
+The old setup is still supported but will be removed in a future release. Make sure to update the format in the configuration file.

--- a/workspaces/vault/plugins/vault-backend/README.md
+++ b/workspaces/vault/plugins/vault-backend/README.md
@@ -65,7 +65,9 @@ To get started, first you need a running instance of Vault. You can follow [this
    vault:
      baseUrl: http://your-internal-vault-url.svc
      publicUrl: https://your-vault-url.example.com
-     token: <VAULT_TOKEN>
+     auth:
+       type: static
+       secret: <VAULT_TOKEN>
      secretEngine: 'customSecretEngine' # Optional. By default it uses 'secrets'. Can be overwritten by the annotation of the entity
      kvVersion: <kv-version> # Optional. The K/V version that your instance is using. The available options are '1' or '2'
      schedule: # Optional. If the token renewal is enabled this schedule will be used instead of the hourly one
@@ -82,6 +84,25 @@ To get started, first you need a running instance of Vault. You can follow [this
        capabilities = ["update"]
      }
    ```
+
+## Login via Kubernetes Auth Method
+
+Alternatively, it's also possible to make Backstage use the [Kubernetes auth method](https://developer.hashicorp.com/vault/docs/auth/kubernetes) to login into Vault. For that, the configuration should look like this:
+
+```yaml
+vault:
+  baseUrl: http://your-internal-vault-url.svc
+  publicUrl: https://your-vault-url.example.com
+  token:
+    type: kubernetes
+    role: <KUBERNETES_ROLE>
+    authPath: <KUBERNETES_AUTH_PATH> # Optional. It defaults to 'kubernetes', but you could set a different authPath if needed
+    serviceAccountTokenPath: <PATH_TO_JWT> # Optional. It defaults to '/var/run/secrets/kubernetes.io/serviceaccount/token'. Where the JWT token is located
+  secretEngine: 'customSecretEngine' # Optional. By default it uses 'secrets'. Can be overwritten by the annotation of the entity
+  kvVersion: <kv-version> # Optional. The K/V version that your instance is using. The available options are '1' or '2'
+```
+
+In these cases the token renewal is not needed. The backend will automatically fetch the token for each request.
 
 ## New Backend System
 

--- a/workspaces/vault/plugins/vault-backend/config.d.ts
+++ b/workspaces/vault/plugins/vault-backend/config.d.ts
@@ -33,8 +33,47 @@ export interface Config {
     /**
      * The token used by Backstage to access Vault.
      * @visibility secret
+     * @deprecated Use `auth` instead.
      */
-    token: string;
+    token?: string;
+
+    /**
+     * The authentication used to connect to vault. Currently a static token and
+     * kubernetes authentication are supported.
+     * @visibility backend
+     */
+    auth:
+      | {
+          type: 'static';
+
+          /**
+           * The token used by Backstage to access Vault.
+           * @visibility secret
+           */
+          secret: string;
+        }
+      | {
+          type: 'kubernetes';
+
+          /**
+           * The role used to login to Vault
+           * @visibility backend
+           */
+          role: string;
+
+          /**
+           * The authPath used to login to Vault. If not set, it defaults to 'kubernetes'.
+           * @visibility backend
+           */
+          authPath?: string;
+
+          /**
+           * The path where the service account token is. If not set,
+           * it defaults to '/var/run/secrets/kubernetes.io/serviceaccount/token'.
+           * @visibility secret
+           */
+          serviceAccountTokenPath?: string;
+        };
 
     /**
      * The secret engine name where in vault. Defaults to `secrets`.

--- a/workspaces/vault/plugins/vault-backend/src/service/router.test.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/router.test.ts
@@ -44,7 +44,10 @@ describe('createRouter', () => {
       config: new ConfigReader({
         vault: {
           baseUrl: 'https://www.example.com',
-          token: '1234567890',
+          auth: {
+            type: 'static',
+            secret: '1234567890',
+          },
         },
       }),
       scheduler: scheduler.forPlugin('vault'),

--- a/workspaces/vault/plugins/vault-backend/src/service/vaultApi.test.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/vaultApi.test.ts
@@ -17,11 +17,16 @@
 import { setupRequestMockHandlers } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { VaultSecret, VaultClient, VaultSecretList } from './vaultApi';
+import {
+  VaultSecret,
+  VaultClient,
+  VaultApi,
+  VaultSecretList,
+} from './vaultApi';
 import { ConfigReader } from '@backstage/config';
 
 describe('VaultApi', () => {
-  let api: VaultClient;
+  let api: VaultApi;
 
   const server = setupServer();
   setupRequestMockHandlers(server);
@@ -30,7 +35,10 @@ describe('VaultApi', () => {
   const config = new ConfigReader({
     vault: {
       baseUrl: mockBaseUrl,
-      token: '1234567890',
+      auth: {
+        type: 'static',
+        secret: '1234567890',
+      },
     },
   });
 
@@ -110,7 +118,7 @@ describe('VaultApi', () => {
   });
 
   it('should return success token renew', async () => {
-    expect(await api.renewToken()).toBe(undefined);
+    expect(await api.renewToken?.()).toBe(undefined);
   });
 
   it('should render frontend url', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is a continuation of https://github.com/backstage/backstage/pull/23325, which was closed some time ago and now the plugins have been moved to a new location.

As mentioned there, I'm trying to add support to login via Kubernetes. The approach has been reworked and, I believe, now it's a bit better. The changes are still a breaking change though.

Basically, the configuration can contain an authentication setup for static tokens or kubernetes auth. The main change is happening internally in the `VaultClient`, when the `callApi` is called, we are loading the token on demand. If the authentication uses a static token, then the value will be returned (the renewal is handled in the scheduler task as before); if we use kubernetes, then the token will be fetched dynamically. This wight mean a little delay when using this setup, but as an initial approach it shouldn't hurt in my opinion.

The documentation has been updated as well, and the changeset contains the needed change and the new configuration for kubernetes as well

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
