### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/sweet-walls-add.md
+++ b/workspaces/linguist/.changeset/sweet-walls-add.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
-'@backstage-community/plugin-linguist-common': patch
-'@backstage-community/plugin-linguist': patch
----
-
-Backstage v1.28.4 version bump

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [fa1553e]
+  - @backstage-community/plugin-linguist@0.1.22
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [fa1553e]
+  - @backstage-community/plugin-linguist-backend@0.5.18
+  - app@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.5.18
+
+### Patch Changes
+
+- fa1553e: Backstage v1.28.4 version bump
+- Updated dependencies [fa1553e]
+  - @backstage-community/plugin-linguist-common@0.1.5
+
 ## 0.5.17
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "backstage": {
     "role": "backend-plugin"
   },

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.1.5
+
+### Patch Changes
+
+- fa1553e: Backstage v1.28.4 version bump
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library"

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist
 
+## 0.1.22
+
+### Patch Changes
+
+- fa1553e: Backstage v1.28.4 version bump
+- Updated dependencies [fa1553e]
+  - @backstage-community/plugin-linguist-common@0.1.5
+
 ## 0.1.21
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "backstage": {
     "role": "frontend-plugin"
   },


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist@0.1.22

### Patch Changes

-   fa1553e: Backstage v1.28.4 version bump
-   Updated dependencies [fa1553e]
    -   @backstage-community/plugin-linguist-common@0.1.5

## @backstage-community/plugin-linguist-backend@0.5.18

### Patch Changes

-   fa1553e: Backstage v1.28.4 version bump
-   Updated dependencies [fa1553e]
    -   @backstage-community/plugin-linguist-common@0.1.5

## @backstage-community/plugin-linguist-common@0.1.5

### Patch Changes

-   fa1553e: Backstage v1.28.4 version bump

## app@0.0.2

### Patch Changes

-   Updated dependencies [fa1553e]
    -   @backstage-community/plugin-linguist@0.1.22

## backend@0.0.2

### Patch Changes

-   Updated dependencies [fa1553e]
    -   @backstage-community/plugin-linguist-backend@0.5.18
    -   app@0.0.2
