### PR TITLE
Add changeset to PR created by version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -97,6 +97,10 @@ jobs:
               echo "Has changes"
               echo "HAS_CHANGES=1" >> $GITHUB_OUTPUT
           fi
+      - name: 'Add changeset'
+        if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
+        working-directory: ./workspaces/${{ matrix.workspace }}  
+        run: node scripts/ci/generate-version-bump-changeset.js ${{ steps.set_release_name.outputs.release_version }}  
       - name: 'Commit changes'
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         run: |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This will add a changeset to the PR created when the version bump workflow is ran. In it's current state it will just assume all of the plugin packages have been updated and will be included in the changeset. This seems pretty safe but we can easily improve the script in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
