### PR TITLE
[code-coverage plugin] Increase express payload size to 10MB

### DIFF
--- a/workspaces/code-coverage/.changeset/yellow-singers-join.md
+++ b/workspaces/code-coverage/.changeset/yellow-singers-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-code-coverage-backend': patch
+---
+
+Increased the payload size of express to 10MB to avoid errors when uploading big coverage report files.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/src/service/router.ts
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/src/service/router.ts
@@ -86,7 +86,7 @@ export const makeRouter = async (
       limit: bodySizeLimit,
     }),
   );
-  router.use(express.json());
+  router.use(express.json({ limit: '10MB' }));
 
   const utils = new CoverageUtils(scm, urlReader);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey folks, 

We were getting the following error when uploading a big a big cobertura style xml 

```
{"error":{"name":"PayloadTooLargeError","message":"request entity too large"
```

This PR increase the size of the accepted payload to 10MB hopefully getting rid of those errors for most use cases.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
