### PR TITLE
[tech-insights] Allow logical conditions on scorecards

### DIFF
--- a/workspaces/tech-insights/.changeset/empty-starfishes-bow.md
+++ b/workspaces/tech-insights/.changeset/empty-starfishes-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-common': patch
+---
+
+Cache identical API calls for a few seconds. This prevents fetching the same checks multiple times when having several Scorecards with the same (or all) checks, although with different filters.

--- a/workspaces/tech-insights/.changeset/gold-ways-talk.md
+++ b/workspaces/tech-insights/.changeset/gold-ways-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+Added optional `filter` prop to `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` for easier and more flexible filtering of what checks to display.

--- a/workspaces/tech-insights/package.json
+++ b/workspaces/tech-insights/package.json
@@ -66,6 +66,7 @@
     "@backstage-community/plugin-tech-insights": "workspace:^",
     "@backstage-community/plugin-tech-insights-backend": "workspace:^",
     "@backstage-community/plugin-tech-insights-backend-module-jsonfc": "workspace:^",
+    "fast-json-stable-stringify": "^2.1.0",
     "knip": "^5.27.4"
   }
 }

--- a/workspaces/tech-insights/plugins/tech-insights-common/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-common/package.json
@@ -62,6 +62,7 @@
     "@backstage/errors": "^1.2.4",
     "@backstage/types": "^1.1.1",
     "@types/luxon": "^3.0.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "luxon": "^3.0.0",
     "qs": "^6.12.3"
   },

--- a/workspaces/tech-insights/plugins/tech-insights/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights/README.md
@@ -57,6 +57,10 @@ You can pass an array `checksId` as a prop with the [Fact Retrievers ids](../tec
 />
 ```
 
+You can also pass a `filter` function to both `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` which filters in/out check result after they have been fetched. This can be useful to filter by more logical conditions on fields like `id` or `name`, e.g. the first characters in a name.
+
+To only show failed checks, you can pass the boolan `onlyFailed` to these components.
+
 If you want to show checks in the overview of an entity use `EntityTechInsightsScorecardCard`.
 
 ```tsx

--- a/workspaces/tech-insights/plugins/tech-insights/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights/report.api.md
@@ -48,6 +48,7 @@ export const EntityTechInsightsScorecardCard: (props: {
   title: string;
   description?: string | undefined;
   checksId?: string[] | undefined;
+  filter?: ((check: Check_2) => boolean) | undefined;
   onlyFailed?: boolean | undefined;
   expanded?: boolean | undefined;
 }) => JSX_2.Element;
@@ -57,6 +58,7 @@ export const EntityTechInsightsScorecardContent: (props: {
   title: string;
   description?: string | undefined;
   checksId?: string[] | undefined;
+  filter?: ((check: Check_2) => boolean) | undefined;
 }) => JSX_2.Element;
 
 // @public @deprecated

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsContent/ScorecardContent.tsx
@@ -24,6 +24,7 @@ import { techInsightsApiRef } from '../../api/TechInsightsApi';
 import { makeStyles } from '@material-ui/core/styles';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { getCompoundEntityRef } from '@backstage/catalog-model';
+import { Check } from '@backstage-community/plugin-tech-insights-common/client';
 
 const useStyles = makeStyles(() => ({
   contentScorecards: {
@@ -36,8 +37,9 @@ export const ScorecardsContent = (props: {
   title: string;
   description?: string;
   checksId?: string[];
+  filter?: (check: Check) => boolean;
 }) => {
-  const { title, description, checksId } = props;
+  const { title, description, checksId, filter } = props;
   const classes = useStyles();
   const api = useApi(techInsightsApiRef);
   const { entity } = useEntity();
@@ -45,6 +47,9 @@ export const ScorecardsContent = (props: {
   const { value, loading, error } = useAsync(
     async () => await api.runChecks({ namespace, kind, name }, checksId),
   );
+
+  const filteredValues =
+    !filter || !value ? value : value.filter(val => filter(val.check));
 
   if (loading) {
     return <Progress />;
@@ -59,7 +64,7 @@ export const ScorecardsContent = (props: {
           title={title}
           description={description}
           entity={entity}
-          checkResults={value || []}
+          checkResults={filteredValues || []}
         />
       </Content>
     </Page>

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -2845,6 +2845,7 @@ __metadata:
     "@backstage/errors": ^1.2.4
     "@backstage/types": ^1.1.1
     "@types/luxon": ^3.0.0
+    fast-json-stable-stringify: ^2.1.0
     luxon: ^3.0.0
     qs: ^6.12.3
   languageName: unknown
@@ -7370,6 +7371,7 @@ __metadata:
     "@changesets/cli": ^2.27.1
     "@spotify/prettier-config": ^15.0.0
     concurrently: ^8.0.0
+    fast-json-stable-stringify: ^2.1.0
     knip: ^5.27.4
     node-gyp: ^10.0.0
     prettier: ^2.3.2


### PR DESCRIPTION
## Allow logical conditions on scorecards

This PR adds the optional prop `filter` to `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` which works in conjunction with `checkIds`.

`checkIds` has the drawback of needing to be an exact set of strings, meaning that if you add/remove/rename checks in the backend, the frontend needs to be precisely updated to match those. When having grouped sets of `EntityTechInsightsScorecardContent`, it is easier and more flexible to group by e.g. the beginning of strings or the occurrence of a word in the name, and have a few filter functions handle this, such as `isCodeQualityCheck()`, `isSecurityCheck()`, `isMetadataCheck()`.

This way you don't need to provide `checkIds`. However, when displaying a couple of `EntityTechInsightsScorecardContent` side-by-side, this will cause multiple identical `/checks/run/` API calls. This PR adds an API cache of 2 seconds, such that multiple concurrent calls to the exact same path and payload will reuse the same call.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
