### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/moody-frogs-speak.md
+++ b/workspaces/azure-sites/.changeset/moody-frogs-speak.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-sites-backend': patch
-'@backstage-community/plugin-azure-sites-common': patch
-'@backstage-community/plugin-azure-sites': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.3.6
+
+### Patch Changes
+
+- 833451a: version:bump to v1.29.1
+- Updated dependencies [833451a]
+  - @backstage-community/plugin-azure-sites-common@0.1.5
+
 ## 0.3.5
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-common
 
+## 0.1.5
+
+### Patch Changes
+
+- 833451a: version:bump to v1.29.1
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-common/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-common",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Common functionalities for the azure plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites
 
+## 0.1.25
+
+### Patch Changes
+
+- 833451a: version:bump to v1.29.1
+- Updated dependencies [833451a]
+  - @backstage-community/plugin-azure-sites-common@0.1.5
+
 ## 0.1.24
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-sites",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites@0.1.25

### Patch Changes

-   833451a: version:bump to v1.29.1
-   Updated dependencies [833451a]
    -   @backstage-community/plugin-azure-sites-common@0.1.5

## @backstage-community/plugin-azure-sites-backend@0.3.6

### Patch Changes

-   833451a: version:bump to v1.29.1
-   Updated dependencies [833451a]
    -   @backstage-community/plugin-azure-sites-common@0.1.5

## @backstage-community/plugin-azure-sites-common@0.1.5

### Patch Changes

-   833451a: version:bump to v1.29.1
