### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/thirty-roses-wonder.md
+++ b/workspaces/jenkins/.changeset/thirty-roses-wonder.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': patch
-'@backstage-community/plugin-jenkins-common': patch
-'@backstage-community/plugin-jenkins': patch
----
-
-Update to backstage version 1.28.3

--- a/workspaces/jenkins/packages/app/CHANGELOG.md
+++ b/workspaces/jenkins/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [7d67a9b]
+  - @backstage-community/plugin-jenkins@0.10.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/jenkins/packages/app/package.json
+++ b/workspaces/jenkins/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/jenkins/packages/backend/CHANGELOG.md
+++ b/workspaces/jenkins/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [7d67a9b]
+  - @backstage-community/plugin-jenkins-backend@0.4.7
+  - app@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/jenkins/packages/backend/package.json
+++ b/workspaces/jenkins/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.4.7
+
+### Patch Changes
+
+- 7d67a9b: Update to backstage version 1.28.3
+- Updated dependencies [7d67a9b]
+  - @backstage-community/plugin-jenkins-common@0.1.27
+
 ## 0.4.6
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-common
 
+## 0.1.27
+
+### Patch Changes
+
+- 7d67a9b: Update to backstage version 1.28.3
+
 ## 0.1.26
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-common/package.json
+++ b/workspaces/jenkins/plugins/jenkins-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-common",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "backstage": {
     "role": "common-library",
     "pluginId": "jenkins",

--- a/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-jenkins
 
+## 0.10.1
+
+### Patch Changes
+
+- 7d67a9b: Update to backstage version 1.28.3
+- Updated dependencies [7d67a9b]
+  - @backstage-community/plugin-jenkins-common@0.1.27
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins/package.json
+++ b/workspaces/jenkins/plugins/jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A Backstage plugin that integrates towards Jenkins",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins@0.10.1

### Patch Changes

-   7d67a9b: Update to backstage version 1.28.3
-   Updated dependencies [7d67a9b]
    -   @backstage-community/plugin-jenkins-common@0.1.27

## @backstage-community/plugin-jenkins-backend@0.4.7

### Patch Changes

-   7d67a9b: Update to backstage version 1.28.3
-   Updated dependencies [7d67a9b]
    -   @backstage-community/plugin-jenkins-common@0.1.27

## @backstage-community/plugin-jenkins-common@0.1.27

### Patch Changes

-   7d67a9b: Update to backstage version 1.28.3

## app@0.0.2

### Patch Changes

-   Updated dependencies [7d67a9b]
    -   @backstage-community/plugin-jenkins@0.10.1

## backend@0.0.2

### Patch Changes

-   Updated dependencies [7d67a9b]
    -   @backstage-community/plugin-jenkins-backend@0.4.7
    -   app@0.0.2
