### PR TITLE
use `fetchApi` instead of native fetch

### DIFF
--- a/workspaces/apache-airflow/.changeset/stale-coins-protect.md
+++ b/workspaces/apache-airflow/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-apache-airflow': patch
+---
+
+Use the `fetchApi` instead of native fetch

--- a/workspaces/apache-airflow/plugins/apache-airflow/package.json
+++ b/workspaces/apache-airflow/plugins/apache-airflow/package.json
@@ -39,7 +39,6 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "cross-fetch": "^4.0.0",
     "qs": "^6.10.1",
     "react-use": "^17.2.4"
   },

--- a/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowApi.ts
+++ b/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createApiRef, DiscoveryApi } from '@backstage/core-plugin-api';
+import { createApiRef } from '@backstage/core-plugin-api';
 import { Dag, InstanceStatus, InstanceVersion } from './types';
 import { DagRun } from './types/Dags';
 
@@ -23,7 +23,6 @@ export const apacheAirflowApiRef = createApiRef<ApacheAirflowApi>({
 });
 
 export type ApacheAirflowApi = {
-  discoveryApi: DiscoveryApi;
   baseUrl: string;
   listDags(options?: { objectsPerRequest: number }): Promise<Dag[]>;
   getDags(dagIds: string[]): Promise<{ dags: Dag[]; dagsNotFound: string[] }>;

--- a/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowClient.test.ts
+++ b/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowClient.test.ts
@@ -105,6 +105,7 @@ describe('ApacheAirflowClient', () => {
 
   const mockBaseUrl = 'http://backstage:9191/api/proxy';
   const discoveryApi = UrlPatternDiscovery.compile(mockBaseUrl);
+  const fetchApi = { fetch };
   let client: ApacheAirflowClient;
   const setupHandlers = () => {
     server.use(
@@ -199,7 +200,8 @@ describe('ApacheAirflowClient', () => {
   beforeEach(() => {
     setupHandlers();
     client = new ApacheAirflowClient({
-      discoveryApi: discoveryApi,
+      discoveryApi,
+      fetchApi,
       baseUrl: 'localhost:8080/',
     });
   });

--- a/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowClient.ts
+++ b/workspaces/apache-airflow/plugins/apache-airflow/src/api/ApacheAirflowClient.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi } from '@backstage/core-plugin-api';
-import fetch from 'cross-fetch';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import qs from 'qs';
 import { ApacheAirflowApi } from './ApacheAirflowApi';
 import {
@@ -28,17 +27,21 @@ import {
 import { DagRun } from './types/Dags';
 
 export class ApacheAirflowClient implements ApacheAirflowApi {
-  discoveryApi: DiscoveryApi;
+  private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
   baseUrl: string;
 
   constructor({
     discoveryApi,
+    fetchApi,
     baseUrl = 'http://localhost:8080',
   }: {
     discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
     baseUrl: string;
   }) {
     this.discoveryApi = discoveryApi;
+    this.fetchApi = fetchApi;
     this.baseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
   }
 
@@ -158,7 +161,7 @@ export class ApacheAirflowClient implements ApacheAirflowApi {
 
   private async fetch<T = any>(input: string, init?: RequestInit): Promise<T> {
     const proxyUri = `${await this.discoveryApi.getBaseUrl('proxy')}/airflow`;
-    const response = await fetch(`${proxyUri}${input}`, init);
+    const response = await this.fetchApi.fetch(`${proxyUri}${input}`, init);
     if (!response.ok) throw new Error(response.statusText);
     return await response.json();
   }

--- a/workspaces/apache-airflow/plugins/apache-airflow/src/plugin.ts
+++ b/workspaces/apache-airflow/plugins/apache-airflow/src/plugin.ts
@@ -23,6 +23,7 @@ import {
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 /** @public */
@@ -34,10 +35,15 @@ export const apacheAirflowPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: apacheAirflowApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-      factory: ({ configApi, discoveryApi }) =>
+      deps: {
+        configApi: configApiRef,
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ configApi, discoveryApi, fetchApi }) =>
         new ApacheAirflowClient({
           discoveryApi,
+          fetchApi,
           baseUrl: configApi.getString('apacheAirflow.baseUrl'),
         }),
     }),

--- a/workspaces/apache-airflow/yarn.lock
+++ b/workspaces/apache-airflow/yarn.lock
@@ -2531,7 +2531,6 @@ __metadata:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     "@types/react-dom": ^18.2.19
     canvas: ^2.11.2
-    cross-fetch: ^4.0.0
     msw: ^1.0.0
     qs: ^6.10.1
     react: ^16.13.1 || ^17.0.0 || ^18.0.0

--- a/workspaces/bitrise/.changeset/stale-coins-protect.md
+++ b/workspaces/bitrise/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-bitrise': patch
+---
+
+Use the `fetchApi` instead of native fetch

--- a/workspaces/bitrise/plugins/bitrise/src/api/bitriseApi.client.test.ts
+++ b/workspaces/bitrise/plugins/bitrise/src/api/bitriseApi.client.test.ts
@@ -26,12 +26,13 @@ const server = setupServer();
 describe('BitriseClientApi', () => {
   setupRequestMockHandlers(server);
 
+  const fetchApi = { fetch };
   const mockBaseUrl = 'http://backstage:9191/api/proxy';
   const discoveryApi = UrlPatternDiscovery.compile(mockBaseUrl);
   let client: BitriseApi;
 
   beforeEach(() => {
-    client = new BitriseClientApi(discoveryApi);
+    client = new BitriseClientApi(discoveryApi, fetchApi);
   });
 
   describe('getBuilds()', () => {
@@ -82,32 +83,29 @@ describe('BitriseClientApi', () => {
   describe('getApp()', () => {
     it('should get all apps', async () => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/bitrise/apps?next=slug-2-1`,
-          (_req, res, ctx) => {
-            const next = _req.url.searchParams.get('next');
-            if (next === 'slug-2-1') {
-              return res(
-                ctx.json({
-                  data: [{ title: 'app21', slug: 'slug-2-1' }],
-                }),
-              );
-            }
+        rest.get(`${mockBaseUrl}/bitrise/apps`, (_req, res, ctx) => {
+          const next = _req.url.searchParams.get('next');
+          if (next === 'slug-2-1') {
             return res(
               ctx.json({
-                data: [
-                  { title: 'app11', slug: 'slug-1-1' },
-                  { title: 'app12', slug: 'slug-1-2' },
-                ],
-                paging: {
-                  next: 'slug-2-1',
-                  page_item_limit: 0,
-                  total_item_count: 0,
-                },
+                data: [{ title: 'app21', slug: 'slug-2-1' }],
               }),
             );
-          },
-        ),
+          }
+          return res(
+            ctx.json({
+              data: [
+                { title: 'app11', slug: 'slug-1-1' },
+                { title: 'app12', slug: 'slug-1-2' },
+              ],
+              paging: {
+                next: 'slug-2-1',
+                page_item_limit: 0,
+                total_item_count: 0,
+              },
+            }),
+          );
+        }),
       );
 
       const apps = await client.getApps();

--- a/workspaces/bitrise/plugins/bitrise/src/api/bitriseApi.client.ts
+++ b/workspaces/bitrise/plugins/bitrise/src/api/bitriseApi.client.ts
@@ -27,10 +27,13 @@ import {
 import qs from 'qs';
 import { DateTime, Interval } from 'luxon';
 import { pickBy, identity } from 'lodash';
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 
 export class BitriseClientApi implements BitriseApi {
-  constructor(private readonly discoveryApi: DiscoveryApi) {}
+  constructor(
+    private readonly discoveryApi: DiscoveryApi,
+    private readonly fetchApi: FetchApi,
+  ) {}
 
   async getArtifactDetails(
     appSlug: string,
@@ -38,7 +41,7 @@ export class BitriseClientApi implements BitriseApi {
     artifactSlug: string,
   ): Promise<BitriseBuildArtifactDetails | undefined> {
     const baseUrl = await this.discoveryApi.getBaseUrl('proxy');
-    const artifactResponse = await fetch(
+    const artifactResponse = await this.fetchApi.fetch(
       `${baseUrl}/bitrise/apps/${appSlug}/builds/${buildSlug}/artifacts/${artifactSlug}`,
     );
 
@@ -52,7 +55,7 @@ export class BitriseClientApi implements BitriseApi {
     buildSlug: string,
   ): Promise<BitriseBuildArtifact[]> {
     const baseUrl = await this.discoveryApi.getBaseUrl('proxy');
-    const response = await fetch(
+    const response = await this.fetchApi.fetch(
       `${baseUrl}/bitrise/apps/${appSlug}/builds/${buildSlug}/artifacts`,
     );
 
@@ -63,7 +66,9 @@ export class BitriseClientApi implements BitriseApi {
 
   async getAppsPaginated(from: string): Promise<BitriseApp[]> {
     const baseUrl = await this.discoveryApi.getBaseUrl('proxy');
-    const appsResponse = await fetch(`${baseUrl}/bitrise/apps?next=${from}`);
+    const appsResponse = await this.fetchApi.fetch(
+      `${baseUrl}/bitrise/apps?next=${from}`,
+    );
 
     const appsData = await appsResponse.json();
 
@@ -88,7 +93,7 @@ export class BitriseClientApi implements BitriseApi {
 
   async getBuildWorkflows(appSlug: string): Promise<string[]> {
     const baseUrl = await this.discoveryApi.getBaseUrl('proxy');
-    const response = await fetch(
+    const response = await this.fetchApi.fetch(
       `${baseUrl}/bitrise/apps/${appSlug}/build-workflows`,
     );
     const data = await response.json();
@@ -106,7 +111,7 @@ export class BitriseClientApi implements BitriseApi {
       url = `${url}?${qs.stringify(pickBy(params, identity))}`;
     }
 
-    const response = await fetch(url);
+    const response = await this.fetchApi.fetch(url);
     const data = await response.json();
     const builds: BitriseBuildResponseItem[] = data.data;
 

--- a/workspaces/bitrise/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.test.tsx
+++ b/workspaces/bitrise/plugins/bitrise/src/components/BitriseArtifactsComponent/BitriseArtifactsComponent.test.tsx
@@ -69,8 +69,8 @@ describe('BitriseArtifactsComponent', () => {
   it('should display a table if there are artifacts', async () => {
     (useBitriseArtifacts as jest.Mock).mockReturnValue({
       value: [
-        { title: 'some-title-1', slug: 'some-slug' },
-        { title: 'some-title-2', slug: 'some-slug' },
+        { title: 'some-title-1', slug: 'some-slug-1' },
+        { title: 'some-title-2', slug: 'some-slug-2' },
       ],
     });
 

--- a/workspaces/bitrise/plugins/bitrise/src/components/BitriseBuildsTableComponent/BitriseBuildsTableComponent.test.tsx
+++ b/workspaces/bitrise/plugins/bitrise/src/components/BitriseBuildsTableComponent/BitriseBuildsTableComponent.test.tsx
@@ -35,6 +35,8 @@ const server = setupServer();
 
 describe('BitriseBuildsFetchComponent', () => {
   setupRequestMockHandlers(server);
+
+  const fetchApi = { fetch: jest.fn() };
   const mockBaseUrl = 'http://backstage:9191';
   const discoveryApi = UrlPatternDiscovery.compile(mockBaseUrl);
   let apis: TestApiRegistry;
@@ -42,7 +44,7 @@ describe('BitriseBuildsFetchComponent', () => {
   beforeEach(() => {
     apis = TestApiRegistry.from([
       bitriseApiRef,
-      new BitriseClientApi(discoveryApi),
+      new BitriseClientApi(discoveryApi, fetchApi),
     ]);
   });
 

--- a/workspaces/bitrise/plugins/bitrise/src/plugin.ts
+++ b/workspaces/bitrise/plugins/bitrise/src/plugin.ts
@@ -22,6 +22,7 @@ import {
   createApiRef,
   createApiFactory,
   createPlugin,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 export const bitriseApiRef = createApiRef<BitriseApi>({
@@ -34,9 +35,12 @@ export const bitrisePlugin = createPlugin({
   apis: [
     createApiFactory({
       api: bitriseApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => {
-        return new BitriseClientApi(discoveryApi);
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) => {
+        return new BitriseClientApi(discoveryApi, fetchApi);
       },
     }),
   ],

--- a/workspaces/codescene/.changeset/stale-coins-protect.md
+++ b/workspaces/codescene/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-codescene': patch
+---
+
+Use the `fetchApi` instead of native fetch

--- a/workspaces/codescene/plugins/codescene/src/api/api.ts
+++ b/workspaces/codescene/plugins/codescene/src/api/api.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createApiRef, DiscoveryApi } from '@backstage/core-plugin-api';
+
+import {
+  createApiRef,
+  DiscoveryApi,
+  FetchApi,
+} from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import {
   FetchProjectsResponse,
@@ -35,13 +40,16 @@ export interface CodeSceneApi {
 
 type Options = {
   discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
 };
 
 export class CodeSceneClient implements CodeSceneApi {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
   }
 
   async fetchProjects(): Promise<FetchProjectsResponse> {
@@ -62,7 +70,7 @@ export class CodeSceneClient implements CodeSceneApi {
 
   private async fetchFromApi(path: string): Promise<any> {
     const apiUrl = await this.getApiUrl();
-    const res = await fetch(`${apiUrl}/${path}`);
+    const res = await this.fetchApi.fetch(`${apiUrl}/${path}`);
     if (!res.ok) {
       throw await ResponseError.fromResponse(res);
     }

--- a/workspaces/codescene/plugins/codescene/src/components/CodeScenePageComponent/CodeScenePageComponent.test.tsx
+++ b/workspaces/codescene/plugins/codescene/src/components/CodeScenePageComponent/CodeScenePageComponent.test.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 import { CodeScenePageComponent } from './CodeScenePageComponent';
 import { rest } from 'msw';
@@ -43,9 +44,10 @@ describe('CodeScenePageComponent', () => {
         return `http://base.com/${pluginId}`;
       },
     };
+    const fetchApi = { fetch };
     apis = TestApiRegistry.from([
       codesceneApiRef,
-      new CodeSceneClient({ discoveryApi }),
+      new CodeSceneClient({ discoveryApi, fetchApi }),
     ]);
   });
 

--- a/workspaces/codescene/plugins/codescene/src/plugin.ts
+++ b/workspaces/codescene/plugins/codescene/src/plugin.ts
@@ -19,6 +19,7 @@ import {
   createApiFactory,
   discoveryApiRef,
   createComponentExtension,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { codesceneApiRef, CodeSceneClient } from './api/api';
 import { rootRouteRef, projectDetailsRouteRef } from './routes';
@@ -31,8 +32,12 @@ export const codescenePlugin = createPlugin({
   apis: [
     createApiFactory({
       api: codesceneApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new CodeSceneClient({ discoveryApi }),
+      deps: {
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new CodeSceneClient({ discoveryApi, fetchApi }),
     }),
   ],
   routes: {

--- a/workspaces/firehydrant/.changeset/stale-coins-protect.md
+++ b/workspaces/firehydrant/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-firehydrant': patch
+---
+
+Use the `fetchApi` instead of native fetch

--- a/workspaces/firehydrant/plugins/firehydrant/src/plugin.ts
+++ b/workspaces/firehydrant/plugins/firehydrant/src/plugin.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { fireHydrantApiRef, FireHydrantAPIClient } from './api';
 import {
   createApiFactory,
   createPlugin,
   discoveryApiRef,
   createComponentExtension,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 import { rootRouteRef } from './routes';
@@ -29,8 +31,9 @@ export const firehydrantPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: fireHydrantApiRef,
-      deps: { discoveryApi: discoveryApiRef },
-      factory: ({ discoveryApi }) => new FireHydrantAPIClient({ discoveryApi }),
+      deps: { discoveryApi: discoveryApiRef, fetchApi: fetchApiRef },
+      factory: ({ discoveryApi, fetchApi }) =>
+        new FireHydrantAPIClient({ discoveryApi, fetchApi }),
     }),
   ],
   routes: {

--- a/workspaces/ilert/.changeset/stale-coins-protect.md
+++ b/workspaces/ilert/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-ilert': minor
+---
+
+**BREAKING**: `ILertClient` now requires the `fetchApi` to be passed in. This lets the plugin work safely with the upcoming `proxy-backend` [security changes](https://github.com/backstage/backstage/pull/24643).

--- a/workspaces/ilert/plugins/ilert/api-report.md
+++ b/workspaces/ilert/plugins/ilert/api-report.md
@@ -10,6 +10,7 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { ConfigApi } from '@backstage/core-plugin-api';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { FetchApi } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { default as React_2 } from 'react';
@@ -450,6 +451,7 @@ export const ILertCard: () => React_2.JSX.Element;
 export class ILertClient implements ILertApi {
   constructor(opts: {
     discoveryApi: DiscoveryApi;
+    fetchApi: FetchApi;
     baseUrl: string;
     proxyPath: string;
   });
@@ -496,6 +498,7 @@ export class ILertClient implements ILertApi {
   static fromConfig(
     configApi: ConfigApi,
     discoveryApi: DiscoveryApi,
+    fetchApi: FetchApi,
   ): ILertClient;
   // (undocumented)
   getAlertDetailsURL(alert: Alert): string;

--- a/workspaces/ilert/plugins/ilert/src/plugin.test.ts
+++ b/workspaces/ilert/plugins/ilert/src/plugin.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ilertPlugin } from './plugin';
 
 describe('plugin-ilert', () => {

--- a/workspaces/ilert/plugins/ilert/src/plugin.ts
+++ b/workspaces/ilert/plugins/ilert/src/plugin.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { ILertClient, ilertApiRef } from './api';
 import { iLertRouteRef } from './route-refs';
 import {
@@ -20,9 +21,9 @@ import {
   createApiFactory,
   createPlugin,
   discoveryApiRef,
-  identityApiRef,
   createRoutableExtension,
   createComponentExtension,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 /** @public */
@@ -33,11 +34,11 @@ export const ilertPlugin = createPlugin({
       api: ilertApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
-        identityApi: identityApiRef,
         configApi: configApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory: ({ discoveryApi, configApi }) =>
-        ILertClient.fromConfig(configApi, discoveryApi),
+      factory: ({ discoveryApi, configApi, fetchApi }) =>
+        ILertClient.fromConfig(configApi, discoveryApi, fetchApi),
     }),
   ],
   routes: {

--- a/workspaces/xcmetrics/.changeset/stale-coins-protect.md
+++ b/workspaces/xcmetrics/.changeset/stale-coins-protect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-xcmetrics': patch
+---
+
+Use the `fetchApi` instead of native fetch

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/api/XcmetricsClient.ts
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/api/XcmetricsClient.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { DateTime } from 'luxon';
 import {
@@ -34,13 +34,16 @@ import {
 
 interface Options {
   discoveryApi: DiscoveryApi;
+  fetchApi: FetchApi;
 }
 
 export class XcmetricsClient implements XcmetricsApi {
   private readonly discoveryApi: DiscoveryApi;
+  private readonly fetchApi: FetchApi;
 
   constructor(options: Options) {
     this.discoveryApi = options.discoveryApi;
+    this.fetchApi = options.fetchApi;
   }
 
   async getBuild(id: string): Promise<BuildResponse> {
@@ -120,7 +123,7 @@ export class XcmetricsClient implements XcmetricsApi {
 
   private async get(path: string): Promise<Response> {
     const baseUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/xcmetrics`;
-    const response = await fetch(`${baseUrl}${path}`);
+    const response = await this.fetchApi.fetch(`${baseUrl}${path}`);
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);
@@ -131,7 +134,7 @@ export class XcmetricsClient implements XcmetricsApi {
 
   private async post(path: string, body: Object): Promise<Response> {
     const baseUrl = `${await this.discoveryApi.getBaseUrl('proxy')}/xcmetrics`;
-    const response = await fetch(`${baseUrl}${path}`, {
+    const response = await this.fetchApi.fetch(`${baseUrl}${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/plugin.ts
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/plugin.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   createApiFactory,
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 import { xcmetricsApiRef, XcmetricsClient } from './api';
 import { rootRouteRef } from './routes';
@@ -33,9 +35,10 @@ export const xcmetricsPlugin = createPlugin({
       api: xcmetricsApiRef,
       deps: {
         discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
       },
-      factory({ discoveryApi }) {
-        return new XcmetricsClient({ discoveryApi });
+      factory({ discoveryApi, fetchApi }) {
+        return new XcmetricsClient({ discoveryApi, fetchApi });
       },
     }),
   ],


### PR DESCRIPTION
This is a prerequisite to https://github.com/backstage/backstage/pull/24643 (the proxy will soon start requiring auth).

Closes #421
Closes #422
Closes #423
Closes #424
Closes #425
Closes #426
