### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/five-taxis-mate.md
+++ b/workspaces/playlist/.changeset/five-taxis-mate.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist-backend': patch
-'@backstage-community/plugin-playlist-common': patch
-'@backstage-community/plugin-playlist': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/playlist/packages/app/CHANGELOG.md
+++ b/workspaces/playlist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [626e5d2]
+  - @backstage-community/plugin-playlist@0.2.13
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/playlist/packages/app/package.json
+++ b/workspaces/playlist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [626e5d2]
+  - @backstage-community/plugin-playlist-backend@0.3.24
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.3.24
+
+### Patch Changes
+
+- 626e5d2: version:bump to v1.29.1
+- Updated dependencies [626e5d2]
+  - @backstage-community/plugin-playlist-common@0.1.18
+
 ## 0.3.23
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",

--- a/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-common
 
+## 0.1.18
+
+### Patch Changes
+
+- 626e5d2: version:bump to v1.29.1
+
 ## 0.1.17
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-common/package.json
+++ b/workspaces/playlist/plugins/playlist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-common",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Common functionalities for the playlist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist
 
+## 0.2.13
+
+### Patch Changes
+
+- 626e5d2: version:bump to v1.29.1
+- Updated dependencies [626e5d2]
+  - @backstage-community/plugin-playlist-common@0.1.18
+
 ## 0.2.12
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.2.13

### Patch Changes

-   626e5d2: version:bump to v1.29.1
-   Updated dependencies [626e5d2]
    -   @backstage-community/plugin-playlist-common@0.1.18

## @backstage-community/plugin-playlist-backend@0.3.24

### Patch Changes

-   626e5d2: version:bump to v1.29.1
-   Updated dependencies [626e5d2]
    -   @backstage-community/plugin-playlist-common@0.1.18

## @backstage-community/plugin-playlist-common@0.1.18

### Patch Changes

-   626e5d2: version:bump to v1.29.1

## app@0.0.3

### Patch Changes

-   Updated dependencies [626e5d2]
    -   @backstage-community/plugin-playlist@0.2.13

## backend@0.0.2

### Patch Changes

-   Updated dependencies [626e5d2]
    -   @backstage-community/plugin-playlist-backend@0.3.24
