### PR TITLE
[Analytics] In GA4 allow custom dimension context and atttributes with falsy values

### DIFF
--- a/workspaces/analytics/.changeset/chatty-cherries-shout.md
+++ b/workspaces/analytics/.changeset/chatty-cherries-shout.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-analytics-module-ga4': minor
+'@backstage-community/plugin-analytics-module-ga4': patch
 ---
 
 allow custom dimension context and atttributes with falsy values

--- a/workspaces/analytics/.changeset/chatty-cherries-shout.md
+++ b/workspaces/analytics/.changeset/chatty-cherries-shout.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-analytics-module-ga4': patch
 ---
 
-allow custom dimension context and atttributes with falsy values
+Allow custom dimension context and attributes with falsy values

--- a/workspaces/analytics/.changeset/tall-grapes-switch.md
+++ b/workspaces/analytics/.changeset/tall-grapes-switch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-ga4': minor
+---
+
+allow custom dimension context and atttributes with falsy values

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.test.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.test.ts
@@ -257,6 +257,8 @@ describe('GoogleAnalytics4', () => {
         value: expectedValue,
         c_pluginId: context.pluginId,
         c_releaseNum: context.releaseNum,
+        a_extraDimension: false,
+        a_extraMetric: 0,
         search_term: expectedLabel,
       });
     });

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -225,7 +225,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         : this.allowedContexts;
 
     contextKeys?.forEach(ctx => {
-      if (context[ctx]) {
+      if (context[ctx] !== undefined && context[ctx] !== null) {
         customEventParameters[`c_${ctx}`] = context[ctx];
       }
     });
@@ -235,7 +235,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         ? Object.keys(attributes)
         : this.allowedAttributes;
     attrKeys?.forEach(attr => {
-      if (attributes[attr]) {
+      if (attributes[attr] !== undefined && attributes[attr] !== null) {
         customEventParameters[`a_${attr}`] = attributes[attr];
       }
     });


### PR DESCRIPTION
We observed that when using the ga4 module any custom dimension context or attribute that has a falsy value boolean false or 0 get dropped and are not sent to GA at all.

Fix: check if value is set for a key and allow falsy values

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
