### PR TITLE
[Community Plugin Maintainers] Added `project-id` to get PR sync working

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,4 +29,5 @@ jobs:
           app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
           private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
           installation-id: ${{ secrets.BACKSTAGE_GOALIE_INSTALLATION_ID }}
+          project-id: PVT_kwDOBFKqdc4AmjVD
           auto-assign: false


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `project-id` to get PR sync working. With this in place it will begin to populate the "[Community Plugins - Pull Request Reviews](https://github.com/orgs/backstage/projects/9/views/1)" Project Board. Access to this board is provided to all Backstage Org Members.

Once this is fully in place it should help us better keep track of reviews.

Note: to find the `project-id` I needed to use `https://api.github.com/graphql` with the following query:

```graphql
{
  organization(login: "backstage") {
    projectsV2(first: 100) {
      edges {
        node {
          id
          title
        }
      }
    }
  }
}
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
