### PR TITLE
Version Packages (grafana)

### DIFF
--- a/workspaces/grafana/.changeset/lucky-kings-smash.md
+++ b/workspaces/grafana/.changeset/lucky-kings-smash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': minor
----
-
-Initial plugin version. It's a copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-grafana)

--- a/workspaces/grafana/plugins/grafana/CHANGELOG.md
+++ b/workspaces/grafana/plugins/grafana/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-grafana
+
+## 0.1.0
+
+### Minor Changes
+
+- 48dbddf: Initial plugin version. It's a copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-grafana)

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-grafana",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "A Backstage backend plugin that integrates towards Grafana",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-grafana@0.1.0

### Minor Changes

-   48dbddf: Initial plugin version. It's a copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-grafana)
