### PR TITLE
fix(jenkins): Fixed rebuild api call on jenkins and project/job's depth on view runs route on jenkins-backend

### DIFF
--- a/workspaces/jenkins/.changeset/ninety-moose-eat.md
+++ b/workspaces/jenkins/.changeset/ninety-moose-eat.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+'@backstage-community/plugin-jenkins': patch
+---
+
+Fixed rebuild api call on frontend and project/job depth on view runs route.

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
@@ -749,9 +749,12 @@ describe('JenkinsApi', () => {
         },
       ]);
 
-      mockFetch.mockResolvedValueOnce({ status: 200 , json: () => {
-        return {}
-      },} as Response);
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: () => {
+          return {};
+        },
+      } as Response);
       const status = await jenkinsApi.rebuildProject(
         jenkinsInfo,
         jobFullName,
@@ -762,26 +765,30 @@ describe('JenkinsApi', () => {
       expect(status).toEqual(401);
     });
   });
-  describe('getJobBuilds', ()=>{
-    it('should return all the builds for a project on root', async ()=>{
-      mockFetch.mockResolvedValueOnce({ status: 200, json :async () => {} } as Response);
-      await jenkinsApi.getJobBuilds(
-        jenkinsInfo,
-        jobFullName,
+  describe('getJobBuilds', () => {
+    it('should return all the builds for a project on root', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: async () => {},
+      } as Response);
+      await jenkinsApi.getJobBuilds(jenkinsInfo, jobFullName);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://jenkins.example.com/job/example-jobName/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]',
+        { headers: { headerName: 'headerValue' }, method: 'get' },
       );
-      expect(mockFetch).toHaveBeenCalledWith("https://jenkins.example.com/job/example-jobName/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]", {"headers": {"headerName": "headerValue"}, "method": "get"})
-      
     });
 
-    it('should return all the builds for a project on depth', async ()=>{
-      mockFetch.mockResolvedValueOnce({ status: 200, json :async () => {} } as Response);
-      const jobFullName = 'test/folder/depth/foo'
-      await jenkinsApi.getJobBuilds(
-        jenkinsInfo,
-        jobFullName,
+    it('should return all the builds for a project on depth', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        json: async () => {},
+      } as Response);
+      const jobFullName = 'test/folder/depth/foo';
+      await jenkinsApi.getJobBuilds(jenkinsInfo, jobFullName);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://jenkins.example.com/job/test/job/folder/job/depth/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]',
+        { headers: { headerName: 'headerValue' }, method: 'get' },
       );
-      expect(mockFetch).toHaveBeenCalledWith("https://jenkins.example.com/job/test/job/folder/job/depth/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]", {"headers": {"headerName": "headerValue"}, "method": "get"})
-      
     });
   });
 });

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
@@ -749,7 +749,9 @@ describe('JenkinsApi', () => {
         },
       ]);
 
