### PR TITLE
feat(sonarqube): add configurable read more url for empty state

### DIFF
--- a/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
+++ b/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-sonarqube': minor
 ---
 
-Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPageProps` and `SonarQubeCard` to allow configurable links to documentation.
+Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPage` and `SonarQubeCard` to allow configurable links to documentation.

--- a/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
+++ b/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-sonarqube': minor
+'@backstage-community/plugin-sonarqube': patch
 ---
 
 Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPage` and `SonarQubeCard` to allow configurable links to documentation.

--- a/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
+++ b/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': minor
+---
+
+Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPageProps` and `SonarQubeCard` to allow configurable links to documentation.

--- a/workspaces/sonarqube/plugins/sonarqube/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube/README.md
@@ -33,6 +33,28 @@ yarn --cwd packages/app add @backstage-community/plugin-sonarqube
  );
 ```
 
+The "Read more" link that shows in the MissingAnnotationEmptyState is also configurable.
+
+```diff
+  // packages/app/src/components/catalog/EntityPage.tsx
++ import { EntitySonarQubeCard } from '@backstage-community/plugin-sonarqube';
+
++ const MISSING_ANNOTATION_READ_MORE_URL = 'https://backstage.io/docs/features/software-catalog/descriptor';
+
+ ...
+
+ const overviewContent = (
+   <Grid container spacing={3} alignItems="stretch">
+     <Grid item md={6}>
+       <EntityAboutCard variant="gridItem" />
+     </Grid>
++    <Grid item md={6}>
++      <EntitySonarQubeCard variant="gridItem" readMoreUrl={MISSING_ANNOTATION_READ_MORE_URL} />
++    </Grid>
+   </Grid>
+ );
+```
+
 3. Run the following commands in the root folder of the project to install and compile the changes.
 
 ```yaml

--- a/workspaces/sonarqube/plugins/sonarqube/api-report.md
+++ b/workspaces/sonarqube/plugins/sonarqube/api-report.md
@@ -25,6 +25,7 @@ export type DuplicationRating = {
 export const EntitySonarQubeCard: (props: {
   variant?: InfoCardVariants | undefined;
   duplicationRatings?: DuplicationRating[] | undefined;
+  missingAnnotationReadMoreUrl?: string | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -42,6 +43,7 @@ export const SONARQUBE_PROJECT_KEY_ANNOTATION = 'sonarqube.org/project-key';
 export const SonarQubeCard: (props: {
   variant?: InfoCardVariants;
   duplicationRatings?: DuplicationRating[];
+  missingAnnotationReadMoreUrl?: string;
 }) => React_2.JSX.Element;
 
 // @public (undocumented)
@@ -68,6 +70,7 @@ export class SonarQubeClient implements SonarQubeApi {
 export type SonarQubeContentPageProps = {
   title?: string;
   supportTitle?: string;
+  missingAnnotationReadMoreUrl?: string;
 };
 
 // @public (undocumented)

--- a/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -91,10 +91,12 @@ const defaultDuplicationRatings: DuplicationRating[] = [
 export const SonarQubeCard = (props: {
   variant?: InfoCardVariants;
   duplicationRatings?: DuplicationRating[];
+  missingAnnotationReadMoreUrl?: string;
 }) => {
   const {
     variant = 'gridItem',
     duplicationRatings = defaultDuplicationRatings,
+    missingAnnotationReadMoreUrl,
   } = props;
   const { entity } = useEntity();
   const sonarQubeApi = useApi(sonarQubeApiRef);
@@ -169,6 +171,7 @@ export const SonarQubeCard = (props: {
       {!loading && !projectTitle && (
         <MissingAnnotationEmptyState
           annotation={SONARQUBE_PROJECT_KEY_ANNOTATION}
+          readMoreUrl={missingAnnotationReadMoreUrl}
         />
       )}
 

--- a/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.test.tsx
+++ b/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.test.tsx
@@ -87,4 +87,18 @@ describe('<SonarQubeContentPage />', () => {
         .length,
     ).toBe(2);
   }, 15000);
+
+  it('renders MissingAnnotationEmptyState Read more link url if missingAnnotationReadMoreUrl is passed', async () => {
+    const { SonarQubeContentPage } = require('./SonarQubeContentPage');
+    const docsUrl =
+      'https://github.com/backstage/community-plugins/blob/main/workspaces/sonarqube/plugins/sonarqube/README.md';
+
+    const rendered = await renderInTestApp(
+      <Providers annotation="foo">
+        <SonarQubeContentPage missingAnnotationReadMoreUrl={docsUrl} />
+      </Providers>,
+    );
+
+    expect(rendered.getByRole('button')).toHaveAttribute('href', docsUrl);
+  }, 15000);
 });

--- a/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.tsx
+++ b/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeContentPage/SonarQubeContentPage.tsx
@@ -34,22 +34,26 @@ import {
 export type SonarQubeContentPageProps = {
   title?: string;
   supportTitle?: string;
+  missingAnnotationReadMoreUrl?: string;
 };
 
 export const SonarQubeContentPage = (props: SonarQubeContentPageProps) => {
   const { entity } = useEntity();
-  const { title, supportTitle } = props;
+  const { title, supportTitle, missingAnnotationReadMoreUrl } = props;
 
   return isSonarQubeAvailable(entity) ? (
     <Content>
       <ContentHeader title={title ?? 'SonarQube Dashboard'}>
         {supportTitle && <SupportButton>{supportTitle}</SupportButton>}
       </ContentHeader>
-      <SonarQubeCard />
+      <SonarQubeCard
+        missingAnnotationReadMoreUrl={missingAnnotationReadMoreUrl}
+      />
     </Content>
   ) : (
     <MissingAnnotationEmptyState
       annotation={SONARQUBE_PROJECT_KEY_ANNOTATION}
+      readMoreUrl={missingAnnotationReadMoreUrl}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds configuration to set the "Read More" link in the empty state in the SonarQube plugin.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~~Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
