### PR TITLE
Version Packages (explore)

### DIFF
--- a/workspaces/explore/.changeset/tall-peas-join.md
+++ b/workspaces/explore/.changeset/tall-peas-join.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-explore-backend': patch
-'@backstage-community/plugin-explore-common': patch
-'@backstage-community/plugin-explore-react': patch
-'@backstage-community/plugin-explore-node': patch
-'@backstage-community/plugin-explore': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/explore/plugins/explore-backend/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-explore-backend
 
+## 0.1.2
+
+### Patch Changes
+
+- 2173f7d: version:bump to v1.29.1
+- Updated dependencies [2173f7d]
+  - @backstage-community/plugin-explore-common@0.0.4
+  - @backstage-community/plugin-explore-node@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-backend/package.json
+++ b/workspaces/explore/plugins/explore-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "explore",

--- a/workspaces/explore/plugins/explore-common/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-explore-common
 
+## 0.0.4
+
+### Patch Changes
+
+- 2173f7d: version:bump to v1.29.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-common/package.json
+++ b/workspaces/explore/plugins/explore-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-common",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Common functionalities for the explore plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/explore/plugins/explore-node/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-explore-node
 
+## 0.1.2
+
+### Patch Changes
+
+- 2173f7d: version:bump to v1.29.1
+- Updated dependencies [2173f7d]
+  - @backstage-community/plugin-explore-common@0.0.4
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-node/package.json
+++ b/workspaces/explore/plugins/explore-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-explore-node",
   "description": "Node.js library for the explore plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/explore/plugins/explore-react/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-explore-react
 
+## 0.0.40
+
+### Patch Changes
+
+- 2173f7d: version:bump to v1.29.1
+- Updated dependencies [2173f7d]
+  - @backstage-community/plugin-explore-common@0.0.4
+
 ## 0.0.39
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-react/package.json
+++ b/workspaces/explore/plugins/explore-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-react",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "A frontend library for Backstage plugins that want to interact with the explore plugin",
   "backstage": {
     "role": "web-library",

--- a/workspaces/explore/plugins/explore/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-explore
 
+## 0.5.2
+
+### Patch Changes
+
+- 2173f7d: version:bump to v1.29.1
+- Updated dependencies [2173f7d]
+  - @backstage-community/plugin-explore-common@0.0.4
+  - @backstage-community/plugin-explore-react@0.0.40
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore/package.json
+++ b/workspaces/explore/plugins/explore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Backstage plugin for building an exploration page of your software ecosystem",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-explore@0.5.2

### Patch Changes

-   2173f7d: version:bump to v1.29.1
-   Updated dependencies [2173f7d]
    -   @backstage-community/plugin-explore-common@0.0.4
    -   @backstage-community/plugin-explore-react@0.0.40

## @backstage-community/plugin-explore-backend@0.1.2

### Patch Changes

-   2173f7d: version:bump to v1.29.1
-   Updated dependencies [2173f7d]
    -   @backstage-community/plugin-explore-common@0.0.4
    -   @backstage-community/plugin-explore-node@0.1.2

## @backstage-community/plugin-explore-common@0.0.4

### Patch Changes

-   2173f7d: version:bump to v1.29.1

## @backstage-community/plugin-explore-node@0.1.2

### Patch Changes

-   2173f7d: version:bump to v1.29.1
-   Updated dependencies [2173f7d]
    -   @backstage-community/plugin-explore-common@0.0.4

## @backstage-community/plugin-explore-react@0.0.40

### Patch Changes

-   2173f7d: version:bump to v1.29.1
-   Updated dependencies [2173f7d]
    -   @backstage-community/plugin-explore-common@0.0.4
