### PR TITLE
Version Packages (3scale)

### DIFF
--- a/workspaces/3scale/.changeset/polite-carrots-arrive.md
+++ b/workspaces/3scale/.changeset/polite-carrots-arrive.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-3scale-backend': patch
----
-
-The 3scale-backend plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

--- a/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
+++ b/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-3scale-backend [1.8.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-3scale-backend@1.7.1...@janus-idp/backstage-plugin-3scale-backend@1.8.0) (2024-07-25)
 
+## 1.8.1
+
+### Patch Changes
+
+- 3f259e2: The 3scale-backend plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
+
 ### Features
 
 - **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))

--- a/workspaces/3scale/plugins/3scale-backend/package.json
+++ b/workspaces/3scale/plugins/3scale-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-3scale-backend",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-3scale-backend@1.8.1

### Patch Changes

-   3f259e2: The 3scale-backend plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/3scale-backend) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

### Features

-   **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))

### Dependencies

-   **@janus-idp/cli:** upgraded to 1.13.0
