### PR TITLE
[Cloudbuild plugin] Remove check for process.env.NODE_ENV Cloudbuild HTTP Header

### DIFF
--- a/workspaces/cloudbuild/.changeset/nice-dolls-tell.md
+++ b/workspaces/cloudbuild/.changeset/nice-dolls-tell.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-cloudbuild': patch
 ---
 
-Remove check for process.env.NODE_ENV X-Goog-Api-Client HTTP Header
+Fixed an issue preventing the `X-Goog-Api-Client` header from being passed.

--- a/workspaces/cloudbuild/.changeset/nice-dolls-tell.md
+++ b/workspaces/cloudbuild/.changeset/nice-dolls-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cloudbuild': patch
+---
+
+Remove check for process.env.NODE_ENV X-Goog-Api-Client HTTP Header

--- a/workspaces/cloudbuild/plugins/cloudbuild/src/api/CloudbuildClient.ts
+++ b/workspaces/cloudbuild/plugins/cloudbuild/src/api/CloudbuildClient.ts
@@ -112,11 +112,7 @@ export class CloudbuildClient implements CloudbuildApi {
     const requestHeaders = {
       Accept: '*/*',
       Authorization: `Bearer ${await this.getToken()}`,
-      ...(process.env.NODE_ENV === 'production'
-        ? {
-            'X-Goog-Api-Client': `backstage/cloudbuild/${packageinfo.version}`,
-          }
-        : {}),
+      'X-Goog-Api-Client': `backstage/cloudbuild/${packageinfo.version}`,
     };
     return fetch(url, {
       method,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change removes a condition for  `X-Goog-Api-Client` http header used on the API calls to Google Cloud APIs. The ApiClient only executes on the browser and the environment variable is not available as `process.env.NODE_ENV`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
