### PR TITLE
Add colors to PR status in github-pull-requests-board

### DIFF
--- a/workspaces/github-pull-requests-board/.changeset/gold-spiders-invent.md
+++ b/workspaces/github-pull-requests-board/.changeset/gold-spiders-invent.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-github-pull-requests-board': minor
+'@backstage-community/plugin-github-pull-requests-board': patch
 ---
 
 Add color decorators to commit statuses

--- a/workspaces/github-pull-requests-board/.changeset/gold-spiders-invent.md
+++ b/workspaces/github-pull-requests-board/.changeset/gold-spiders-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-pull-requests-board': minor
+---
+
+Add color decorators to commit statuses

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -91,10 +91,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
       {status && (
         <Box display="flex" alignItems="center" flexWrap="wrap" paddingTop={1}>
           <Typography variant="body2" component="p">
-            Commit Status:{' '}
-            <strong>
-              {decorateCommitStatus(status)}
-            </strong>
+            Commit Status: <strong>{decorateCommitStatus(status)}</strong>
           </Typography>
         </Box>
       )}

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/components/Card/CardHeader.tsx
@@ -15,7 +15,7 @@
  */
 import React, { FunctionComponent } from 'react';
 import { Typography, Box, Tooltip, Chip } from '@material-ui/core';
-import { getElapsedTime } from '../../utils/functions';
+import { getElapsedTime, decorateCommitStatus } from '../../utils/functions';
 import { UserHeader } from '../UserHeader';
 import { DraftPrIcon } from '../icons/DraftPr';
 import UnarchiveIcon from '@material-ui/icons/Unarchive';
@@ -80,7 +80,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
       </Typography>
       <Box display="flex" justifyContent="space-between" marginY={1}>
         <Typography variant="body2" component="p">
-          Created at: <strong>{getElapsedTime(createdAt)}</strong>
+          Created: <strong>{getElapsedTime(createdAt)}</strong>
         </Typography>
         {updatedAt && (
           <Typography variant="body2" component="p">
@@ -93,7 +93,7 @@ const CardHeader: FunctionComponent<Props> = (props: Props) => {
           <Typography variant="body2" component="p">
             Commit Status:{' '}
             <strong>
-              {status[0]?.commit.statusCheckRollup?.state || 'N/A'}
+              {decorateCommitStatus(status)}
             </strong>
           </Typography>
         </Box>

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -171,6 +171,6 @@ export const decorateCommitStatus = (status: Status[]) => {
     case 'EXPECTED':
       return '🔵 EXPECTED';
     default:
-      return 'statusString';
+      return statusString;
   }
 };

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -23,6 +23,7 @@ import {
   Author,
   PRCardFormating,
   Repository,
+  Status
 } from './types';
 import { COLUMNS } from './constants';
 
@@ -156,4 +157,19 @@ export const shouldDisplayCard = (
 
   // when "team" filter is toggled off, only shows PR on team repos
   return repositories.includes(fullRepoName);
+};
+
+export const decorateCommitStatus = (status: Status[]) => {
+  var statusString = status[0]?.commit.statusCheckRollup?.state || 'N/A';
+  if (statusString === 'SUCCESS') {
+    return '🟢 SUCCESS';
+  } else if (statusString === 'FAILURE') {
+    return '🔴 FAILURE';
+  } else if (statusString === 'PENDING') {
+    return '🟡 PENDING';
+  } else if (statusString === 'EXPECTED') {
+    return '🔵 EXPECTED';
+  } else {
+    return 'statusString';
+  }
 };

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/utils/functions.ts
@@ -23,7 +23,7 @@ import {
   Author,
   PRCardFormating,
   Repository,
-  Status
+  Status,
 } from './types';
 import { COLUMNS } from './constants';
 
@@ -160,16 +160,17 @@ export const shouldDisplayCard = (
 };
 
 export const decorateCommitStatus = (status: Status[]) => {
-  var statusString = status[0]?.commit.statusCheckRollup?.state || 'N/A';
-  if (statusString === 'SUCCESS') {
-    return '🟢 SUCCESS';
-  } else if (statusString === 'FAILURE') {
-    return '🔴 FAILURE';
-  } else if (statusString === 'PENDING') {
-    return '🟡 PENDING';
-  } else if (statusString === 'EXPECTED') {
-    return '🔵 EXPECTED';
-  } else {
-    return 'statusString';
+  const statusString = status[0]?.commit.statusCheckRollup?.state || 'N/A';
+  switch (statusString) {
+    case 'SUCCESS':
+      return '🟢 SUCCESS';
+    case 'FAILURE':
+      return '🔴 FAILURE';
+    case 'PENDING':
+      return '🟡 PENDING';
+    case 'EXPECTED':
+      return '🔵 EXPECTED';
+    default:
+      return 'statusString';
   }
 };


### PR DESCRIPTION
Also remove "at" from "Created" line to match "Last update"

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Add colors to PR status in github-pull-requests-board
Also remove "at" from "Created" line to match "Last update"


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
