### PR TITLE
Jenkins configuration project limit

### DIFF
--- a/workspaces/jenkins/plugins/jenkins-backend/README.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/README.md
@@ -121,7 +121,7 @@ metadata:
     'jenkins.io/job-full-name': teamA/artistLookup-build
 ```
 
-The projectCountLimit is optional and if not set, the default limit is 50.
+The `projectCountLimit` is optional and if not set, the default limit is 50.
 The old annotation name of `jenkins.io/github-folder` is equivalent to `jenkins.io/job-full-name`
 
 #### Example - Multiple global instances

--- a/workspaces/jenkins/plugins/jenkins-backend/README.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/README.md
@@ -103,6 +103,7 @@ Config
 jenkins:
   baseUrl: https://jenkins.example.com
   username: backstage-bot
+  projectCountLimit: 100
   apiKey: 123456789abcdef0123456789abcedf012
   # optionally add extra headers
   # extraRequestHeaders:
@@ -120,6 +121,7 @@ metadata:
     'jenkins.io/job-full-name': teamA/artistLookup-build
 ```
 
+The projectCountLimit is optional and if not set, the default limit is 50.
 The old annotation name of `jenkins.io/github-folder` is equivalent to `jenkins.io/job-full-name`
 
 #### Example - Multiple global instances
@@ -134,10 +136,12 @@ jenkins:
     - name: default
       baseUrl: https://jenkins.example.com
       username: backstage-bot
+      projectCountLimit: 100
       apiKey: 123456789abcdef0123456789abcedf012
     - name: departmentFoo
       baseUrl: https://jenkins-foo.example.com
       username: backstage-bot
+      projectCountLimit: 100
       apiKey: 123456789abcdef0123456789abcedf012
 ```
 
@@ -165,6 +169,7 @@ jenkins:
     - name: departmentFoo
       baseUrl: https://jenkins-foo.example.com
       username: backstage-bot
+      projectCountLimit: 100
       apiKey: 123456789abcdef0123456789abcedf012
 ```
 
