### PR TITLE
Dedupe during version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -86,6 +86,8 @@ jobs:
         run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
         env:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
+      - name: Run dedupe
+        run: yarn dedupe    
       - name: 'Check for changes'
         id: check_for_changes
         run: |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Every PR created using the version bump workflow has needed to have `yarn dedupe` ran. This just adds this to the workflow itself. ~~There's probably a bug upstream that I'm masking with this change but for now it seems like the best temporary step.~~ After bringing this up on Discord the main Backstage repo is doing this as a commit hook. For now it makes sense to keep this until we have something like that in place for this repo.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
