### PR TITLE
Version Packages (gocd)

### DIFF
--- a/workspaces/gocd/.changeset/fresh-weeks-refuse.md
+++ b/workspaces/gocd/.changeset/fresh-weeks-refuse.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gocd': patch
----
-
-use the `fetchApi` instead of native `fetch`

--- a/workspaces/gocd/plugins/gocd/CHANGELOG.md
+++ b/workspaces/gocd/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gocd
 
+## 0.1.42
+
+### Patch Changes
+
+- 636a1cd: use the `fetchApi` instead of native `fetch`
+
 ## 0.1.41
 
 ### Patch Changes

--- a/workspaces/gocd/plugins/gocd/package.json
+++ b/workspaces/gocd/plugins/gocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gocd",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "A Backstage plugin that integrates towards GoCD",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gocd@0.1.42

### Patch Changes

-   636a1cd: use the `fetchApi` instead of native `fetch`