@@ -205,6 +210,7 @@ class AcmeJenkinsInfoProvider implements JenkinsInfoProvider {
     const baseUrl = `https://jenkins-${dept}.example.com/`;
     const jobFullName = `${team}/${paasProjectName}`;
     const username = 'backstage-bot';
+    const projectCountLimit = 100;
     const apiKey = this.getJenkinsApiKey(paasProjectName);
     const creds = btoa(`${username}:${apiKey}`);
 

--- a/workspaces/jenkins/plugins/jenkins-backend/api-report.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/api-report.md
@@ -60,6 +60,8 @@ export interface JenkinsInfo {
   headers?: Record<string, string | string[]>;
   // (undocumented)
   jobFullName: string;
+  // (undocumented)
+  projectCountLimit: number;
 }
 
 // @public (undocumented)
@@ -83,6 +85,8 @@ export interface JenkinsInstanceConfig {
   extraRequestHeaders?: Record<string, string>;
   // (undocumented)
   name: string;
+  // (undocumented)
+  projectCountLimit?: number;
   // (undocumented)
   username: string;
 }

--- a/workspaces/jenkins/plugins/jenkins-backend/config.d.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/config.d.ts
@@ -25,6 +25,10 @@ export interface Config {
      */
     username?: string;
     /**
+     * Default instance projectCountLimit, can be specified on a named instance called "default"
+     */
+    projectCountLimit?: number;
+    /**
      * Default Instance apiKey, can be specified on a named instance called "default"
      * @visibility secret
      */
@@ -40,6 +44,7 @@ export interface Config {
       name: string;
       baseUrl: string;
       username: string;
+      projectCountLimit?: number;
       /** @visibility secret */
       apiKey: string;
       extraRequestHeaders?: {

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.test.ts
@@ -43,6 +43,7 @@ const jenkinsInfo: JenkinsInfo = {
   baseUrl: 'https://jenkins.example.com',
   headers: { headerName: 'headerValue' },
   jobFullName: 'example-jobName',
+  projectCountLimit: 60,
 };
 
 const fakePermissionApi = {

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -103,21 +103,24 @@ export class JenkinsApiImpl {
       // Assume jenkinsInfo.jobFullName is either
       // a MultiBranch Pipeline (folder with one job per branch) project
       // a Pipeline (standalone) project
+      
+      // Add count limit to projects
+      // If limit is set in the config, use it, otherwise use the default limit of 50
+      const limitedJobsTreeSpec: string = `${JenkinsApiImpl.jobsTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`;
+
       const project = await client.job.get({
         name: jenkinsInfo.jobFullName,
         // Filter only be the information we need, instead of loading all fields.
-        // Limit to only show the latest build for each job and only load 50 jobs
-        // at all.
         // Whitespaces are only included for readability here and stripped out
         // before sending to Jenkins
-        tree: JenkinsApiImpl.jobsTreeSpec.replace(/\s/g, ''),
+        tree: limitedJobsTreeSpec.replace(/\s/g, ''),
       });
 
       const isStandaloneProject = !project.jobs;
       if (isStandaloneProject) {
         const standaloneProject = await client.job.get({
           name: jenkinsInfo.jobFullName,
-          tree: JenkinsApiImpl.jobTreeSpec.replace(/\s/g, ''),
+          tree: limitedJobsTreeSpec.replace(/\s/g, ''),
         });
         projects.push(this.augmentProject(standaloneProject));
         return projects;

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -103,7 +103,7 @@ export class JenkinsApiImpl {
       // Assume jenkinsInfo.jobFullName is either
       // a MultiBranch Pipeline (folder with one job per branch) project
       // a Pipeline (standalone) project
-      
+
       // Add count limit to projects
       // If limit is set in the config, use it, otherwise use the default limit of 50
       const limitedJobsTreeSpec: string = `${JenkinsApiImpl.jobsTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`;

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
@@ -235,6 +235,7 @@ describe('DefaultJenkinsInfoProvider', () => {
         'extra-header': 'extra-value',
       },
       jobFullName: 'teamA/artistLookup-build',
+      projectCountLimit: 50,
     });
   });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -218,7 +218,7 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
   }): Promise<JenkinsInfo> {
     // default limitation of projects
     const DEFAULT_LIMITATION_OF_PROJECTS = 50;
-    
+
     // load entity
     const entity = await this.catalog.getEntityByRef(
       opt.entityRef,

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -50,7 +50,7 @@ export interface JenkinsInfo {
   baseUrl: string;
   headers?: Record<string, string | string[]>;
   jobFullName: string; // TODO: make this an array
-  projectCountLimit?: number;
+  projectCountLimit: number;
   crumbIssuer?: boolean;
 }
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -50,6 +50,7 @@ export interface JenkinsInfo {
   baseUrl: string;
   headers?: Record<string, string | string[]>;
   jobFullName: string; // TODO: make this an array
+  projectCountLimit?: number;
   crumbIssuer?: boolean;
 }
 
@@ -58,6 +59,7 @@ export interface JenkinsInstanceConfig {
   name: string;
   baseUrl: string;
   username: string;
+  projectCountLimit?: number;
   apiKey: string;
   crumbIssuer?: boolean;
   /**
@@ -90,6 +92,7 @@ export class JenkinsConfig {
         name: c.getString('name'),
         baseUrl: c.getString('baseUrl'),
         username: c.getString('username'),
+        projectCountLimit: c.getOptionalNumber('projectCountLimit'),
         apiKey: c.getString('apiKey'),
         extraRequestHeaders: c.getOptional('extraRequestHeaders'),
         crumbIssuer: c.getOptionalBoolean('crumbIssuer'),
@@ -213,6 +216,9 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
     jobFullName?: string;
     credentials?: BackstageCredentials;
   }): Promise<JenkinsInfo> {
+    // default limitation of projects
+    const DEFAULT_LIMITATION_OF_PROJECTS = 50;
+    
     // load entity
     const entity = await this.catalog.getEntityByRef(
       opt.entityRef,
@@ -269,6 +275,8 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
         ...instanceConfig.extraRequestHeaders,
       },
       jobFullName,
+      projectCountLimit:
+        instanceConfig.projectCountLimit ?? DEFAULT_LIMITATION_OF_PROJECTS,
       crumbIssuer: instanceConfig.crumbIssuer,
     };
   }

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/standaloneServer.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/standaloneServer.ts
@@ -40,7 +40,11 @@ export async function startStandaloneServer(
       async getInstance(_: {
         entityRef: CompoundEntityRef;
       }): Promise<JenkinsInfo> {
-        return { baseUrl: 'https://example.com/', jobFullName: 'build-foo', projectCountLimit: 60 };
+        return {
+          baseUrl: 'https://example.com/',
+          jobFullName: 'build-foo',
+          projectCountLimit: 60,
+        };
       },
     },
     discovery: HostDiscovery.fromConfig(options.config),

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/standaloneServer.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/standaloneServer.ts
@@ -40,7 +40,7 @@ export async function startStandaloneServer(
       async getInstance(_: {
         entityRef: CompoundEntityRef;
       }): Promise<JenkinsInfo> {
-        return { baseUrl: 'https://example.com/', jobFullName: 'build-foo' };
+        return { baseUrl: 'https://example.com/', jobFullName: 'build-foo', projectCountLimit: 60 };
       },
     },
     discovery: HostDiscovery.fromConfig(options.config),

--- a/workspaces/jenkins/plugins/jenkins/README.md
+++ b/workspaces/jenkins/plugins/jenkins/README.md
@@ -99,8 +99,7 @@ spec:
 ## Limitations
 
 - Only works with organization folder projects backed by GitHub
-- No pagination support currently, limited to 50 projects - don't run this on a
-  Jenkins instance with lots of builds
+- No pagination support currently
 
 ## EntityJobRunsTable
 


### PR DESCRIPTION
## Jenkins Plugin - Configuration of project limit pull request!

#### :heavy_check_mark: Checklist

- [x] Edits readme files
- [x] Add configuration of project count limit
- [x] If not configured the default limit is 50
