### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/shy-llamas-wink.md
+++ b/workspaces/adr/.changeset/shy-llamas-wink.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': patch
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr-common': patch
-'@backstage-community/plugin-adr': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.20
+
+### Patch Changes
+
+- 72e8c01: version:bump to v1.29.1
+- Updated dependencies [72e8c01]
+  - @backstage-community/plugin-adr-common@0.2.26
+
 ## 0.4.19
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.2.26
+
+### Patch Changes
+
+- 72e8c01: version:bump to v1.29.1
+
 ## 0.2.25
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.6.22
+
+### Patch Changes
+
+- 72e8c01: version:bump to v1.29.1
+- Updated dependencies [72e8c01]
+  - @backstage-community/plugin-adr-common@0.2.26
+
 ## 0.6.21
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.1.1
+
+### Patch Changes
+
+- 72e8c01: version:bump to v1.29.1
+- Updated dependencies [72e8c01]
+  - @backstage-community/plugin-adr-common@0.2.26
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.6.22

### Patch Changes

-   72e8c01: version:bump to v1.29.1
-   Updated dependencies [72e8c01]
    -   @backstage-community/plugin-adr-common@0.2.26

## @backstage-community/plugin-adr-backend@0.4.20

### Patch Changes

-   72e8c01: version:bump to v1.29.1
-   Updated dependencies [72e8c01]
    -   @backstage-community/plugin-adr-common@0.2.26

## @backstage-community/plugin-adr-common@0.2.26

### Patch Changes

-   72e8c01: version:bump to v1.29.1

## @backstage-community/search-backend-module-adr@0.1.1

### Patch Changes

-   72e8c01: version:bump to v1.29.1
-   Updated dependencies [72e8c01]
    -   @backstage-community/plugin-adr-common@0.2.26
