### PR TITLE
scripts(check-if-release): add optional branch env variable to script

### DIFF
--- a/scripts/ci/check-if-release.js
+++ b/scripts/ci/check-if-release.js
@@ -34,6 +34,7 @@ import * as url from 'url';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
 const parentRef = process.env.COMMIT_SHA_BEFORE || 'HEAD^';
+const targetBranch = process.env.TARGET_BRANCH || 'main';
 
 const execFile = promisify(execFileCb);
 
@@ -66,11 +67,14 @@ async function main() {
     throw new Error('GITHUB_OUTPUT environment variable not set');
   }
 
+  // Ensure we have fetched the targetBranch
+  await runPlain('git', 'fetch', 'origin', targetBranch);
+
   const diff = await runPlain(
     'git',
     'diff',
     '--name-only',
-    parentRef,
+    `${targetBranch}..${parentRef}`,
     "'*/package.json'", // Git treats this as what would usually be **/package.json
   );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This allows the script to handle an optional branch to `check-if-release` script to run releases on separate branches where necessary. This is a step towards a workflow to support https://github.com/backstage/community-plugins/issues/860. 

This should not cause any breakages because it will default to `main` otherwise.

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
