### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/spicy-planets-peel.md
+++ b/workspaces/linkerd/.changeset/spicy-planets-peel.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': minor
-'@backstage-community/plugin-linkerd': minor
----
-
-Added `LinkerdIsMeshedBanner` and `LinkerdEdgesTable` for use in the Entity pages

--- a/workspaces/linkerd/packages/app/CHANGELOG.md
+++ b/workspaces/linkerd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [a708efd]
+  - @backstage-community/plugin-linkerd@0.2.0
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/app/package.json
+++ b/workspaces/linkerd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [a708efd]
+  - @backstage-community/plugin-linkerd-backend@0.2.0
+  - app@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.2.0
+
+### Minor Changes
+
+- a708efd: Added `LinkerdIsMeshedBanner` and `LinkerdEdgesTable` for use in the Entity pages
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd
 
+## 0.2.0
+
+### Minor Changes
+
+- a708efd: Added `LinkerdIsMeshedBanner` and `LinkerdEdgesTable` for use in the Entity pages
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd/package.json
+++ b/workspaces/linkerd/plugins/linkerd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd@0.2.0

### Minor Changes

-   a708efd: Added `LinkerdIsMeshedBanner` and `LinkerdEdgesTable` for use in the Entity pages

## @backstage-community/plugin-linkerd-backend@0.2.0

### Minor Changes

-   a708efd: Added `LinkerdIsMeshedBanner` and `LinkerdEdgesTable` for use in the Entity pages

## app@0.0.2

### Patch Changes

-   Updated dependencies [a708efd]
    -   @backstage-community/plugin-linkerd@0.2.0

## backend@0.0.2

### Patch Changes

-   Updated dependencies [a708efd]
    -   @backstage-community/plugin-linkerd-backend@0.2.0
    -   app@0.0.2
