### PR TITLE
[Analytics] GA4 filter out custom dimensions with empty string value

### DIFF
--- a/workspaces/analytics/.changeset/gorgeous-doors-jam.md
+++ b/workspaces/analytics/.changeset/gorgeous-doors-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-ga4': patch
+---
+
+Filter out custom dimenstion keys with empty string values

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.test.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.test.ts
@@ -263,6 +263,35 @@ describe('GoogleAnalytics4', () => {
       });
     });
 
+    it('filters out custom dimenstions with empty string value', () => {
+      const api = GoogleAnalytics4.fromConfig(advancedConfig);
+
+      const expectedAction = 'search';
+      const expectedLabel = 'some query';
+      const expectedValue = 5;
+      api.captureEvent({
+        action: expectedAction,
+        subject: expectedLabel,
+        value: expectedValue,
+        attributes: {
+          extraDimension: '',
+          extraMetric: 0,
+        },
+        context,
+      });
+
+      expect(fnEvent).toHaveBeenCalledWith('search', {
+        action: 'search',
+        category: context.extension,
+        label: expectedLabel,
+        value: expectedValue,
+        c_pluginId: context.pluginId,
+        c_releaseNum: context.releaseNum,
+        a_extraMetric: 0,
+        search_term: expectedLabel,
+      });
+    });
+
     it('does not pass non-numeric data on metrics', () => {
       const api = GoogleAnalytics4.fromConfig(advancedConfig);
 

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -225,7 +225,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         : this.allowedContexts;
 
     contextKeys?.forEach(ctx => {
-      if (context[ctx] !== undefined && context[ctx] !== null) {
+      if (context[ctx] !== undefined && context[ctx] !== null && context[ctx] !== '') {
         customEventParameters[`c_${ctx}`] = context[ctx];
       }
     });
@@ -235,7 +235,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         ? Object.keys(attributes)
         : this.allowedAttributes;
     attrKeys?.forEach(attr => {
-      if (attributes[attr] !== undefined && attributes[attr] !== null) {
+      if (attributes[attr] !== undefined && attributes[attr] !== null && attributes[attr] !== '') {
         customEventParameters[`a_${attr}`] = attributes[attr];
       }
     });

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -225,7 +225,11 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         : this.allowedContexts;
 
     contextKeys?.forEach(ctx => {
-      if (context[ctx] !== undefined && context[ctx] !== null && context[ctx] !== '') {
+      if (
+        context[ctx] !== undefined &&
+        context[ctx] !== null &&
+        context[ctx] !== ''
+      ) {
         customEventParameters[`c_${ctx}`] = context[ctx];
       }
     });
@@ -235,7 +239,11 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
         ? Object.keys(attributes)
         : this.allowedAttributes;
     attrKeys?.forEach(attr => {
-      if (attributes[attr] !== undefined && attributes[attr] !== null && attributes[attr] !== '') {
+      if (
+        attributes[attr] !== undefined &&
+        attributes[attr] !== null &&
+        attributes[attr] !== ''
+      ) {
         customEventParameters[`a_${attr}`] = attributes[attr];
       }
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup to this [PR](https://github.com/backstage/community-plugins/pull/512) custom dimensions with empty string values should not be passed to GA

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
