### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/version-bump-1-29-2.md
+++ b/workspaces/cost-insights/.changeset/version-bump-1-29-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': patch
-'@backstage-community/plugin-cost-insights-common': patch
----
-
-Backstage version bump to v1.29.2

--- a/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights-common
 
+## 0.1.4
+
+### Patch Changes
+
+- 22de2f8: Backstage version bump to v1.29.2
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights-common/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights-common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Common functionalities for the cost-insights plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.12.26
+
+### Patch Changes
+
+- 22de2f8: Backstage version bump to v1.29.2
+- Updated dependencies [22de2f8]
+  - @backstage-community/plugin-cost-insights-common@0.1.4
+
 ## 0.12.25
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.12.25",
+  "version": "0.12.26",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.12.26

### Patch Changes

-   22de2f8: Backstage version bump to v1.29.2
-   Updated dependencies [22de2f8]
    -   @backstage-community/plugin-cost-insights-common@0.1.4

## @backstage-community/plugin-cost-insights-common@0.1.4

### Patch Changes

-   22de2f8: Backstage version bump to v1.29.2
