### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/quiet-beans-refuse.md
+++ b/workspaces/linguist/.changeset/quiet-beans-refuse.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
-'@backstage-community/plugin-linguist': patch
-'@backstage-community/plugin-linguist-backend': patch
-'@backstage-community/plugin-linguist-common': patch
----
-
-version:bump to v1.29.1

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [fced742]
+  - @backstage-community/plugin-linguist@0.1.24
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [fced742]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.2
+  - @backstage-community/plugin-linguist-backend@0.5.20
+  - app@0.0.4
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.1.2
+
+### Patch Changes
+
+- fced742: version:bump to v1.29.1
+- Updated dependencies [fced742]
+  - @backstage-community/plugin-linguist-common@0.1.7
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.5.20
+
+### Patch Changes
+
+- fced742: version:bump to v1.29.1
+- Updated dependencies [fced742]
+  - @backstage-community/plugin-linguist-common@0.1.7
+
 ## 0.5.19
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.19",
+  "version": "0.5.20",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.1.7
+
+### Patch Changes
+
+- fced742: version:bump to v1.29.1
+
 ## 0.1.6
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist
 
+## 0.1.24
+
+### Patch Changes
+
+- fced742: version:bump to v1.29.1
+- Updated dependencies [fced742]
+  - @backstage-community/plugin-linguist-common@0.1.7
+
 ## 0.1.23
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.2

### Patch Changes

-   fced742: version:bump to v1.29.1
-   Updated dependencies [fced742]
    -   @backstage-community/plugin-linguist-common@0.1.7

## @backstage-community/plugin-linguist@0.1.24

### Patch Changes

-   fced742: version:bump to v1.29.1
-   Updated dependencies [fced742]
    -   @backstage-community/plugin-linguist-common@0.1.7

## @backstage-community/plugin-linguist-backend@0.5.20

### Patch Changes

-   fced742: version:bump to v1.29.1
-   Updated dependencies [fced742]
    -   @backstage-community/plugin-linguist-common@0.1.7

## @backstage-community/plugin-linguist-common@0.1.7

### Patch Changes

-   fced742: version:bump to v1.29.1

## app@0.0.4

### Patch Changes

-   Updated dependencies [fced742]
    -   @backstage-community/plugin-linguist@0.1.24

## backend@0.0.4

### Patch Changes

-   Updated dependencies [fced742]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.2
    -   @backstage-community/plugin-linguist-backend@0.5.20
    -   app@0.0.4
