### PR TITLE
feat: refactor `ScorecardInfo` to accordion

### DIFF
--- a/workspaces/tech-insights/.changeset/wet-walls-clap.md
+++ b/workspaces/tech-insights/.changeset/wet-walls-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+Refactor `ScorecardInfo` to accordion to display categories and fail counts.

--- a/workspaces/tech-insights/plugins/tech-insights/api-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights/api-report.md
@@ -49,6 +49,7 @@ export const EntityTechInsightsScorecardCard: (props: {
   description?: string | undefined;
   checksId?: string[] | undefined;
   onlyFailed?: boolean | undefined;
+  expanded?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -77,6 +78,7 @@ export const ScorecardInfo: (props: {
   title: ReactNode;
   description?: string | undefined;
   noWarning?: boolean | undefined;
+  expanded?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -94,6 +96,8 @@ export interface TechInsightsApi {
   getFacts(entity: CompoundEntityRef, facts: string[]): Promise<InsightFacts>;
   // (undocumented)
   getFactSchemas(): Promise<FactSchema[]>;
+  // (undocumented)
+  isCheckResultFailed: (check: CheckResult) => boolean;
   // (undocumented)
   runBulkChecks(
     entities: CompoundEntityRef[],
@@ -124,6 +128,8 @@ export class TechInsightsClient implements TechInsightsApi {
   getFacts(entity: CompoundEntityRef, facts: string[]): Promise<InsightFacts>;
   // (undocumented)
   getFactSchemas(): Promise<FactSchema[]>;
+  // (undocumented)
+  isCheckResultFailed(check: CheckResult): boolean;
   // (undocumented)
   runBulkChecks(
     entities: CompoundEntityRef[],

--- a/workspaces/tech-insights/plugins/tech-insights/dev/index.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/dev/index.tsx
@@ -30,6 +30,7 @@ import {
   checkResultRenderers,
   runChecksResponse,
 } from './mocks';
+import { CheckResult } from '@backstage-community/plugin-tech-insights-common';
 
 const entity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -47,6 +48,7 @@ createDevApp()
     factory: () =>
       ({
         getCheckResultRenderers: (_: string[]) => checkResultRenderers,
+        isCheckResultFailed: (_: CheckResult) => true,
         getAllChecks: async () => [],
         runChecks: async (_: CompoundEntityRef, __?: string[]) =>
           runChecksResponse,

--- a/workspaces/tech-insights/plugins/tech-insights/src/api/TechInsightsApi.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/api/TechInsightsApi.ts
@@ -40,6 +40,7 @@ export const techInsightsApiRef = createApiRef<TechInsightsApi>({
  */
 export interface TechInsightsApi {
   getCheckResultRenderers: (types: string[]) => CheckResultRenderer[];
+  isCheckResultFailed: (check: CheckResult) => boolean;
   getAllChecks(): Promise<Check[]>;
   runChecks(
     entityParams: CompoundEntityRef,

--- a/workspaces/tech-insights/plugins/tech-insights/src/api/TechInsightsClient.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/api/TechInsightsClient.ts
@@ -66,6 +66,16 @@ export class TechInsightsClient implements TechInsightsApi {
     return renderers.filter(d => types.includes(d.type));
   }
 
+  isCheckResultFailed(check: CheckResult) {
+    const checkResultRenderers = this.getCheckResultRenderers([
+      check.check.type,
+    ]);
+    if (checkResultRenderers[0] && checkResultRenderers[0].isFailed) {
+      return checkResultRenderers[0].isFailed(check);
+    }
+    return true;
+  }
+
   async getAllChecks(): Promise<Check[]> {
     return this.api('/checks');
   }

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsCard/ScorecardsCard.tsx
@@ -19,7 +19,7 @@ import useAsync from 'react-use/esm/useAsync';
 import { ErrorPanel, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { ScorecardInfo } from '../ScorecardsInfo';
-import { techInsightsApiRef } from '../../api/TechInsightsApi';
+import { techInsightsApiRef } from '../../api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { getCompoundEntityRef } from '@backstage/catalog-model';
 
@@ -28,8 +28,9 @@ export const ScorecardsCard = (props: {
   description?: string;
   checksId?: string[];
   onlyFailed?: boolean;
+  expanded?: boolean;
 }) => {
-  const { title, description, checksId, onlyFailed } = props;
+  const { title, description, checksId, onlyFailed, expanded = true } = props;
   const api = useApi(techInsightsApiRef);
   const { entity } = useEntity();
   const { value, loading, error } = useAsync(
@@ -65,6 +66,7 @@ export const ScorecardsCard = (props: {
       description={description}
       checkResults={filteredValue}
       noWarning={onlyFailed}
+      expanded={expanded}
     />
   );
 };

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
@@ -14,39 +14,77 @@
  * limitations under the License.
  */
 
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
-import { InfoCard } from '@backstage/core-components';
 import { CheckResult } from '@backstage-community/plugin-tech-insights-common';
 import Alert from '@material-ui/lab/Alert';
 import { ScorecardsList } from '../ScorecardsList';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import { useApi } from '@backstage/core-plugin-api';
+import { techInsightsApiRef } from '../../api';
 
 const useStyles = makeStyles(theme => ({
   subheader: {
-    fontWeight: 'bold',
     paddingLeft: theme.spacing(0.5),
+  },
+  accordionHeader: {
+    borderBottom: `1px solid ${theme.palette.border}`,
+  },
+  accordionHeaderContent: {
+    margin: `${theme.spacing(2)}px 0 !important`,
   },
 }));
 
 const infoCard = (
-  title: ReactNode,
+  title: React.ReactNode,
   description: string | undefined,
-  className: string,
-  element: ReactElement,
+  classes: ReturnType<typeof useStyles>,
+  element: React.ReactElement,
+  expanded: boolean,
+  summary?: string,
 ) => (
   <Grid item xs={12}>
-    <InfoCard title={title}>
-      {description && (
-        <Typography className={className} variant="body1" gutterBottom>
-          {description}
-        </Typography>
-      )}
-      <Grid item xs={12}>
-        {element}
-      </Grid>
-    </InfoCard>
+    <Accordion defaultExpanded={expanded}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        className={classes.accordionHeader}
+        classes={{
+          content: classes.accordionHeaderContent,
+        }}
+      >
+        <Grid container justifyContent="space-between" alignItems="center">
+          <Grid item>
+            <Typography variant="h5">{title}</Typography>
+          </Grid>
+          <Grid item>
+            <Typography>{summary}</Typography>
+          </Grid>
+        </Grid>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid container>
+          {description && (
+            <Grid item xs={12}>
+              <Typography
+                className={classes.subheader}
+                variant="body1"
+                gutterBottom
+              >
+                {description}
+              </Typography>
+            </Grid>
+          )}
+          <Grid item xs={12}>
+            {element}
+          </Grid>
+        </Grid>
+      </AccordionDetails>
+    </Accordion>
   </Grid>
 );
 
@@ -55,33 +93,48 @@ export const ScorecardInfo = (props: {
   title: ReactNode;
   description?: string;
   noWarning?: boolean;
+  expanded?: boolean;
 }) => {
-  const { checkResults, title, description, noWarning } = props;
+  const {
+    checkResults,
+    title,
+    description,
+    noWarning,
+    expanded = true,
+  } = props;
   const classes = useStyles();
+  const api = useApi(techInsightsApiRef);
 
   if (!checkResults.length) {
     if (noWarning) {
       return infoCard(
         title,
         description,
-        classes.subheader,
+        classes,
         <Alert severity="info">
           All checks passed, or no checks have been performed yet
         </Alert>,
+        expanded,
       );
     }
     return infoCard(
       title,
       description,
-      classes.subheader,
+      classes,
       <Alert severity="warning">No checks have any data yet.</Alert>,
+      expanded,
     );
   }
 
   return infoCard(
     title,
     description,
-    classes.subheader,
+    classes,
     <ScorecardsList checkResults={checkResults} />,
+    expanded,
+    `${
+      checkResults.filter(checkResult => !api.isCheckResultFailed(checkResult))
+        .length
+    }/${checkResults.length}`,
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We like to categorise some tests and have more concise overview of checks. 
We are thinking in going the direction of https://roadie.io/product/tech-insights/ or https://backstage.spotify.com/marketplace/spotify/plugin/soundcheck/

As a first step we could refactor the card to a accordion and show how many checks failed compared to the total of checks.

![Screen Shot 2024-08-04 at 12 35 54 PM](https://github.com/user-attachments/assets/e74e08cd-2e4b-45d8-9067-a614d8e8bade)
![Screen Shot 2024-08-04 at 12 36 05 PM](https://github.com/user-attachments/assets/3e446c73-485f-4185-a7e6-442d1a8fee30)

What is your opinion on this change?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
