### PR TITLE
chore: add initial SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a potential security vulnerability within this repository, please report it through the GitHub reporting interface.
+
+1. Click on the [Security](https://github.com/backstage/community-plugins/security) tab on this repository
+2. Select **Report a vulnerability**.
+3. Provides the necessary information and submit your report. Please ensure you include the name of the effected workspace or plugin.
+
+For vulnerabilities in the core Backstage project, please follow their [security policy](https://github.com/backstage/backstage/blob/master/SECURITY.md). For vulnerabilities in third-party dependencies, please follow the respective processes outlined by those projects.
+
+If you are unsure, please reach out to one of the  [Community Plugins Maintainers](https://github.com/backstage/backstage/blob/master/OWNERS.md#community-plugins) on Discord.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

An initial security policy for Community Plugins repository. I anticipate it will need to be extended with processes, but directing reporters to the right place(s) seems like a reasonable first pass.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
