### PR TITLE
chore: restructure README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,12 @@ Whenever a new changeset is introduced, a fresh "Version packages ($workspace_na
 $ yarn create-workspace
 ```
 
-## The migration of plugins from the `backstage/backstage` monorepo
+## Plugins migrated from `backstage/backstage`
 
-The migration of plugins from the `backstage/backstage` monorepo to the `community-plugins` repository has been automated under the `community-cli` tool.
+A number of plugins that originally resided in `backstage/backstage` monorepo have moved to this `backstage/community-plugins` repository.
 
-You provide it with a path to the `monorepo` which should be cloned locally, and a plugin ID. It will then create a new workspace in the `community-plugins` repository with all of the plugins and modules that surround that workspace. For instance, if I use the `todo` plugin as an ID, It will automatically move over `@backstage/plugin-todo` as well as `@backstage/plugin-todo-backend` and any other `-common`, `-node` or `-modules` that are related.
-
-Once the code is copied over, the npm scopes and all code references are updated to reflect the new scopes of `@backstage-community/plugin-*`, and a changeset is created for the package to be published. The versions are kept the same for now, but the resulting changeset will publish the next version along, so if the package released at `1.25.0` was `0.10.0` then the new version will be `@backstage-community/plugin-todo` `0.10.1`.
-
-There is a commit that is created in the `monorepo` on either a specified branch as `--branch` or on a new branch that is created for the migration. In this commit is a deprecation and a changeset for this package to go out, so `0.10.1` in `@backstage/plugin-todo` will be marked as deprecated and replaced with `@backstage-community/plugin-todo` as the same version.
-
-### Workspaces that will be created
-
-Looking through the `monorepo` we can expect the following workspaces:
+<details>
+<summary>List of migrated plugins</summary>
 
 - `adr`
 - `airbreak`
@@ -109,5 +102,14 @@ Looking through the `monorepo` we can expect the following workspaces:
 - `todo`
 - `vault`
 - `xcmetrics`
+</details>
 
-Of course, there could be simplifcations to this workspace list and some workspaces will be merged into one, like for example the `github-` workspaces could become one `github` workspace instead, but for the inital migration, we will keep them separate.
+### Migration process
+
+The migration of plugins from the `backstage/backstage` monorepo to the `community-plugins` repository was automated under the `community-cli` tool.
+
+You provide it with a path to the `monorepo` which should be cloned locally, and a plugin ID. It will then create a new workspace in the `community-plugins` repository with all of the plugins and modules that surround that workspace. For instance, if I use the `todo` plugin as an ID, It will automatically move over `@backstage/plugin-todo` as well as `@backstage/plugin-todo-backend` and any other `-common`, `-node` or `-modules` that are related.
+
+Once the code is copied over, the npm scopes and all code references are updated to reflect the new scopes of `@backstage-community/plugin-*`, and a changeset is created for the package to be published. The versions are kept the same for now, but the resulting changeset will publish the next version along, so if the package released at `1.25.0` was `0.10.0` then the new version will be `@backstage-community/plugin-todo` `0.10.1`.
+
+There is a commit that is created in the `monorepo` on either a specified branch as `--branch` or on a new branch that is created for the migration. In this commit is a deprecation and a changeset for this package to go out, so `0.10.1` in `@backstage/plugin-todo` will be marked as deprecated and replaced with `@backstage-community/plugin-todo` as the same version.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I figure there's some prominent information in the main README that is quite specific to community plugin maintainers. I've opened this PR to restructure the README slightly in effort to make the information more consumable for end-users and potential plugin contributors.

I've not removed any information. But, a summary of adjustments:
* Change tense of wording now that the main migration of plugins from `backstage/backstage` has occurred.
* Move the list of migrated plugins to a collapsed section.
* Move migration steps to the bottom of README as this information is the most specific to community plugin maintainers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
