### PR TITLE
feat: enable npm provenance on published packages

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -131,6 +131,6 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          yarn workspaces foreach -v --no-private npm publish --provenance --access public --tolerate-republish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Opened this to attempt to enable provenance so that we can get references back to the commit and GitHub actions flow that published the package.

I am unsure if this will _just work_ as we're publishing via `yarn workspaces foreach <command>`. 
> Note: At this time, yarn is not a supported tool for publishing your packages with provenance.

I'll try and test locally and confirm.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
