### PR TITLE
Updating Bazaar Plugin README URL

### DIFF
--- a/.changeset/brave-fans-rhyme.md
+++ b/.changeset/brave-fans-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-bazaar': patch
+---
+
+The url in the README of bazaar was referencing an old URL resulting in a 404 error.

--- a/workspaces/bazaar/plugins/bazaar/README.md
+++ b/workspaces/bazaar/plugins/bazaar/README.md
@@ -14,7 +14,7 @@ The Bazaar allows engineers and teams to open up and announce their new and exci
 
 # Note
 
-You will **need** to also perform the installation instructions in [Bazaar Backend](https://github.com/backstage/backstage/tree/master/plugins/bazaar-backend) in order for this plugin to work.
+You will **need** to also perform the installation instructions in [Bazaar Backend](https://github.com/backstage/community-plugins/tree/main/workspaces/bazaar/plugins/bazaar-backend) in order for this plugin to work.
 
 ## Getting Started
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The URL in the bazaar plugin was referencing an old URL and 404'ing.  

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
