### PR TITLE
Version Packages (apache-airflow)

### DIFF
--- a/workspaces/apache-airflow/.changeset/stale-coins-protect.md
+++ b/workspaces/apache-airflow/.changeset/stale-coins-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-apache-airflow': patch
----
-
-Use the `fetchApi` instead of native fetch

--- a/workspaces/apache-airflow/plugins/apache-airflow/CHANGELOG.md
+++ b/workspaces/apache-airflow/plugins/apache-airflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-apache-airflow
 
+## 0.2.26
+
+### Patch Changes
+
+- 1255628: Use the `fetchApi` instead of native fetch
+
 ## 0.2.25
 
 ### Patch Changes

--- a/workspaces/apache-airflow/plugins/apache-airflow/package.json
+++ b/workspaces/apache-airflow/plugins/apache-airflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apache-airflow",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-apache-airflow@0.2.26

### Patch Changes

-   1255628: Use the `fetchApi` instead of native fetch
