### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/renovate-82637a0.md
+++ b/workspaces/code-coverage/.changeset/renovate-82637a0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage': patch
----
-
-Updated dependency `highlight.js` to `^11.0.0`.

--- a/workspaces/code-coverage/.changeset/small-bananas-listen.md
+++ b/workspaces/code-coverage/.changeset/small-bananas-listen.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
-'@backstage-community/plugin-code-coverage': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.2.33
+
+### Patch Changes
+
+- 1a94274: version:bump to v1.29.1
+
 ## 0.2.32
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-code-coverage
 
+## 0.2.29
+
+### Patch Changes
+
+- a53dea5: Updated dependency `highlight.js` to `^11.0.0`.
+- 1a94274: version:bump to v1.29.1
+
 ## 0.2.28
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage@0.2.29

### Patch Changes

-   a53dea5: Updated dependency `highlight.js` to `^11.0.0`.
-   1a94274: version:bump to v1.29.1

## @backstage-community/plugin-code-coverage-backend@0.2.33

### Patch Changes

-   1a94274: version:bump to v1.29.1
