### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/fast-cycles-dress.md
+++ b/workspaces/tech-insights/.changeset/fast-cycles-dress.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend-module-jsonfc': patch
-'@backstage-community/plugin-tech-insights-backend': patch
-'@backstage-community/plugin-tech-insights-common': patch
-'@backstage-community/plugin-tech-insights-node': patch
-'@backstage-community/plugin-tech-insights': patch
----
-
-Updated dependencies.

--- a/workspaces/tech-insights/.changeset/metal-sloths-wave.md
+++ b/workspaces/tech-insights/.changeset/metal-sloths-wave.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-Added a filter to `ScorecardsPage` to only shows entities with results.

--- a/workspaces/tech-insights/packages/app/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/app/CHANGELOG.md
@@ -1,0 +1,9 @@
+# app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [cbad35a]
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights@0.3.29

--- a/workspaces/tech-insights/packages/app/package.json
+++ b/workspaces/tech-insights/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/tech-insights/packages/backend/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/backend/CHANGELOG.md
@@ -1,0 +1,10 @@
+# backend
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.52
+  - @backstage-community/plugin-tech-insights-backend@0.5.34
+  - app@0.0.1

--- a/workspaces/tech-insights/packages/backend/package.json
+++ b/workspaces/tech-insights/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.52
+
+### Patch Changes
+
+- cbad35a: Updated dependencies.
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights-common@0.2.14
+  - @backstage-community/plugin-tech-insights-node@0.6.3
+
 ## 0.1.51
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "backstage": {
     "role": "backend-plugin-module"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 0.5.34
+
+### Patch Changes
+
+- cbad35a: Updated dependencies.
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights-common@0.2.14
+  - @backstage-community/plugin-tech-insights-node@0.6.3
+
 ## 0.5.33
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "0.5.33",
+  "version": "0.5.34",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-common
 
+## 0.2.14
+
+### Patch Changes
+
+- cbad35a: Updated dependencies.
+
 ## 0.2.13
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-common/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-common",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "backstage": {
     "role": "common-library"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights-node
 
+## 0.6.3
+
+### Patch Changes
+
+- cbad35a: Updated dependencies.
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights-common@0.2.14
+
 ## 0.6.2
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-node",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "backstage": {
     "role": "node-library"
   },

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.3.29
+
+### Patch Changes
+
+- cbad35a: Updated dependencies.
+- cbad35a: Added a filter to `ScorecardsPage` to only shows entities with results.
+- Updated dependencies [cbad35a]
+  - @backstage-community/plugin-tech-insights-common@0.2.14
+
 ## 0.3.28
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights@0.3.29

### Patch Changes

-   cbad35a: Updated dependencies.
-   cbad35a: Added a filter to `ScorecardsPage` to only shows entities with results.
-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights-common@0.2.14

## @backstage-community/plugin-tech-insights-backend@0.5.34

### Patch Changes

-   cbad35a: Updated dependencies.
-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights-common@0.2.14
    -   @backstage-community/plugin-tech-insights-node@0.6.3

## @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.52

### Patch Changes

-   cbad35a: Updated dependencies.
-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights-common@0.2.14
    -   @backstage-community/plugin-tech-insights-node@0.6.3

## @backstage-community/plugin-tech-insights-common@0.2.14

### Patch Changes

-   cbad35a: Updated dependencies.

## @backstage-community/plugin-tech-insights-node@0.6.3

### Patch Changes

-   cbad35a: Updated dependencies.
-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights-common@0.2.14

## app@0.0.1

### Patch Changes

-   Updated dependencies [cbad35a]
-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights@0.3.29

## backend@0.0.1

### Patch Changes

-   Updated dependencies [cbad35a]
    -   @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.52
    -   @backstage-community/plugin-tech-insights-backend@0.5.34
    -   app@0.0.1
