### PR TITLE
Linguist - Fixed age config in router

### DIFF
--- a/workspaces/linguist/.changeset/hot-crews-fold.md
+++ b/workspaces/linguist/.changeset/hot-crews-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-linguist-backend': patch
+---
+
+Fixed how the `age` config value was being pulled in the router when using the new backend system

--- a/workspaces/linguist/plugins/linguist-backend/src/service/router.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/service/router.ts
@@ -31,7 +31,7 @@ import {
   readTaskScheduleDefinitionFromConfig,
   TaskScheduleDefinition,
 } from '@backstage/backend-tasks';
-import { HumanDuration } from '@backstage/types';
+import { HumanDuration, JsonObject } from '@backstage/types';
 import { CatalogClient } from '@backstage/catalog-client';
 import { LinguistBackendClient } from '../api/LinguistBackendClient';
 import { Config } from '@backstage/config';
@@ -165,7 +165,7 @@ export async function createRouterFromConfig(routerOptions: RouterOptions) {
     pluginOptions.batchSize = config.getOptionalNumber('linguist.batchSize');
     pluginOptions.useSourceLocation =
       config.getOptionalBoolean('linguist.useSourceLocation') ?? false;
-    pluginOptions.age = config.getOptionalConfig('linguist.age') as
+    pluginOptions.age = config.getOptional<JsonObject>('linguist.age') as
       | HumanDuration
       | undefined;
     pluginOptions.kind = config.getOptionalStringArray('linguist.kind');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While working on the Linguist Tag Processor module for the new backend system I discovered that there was a small bug in how we were getting the `age` config when using Linguist itself with the new backend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
