### PR TITLE
[plugin-azure-devops] bugfix: fix duplicated query params on multiple build definitions

### DIFF
--- a/workspaces/azure-devops/.changeset/angry-penguins-search.md
+++ b/workspaces/azure-devops/.changeset/angry-penguins-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops': patch
+---
+
+Fixed bug in AzureDevOpsClient where multiple entityRef query parameters were appended in case of multiple build definitions, which caused 400 Bad Request error.

--- a/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AzureDevOpsClient } from './AzureDevOpsClient';
+
+describe('AzureDevOpsClient', () => {
+  const discoveryApiMock = {
+    getBaseUrl: jest.fn().mockResolvedValue('http://mocked-url'),
+  };
+
+  const fetchApiMock = {
+    fetch: jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    }),
+  };
+
+  const azureDevOpsClient = new AzureDevOpsClient({
+    discoveryApi: discoveryApiMock,
+    fetchApi: fetchApiMock,
+  });
+
+  beforeEach(() => {
+    fetchApiMock.fetch.mockClear();
+  });
+
+  it('should call get with correct parameters for single build definition', async () => {
+    const projectName = 'project';
+    const entityRef = 'some-entity-ref';
+    const hostName = 'host';
+    const definitionNames = 'def1';
+
+    await azureDevOpsClient.getBuildRuns(
+      projectName,
+      entityRef,
+      undefined,
+      definitionNames,
+      hostName,
+      undefined,
+      undefined,
+    );
+
+    expect(fetchApiMock.fetch).toHaveBeenCalledTimes(1);
+    expect(fetchApiMock.fetch).toHaveBeenCalledWith(
+      'http://mocked-url/builds/project?entityRef=some-entity-ref&host=host&definitionName=def1',
+    );
+  });
+
+  it('should call get with correct parameters for multiple build definitions', async () => {
+    const projectName = 'project';
+    const entityRef = 'some-entity-ref';
+    const hostName = 'host';
+    const definitionNames = 'def1,def2,def3';
+
+    await azureDevOpsClient.getBuildRuns(
+      projectName,
+      entityRef,
+      undefined,
+      definitionNames,
+      hostName,
+      undefined,
+      undefined,
+    );
+
+    expect(fetchApiMock.fetch).toHaveBeenCalledTimes(3);
+    expect(fetchApiMock.fetch).toHaveBeenCalledWith(
+      'http://mocked-url/builds/project?entityRef=some-entity-ref&host=host&definitionName=def1',
+    );
+    expect(fetchApiMock.fetch).toHaveBeenCalledWith(
+      'http://mocked-url/builds/project?entityRef=some-entity-ref&host=host&definitionName=def2',
+    );
+    expect(fetchApiMock.fetch).toHaveBeenCalledWith(
+      'http://mocked-url/builds/project?entityRef=some-entity-ref&host=host&definitionName=def3',
+    );
+  });
+});

--- a/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -164,6 +164,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     options?: BuildRunOptions,
   ): Promise<{ items: BuildRun[] }> {
     const queryString = new URLSearchParams();
+    queryString.append('entityRef', entityRef);
     if (repoName) {
       queryString.append('repoName', repoName);
     }
@@ -182,7 +183,6 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
           if (options?.top) {
             queryString.set('top', options.top.toString());
           }
-          queryString.append('entityRef', entityRef);
           const urlSegment = `builds/${encodeURIComponent(
             projectName,
           )}?${queryString}`;
@@ -196,7 +196,6 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     if (options?.top) {
       queryString.append('top', options.top.toString());
     }
-    queryString.append('entityRef', entityRef);
     const urlSegment = `builds/${encodeURIComponent(
       projectName,
     )}?${queryString}`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed bug in AzureDevOpsClient where multiple entityRef query parameters were appended in case of multiple build definitions, which caused 400 Bad Request error.

Link to issue: https://github.com/backstage/community-plugins/issues/544

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
