### PR TITLE
feat(entity-validation): Enable embedding plugin within other pages

### DIFF
--- a/workspaces/entity-validation/.changeset/smooth-cameras-look.md
+++ b/workspaces/entity-validation/.changeset/smooth-cameras-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-validation': minor
+---
+
+Added a new component `EntityValidationContent` to allow embedding inside other pages without a duplicated header.

--- a/workspaces/entity-validation/app-config.yaml
+++ b/workspaces/entity-validation/app-config.yaml
@@ -7,7 +7,7 @@ backend:
   listen:
     port: 7007
   cors:
-    origin: http://localhost:3001
+    origin: http://localhost:3000
     methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
     credentials: true
   csp:

--- a/workspaces/entity-validation/app-config.yaml
+++ b/workspaces/entity-validation/app-config.yaml
@@ -1,0 +1,22 @@
+app:
+  title: Backstage Example App
+  baseUrl: http://localhost:3000
+
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  cors:
+    origin: http://localhost:3001
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+
+auth:
+  environment: development
+  providers:
+    guest: {}
+
+permission:
+  enabled: true

--- a/workspaces/entity-validation/plugins/entity-validation/README.md
+++ b/workspaces/entity-validation/plugins/entity-validation/README.md
@@ -52,3 +52,29 @@ To add the new page to your sidebar, you must include these lines in your `Root.
       </SidebarPage>
     );
 ```
