### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/odd-needles-act.md
+++ b/workspaces/adr/.changeset/odd-needles-act.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr': patch
----
-
-Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.18
+
+### Patch Changes
+
+- 7ebbafb: Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.
+
 ## 0.4.17
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr
 
+## 0.6.20
+
+### Patch Changes
+
+- 7ebbafb: Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.
+
 ## 0.6.19
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.6.20

### Patch Changes

-   7ebbafb: Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.

## @backstage-community/plugin-adr-backend@0.4.18

### Patch Changes

-   7ebbafb: Fixed bug where images from private repositories weren't accessible by the ADR plugin. Added `/image` API endpoint to adr-backend plugin which allows frontend to fetch images via backend with auth.
