### PR TITLE
Version Packages (xcmetrics)

### DIFF
--- a/workspaces/xcmetrics/.changeset/stale-coins-protect.md
+++ b/workspaces/xcmetrics/.changeset/stale-coins-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-xcmetrics': patch
----
-
-Use the `fetchApi` instead of native fetch

--- a/workspaces/xcmetrics/plugins/xcmetrics/CHANGELOG.md
+++ b/workspaces/xcmetrics/plugins/xcmetrics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-xcmetrics
 
+## 0.2.54
+
+### Patch Changes
+
+- 1255628: Use the `fetchApi` instead of native fetch
+
 ## 0.2.53
 
 ### Patch Changes

--- a/workspaces/xcmetrics/plugins/xcmetrics/package.json
+++ b/workspaces/xcmetrics/plugins/xcmetrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-xcmetrics",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "A Backstage plugin that shows XCode build metrics for your components",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-xcmetrics@0.2.54

### Patch Changes

-   1255628: Use the `fetchApi` instead of native fetch