-      mockFetch.mockResolvedValueOnce({ status: 200 } as Response);
+      mockFetch.mockResolvedValueOnce({ status: 200 , json: () => {
+        return {}
+      },} as Response);
       const status = await jenkinsApi.rebuildProject(
         jenkinsInfo,
         jobFullName,
@@ -758,6 +760,28 @@ describe('JenkinsApi', () => {
         { credentials: await auth.getOwnServiceCredentials() },
       );
       expect(status).toEqual(401);
+    });
+  });
+  describe('getJobBuilds', ()=>{
+    it('should return all the builds for a project on root', async ()=>{
+      mockFetch.mockResolvedValueOnce({ status: 200, json :async () => {} } as Response);
+      await jenkinsApi.getJobBuilds(
+        jenkinsInfo,
+        jobFullName,
+      );
+      expect(mockFetch).toHaveBeenCalledWith("https://jenkins.example.com/job/example-jobName/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]", {"headers": {"headerName": "headerValue"}, "method": "get"})
+      
+    });
+
+    it('should return all the builds for a project on depth', async ()=>{
+      mockFetch.mockResolvedValueOnce({ status: 200, json :async () => {} } as Response);
+      const jobFullName = 'test/folder/depth/foo'
+      await jenkinsApi.getJobBuilds(
+        jenkinsInfo,
+        jobFullName,
+      );
+      expect(mockFetch).toHaveBeenCalledWith("https://jenkins.example.com/job/test/job/folder/job/depth/job/foo/api/json?tree=name,description,url,fullName,displayName,fullDisplayName,inQueue,builds[*]", {"headers": {"headerName": "headerValue"}, "method": "get"})
+      
     });
   });
 });

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -345,7 +345,10 @@ export class JenkinsApiImpl {
   async getJobBuilds(jenkinsInfo: JenkinsInfo, jobFullName: string) {
     let jobName = jobFullName;
     if (jobFullName.includes('/')) {
-      jobName = jobFullName.split('/').map((s: string) => `${encodeURIComponent(s)}`).join('/job/');
+      jobName = jobFullName
+        .split('/')
+        .map((s: string) => `${encodeURIComponent(s)}`)
+        .join('/job/');
     }
 
     const response = await fetch(

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -344,15 +344,8 @@ export class JenkinsApiImpl {
 
   async getJobBuilds(jenkinsInfo: JenkinsInfo, jobFullName: string) {
     let jobName = jobFullName;
-
     if (jobFullName.includes('/')) {
-      const arr = jobFullName.split('/');
-      const multibranchJobName = arr.shift();
-      jobName = [
-        multibranchJobName,
-        'job',
-        encodeURIComponent(arr.join('/')),
-      ].join('/');
+      jobName = jobFullName.split('/').map((s: string) => `${encodeURIComponent(s)}`).join('/job/');
     }
 
     const response = await fetch(
@@ -369,7 +362,6 @@ export class JenkinsApiImpl {
     );
 
     const jobBuilds = await response.json();
-
     return jobBuilds;
   }
 }

--- a/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
@@ -208,9 +208,9 @@ export class JenkinsClient implements JenkinsApi {
       entity.kind,
     )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
       jobFullName,
-    )}/${encodeURIComponent(buildNumber)}:rebuild`;
+    )}/${encodeURIComponent(buildNumber)}`;
 
-    const response = await this.fetchApi.fetch(url);
+    const response = await this.fetchApi.fetch(url, {method: "POST"});
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);

--- a/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
@@ -210,7 +210,7 @@ export class JenkinsClient implements JenkinsApi {
       jobFullName,
     )}/${encodeURIComponent(buildNumber)}`;
 
-    const response = await this.fetchApi.fetch(url, {method: "POST"});
+    const response = await this.fetchApi.fetch(url, { method: 'POST' });
 
     if (!response.ok) {
       throw await ResponseError.fromResponse(response);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue:- https://github.com/backstage/community-plugins/issues/541

On jenkins community backend plugin:
1. Rebuild route ❌
   `const response = await this.fetchApi.fetch(url);`
     In backend, the rebuild route was created with POST method but frontend was calling with GET.
   
2. View runs route ❌
     `const arr = jobFullName.split('/');
      const multibranchJobName = arr.shift();
      jobName = [
        multibranchJobName,
        'job',
        encodeURIComponent(arr.join('/')),
      ].join('/');`
      The above code was not correctly written for job depth more than 1 from root.
    
## Multibranch pipeline job on root
### Jenkins Latest Run Card
<img width="737" alt="Screenshot 2024-07-30 at 7 14 38 PM" src="https://github.com/user-attachments/assets/ef4b32a2-0f89-4c14-947d-19de3bdc2309">

### Jenkins Content Card
<img width="1500" alt="Screenshot 2024-07-30 at 7 15 15 PM" src="https://github.com/user-attachments/assets/5f048bc6-24e5-4a33-b066-dfe39bd405aa">

### Jenkins View Runs table
<img width="1490" alt="Screenshot 2024-07-30 at 7 15 32 PM" src="https://github.com/user-attachments/assets/fec58e8d-fe42-40e1-8a6d-8cdb9b23f970">

## Multibranch pipeline job on depth
### Jenkins Content Card
![image](https://github.com/user-attachments/assets/f021ed2a-21e7-426a-b0fa-e0ef99c65169)





- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
