### PR TITLE
badges: Support customizing badge styles

### DIFF
--- a/workspaces/badges/.changeset/calm-crews-provide.md
+++ b/workspaces/badges/.changeset/calm-crews-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-badges': minor
+---
+
+UI now supports customizing badge styles.

--- a/workspaces/badges/.changeset/khaki-dingos-bathe.md
+++ b/workspaces/badges/.changeset/khaki-dingos-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-badges-backend': minor
+---
+
+APIs now accept color and style query parameters to support badge customization.

--- a/workspaces/badges/plugins/badges-backend/README.md
+++ b/workspaces/badges/plugins/badges-backend/README.md
@@ -180,6 +180,15 @@ The badges backend api exposes two main endpoints for entity badges. The
   [BadgeSpec](https://github.com/backstage/backstage/tree/master/plugins/badges/src/api/types.ts)
   from the frontend plugin for a type declaration.
 
+### Custom badge styles
+
+The badge builder supports custom badge styles and colors.
+While requesting a badge or badge spec JSON, you can pass the `style` and `color` query parameters to customize the badge.
+
+```http
+GET /badge/entity/:entityUuid/badge-specs?style=flat&color=blue
+```
+
 ## Links
 
 - [Frontend part of the plugin](https://github.com/backstage/backstage/tree/master/plugins/badges)

--- a/workspaces/badges/plugins/badges-backend/api-report.md
+++ b/workspaces/badges/plugins/badges-backend/api-report.md
@@ -48,9 +48,13 @@ export interface BadgeContext {
   // (undocumented)
   badgeUrl: string;
   // (undocumented)
+  color?: string;
+  // (undocumented)
   config: Config;
   // (undocumented)
   entity?: Entity;
+  // (undocumented)
+  style?: BadgeStyle;
 }
 
 // @public (undocumented)

--- a/workspaces/badges/plugins/badges-backend/src/badges.test.ts
+++ b/workspaces/badges/plugins/badges-backend/src/badges.test.ts
@@ -89,4 +89,51 @@ describe('BadgeFactories', () => {
       );
     }
   });
+
+  it('should be able to set styles', () => {
+    const entity: Entity = {
+      apiVersion: 'v1',
+      kind: 'service',
+      metadata: {
+        name: 'test',
+      },
+    };
+
+    const context: BadgeContext = {
+      badgeUrl: '/dummy/url',
+      config,
+      entity,
+      style: 'plastic',
+      color: 'black',
+    };
+
+    expect.assertions(Object.keys(badgeFactories).length);
+    for (const badgeFactory of Object.values(badgeFactories)) {
+      const badge = badgeFactory.createBadge(context);
+      expect(badge.style).toContain('plastic');
+    }
+  });
+
+  it('should be able to set color', () => {
+    const entity: Entity = {
+      apiVersion: 'v1',
+      kind: 'service',
+      metadata: {
+        name: 'test',
+      },
+    };
+
+    const context: BadgeContext = {
+      badgeUrl: '/dummy/url',
+      config,
+      entity,
+      color: 'black',
+    };
+
+    expect.assertions(Object.keys(badgeFactories).length);
+    for (const badgeFactory of Object.values(badgeFactories)) {
+      const badge = badgeFactory.createBadge(context);
+      expect(badge.color).toContain('black');
+    }
+  });
 });

--- a/workspaces/badges/plugins/badges-backend/src/badges.ts
+++ b/workspaces/badges/plugins/badges-backend/src/badges.ts
@@ -46,7 +46,8 @@ export const createDefaultBadgeFactories = (): BadgeFactories => ({
         label: context.entity.kind,
         link: entityUrl(context),
         message: context.entity.metadata.name,
-        style: 'flat-square',
+        style: context.style || 'flat-square',
+        color: context.color,
       };
     },
   },
@@ -62,7 +63,8 @@ export const createDefaultBadgeFactories = (): BadgeFactories => ({
         label: 'lifecycle',
         link: entityUrl(context),
         message: `${context.entity.spec?.lifecycle || 'unknown'}`,
-        style: 'flat-square',
+        style: context.style || 'flat-square',
+        color: context.color,
       };
     },
   },
@@ -78,7 +80,8 @@ export const createDefaultBadgeFactories = (): BadgeFactories => ({
         label: 'owner',
         link: entityUrl(context),
         message: `${context.entity.spec?.owner || 'unknown'}`,
-        style: 'flat-square',
+        style: context.style || 'flat-square',
+        color: context.color,
       };
     },
   },
@@ -94,7 +97,8 @@ export const createDefaultBadgeFactories = (): BadgeFactories => ({
         label: 'docs',
         link: `${entityUrl(context)}/docs`,
         message: context.entity.metadata.name,
-        style: 'flat-square',
+        style: context.style || 'flat-square',
+        color: context.color,
       };
     },
   },

