### PR TITLE
add navItem extension for tech radar alpha FE plugin

### DIFF
--- a/workspaces/tech-radar/.changeset/eight-insects-listen.md
+++ b/workspaces/tech-radar/.changeset/eight-insects-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-radar': patch
+---
+
+Add navbar item to the alpha version of FE plugin

--- a/workspaces/tech-radar/plugins/tech-radar/api-report-alpha.md
+++ b/workspaces/tech-radar/plugins/tech-radar/api-report-alpha.md
@@ -20,6 +20,11 @@ export default _default;
 export const techRadarApi: ExtensionDefinition<{}>;
 
 // @alpha (undocumented)
+export const techRadarNavItem: ExtensionDefinition<{
+  title: string;
+}>;
+
+// @alpha (undocumented)
 export const techRadarPage: ExtensionDefinition<{
   height: number;
   width: number;

--- a/workspaces/tech-radar/plugins/tech-radar/src/alpha.tsx
+++ b/workspaces/tech-radar/plugins/tech-radar/src/alpha.tsx
@@ -17,6 +17,7 @@
 import { createApiFactory } from '@backstage/core-plugin-api';
 import {
   createApiExtension,
+  createNavItemExtension,
   createPageExtension,
   createPlugin,
   createSchemaFromZod,
@@ -29,7 +30,15 @@ import {
   convertLegacyRouteRef,
   convertLegacyRouteRefs,
 } from '@backstage/core-compat-api';
+import MapIcon from '@material-ui/icons/MyLocation';
 import { rootRouteRef } from './plugin';
+
+/** @alpha */
+export const techRadarNavItem = createNavItemExtension({
+  icon: MapIcon,
+  routeRef: convertLegacyRouteRef(rootRouteRef),
+  title: 'Tech Radar',
+});
 
 /** @alpha */
 export const techRadarPage = createPageExtension({
@@ -61,7 +70,7 @@ export const techRadarApi = createApiExtension({
 /** @alpha */
 export default createPlugin({
   id: 'tech-radar',
-  extensions: [techRadarPage, techRadarApi],
+  extensions: [techRadarPage, techRadarApi, techRadarNavItem],
   routes: convertLegacyRouteRefs({
     root: rootRouteRef,
   }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ensure that when using the new frontend system, importing the tech radar plugin includes a sidebar nav item that redirects to the plugin page

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
