### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/version-bump-1-29-2.md
+++ b/workspaces/cicd-statistics/.changeset/version-bump-1-29-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics': patch
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
----
-
-Backstage version bump to v1.29.2

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.1.32
+
+### Patch Changes
+
+- 2448d1c: Backstage version bump to v1.29.2
+- Updated dependencies [2448d1c]
+  - @backstage-community/plugin-cicd-statistics@0.1.38
+
 ## 0.1.31
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.1.38
+
+### Patch Changes
+
+- 2448d1c: Backstage version bump to v1.29.2
+
 ## 0.1.37
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.1.38

### Patch Changes

-   2448d1c: Backstage version bump to v1.29.2

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.32

### Patch Changes

-   2448d1c: Backstage version bump to v1.29.2
-   Updated dependencies [2448d1c]
    -   @backstage-community/plugin-cicd-statistics@0.1.38
