### PR TITLE
cli: added @microsoft/api-extractor to package.json when creating a new workspace

### DIFF
--- a/workspaces/repo-tools/.changeset/config.json
+++ b/workspaces/repo-tools/.changeset/config.json
@@ -6,6 +6,5 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "ignore": ["app", "backend"]
+  "updateInternalDependencies": "patch"
 }

--- a/workspaces/repo-tools/.changeset/lovely-crabs-judge.md
+++ b/workspaces/repo-tools/.changeset/lovely-crabs-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/cli': patch
+---
+
+Added @microsoft/api-extractor to resolutions in the package.json file which is created when creating a new workspace using yarn create-workspace

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -44,7 +44,8 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "@microsoft/api-extractor": "7.36.4"
   },
   "prettier": "@spotify/prettier-config",
   "lint-staged": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR adds @microsoft/api-extractor to resolutions in the `package.json` file which is created when creating a new workspace using `yarn create-workspace` 

Fixes: https://github.com/backstage/community-plugins/issues/886 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
