### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/fresh-jokes-begin.md
+++ b/workspaces/github-actions/.changeset/fresh-jokes-begin.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

--- a/workspaces/github-actions/packages/app-next/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app-next/CHANGELOG.md
@@ -1,0 +1,8 @@
+# app-next
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [9c52968]
+  - @backstage-community/plugin-github-actions@0.6.18

--- a/workspaces/github-actions/packages/app-next/package.json
+++ b/workspaces/github-actions/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/packages/app/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app/CHANGELOG.md
@@ -1,0 +1,8 @@
+# app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [9c52968]
+  - @backstage-community/plugin-github-actions@0.6.18

--- a/workspaces/github-actions/packages/app/package.json
+++ b/workspaces/github-actions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.6.18
+
+### Patch Changes
+
+- 9c52968: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
+
 ## 0.6.17
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.6.18

### Patch Changes

-   9c52968: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

## app@0.0.1

### Patch Changes

-   Updated dependencies [9c52968]
    -   @backstage-community/plugin-github-actions@0.6.18

## app-next@0.0.1

### Patch Changes

-   Updated dependencies [9c52968]
    -   @backstage-community/plugin-github-actions@0.6.18