--- a/workspaces/badges/plugins/badges-backend/src/service/router.test.ts
+++ b/workspaces/badges/plugins/badges-backend/src/service/router.test.ts
@@ -233,6 +233,33 @@ describe('createRouter', () => {
         expect(response.status).toEqual(200);
         expect(response.body).toEqual(badge);
       });
+
+      it('returns badge with style', async () => {
+        catalog.getEntityByRef.mockResolvedValueOnce(entity);
+
+        const image = '<svg>...</svg>';
+        badgeBuilder.createBadgeSvg.mockResolvedValueOnce(image);
+
+        const response = await request(app).get(
+          '/entity/default/component/test/badge/test-badge?style=flat',
+        );
+
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual(Buffer.from(image));
+
+        expect(badgeBuilder.createBadgeSvg).toHaveBeenCalledTimes(1);
+        expect(badgeBuilder.createBadgeSvg).toHaveBeenCalledWith({
+          badgeInfo: { id: badge.id },
+          context: {
+            badgeUrl: expect.stringMatching(
+              /http:\/\/127.0.0.1\/api\/badges\/entity\/default\/component\/test\/badge\/test-badge/,
+            ),
+            config,
+            entity,
+            style: 'flat',
+          },
+        });
+      });
     });
 
     describe('Errors', () => {

--- a/workspaces/badges/plugins/badges-backend/src/service/router.ts
+++ b/workspaces/badges/plugins/badges-backend/src/service/router.ts
@@ -27,7 +27,12 @@ import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
 import { Config } from '@backstage/config';
 import { NotFoundError } from '@backstage/errors';
 import { BadgeBuilder, DefaultBadgeBuilder } from '../lib/BadgeBuilder';
-import { BadgeContext, BadgeFactories } from '../types';
+import {
+  BADGE_STYLES,
+  BadgeContext,
+  BadgeFactories,
+  BadgeStyle,
+} from '../types';
 import { isNil } from 'lodash';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { BadgesStore, DatabaseBadgesStore } from '../database/badgesStore';
@@ -144,6 +149,14 @@ async function obfuscatedRoute(
       );
     }
 
+    let style: BadgeStyle | undefined = undefined;
+    if (
+      typeof req.query.style === 'string' &&
+      BADGE_STYLES.includes(req.query.style as any)
+    ) {
+      style = req.query.style as BadgeStyle;
+    }
+
     // Create the badge specs
     const specs = [];
     for (const badgeInfo of await badgeBuilder.getBadges()) {
@@ -151,6 +164,7 @@ async function obfuscatedRoute(
         badgeUrl: `${baseUrl}/entity/${entityUuid}/${badgeInfo.id}`,
         config: config,
         entity,
+        style,
       };
 
       const badge = await badgeBuilder.createBadgeJson({
@@ -200,12 +214,21 @@ async function obfuscatedRoute(
       format = 'application/json';
     }
 
+    let style: BadgeStyle | undefined = undefined;
+    if (
+      typeof req.query.style === 'string' &&
+      BADGE_STYLES.includes(req.query.style as any)
+    ) {
+      style = req.query.style as BadgeStyle;
+    }
+
     const badgeOptions = {
       badgeInfo: { id: badgeId },
       context: {
         badgeUrl: `${baseUrl}/entity/${entityUuid}/${badgeId}`,
         config: config,
         entity,
+        style,
       },
     };
 
@@ -339,12 +362,21 @@ async function nonObfuscatedRoute(
         format = 'application/json';
       }
 
+      let style: BadgeStyle | undefined = undefined;
+      if (
+        typeof req.query.style === 'string' &&
+        BADGE_STYLES.includes(req.query.style as any)
+      ) {
+        style = req.query.style as BadgeStyle;
+      }
+
       const badgeOptions = {
         badgeInfo: { id: badgeId },
         context: {
           badgeUrl: `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}`,
           config: config,
           entity,
+          style,
         },
       };
 

--- a/workspaces/badges/plugins/badges-backend/src/service/router.ts
+++ b/workspaces/badges/plugins/badges-backend/src/service/router.ts
@@ -149,22 +149,19 @@ async function obfuscatedRoute(
       );
     }
 
-    let style: BadgeStyle | undefined = undefined;
-    if (
-      typeof req.query.style === 'string' &&
-      BADGE_STYLES.includes(req.query.style as any)
-    ) {
-      style = req.query.style as BadgeStyle;
-    }
+    const bsOptions = parseBadgeStyleOptions(req.query);
 
     // Create the badge specs
     const specs = [];
     for (const badgeInfo of await badgeBuilder.getBadges()) {
       const context: BadgeContext = {
-        badgeUrl: `${baseUrl}/entity/${entityUuid}/${badgeInfo.id}`,
+        badgeUrl: `${baseUrl}/entity/${entityUuid}/${
+          badgeInfo.id
+        }${buildBadgeStyleOptionsQuery(bsOptions)}`,
         config: config,
         entity,
-        style,
+        style: bsOptions.style,
+        color: bsOptions.style,
       };
 
       const badge = await badgeBuilder.createBadgeJson({
@@ -214,21 +211,18 @@ async function obfuscatedRoute(
       format = 'application/json';
     }
 
-    let style: BadgeStyle | undefined = undefined;
-    if (
-      typeof req.query.style === 'string' &&
-      BADGE_STYLES.includes(req.query.style as any)
-    ) {
-      style = req.query.style as BadgeStyle;
-    }
+    const bsOptions = parseBadgeStyleOptions(req.query);
 
     const badgeOptions = {
       badgeInfo: { id: badgeId },
       context: {
-        badgeUrl: `${baseUrl}/entity/${entityUuid}/${badgeId}`,
+        badgeUrl: `${baseUrl}/entity/${entityUuid}/${badgeId}${buildBadgeStyleOptionsQuery(
+          bsOptions,
+        )}`,
         config: config,
         entity,
-        style,
+        style: bsOptions.style,
+        color: bsOptions.color,
       },
     };
 
@@ -317,13 +311,19 @@ async function nonObfuscatedRoute(
       );
     }
 
+    const bsOptions = parseBadgeStyleOptions(req.query);
+
     const specs = [];
     for (const badgeInfo of await badgeBuilder.getBadges()) {
       const badgeId = badgeInfo.id;
       const context: BadgeContext = {
-        badgeUrl: `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}`,
+        badgeUrl: `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}${buildBadgeStyleOptionsQuery(
+          bsOptions,
+        )}`,
         config: config,
         entity,
+        style: bsOptions.style,
+        color: bsOptions.color,
       };
 
       const badge = await badgeBuilder.createBadgeJson({
@@ -362,21 +362,18 @@ async function nonObfuscatedRoute(
         format = 'application/json';
       }
 
-      let style: BadgeStyle | undefined = undefined;
-      if (
-        typeof req.query.style === 'string' &&
-        BADGE_STYLES.includes(req.query.style as any)
-      ) {
-        style = req.query.style as BadgeStyle;
-      }
+      const bsOptions = parseBadgeStyleOptions(req.query);
 
       const badgeOptions = {
         badgeInfo: { id: badgeId },
         context: {
-          badgeUrl: `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}`,
+          badgeUrl: `${baseUrl}/entity/${namespace}/${kind}/${name}/badge/${badgeId}${buildBadgeStyleOptionsQuery(
+            bsOptions,
+          )}`,
           config: config,
           entity,
-          style,
+          style: bsOptions.style,
+          color: bsOptions.color,
         },
       };
 
@@ -399,4 +396,50 @@ async function nonObfuscatedRoute(
   router.use(errorHandler());
 
   return router;
+}
+
+interface BadgeStyleOptions {
+  style?: BadgeStyle;
+  color?: string;
+}
+
+// Parse common badge style options from query parameters.
+//
+// This function will parse the following query parameters:
+// - `style`: One of the supported badge styles.
+// - `color`: A custom color for the badge message.
+function parseBadgeStyleOptions(query: qs.ParsedQs): BadgeStyleOptions {
+  let style: BadgeStyle | undefined = undefined;
+  let color: string | undefined = undefined;
+
+  if (
+    typeof query.style === 'string' &&
+    BADGE_STYLES.includes(query.style as any)
+  ) {
+    style = query.style as BadgeStyle;
+  }
+
+  if (typeof query.color === 'string') {
+    color = query.color;
+  }
+
+  return { style, color };
+}
+
+// Build a query string including explanation mark if there are any options.
+function buildBadgeStyleOptionsQuery({
+  style,
+  color,
+}: BadgeStyleOptions): string {
+  const query: string[] = [];
+
+  if (style) {
+    query.push(`style=${style}`);
+  }
+
+  if (color) {
+    query.push(`color=${color}`);
+  }
+
+  return query.length > 0 ? `?${query.join('&')}` : '';
 }

--- a/workspaces/badges/plugins/badges-backend/src/types.ts
+++ b/workspaces/badges/plugins/badges-backend/src/types.ts
@@ -57,6 +57,9 @@ export interface BadgeContext {
   badgeUrl: string;
   config: Config;
   entity?: Entity; // for entity badges
+
+  color?: string; // for custom badges
+  style?: BadgeStyle; // for custom badges
 }
 
 /** @public */

--- a/workspaces/badges/plugins/badges/src/api/types.ts
+++ b/workspaces/badges/plugins/badges/src/api/types.ts
@@ -21,12 +21,15 @@ export const badgesApiRef = createApiRef<BadgesApi>({
   id: 'plugin.badges.client',
 });
 
-export type BadgeStyle =
-  | 'plastic'
-  | 'flat'
-  | 'flat-square'
-  | 'for-the-badge'
-  | 'social';
+export const BADGE_STYLES = [
+  'plastic',
+  'flat',
+  'flat-square',
+  'for-the-badge',
+  'social',
+] as const;
+
+export type BadgeStyle = (typeof BADGE_STYLES)[number];
 
 interface Badge {
   color?: string;
@@ -53,6 +56,14 @@ export interface BadgeSpec {
   markdown: string;
 }
 
+export interface BadgeStyleOptions {
+  style?: BadgeStyle;
+  color?: string;
+}
+
 export interface BadgesApi {
-  getEntityBadgeSpecs(entity: Entity): Promise<BadgeSpec[]>;
+  getEntityBadgeSpecs(
+    entity: Entity,
+    bsOptions?: BadgeStyleOptions,
+  ): Promise<BadgeSpec[]>;
 }

--- a/workspaces/badges/plugins/badges/src/components/EntityBadgesDialog.tsx
+++ b/workspaces/badges/plugins/badges/src/components/EntityBadgesDialog.tsx
@@ -23,10 +23,15 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import Typography from '@material-ui/core/Typography';
 import { useTheme } from '@material-ui/core/styles';
-import React from 'react';
+import React, { useState } from 'react';
 import useAsync from 'react-use/esm/useAsync';
-import { badgesApiRef } from '../api';
+import { BadgeStyle, BADGE_STYLES, badgesApiRef } from '../api';
 
 import {
   CodeSnippet,
@@ -45,27 +50,18 @@ export const EntityBadgesDialog = (props: {
   const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const badgesApi = useApi(badgesApiRef);
 
+  const [style, setStyle] = useState<BadgeStyle>();
+
   const {
     value: badges,
     loading,
     error,
   } = useAsync(async () => {
     if (open && entity) {
-      return await badgesApi.getEntityBadgeSpecs(entity);
+      return await badgesApi.getEntityBadgeSpecs(entity, { style });
     }
     return [];
-  }, [badgesApi, entity, open]);
-
-  const content = (badges || []).map(
-    ({ badge: { description }, id, url, markdown }) => (
-      <Box marginTop={4} key={id}>
-        <DialogContentText component="div">
-          <img alt={description || id} src={url} />
-          <CodeSnippet language="markdown" text={markdown} showCopyCodeButton />
-        </DialogContentText>
-      </Box>
-    ),
-  );
+  }, [badgesApi, entity, open, style]);
 
   return (
     <Dialog fullScreen={fullScreen} open={open} onClose={onClose}>
@@ -76,10 +72,50 @@ export const EntityBadgesDialog = (props: {
           the relevant snippet of Markdown code to use the badge.
         </DialogContentText>
 
+        <Typography variant="subtitle1">Select Badge Style</Typography>
+        <FormControl
+          variant="standard"
+          style={{ width: '100%', marginBottom: '16px' }}
+        >
+          <InputLabel id="badge-style-label">Style</InputLabel>
+          <Select
+            labelId="badge-style-label"
+            id="badge-style"
+            value={style}
+            label="Style"
+            onChange={e => setStyle(e.target.value as BadgeStyle)}
+          >
+            <MenuItem value={undefined}>
+              <em>Default</em>
+            </MenuItem>
+            {BADGE_STYLES.map(s => (
+              <MenuItem key={s} value={s}>
+                {s}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
         {loading && <Progress />}
         {error && <ResponseErrorPanel error={error} />}
 
-        {content}
+        {badges && (
+          <>
+            <Typography variant="subtitle1">Badge Previews</Typography>
+            {badges.map(({ badge: { description }, id, url, markdown }) => (
+              <Box marginTop={2} marginBottom={2} key={id}>
+                <DialogContentText component="div">
+                  <img alt={description || id} src={url} />
+                  <CodeSnippet
+                    language="markdown"
+                    text={markdown}
+                    showCopyCodeButton
+                  />
+                </DialogContentText>
+              </Box>
+            ))}
+          </>
+        )}
       </DialogContent>
 
       <DialogActions>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

* Changes in badges-backend
  * Make all APIs to accept `style` and `color` query parameters. This will generate JSON or SVG images with a given style and color.
* Changes in badges
  * Make UI can select the `style` parameter. This will generate previews and markdown codes with a given style. You can check the following video

Note that, my main purpose is to allow customizing badge styles (not colors), so I updated the UI to customize only styles. But if this looks fine, I will raise additional PR to make badge plugin to allow customizing badge colors.

### Preview Video

https://github.com/user-attachments/assets/eda50c63-63c3-47d0-be49-28bd2bdaac01

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Related Issue

Fix #840 