### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/swift-garlics-guess.md
+++ b/workspaces/adr/.changeset/swift-garlics-guess.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Add missing dependency on `@backstage-community/search-backend-module-adr`

--- a/workspaces/adr/.changeset/violet-toys-fix.md
+++ b/workspaces/adr/.changeset/violet-toys-fix.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-common': patch
----
-
-Add missing dependency on `marked`

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.21
+
+### Patch Changes
+
+- 5541765: Add missing dependency on `@backstage-community/search-backend-module-adr`
+- Updated dependencies [5541765]
+  - @backstage-community/plugin-adr-common@0.2.27
+  - @backstage-community/search-backend-module-adr@0.1.2
+
 ## 0.4.20
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.2.27
+
+### Patch Changes
+
+- 5541765: Add missing dependency on `marked`
+
 ## 0.2.26
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-adr
 
+## 0.6.23
+
+### Patch Changes
+
+- Updated dependencies [5541765]
+  - @backstage-community/plugin-adr-common@0.2.27
+
 ## 0.6.22
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [5541765]
+  - @backstage-community/plugin-adr-common@0.2.27
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.6.23

### Patch Changes

-   Updated dependencies [5541765]
    -   @backstage-community/plugin-adr-common@0.2.27

## @backstage-community/plugin-adr-backend@0.4.21

### Patch Changes

-   5541765: Add missing dependency on `@backstage-community/search-backend-module-adr`
-   Updated dependencies [5541765]
    -   @backstage-community/plugin-adr-common@0.2.27
    -   @backstage-community/search-backend-module-adr@0.1.2

## @backstage-community/plugin-adr-common@0.2.27

### Patch Changes

-   5541765: Add missing dependency on `marked`

## @backstage-community/search-backend-module-adr@0.1.2

### Patch Changes

-   Updated dependencies [5541765]
    -   @backstage-community/plugin-adr-common@0.2.27
