### PR TITLE
chore(entity-validation): fine-tune language

### DIFF
--- a/workspaces/entity-validation/.changeset/metal-cameras-carry.md
+++ b/workspaces/entity-validation/.changeset/metal-cameras-carry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-validation': patch
+---
+
+Fine-tune the language used throughout the plugin copy to be a bit more file name agnostic, given that not all Backstage entity descriptor YAML files are named catalog-info.yaml.

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityTextArea/EntityTextArea.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityTextArea/EntityTextArea.tsx
@@ -65,7 +65,7 @@ export const EntityTextArea = ({
     const dom = document.createElement('div');
     dom.classList.add(classes.infoPanel);
     dom.textContent =
-      'To validate your catalog-info.yaml click on the "Validate" button or use "Ctrl + S" or "Ctrl + Enter"';
+      'To validate the provided entity descriptor YAML, click the "Validate" button or use "Ctrl + S" or "Ctrl + Enter"';
     dom.onclick = () => setClose(true);
     return showPanel.of(() => ({ dom, top: true }));
   }, [classes, close]);

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.test.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.test.tsx
@@ -43,7 +43,7 @@ describe('EntityValidatorPage', () => {
 
   const contentHead = <MarkdownContent content="Content Head" />;
 
-  it('should show loation text field', async () => {
+  it('should show location text field', async () => {
     const { getByText, getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <EntityValidationPage />
@@ -55,7 +55,7 @@ describe('EntityValidatorPage', () => {
     expect(getByText('File Location')).toBeInTheDocument();
   });
 
-  it('should not show loation text field', async () => {
+  it('should not show location text field', async () => {
     const { queryByText, getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
         <EntityValidationPage hideFileLocationField />

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
@@ -24,7 +24,7 @@ import { CatalogProcessorResult } from '../../types';
 import { parseEntityYaml } from '../../utils';
 import { EntityValidationOutput } from '../EntityValidationOutput';
 
-const EXAMPLE_CATALOG_INFO_YAML = `# Put your catalog-info.yaml below and validate it
+const EXAMPLE_CATALOG_INFO_YAML = `# Provide your entity descriptor YAML to validate its structure
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
@@ -70,7 +70,7 @@ export const EntityValidationPage = (props: {
     <Page themeId="tool">
       <Header
         title="Entity Validator"
-        subtitle="Tool to validate catalog-info.yaml files"
+        subtitle="Validate Backstage catalog entity descriptor YAML files"
       />
       <Content>
         <Grid
@@ -91,7 +91,7 @@ export const EntityValidationPage = (props: {
               required
               value={locationUrl}
               placeholder={defaultLocation}
-              helperText="Location where you catalog-info.yaml file is, or will be, located. This is not the file that is being validated - it only adds location annotations to the entity that is going to be validated."
+              helperText="Present or future location of your entity descriptor YAML file. This is not the file being validated; this merely adds location annotations to the entity descriptor file being validated."
               onChange={e => setLocationUrl(e.target.value)}
             />
           )}


### PR DESCRIPTION
👋 This seeks to improve the language used throughout the plugin to be a bit more file name agnostic, given that not all Backstage entity descriptor YAML files are named `catalog-info.yaml`.

In the process, this also fixes a few minor grammar and spelling typos.

Is this a change the maintainers would be receptive to?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
