### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/shy-readers-fly.md
+++ b/workspaces/confluence/.changeset/shy-readers-fly.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': minor
-'@backstage-community/plugin-confluence': minor
----
-
-Initial plugin version. A copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-confluence) updated to support the new backend system and compatible with the configuration specs of the [Confluence to Markdown action](https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-confluence-to-markdown) scaffolder plugin.

--- a/workspaces/confluence/packages/app/CHANGELOG.md
+++ b/workspaces/confluence/packages/app/CHANGELOG.md
@@ -1,0 +1,8 @@
+# app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [3ee48db]
+  - @backstage-community/plugin-confluence@0.1.0

--- a/workspaces/confluence/packages/app/package.json
+++ b/workspaces/confluence/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/confluence/packages/backend/CHANGELOG.md
+++ b/workspaces/confluence/packages/backend/CHANGELOG.md
@@ -1,0 +1,9 @@
+# backend
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [3ee48db]
+  - @backstage-community/plugin-search-backend-module-confluence-collator@0.1.0
+  - app@0.0.1

--- a/workspaces/confluence/packages/backend/package.json
+++ b/workspaces/confluence/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-confluence
+
+## 0.1.0
+
+### Minor Changes
+
+- 3ee48db: Initial plugin version. A copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-confluence) updated to support the new backend system and compatible with the configuration specs of the [Confluence to Markdown action](https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-confluence-to-markdown) scaffolder plugin.

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-search-backend-module-confluence-collator
+
+## 0.1.0
+
+### Minor Changes
+
+- 3ee48db: Initial plugin version. A copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-confluence) updated to support the new backend system and compatible with the configuration specs of the [Confluence to Markdown action](https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-confluence-to-markdown) scaffolder plugin.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.1.0

### Minor Changes

-   3ee48db: Initial plugin version. A copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-confluence) updated to support the new backend system and compatible with the configuration specs of the [Confluence to Markdown action](https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-confluence-to-markdown) scaffolder plugin.

## @backstage-community/plugin-search-backend-module-confluence-collator@0.1.0

### Minor Changes

-   3ee48db: Initial plugin version. A copy of its original [repo](https://github.com/K-Phoen/backstage-plugin-confluence) updated to support the new backend system and compatible with the configuration specs of the [Confluence to Markdown action](https://github.com/backstage/backstage/tree/master/plugins/scaffolder-backend-module-confluence-to-markdown) scaffolder plugin.

## app@0.0.1

### Patch Changes

-   Updated dependencies [3ee48db]
    -   @backstage-community/plugin-confluence@0.1.0

## backend@0.0.1

### Patch Changes

-   Updated dependencies [3ee48db]
    -   @backstage-community/plugin-search-backend-module-confluence-collator@0.1.0
    -   app@0.0.1
