### PR TITLE
Version Packages (vault)

### DIFF
--- a/workspaces/vault/.changeset/gorgeous-taxis-smoke.md
+++ b/workspaces/vault/.changeset/gorgeous-taxis-smoke.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-vault-backend': patch
-'@backstage-community/plugin-vault-node': patch
-'@backstage-community/plugin-vault': patch
----
-
-Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations

--- a/workspaces/vault/plugins/vault-backend/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-vault-backend
 
+## 0.4.13
+
+### Patch Changes
+
+- 6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations
+- Updated dependencies [6757373]
+  - @backstage-community/plugin-vault-node@0.1.12
+
 ## 0.4.12
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault-backend/package.json
+++ b/workspaces/vault/plugins/vault-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault-backend",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "A Backstage backend plugin that integrates towards Vault",
   "backstage": {
     "role": "backend-plugin"

--- a/workspaces/vault/plugins/vault-node/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-vault-node
 
+## 0.1.12
+
+### Patch Changes
+
+- 6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations
+
 ## 0.1.11
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault-node/package.json
+++ b/workspaces/vault/plugins/vault-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault-node",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Node.js library for the vault plugin",
   "backstage": {
     "role": "node-library"

--- a/workspaces/vault/plugins/vault/CHANGELOG.md
+++ b/workspaces/vault/plugins/vault/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-vault
 
+## 0.1.31
+
+### Patch Changes
+
+- 6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations
+
 ## 0.1.30
 
 ### Patch Changes

--- a/workspaces/vault/plugins/vault/package.json
+++ b/workspaces/vault/plugins/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-vault",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "A Backstage plugin that integrates towards Vault",
   "backstage": {
     "role": "frontend-plugin"


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-vault@0.1.31

### Patch Changes

-   6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations

## @backstage-community/plugin-vault-backend@0.4.13

### Patch Changes

-   6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations
-   Updated dependencies [6757373]
    -   @backstage-community/plugin-vault-node@0.1.12

## @backstage-community/plugin-vault-node@0.1.12

### Patch Changes

-   6757373: Backstage v1.28.4 version bump. Also addressed some of the upstream deprecations
