### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/lucky-cherries-brush.md
+++ b/workspaces/entity-feedback/.changeset/lucky-cherries-brush.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': patch
-'@backstage-community/plugin-entity-feedback-common': patch
-'@backstage-community/plugin-entity-feedback': patch
----
-
-Update dependencies to Backstage version 1.27

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.2.16
+
+### Patch Changes
+
+- 063687c: Update dependencies to Backstage version 1.27
+- Updated dependencies [063687c]
+  - @backstage-community/plugin-entity-feedback-common@0.1.5
+
 ## 0.2.15
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-feedback-common
 
+## 0.1.5
+
+### Patch Changes
+
+- 063687c: Update dependencies to Backstage version 1.27
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-common/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Common functionalities for the entity-feedback plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-entity-feedback
 
+## 0.2.19
+
+### Patch Changes
+
+- 063687c: Update dependencies to Backstage version 1.27
+- Updated dependencies [063687c]
+  - @backstage-community/plugin-entity-feedback-common@0.1.5
+
 ## 0.2.18
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback@0.2.19

### Patch Changes

-   063687c: Update dependencies to Backstage version 1.27
-   Updated dependencies [063687c]
    -   @backstage-community/plugin-entity-feedback-common@0.1.5

## @backstage-community/plugin-entity-feedback-backend@0.2.16

### Patch Changes

-   063687c: Update dependencies to Backstage version 1.27
-   Updated dependencies [063687c]
    -   @backstage-community/plugin-entity-feedback-common@0.1.5

## @backstage-community/plugin-entity-feedback-common@0.1.5

### Patch Changes

-   063687c: Update dependencies to Backstage version 1.27