+
+## Embedding inside other pages
+
+The plugin can also be embedded inside other pages.
+
+### Devtools
+
+Here's how to add Entity Validation to the [DevTools](https://github.com/backstage/backstage/tree/master/plugins/devtools) plugin:
+
+1. Install the Entity Validation plugin and add the route to your app as per the [Getting Started](#getting-started) section.
+
+2. Add the following import to your `CustomDevToolsPage.tsx`:
+
+   `import { EntityValidationContent } from '@backstage-community/plugin-entity-validation';`
+
+3. Then add a new `DevToolsLayout.Route` to the end of your `DevToolsLayout` like this:
+
+   ```diff
+     <DevToolsLayout>
+       ...
+   +   <DevToolsLayout.Route path="entity-validation" title="Entity Validation">
+   +     <EntityValidationContent
+   +      contentHead={<Typography variant="h6">Entity Validation</Typography>} />
+   +   </DevToolsLayout.Route>
+     </DevToolsLayout>
+   ```

--- a/workspaces/entity-validation/plugins/entity-validation/api-report.md
+++ b/workspaces/entity-validation/plugins/entity-validation/api-report.md
@@ -11,6 +11,14 @@ import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
+export const EntityValidationContent: (props: {
+  defaultYaml?: string | undefined;
+  defaultLocation?: string | undefined;
+  hideFileLocationField?: boolean | undefined;
+  contentHead?: ReactNode;
+}) => JSX_2.Element;
+
+// @public (undocumented)
 export const EntityValidationPage: (props: {
   defaultYaml?: string | undefined;
   defaultLocation?: string | undefined;

--- a/workspaces/entity-validation/plugins/entity-validation/dev/index.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/dev/index.tsx
@@ -14,9 +14,29 @@
  * limitations under the License.
  */
 import React from 'react';
+import { Page, Header, Content } from '@backstage/core-components';
 import { createDevApp } from '@backstage/dev-utils';
-import { entityValidationPlugin, EntityValidationPage } from '../src/plugin';
+import {
+  entityValidationPlugin,
+  EntityValidationPage,
+  EntityValidationContent,
+} from '../src/plugin';
 import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
+
+import Typography from '@material-ui/core/Typography';
+
+const EmbedExamplePage = () => {
+  return (
+    <Page themeId="tool">
+      <Header title="Embed Example" />
+      <Content>
+        <EntityValidationContent
+          contentHead={<Typography variant="h6">Entity Validation</Typography>}
+        />
+      </Content>
+    </Page>
+  );
+};
 
 createDevApp()
   .registerPlugin(entityValidationPlugin)
@@ -32,5 +52,10 @@ createDevApp()
     element: <EntityValidationPage />,
     title: 'Root Page',
     path: '/entity-validation',
+  })
+  .addPage({
+    element: <EmbedExamplePage />,
+    title: 'Embedded Page',
+    path: '/entity-validation-embed',
   })
   .render();

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.test.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.test.tsx
@@ -16,37 +16,40 @@
 
 import React from 'react';
 import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
-import { EntityValidationPage } from './EntityValidationPage';
+import {
+  EntityValidationPage,
+  EntityValidationContent,
+} from './EntityValidationPage';
 import { CatalogApi, catalogApiRef } from '@backstage/plugin-catalog-react';
 import { MarkdownContent } from '@backstage/core-components';
 
-describe('EntityValidatorPage', () => {
-  const catalogApi: Partial<CatalogApi> = {
-    getEntities: () =>
-      Promise.resolve({
-        items: [
-          {
-            apiVersion: 'backstage.io/v1alpha1',
-            kind: 'API',
-            metadata: {
-              name: 'Entity1',
-              annotations: {
-                'backstage.io/view-url': 'viewurl',
-                'backstage.io/edit-url': 'editurl',
-              },
+const catalogApi: Partial<CatalogApi> = {
+  getEntities: () =>
+    Promise.resolve({
+      items: [
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'API',
+          metadata: {
+            name: 'Entity1',
+            annotations: {
+              'backstage.io/view-url': 'viewurl',
+              'backstage.io/edit-url': 'editurl',
             },
-            spec: { type: 'openapi' },
           },
-        ],
-      }),
-  };
+          spec: { type: 'openapi' },
+        },
+      ],
+    }),
+};
 
+describe('EntityValidatorContent', () => {
   const contentHead = <MarkdownContent content="Content Head" />;
 
   it('should show location text field', async () => {
     const { getByText, getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
-        <EntityValidationPage />
+        <EntityValidationContent />
       </TestApiProvider>,
     );
     const mainGrid = getByTestId('main-grid');
@@ -58,7 +61,7 @@ describe('EntityValidatorPage', () => {
   it('should not show location text field', async () => {
     const { queryByText, getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
-        <EntityValidationPage hideFileLocationField />
+        <EntityValidationContent hideFileLocationField />
       </TestApiProvider>,
     );
     const mainGrid = getByTestId('main-grid');
@@ -70,7 +73,7 @@ describe('EntityValidatorPage', () => {
   it('should not show content head', async () => {
     const { getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
-        <EntityValidationPage />
+        <EntityValidationContent />
       </TestApiProvider>,
     );
     const mainGrid = getByTestId('main-grid');
@@ -81,11 +84,26 @@ describe('EntityValidatorPage', () => {
   it('should show content head', async () => {
     const { getByTestId } = await renderInTestApp(
       <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
-        <EntityValidationPage contentHead={contentHead} />
+        <EntityValidationContent contentHead={contentHead} />
       </TestApiProvider>,
     );
     const mainGrid = getByTestId('main-grid');
 
     expect(mainGrid.children.length).toBe(3);
+  });
+});
+
+describe('EntityValidatorPage', () => {
+  it('should load the Content element', async () => {
+    const { getByText, getByTestId } = await renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <EntityValidationPage />
+      </TestApiProvider>,
+    );
+
+    const mainGrid = getByTestId('main-grid');
+
+    expect(mainGrid.children.length).toBe(2);
+    expect(getByText('File Location')).toBeInTheDocument();
   });
 });

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationPage/EntityValidationPage.tsx
@@ -39,7 +39,7 @@ spec:
   owner: owner
 `;
 
-export const EntityValidationPage = (props: {
+export const EntityValidationContent = (props: {
   defaultYaml?: string;
   defaultLocation?: string;
   hideFileLocationField?: boolean;
@@ -67,74 +67,93 @@ export const EntityValidationPage = (props: {
   };
 
   return (
+    <Grid
+      container
+      direction="column"
+      style={{ height: '100%' }}
+      wrap="nowrap"
+      data-testid="main-grid"
+    >
+      {contentHead}
+
+      {!hideFileLocationField && (
+        <TextField
+          fullWidth
+          label="File Location"
+          margin="normal"
+          variant="outlined"
+          required
+          value={locationUrl}
+          placeholder={defaultLocation}
+          helperText="Present or future location of your entity descriptor YAML file. This is not the file being validated; this merely adds location annotations to the entity descriptor file being validated."
+          onChange={e => setLocationUrl(e.target.value)}
+        />
+      )}
+
+      <Grid container direction="row" style={{ height: '100%' }}>
+        <Grid item md={6} xs={12}>
+          <Grid
+            container
+            direction="column"
+            alignItems="flex-end"
+            style={{ height: '100%' }}
+            wrap="nowrap"
+          >
+            <Grid item style={{ width: '100%', flex: '1 1 auto' }}>
+              <EntityTextArea
+                onValidate={parseYaml}
+                onChange={(value: string) => setCatalogYaml(value)}
+                catalogYaml={catalogYaml}
+              />
+            </Grid>
+            <Grid item>
+              <Button variant="contained" color="primary" onClick={parseYaml}>
+                Validate
+              </Button>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <EntityValidationOutput
+                processorResults={yamlFiles}
+                locationUrl={locationUrl}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export const EntityValidationPage = (props: {
+  defaultYaml?: string;
+  defaultLocation?: string;
+  hideFileLocationField?: boolean;
+  contentHead?: React.ReactNode;
+}) => {
+  const {
+    defaultYaml = EXAMPLE_CATALOG_INFO_YAML,
+    defaultLocation = 'https://github.com/backstage/backstage/blob/master/catalog-info.yaml',
+    hideFileLocationField = false,
+    contentHead,
+  } = props;
+
+  return (
     <Page themeId="tool">
       <Header
         title="Entity Validator"
         subtitle="Validate Backstage catalog entity descriptor YAML files"
       />
       <Content>
-        <Grid
-          container
-          direction="column"
-          style={{ height: '100%' }}
-          wrap="nowrap"
-          data-testid="main-grid"
-        >
-          {contentHead}
-
-          {!hideFileLocationField && (
-            <TextField
-              fullWidth
-              label="File Location"
-              margin="normal"
-              variant="outlined"
-              required
-              value={locationUrl}
-              placeholder={defaultLocation}
-              helperText="Present or future location of your entity descriptor YAML file. This is not the file being validated; this merely adds location annotations to the entity descriptor file being validated."
-              onChange={e => setLocationUrl(e.target.value)}
-            />
-          )}
-
-          <Grid container direction="row" style={{ height: '100%' }}>
-            <Grid item md={6} xs={12}>
-              <Grid
-                container
-                direction="column"
-                alignItems="flex-end"
-                style={{ height: '100%' }}
-                wrap="nowrap"
-              >
-                <Grid item style={{ width: '100%', flex: '1 1 auto' }}>
-                  <EntityTextArea
-                    onValidate={parseYaml}
-                    onChange={(value: string) => setCatalogYaml(value)}
-                    catalogYaml={catalogYaml}
-                  />
-                </Grid>
-                <Grid item>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={parseYaml}
-                  >
-                    Validate
-                  </Button>
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid item md={6} xs={12}>
-              <Grid container spacing={3}>
-                <Grid item xs={12}>
-                  <EntityValidationOutput
-                    processorResults={yamlFiles}
-                    locationUrl={locationUrl}
-                  />
-                </Grid>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
+        <EntityValidationContent
+          defaultYaml={defaultYaml}
+          defaultLocation={defaultLocation}
+          hideFileLocationField={hideFileLocationField}
+          contentHead={contentHead}
+        />
       </Content>
     </Page>
   );

--- a/workspaces/entity-validation/plugins/entity-validation/src/index.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/index.ts
@@ -13,4 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { entityValidationPlugin, EntityValidationPage } from './plugin';
+export {
+  entityValidationPlugin,
+  EntityValidationPage,
+  EntityValidationContent,
+} from './plugin';

--- a/workspaces/entity-validation/plugins/entity-validation/src/plugin.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/plugin.ts
@@ -40,3 +40,16 @@ export const EntityValidationPage = entityValidationPlugin.provide(
     },
   }),
 );
+
+/** @public */
+export const EntityValidationContent = entityValidationPlugin.provide(
+  createComponentExtension({
+    name: 'EntityValidationContent',
+    component: {
+      lazy: () =>
+        import('./components/EntityValidationPage').then(
+          m => m.EntityValidationContent,
+        ),
+    },
+  }),
+);

--- a/workspaces/entity-validation/yarn.lock
+++ b/workspaces/entity-validation/yarn.lock
@@ -11968,9 +11968,9 @@ __metadata:
   linkType: hard
 
 "detect-libc@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "detect-libc@npm:2.0.1"
-  checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 2ba6a939ae55f189aea996ac67afceb650413c7a34726ee92c40fb0deb2400d57ef94631a8a3f052055eea7efb0f99a9b5e6ce923415daa3e68221f963cfc27d
   languageName: node
   linkType: hard
 
@@ -23332,7 +23332,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"triple-beam@npm:^1.3.0, triple-beam@npm:^1.4.1":
+"triple-beam@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "triple-beam@npm:1.3.0"
+  checksum: 7d7b77d8625fb252c126c24984a68de462b538a8fcd1de2abd0a26421629cf3527d48e23b3c2264f08f4a6c3bc40a478a722176f4d7b6a1acc154cb70c359f2b
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.4.1":
   version: 1.4.1
   resolution: "triple-beam@npm:1.4.1"
   checksum: 2e881a3e8e076b6f2b85b9ec9dd4a900d3f5016e6d21183ed98e78f9abcc0149e7d54d79a3f432b23afde46b0885bdcdcbff789f39bc75de796316961ec07f61
@@ -23373,6 +23380,15 @@ __metadata:
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 20c29189c2dd6067a8775e07823ddf8d59a33e2ffc47a1bd59a5cb28bb0121a2969a816d5e77eda2ed85b18171aa5d1c4005a6b88ae8499ec7cc49f78571cb5e
+  languageName: node
+  linkType: hard
+
+"ts-invariant@npm:^0.9.3":
+  version: 0.9.4
+  resolution: "ts-invariant@npm:0.9.4"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: c9e5726361fa266916966b2070605f8664b6dd1d8b0ef7565dbf056abb6a87be26195985ef62dd97aeb0894cf2f4ad5b7f0d89dadadc197eaa38e99222afa29c
   languageName: node
   linkType: hard
 

--- a/workspaces/entity-validation/yarn.lock
+++ b/workspaces/entity-validation/yarn.lock
@@ -11968,9 +11968,9 @@ __metadata:
   linkType: hard
 
 "detect-libc@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "detect-libc@npm:2.0.3"
-  checksum: 2ba6a939ae55f189aea996ac67afceb650413c7a34726ee92c40fb0deb2400d57ef94631a8a3f052055eea7efb0f99a9b5e6ce923415daa3e68221f963cfc27d
+  version: 2.0.1
+  resolution: "detect-libc@npm:2.0.1"
+  checksum: ccb05fcabbb555beb544d48080179c18523a343face9ee4e1a86605a8715b4169f94d663c21a03c310ac824592f2ba9a5270218819bb411ad7be578a527593d7
   languageName: node
   linkType: hard
 
@@ -23332,14 +23332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"triple-beam@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "triple-beam@npm:1.3.0"
-  checksum: 7d7b77d8625fb252c126c24984a68de462b538a8fcd1de2abd0a26421629cf3527d48e23b3c2264f08f4a6c3bc40a478a722176f4d7b6a1acc154cb70c359f2b
-  languageName: node
-  linkType: hard
-
-"triple-beam@npm:^1.4.1":
+"triple-beam@npm:^1.3.0, triple-beam@npm:^1.4.1":
   version: 1.4.1
   resolution: "triple-beam@npm:1.4.1"
   checksum: 2e881a3e8e076b6f2b85b9ec9dd4a900d3f5016e6d21183ed98e78f9abcc0149e7d54d79a3f432b23afde46b0885bdcdcbff789f39bc75de796316961ec07f61
@@ -23380,15 +23373,6 @@ __metadata:
   version: 0.1.13
   resolution: "ts-interface-checker@npm:0.1.13"
   checksum: 20c29189c2dd6067a8775e07823ddf8d59a33e2ffc47a1bd59a5cb28bb0121a2969a816d5e77eda2ed85b18171aa5d1c4005a6b88ae8499ec7cc49f78571cb5e
-  languageName: node
-  linkType: hard
-
-"ts-invariant@npm:^0.9.3":
-  version: 0.9.4
-  resolution: "ts-invariant@npm:0.9.4"
-  dependencies:
-    tslib: ^2.1.0
-  checksum: c9e5726361fa266916966b2070605f8664b6dd1d8b0ef7565dbf056abb6a87be26195985ef62dd97aeb0894cf2f4ad5b7f0d89dadadc197eaa38e99222afa29c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a new component `EntityValidationContent` to allow embedding inside other pages without a duplicated header.

This enables adding Entity Validation as a tab under the [DevTools](https://github.com/backstage/backstage/tree/master/plugins/devtools) plugin without having the `<Header>` component duplicated in the final rendered page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
