### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/olive-carrots-roll.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/olive-carrots-roll.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
----
-
-fix(metadata): update backstage.pluginId and pluginPackage values to align with workspace and plugin names

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 1.2.4
+
+### Patch Changes
+
+- a6b6fc0: fix(metadata): update backstage.pluginId and pluginPackage values to align with workspace and plugin names
+
 ## 1.2.3
 
 ### Patch Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@1.2.4

### Patch Changes

-   a6b6fc0: fix(metadata): update backstage.pluginId and pluginPackage values to align with workspace and plugin names
