### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/chatty-wombats-begin.md
+++ b/workspaces/linguist/.changeset/chatty-wombats-begin.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
-'@backstage-community/plugin-linguist-backend': patch
----
-
-Removed code marked as deprecated in the upstream Backstage project

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [78129a3]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.3
+  - @backstage-community/plugin-linguist-backend@0.5.21
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.1.3
+
+### Patch Changes
+
+- 78129a3: Removed code marked as deprecated in the upstream Backstage project
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.5.21
+
+### Patch Changes
+
+- 78129a3: Removed code marked as deprecated in the upstream Backstage project
+
 ## 0.5.20
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.3

### Patch Changes

-   78129a3: Removed code marked as deprecated in the upstream Backstage project

## @backstage-community/plugin-linguist-backend@0.5.21

### Patch Changes

-   78129a3: Removed code marked as deprecated in the upstream Backstage project

## backend@0.0.5

### Patch Changes

-   Updated dependencies [78129a3]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.3
    -   @backstage-community/plugin-linguist-backend@0.5.21
