### PR TITLE
Version Packages (codescene)

### DIFF
--- a/workspaces/codescene/.changeset/stale-coins-protect.md
+++ b/workspaces/codescene/.changeset/stale-coins-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-codescene': patch
----
-
-Use the `fetchApi` instead of native fetch

--- a/workspaces/codescene/plugins/codescene/CHANGELOG.md
+++ b/workspaces/codescene/plugins/codescene/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-codescene
 
+## 0.1.28
+
+### Patch Changes
+
+- 1255628: Use the `fetchApi` instead of native fetch
+
 ## 0.1.27
 
 ### Patch Changes

--- a/workspaces/codescene/plugins/codescene/package.json
+++ b/workspaces/codescene/plugins/codescene/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-codescene",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-codescene@0.1.28

### Patch Changes

-   1255628: Use the `fetchApi` instead of native fetch
