### PR TITLE
ADR plugin - fix image rendering

### DIFF
--- a/workspaces/adr/.changeset/odd-needles-act.md
+++ b/workspaces/adr/.changeset/odd-needles-act.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-adr-backend': patch
+'@backstage-community/plugin-adr': patch
+---
+
+Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -28,6 +28,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 
 const listEndpointName = '/list';
 const fileEndpointName = '/file';
+const imageEndpointName = '/image';
 
 const makeBufferFromString = (string: string) => async () =>
   Buffer.from(string);
@@ -57,6 +58,7 @@ const makeFileContent = async (fileContent: string) => {
 const testFileOneContent = 'testFileOne content';
 const testFileTwoContent = 'testFileTwo content';
 const genericFileContent = 'file content';
+const testImageContent = 'image content';
 
 const mockUrlReader: UrlReader = {
   readUrl(url: string) {
@@ -65,6 +67,8 @@ const mockUrlReader: UrlReader = {
         return makeFileContent(testFileOneContent);
       case 'testFileTwo':
         return makeFileContent(testFileTwoContent);
+      case 'testImage.png':
+        return makeFileContent(testImageContent);
       default:
         return makeFileContent(genericFileContent);
     }
@@ -226,6 +230,74 @@ describe('createRouter', () => {
       expect(fileTwoError).toBeFalsy();
       expect(fileTwoStatus).toBe(expectedStatusCode);
       expect(fileTwoBody.data).toBe(testFileTwoContent);
+    });
+  });
+
+  describe(`GET ${imageEndpointName}`, () => {
+    it('returns bad request (400) when no url is provided', async () => {
+      const urlNotSpecifiedRequest = await request(app).get(imageEndpointName);
+      const urlNotSpecifiedStatus = urlNotSpecifiedRequest.status;
+      const urlNotSpecifiedMessage = urlNotSpecifiedRequest.body.message;
+
+      const urlNotFilledRequest = await request(app).get(
+        `${imageEndpointName}?url=`,
+      );
+      const urlNotFilledStatus = urlNotFilledRequest.status;
+      const urlNotFilledMessage = urlNotFilledRequest.body.message;
+
+      const expectedStatusCode = 400;
+      const expectedErrorMessage = 'No URL provided';
+
+      expect(urlNotSpecifiedStatus).toBe(expectedStatusCode);
+      expect(urlNotSpecifiedMessage).toBe(expectedErrorMessage);
+
+      expect(urlNotFilledStatus).toBe(expectedStatusCode);
+      expect(urlNotFilledMessage).toBe(expectedErrorMessage);
+    });
+
+    it('returns bad request (400) when unsupported image format is provided', async () => {
+      const urlNotFilledRequest = await request(app).get(
+        `${imageEndpointName}?url=testImage.txt`,
+      );
+      const urlNotFilledStatus = urlNotFilledRequest.status;
+      const urlNotFilledMessage = urlNotFilledRequest.body.message;
+
+      const expectedStatusCode = 400;
+      const expectedErrorMessage = 'Image type txt is not supported';
+
+      expect(urlNotFilledStatus).toBe(expectedStatusCode);
+      expect(urlNotFilledMessage).toBe(expectedErrorMessage);
+    });
+
+    it('returns the correct image when reading a url', async () => {
+      const urlToProcess = 'testImage.png';
+      const imageTypeMap: Record<string, string> = {
+        png: 'image/png',
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        gif: 'image/gif',
+        svg: 'image/svg+xml',
+        webp: 'image/webp',
+      };
+      const imageResponse = await request(app).get(
+        `${imageEndpointName}?url=${urlToProcess}`,
+      );
+      const imageStatus = imageResponse.status;
+      const imageData = imageResponse.body;
+      const imageError = imageResponse.error;
+      const imageType = urlToProcess.match(/\.([a-z0-9]+)(\?.*)?$/i);
+      let contentType;
+      if (imageType) {
+        contentType = imageTypeMap[imageType[1].toLowerCase()];
+      }
+
+      const expectedStatusCode = 200;
+
+      expect(imageError).toBeFalsy();
+      expect(imageStatus).toBe(expectedStatusCode);
+      expect(imageData.data).toBe(
+        `data:${contentType};base64,${btoa(testImageContent)}`,
+      );
     });
   });
 });

--- a/workspaces/adr/plugins/adr-backend/src/service/router.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.ts
@@ -133,5 +133,70 @@ export async function createRouter(
     }
   });
 
