### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/angry-penguins-search.md
+++ b/workspaces/azure-devops/.changeset/angry-penguins-search.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Fixed bug in AzureDevOpsClient where multiple entityRef query parameters were appended in case of multiple build definitions, which caused 400 Bad Request error.

--- a/workspaces/azure-devops/.changeset/fresh-shoes-play.md
+++ b/workspaces/azure-devops/.changeset/fresh-shoes-play.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': patch
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Backstage v1.28.4 version bump

--- a/workspaces/azure-devops/.changeset/mean-needles-run.md
+++ b/workspaces/azure-devops/.changeset/mean-needles-run.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': patch
----
-
-Added new dedicated module for the Azure DevOps Annotator Processor and deprecated the version in the Azure DevOps Backend

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [8276458]
+- Updated dependencies [2deaaa0]
+  - @backstage-community/plugin-azure-devops@0.4.6
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [2deaaa0]
+- Updated dependencies [f31e04a]
+  - @backstage-community/plugin-azure-devops-backend@0.6.7
+  - app@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.6.7
+
+### Patch Changes
+
+- 2deaaa0: Backstage v1.28.4 version bump
+- f31e04a: Added new dedicated module for the Azure DevOps Annotator Processor and deprecated the version in the Azure DevOps Backend
+- Updated dependencies [2deaaa0]
+  - @backstage-community/plugin-azure-devops-common@0.4.4
+
 ## 0.6.6
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.4.4
+
+### Patch Changes
+
+- 2deaaa0: Backstage v1.28.4 version bump
+
 ## 0.4.3
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "backstage": {
     "role": "common-library"
   },

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.4.6
+
+### Patch Changes
+
+- 8276458: Fixed bug in AzureDevOpsClient where multiple entityRef query parameters were appended in case of multiple build definitions, which caused 400 Bad Request error.
+- 2deaaa0: Backstage v1.28.4 version bump
+- Updated dependencies [2deaaa0]
+  - @backstage-community/plugin-azure-devops-common@0.4.4
+
 ## 0.4.5
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "backstage": {
     "role": "frontend-plugin"
   },

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
+
+## 0.0.1
+
+### Patch Changes
+
+- 2deaaa0: Backstage v1.28.4 version bump
+- f31e04a: Added new dedicated module for the Azure DevOps Annotator Processor and deprecated the version in the Azure DevOps Backend
+- Updated dependencies [2deaaa0]
+  - @backstage-community/plugin-azure-devops-common@0.4.4

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.4.6

### Patch Changes

-   8276458: Fixed bug in AzureDevOpsClient where multiple entityRef query parameters were appended in case of multiple build definitions, which caused 400 Bad Request error.
-   2deaaa0: Backstage v1.28.4 version bump
-   Updated dependencies [2deaaa0]
    -   @backstage-community/plugin-azure-devops-common@0.4.4

## @backstage-community/plugin-azure-devops-backend@0.6.7

### Patch Changes

-   2deaaa0: Backstage v1.28.4 version bump
-   f31e04a: Added new dedicated module for the Azure DevOps Annotator Processor and deprecated the version in the Azure DevOps Backend
-   Updated dependencies [2deaaa0]
    -   @backstage-community/plugin-azure-devops-common@0.4.4

## @backstage-community/plugin-azure-devops-common@0.4.4

### Patch Changes

-   2deaaa0: Backstage v1.28.4 version bump

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.0.1

### Patch Changes

-   2deaaa0: Backstage v1.28.4 version bump
-   f31e04a: Added new dedicated module for the Azure DevOps Annotator Processor and deprecated the version in the Azure DevOps Backend
-   Updated dependencies [2deaaa0]
    -   @backstage-community/plugin-azure-devops-common@0.4.4

## app@0.0.2

### Patch Changes

-   Updated dependencies [8276458]
-   Updated dependencies [2deaaa0]
    -   @backstage-community/plugin-azure-devops@0.4.6

## backend@0.0.2

### Patch Changes

-   Updated dependencies [2deaaa0]
-   Updated dependencies [f31e04a]
    -   @backstage-community/plugin-azure-devops-backend@0.6.7
    -   app@0.0.2
