### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/flat-forks-compare.md
+++ b/workspaces/tech-insights/.changeset/flat-forks-compare.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-Update to latest backstage versions.

--- a/workspaces/tech-insights/.changeset/wise-pillows-share.md
+++ b/workspaces/tech-insights/.changeset/wise-pillows-share.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': minor
----
-
-Remove dependency to `backend-test-utils` in none test code.
-
-**BREAKING**: From now on the `logger` must be provided, when using `initializePersistenceContext`.

--- a/workspaces/tech-insights/packages/app/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [0265767]
+  - @backstage-community/plugin-tech-insights@0.3.31
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/tech-insights/packages/app/package.json
+++ b/workspaces/tech-insights/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/tech-insights/packages/backend/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [e49b4eb]
+  - @backstage-community/plugin-tech-insights-backend@0.6.0
+  - app@0.0.3
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/tech-insights/packages/backend/package.json
+++ b/workspaces/tech-insights/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- e49b4eb: Remove dependency to `backend-test-utils` in none test code.
+
+  **BREAKING**: From now on the `logger` must be provided, when using `initializePersistenceContext`.
+
 ## 0.5.35
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "0.5.35",
+  "version": "0.6.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.3.31
+
+### Patch Changes
+
+- 0265767: Update to latest backstage versions.
+
 ## 0.3.30
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-backend@0.6.0

### Minor Changes

-   e49b4eb: Remove dependency to `backend-test-utils` in none test code.

    **BREAKING**: From now on the `logger` must be provided, when using `initializePersistenceContext`.

## @backstage-community/plugin-tech-insights@0.3.31

### Patch Changes

-   0265767: Update to latest backstage versions.

## app@0.0.3

### Patch Changes

-   Updated dependencies [0265767]
    -   @backstage-community/plugin-tech-insights@0.3.31

## backend@0.0.3

### Patch Changes

-   Updated dependencies [e49b4eb]
    -   @backstage-community/plugin-tech-insights-backend@0.6.0
    -   app@0.0.3
