### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
+++ b/workspaces/sonarqube/.changeset/metal-dolphins-serve.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPage` and `SonarQubeCard` to allow configurable links to documentation.

--- a/workspaces/sonarqube/.changeset/renovate-026ec57.md
+++ b/workspaces/sonarqube/.changeset/renovate-026ec57.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-Updated dependency `rc-progress` to `4.0.0`.

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.7.18
+
+### Patch Changes
+
+- c9ceb6e: Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPage` and `SonarQubeCard` to allow configurable links to documentation.
+- 842559f: Updated dependency `rc-progress` to `4.0.0`.
+
 ## 0.7.17
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.7.18

### Patch Changes

-   c9ceb6e: Added optional `missingAnnotationReadMoreUrl` prop to `SonarQubeContentPage` and `SonarQubeCard` to allow configurable links to documentation.
-   842559f: Updated dependency `rc-progress` to `4.0.0`.