+  router.get('/image', async (req, res) => {
+    const urlToProcess = req.query.url as string;
+    if (!urlToProcess) {
+      res.statusCode = 400;
+      res.json({ message: 'No URL provided' });
+      return;
+    }
+
+    const imageTypeMap: Record<string, string> = {
+      png: 'image/png',
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      gif: 'image/gif',
+      svg: 'image/svg+xml',
+      webp: 'image/webp',
+    };
+
+    const imageType = urlToProcess.match(/\.([a-z0-9]+)(\?.*)?$/i);
+    if (!(imageType && imageType[1])) {
+      res.statusCode = 400;
+      res.json({ message: 'No URL to image' });
+      return;
+    }
+    if (!imageTypeMap[imageType[1].toLowerCase()]) {
+      res.statusCode = 400;
+      res.json({ message: `Image type ${imageType[1]} is not supported` });
+      return;
+    }
+    const contentType = imageTypeMap[imageType[1].toLowerCase()];
+
+    const cachedFileContent = (await cacheClient.get(urlToProcess)) as {
+      data: string;
+      etag: string;
+    };
+
+    try {
+      const fileGetResponse = await reader.readUrl(urlToProcess, {
+        etag: cachedFileContent?.etag,
+      });
+
+      const fileBuffer = await fileGetResponse.buffer();
+      const data = fileBuffer.toString('base64');
+
+      await cacheClient.set(urlToProcess, {
+        data,
+        etag: fileGetResponse.etag,
+      });
+      res.json({ data: `data:${contentType};base64,${data}` });
+    } catch (error) {
+      if (cachedFileContent && error.name === NotModifiedError.name) {
+        const buffer = Buffer.from(cachedFileContent.data, 'utf-8');
+        res.setHeader('Content-Type', contentType);
+        res.send(buffer);
+        return;
+      }
+
+      const message = stringifyError(error);
+      logger.error(
+        `Unable to fetch ADRs images from ${urlToProcess}: ${message}`,
+      );
+      res.statusCode = 500;
+      res.json({ message });
+    }
+  });
+
   return router;
 }

--- a/workspaces/adr/plugins/adr/api-report.md
+++ b/workspaces/adr/plugins/adr/api-report.md
@@ -20,6 +20,7 @@ import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public
 export interface AdrApi {
+  imageAdr(url: string): Promise<AdrImageResult>;
   listAdrs(url: string): Promise<AdrListResult>;
   readAdr(url: string): Promise<AdrReadResult>;
 }
@@ -30,6 +31,8 @@ export const adrApiRef: ApiRef<AdrApi>;
 // @public
 export class AdrClient implements AdrApi {
   constructor(options: AdrClientOptions);
+  // (undocumented)
+  imageAdr(url: string): Promise<AdrReadResult>;
   // (undocumented)
   listAdrs(url: string): Promise<AdrListResult>;
   // (undocumented)
@@ -60,6 +63,11 @@ export type AdrFileInfo = {
   title?: string;
   status?: string;
   date?: string;
+};
+
+// @public
+export type AdrImageResult = {
+  data: string;
 };
 
 // @public

--- a/workspaces/adr/plugins/adr/src/api/AdrClient.ts
+++ b/workspaces/adr/plugins/adr/src/api/AdrClient.ts
@@ -29,6 +29,7 @@ export interface AdrClientOptions {
 
 const readEndpoint = 'file';
 const listEndpoint = 'list';
+const imageEndpoint = 'image';
 
 /**
  * An implementation of the AdrApi that communicates with the ADR backend plugin.
@@ -65,5 +66,9 @@ export class AdrClient implements AdrApi {
 
   async readAdr(url: string): Promise<AdrReadResult> {
     return this.fetchAdrApi<AdrReadResult>(readEndpoint, url);
+  }
+
+  async imageAdr(url: string): Promise<AdrReadResult> {
+    return this.fetchAdrApi<AdrReadResult>(imageEndpoint, url);
   }
 }

--- a/workspaces/adr/plugins/adr/src/api/index.ts
+++ b/workspaces/adr/plugins/adr/src/api/index.ts
@@ -22,4 +22,5 @@ export type {
   AdrFileInfo,
   AdrListResult,
   AdrReadResult,
+  AdrImageResult
 } from './types';

--- a/workspaces/adr/plugins/adr/src/api/types.ts
+++ b/workspaces/adr/plugins/adr/src/api/types.ts
@@ -61,6 +61,15 @@ export type AdrReadResult = {
 };
 
 /**
+ * The result of fetching an ADR image.
+ *
+ * @public
+ */
+export type AdrImageResult = {
+  data: string;
+};
+
+/**
  * The API used by the adr plugin to list and read ADRs.
  *
  * @public
@@ -71,6 +80,9 @@ export interface AdrApi {
 
   /** Reads the contents of the ADR at the provided url. */
   readAdr(url: string): Promise<AdrReadResult>;
+
+  /** Reads the images from contents of the ADR at the provided url. */
+  imageAdr(url: string): Promise<AdrImageResult>;
 }
 
 /**

--- a/workspaces/adr/plugins/adr/src/index.ts
+++ b/workspaces/adr/plugins/adr/src/index.ts
@@ -27,6 +27,7 @@ export type {
   AdrFileInfo,
   AdrListResult,
   AdrReadResult,
+  AdrImageResult,
 } from './api';
 export { isAdrAvailable } from '@backstage-community/plugin-adr-common';
 export * from './components/AdrReader';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR has been re-opened since the previous one have been close due to plugin migration from Backstage Monorepo.
Previous PR for context: https://github.com/backstage/backstage/pull/23237 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Hey everyone! :)
I've stepped upon an use-case in which images for ADR files will not render when they required authentication to access them.
Fetching image was done via Backstage Frontend.

With this Pull Request I added a fix which transfers fetching to the Backstage Backend and uses auth token to fetch the image from the source. 

Changes are also related to issue [#16255](https://github.com/backstage/backstage/issues/16255)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
