### PR TITLE
Version Packages (entity-validation)

### DIFF
--- a/workspaces/entity-validation/.changeset/metal-cameras-carry.md
+++ b/workspaces/entity-validation/.changeset/metal-cameras-carry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-entity-validation': patch
----
-
-Fine-tune the language used throughout the plugin copy to be a bit more file name agnostic, given that not all Backstage entity descriptor YAML files are named catalog-info.yaml.

--- a/workspaces/entity-validation/plugins/entity-validation/CHANGELOG.md
+++ b/workspaces/entity-validation/plugins/entity-validation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-validation
 
+## 0.1.21
+
+### Patch Changes
+
+- fb7f04c: Fine-tune the language used throughout the plugin copy to be a bit more file name agnostic, given that not all Backstage entity descriptor YAML files are named catalog-info.yaml.
+
 ## 0.1.20
 
 ### Patch Changes

--- a/workspaces/entity-validation/plugins/entity-validation/package.json
+++ b/workspaces/entity-validation/plugins/entity-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-validation",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-validation@0.1.21

### Patch Changes

-   fb7f04c: Fine-tune the language used throughout the plugin copy to be a bit more file name agnostic, given that not all Backstage entity descriptor YAML files are named catalog-info.yaml.
