### PR TITLE
Introducing read timeout when reading from the cache to overcome issues when the cache is unavailable

### DIFF
--- a/workspaces/adr/.changeset/fair-turkeys-push.md
+++ b/workspaces/adr/.changeset/fair-turkeys-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-adr-backend': patch
+---
+
+Introduce read timeout for the cache client as it is known to sometimes hang

--- a/workspaces/adr/plugins/adr-backend/src/plugin.ts
+++ b/workspaces/adr/plugins/adr-backend/src/plugin.ts
@@ -29,16 +29,18 @@ export const adrPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
+        config: coreServices.rootConfig,
         logger: coreServices.logger,
         reader: coreServices.urlReader,
         cache: coreServices.cache,
         httpRouter: coreServices.httpRouter,
       },
-      async init({ httpRouter, logger, reader, cache }) {
+      async init({ httpRouter, logger, reader, cache, config }) {
         httpRouter.use(
           await createRouter({
             logger,
             reader,
+            config,
             cacheClient: cache,
           }),
         );

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -121,7 +121,7 @@ describe('createRouter', () => {
 
     config = new ConfigReader({
       adrs: {
-        cache: { timeout: 30 },
+        cache: { readTimeout: 30 },
       },
     });
 

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -25,6 +25,7 @@ import express from 'express';
 import request from 'supertest';
 import { createRouter } from './router';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { Config, ConfigReader } from '@backstage/config';
 
 const listEndpointName = '/list';
 const fileEndpointName = '/file';
@@ -113,11 +114,19 @@ class MockCacheClient implements CacheClient {
 
 describe('createRouter', () => {
   let app: express.Express;
+  let config: Config;
 
   beforeEach(async () => {
     jest.resetAllMocks();
 
+    config = new ConfigReader({
+      adrs: {
+        cache: { timeout: 30 },
+      },
+    });
+
     const router = await createRouter({
+      config: config,
       reader: mockUrlReader,
       cacheClient: new MockCacheClient(),
       logger: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The cache client sometimes gets stuck so with this PR I am introducing a read timeout to prevent such issues.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
