### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/rare-dolls-fly.md
+++ b/workspaces/linkerd/.changeset/rare-dolls-fly.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Fix issue with logging errors, and native in cluster API calls to control plane

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [ecb0e86]
+  - @backstage-community/plugin-linkerd-backend@0.2.1
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.2.1
+
+### Patch Changes
+
+- ecb0e86: Fix issue with logging errors, and native in cluster API calls to control plane
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd-backend@0.2.1

### Patch Changes

-   ecb0e86: Fix issue with logging errors, and native in cluster API calls to control plane

## backend@0.0.3

### Patch Changes

-   Updated dependencies [ecb0e86]
    -   @backstage-community/plugin-linkerd-backend@0.2.1
