### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/modern-penguins-smash.md
+++ b/workspaces/linguist/.changeset/modern-penguins-smash.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
-'@backstage-community/plugin-linguist-common': patch
-'@backstage-community/plugin-linguist': patch
----
-
-Added package metadata

--- a/workspaces/linguist/.changeset/polite-pots-smile.md
+++ b/workspaces/linguist/.changeset/polite-pots-smile.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
----
-
-Added new dedicated module for the Linguist Tags Processor and deprecated the version in the Linguist Backend

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [dd19841]
+  - @backstage-community/plugin-linguist@0.1.23
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [dd19841]
+- Updated dependencies [3651de6]
+  - @backstage-community/plugin-linguist-backend@0.5.19
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.1
+  - app@0.0.3
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
+
+## 0.1.1
+
+### Patch Changes
+
+- 3651de6: Added new dedicated module for the Linguist Tags Processor and deprecated the version in the Linguist Backend
+- Updated dependencies [dd19841]
+  - @backstage-community/plugin-linguist-common@0.1.6

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.5.19
+
+### Patch Changes
+
+- dd19841: Added package metadata
+- 3651de6: Added new dedicated module for the Linguist Tags Processor and deprecated the version in the Linguist Backend
+- Updated dependencies [dd19841]
+  - @backstage-community/plugin-linguist-common@0.1.6
+
 ## 0.5.18
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.1.6
+
+### Patch Changes
+
+- dd19841: Added package metadata
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist
 
+## 0.1.23
+
+### Patch Changes
+
+- dd19841: Added package metadata
+- Updated dependencies [dd19841]
+  - @backstage-community/plugin-linguist-common@0.1.6
+
 ## 0.1.22
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.1

### Patch Changes

-   3651de6: Added new dedicated module for the Linguist Tags Processor and deprecated the version in the Linguist Backend
-   Updated dependencies [dd19841]
    -   @backstage-community/plugin-linguist-common@0.1.6

## @backstage-community/plugin-linguist@0.1.23

### Patch Changes

-   dd19841: Added package metadata
-   Updated dependencies [dd19841]
    -   @backstage-community/plugin-linguist-common@0.1.6

## @backstage-community/plugin-linguist-backend@0.5.19

### Patch Changes

-   dd19841: Added package metadata
-   3651de6: Added new dedicated module for the Linguist Tags Processor and deprecated the version in the Linguist Backend
-   Updated dependencies [dd19841]
    -   @backstage-community/plugin-linguist-common@0.1.6

## @backstage-community/plugin-linguist-common@0.1.6

### Patch Changes

-   dd19841: Added package metadata

## app@0.0.3

### Patch Changes

-   Updated dependencies [dd19841]
    -   @backstage-community/plugin-linguist@0.1.23

## backend@0.0.3

### Patch Changes

-   Updated dependencies [dd19841]
-   Updated dependencies [3651de6]
    -   @backstage-community/plugin-linguist-backend@0.5.19
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.1
    -   app@0.0.3
