### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/polite-bottles-invent.md
+++ b/workspaces/linkerd/.changeset/polite-bottles-invent.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
-'@backstage-community/plugin-linkerd': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/linkerd/packages/app/CHANGELOG.md
+++ b/workspaces/linkerd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [b2a3525]
+  - @backstage-community/plugin-linkerd@0.3.2
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/app/package.json
+++ b/workspaces/linkerd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [b2a3525]
+  - @backstage-community/plugin-linkerd-backend@0.3.2
+  - app@0.0.5
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.3.2
+
+### Patch Changes
+
+- b2a3525: version:bump to v1.29.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd
 
+## 0.3.2
+
+### Patch Changes
+
+- b2a3525: version:bump to v1.29.1
+
 ## 0.3.1
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd/package.json
+++ b/workspaces/linkerd/plugins/linkerd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd@0.3.2

### Patch Changes

-   b2a3525: version:bump to v1.29.1

## @backstage-community/plugin-linkerd-backend@0.3.2

### Patch Changes

-   b2a3525: version:bump to v1.29.1

## app@0.0.5

### Patch Changes

-   Updated dependencies [b2a3525]
    -   @backstage-community/plugin-linkerd@0.3.2

## backend@0.0.7

### Patch Changes

-   Updated dependencies [b2a3525]
    -   @backstage-community/plugin-linkerd-backend@0.3.2
    -   app@0.0.5
