### PR TITLE
CI: list only workspaces with changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,16 @@ jobs:
     outputs:
       workspaces: ${{ steps.find-changed-workspaces.outputs.workspaces }}
     steps:
-      - name: Checkout
+      - name: Checkout base branch for diff purposes
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Checkout head branch
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        with:
+          # Needed for diff
+          fetch-depth: ${{ github.event.pull_request.commits }}
 
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -23,14 +31,11 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
-      - name: Fetch previous commit for check
-        run: git fetch origin '${{ github.event.pull_request.base.sha }}'
-
       - name: Find changed workspaces
         id: find-changed-workspaces
         run: node ./scripts/ci/list-workspaces-with-changes.js
         env:
-          COMMIT_SHA_BEFORE: "${{ github.event.pull_request.base.sha }}"
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
 
   ci:
     name: Workspace ${{ matrix.workspace }}, CI step for node ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/ # Needed for auth
-      
+
       - name: Fetch previous commit for check
         run: git fetch origin '${{ github.event.before }}'
 
@@ -29,7 +29,7 @@ jobs:
         id: find-changed-workspaces
         run: node ./scripts/ci/list-workspaces-with-changes.js
         env:
-          COMMIT_SHA_BEFORE: '${{ github.event.before }}'
+          COMMIT_SHA_BEFORE: "${{ github.event.before }}"
 
   maybe-release-workspace:
     name: Maybe release ${{ matrix.workspace }}

--- a/scripts/ci/list-workspaces-with-changes.js
+++ b/scripts/ci/list-workspaces-with-changes.js
@@ -7,7 +7,8 @@ import { EOL } from "os";
 import * as url from "url";
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
-const parentRef = process.env.COMMIT_SHA_BEFORE || "origin/main";
+const commitShaBefore = process.env.COMMIT_SHA_BEFORE;
+const baseRef = process.env.BASE_REF || "origin/main";
 
 const execFile = promisify(execFileCb);
 
@@ -36,7 +37,9 @@ async function main() {
   const repoRoot = resolvePath(__dirname, "..", "..");
   process.chdir(repoRoot);
 
-  const diff = await runPlain("git", "diff", "--name-only", `${parentRef}...`);
+  const diff = process.env.COMMIT_SHA_BEFORE
+    ? await runPlain("git", "diff", "--name-only", commitShaBefore)
+    : await runPlain("git", "diff", "--name-only", `${baseRef}...`);
 
   const packageList = diff.split("\n");
 

--- a/scripts/ci/list-workspaces-with-changes.js
+++ b/scripts/ci/list-workspaces-with-changes.js
@@ -36,7 +36,7 @@ async function main() {
   const repoRoot = resolvePath(__dirname, "..", "..");
   process.chdir(repoRoot);
 
-  const diff = await runPlain("git", "diff", "--name-only", parentRef);
+  const diff = await runPlain("git", "diff", "--name-only", `${parentRef}...`);
 
   const packageList = diff.split("\n");
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes an issue where the `list-workspaces-with-changes` script was returning workspaces which didn't have any change. The issue was caused by the diff command, which returned the files that differed between the new branch and main (which might include files pushed to main by other PRs), instead of just the files changed in the new branch.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
