### PR TITLE
Update Code Coverage Frontend to Reference Correct Path for API

### DIFF
--- a/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage
 
+## 0.2.30
+
+### Patch Changes
+
+- 7f16138: Updated `discoveryApi` to use base URL `codeCoverage` to be compatible with backend plugin ID, (previously `code-coverage`).
+
 ## 0.2.29
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/code-coverage/plugins/code-coverage/src/api.ts
+++ b/workspaces/code-coverage/plugins/code-coverage/src/api.ts
@@ -59,7 +59,7 @@ export class CodeCoverageRestApi implements CodeCoverageApi {
   private async fetch<T = unknown | string | JsonCoverageHistory>(
     path: string,
   ): Promise<T | string> {
-    const url = await this.discoveryApi.getBaseUrl('code-coverage');
+    const url = await this.discoveryApi.getBaseUrl('codeCoverage');
     const resp = await this.fetchApi.fetch(`${url}${path}`);
     if (!resp.ok) {
       throw await ResponseError.fromResponse(resp);


### PR DESCRIPTION
Fixes #556

## Hey, I just made a Pull Request!

Updating the baseUrl from `code-coverage` to `codeCoverage`  to match the backend plugin ID.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
