### PR TITLE
Version Packages (ilert)

### DIFF
--- a/workspaces/ilert/.changeset/stale-coins-protect.md
+++ b/workspaces/ilert/.changeset/stale-coins-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ilert': minor
----
-
-**BREAKING**: `ILertClient` now requires the `fetchApi` to be passed in. This lets the plugin work safely with the upcoming `proxy-backend` [security changes](https://github.com/backstage/backstage/pull/24643).

--- a/workspaces/ilert/plugins/ilert/CHANGELOG.md
+++ b/workspaces/ilert/plugins/ilert/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-ilert
 
+## 0.3.0
+
+### Minor Changes
+
+- 1255628: **BREAKING**: `ILertClient` now requires the `fetchApi` to be passed in. This lets the plugin work safely with the upcoming `proxy-backend` [security changes](https://github.com/backstage/backstage/pull/24643).
+
 ## 0.2.24
 
 ### Patch Changes

--- a/workspaces/ilert/plugins/ilert/package.json
+++ b/workspaces/ilert/plugins/ilert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ilert",
-  "version": "0.2.24",
+  "version": "0.3.0",
   "description": "A Backstage plugin that integrates towards iLert",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ilert@0.3.0

### Minor Changes

-   1255628: **BREAKING**: `ILertClient` now requires the `fetchApi` to be passed in. This lets the plugin work safely with the upcoming `proxy-backend` [security changes](https://github.com/backstage/backstage/pull/24643).
