### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/olive-timers-applaud.md
+++ b/workspaces/linguist/.changeset/olive-timers-applaud.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
----
-
-Added missing `config.d.ts` to `files` section in `package.json`

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [ee627fb]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.4
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.1.4
+
+### Patch Changes
+
+- ee627fb: Added missing `config.d.ts` to `files` section in `package.json`
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.4

### Patch Changes

-   ee627fb: Added missing `config.d.ts` to `files` section in `package.json`

## backend@0.0.6

### Patch Changes

-   Updated dependencies [ee627fb]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.4
