### PR TITLE
Add default 'component' filters to plugins using new FE system

### DIFF
--- a/workspaces/github-actions/.changeset/silly-birds-clean.md
+++ b/workspaces/github-actions/.changeset/silly-birds-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-actions': patch
+---
+
+Make entity cards/content appear on Components only by default in new FE system

--- a/workspaces/github-actions/examples/entities.yaml
+++ b/workspaces/github-actions/examples/entities.yaml
@@ -41,6 +41,8 @@ apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
   name: example-grpc-api
+  annotations:
+    github.com/project-slug: 'backstage/backstage'
 spec:
   type: grpc
   lifecycle: experimental

--- a/workspaces/github-actions/plugins/github-actions/README.md
+++ b/workspaces/github-actions/plugins/github-actions/README.md
@@ -115,7 +115,8 @@ export const app = createApp({
 });
 ```
 
-2. Next, enable your desired extensions in `app-config.yaml`
+2. Next, enable your desired extensions in `app-config.yaml`. By default, the content and cards will only appear on entities
+   that are Components. You can override that behavior here by adding a config block, demonstrated on the 'recent-workflow' card.
 
 ```yaml
 app:
@@ -123,7 +124,9 @@ app:
     - entity-content:github-actions/entity
     - entity-card:github-actions/latest-workflow-run
     - entity-card:github-actions/latest-branch-workflow-runs
-    - entity-card:github-actions/recent-workflow-runs
+    - entity-card:github-actions/recent-workflow-runs:
+        config:
+          filter: kind:component,api,group
 ```
 
 3. Whichever extensions you've enabled should now appear in your entity page.

--- a/workspaces/github-actions/plugins/github-actions/src/alpha/entityCards.tsx
+++ b/workspaces/github-actions/plugins/github-actions/src/alpha/entityCards.tsx
@@ -7,6 +7,7 @@ import { createEntityCardExtension } from '@backstage/plugin-catalog-react/alpha
  */
 export const entityGithubActionsCard = createEntityCardExtension({
   name: 'workflow-runs',
+  filter: 'kind:component',
   loader: () =>
     import('../components/Router').then(m => <m.Router view="cards" />),
 });
@@ -16,6 +17,7 @@ export const entityGithubActionsCard = createEntityCardExtension({
  */
 export const entityLatestGithubActionRunCard = createEntityCardExtension({
   name: 'latest-workflow-run',
+  filter: 'kind:component',
   configSchema: createSchemaFromZod(z =>
     z.object({
       props: z
@@ -38,6 +40,7 @@ export const entityLatestGithubActionRunCard = createEntityCardExtension({
 export const entityLatestGithubActionsForBranchCard = createEntityCardExtension(
   {
     name: 'latest-branch-workflow-runs',
+    filter: 'kind:component',
     configSchema: createSchemaFromZod(z =>
       z.object({
         props: z
@@ -60,6 +63,7 @@ export const entityLatestGithubActionsForBranchCard = createEntityCardExtension(
  */
 export const entityRecentGithubActionsRunsCard = createEntityCardExtension({
   name: 'recent-workflow-runs',
+  filter: 'kind:component',
   configSchema: createSchemaFromZod(z =>
     z.object({
       props: z

--- a/workspaces/github-actions/plugins/github-actions/src/alpha/entityContent.tsx
+++ b/workspaces/github-actions/plugins/github-actions/src/alpha/entityContent.tsx
@@ -10,6 +10,7 @@ export const entityGithubActionsContent = createEntityContentExtension({
   defaultPath: 'github-actions',
   defaultTitle: 'GitHub Actions',
   name: 'entity',
+  filter: 'kind:component',
   routeRef: convertLegacyRouteRef(rootRouteRef),
   loader: () =>
     import('../components/Router').then(m => <m.Router view="table" />),

--- a/workspaces/grafana/.changeset/modern-zoos-count.md
+++ b/workspaces/grafana/.changeset/modern-zoos-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': patch
+---
+
+Make entity cards appear on Components only by default in new FE system

--- a/workspaces/grafana/plugins/grafana/docs/alerts-on-component-page.md
+++ b/workspaces/grafana/plugins/grafana/docs/alerts-on-component-page.md
@@ -54,3 +54,35 @@ annotations:
 ```
 
 The `EntityGrafanaAlertsCard` component will then display alerts matching the given tag.
+
+### Integrating with `EntityPage` (New Frontend System)
+
+Follow this section if you are using Backstage's [new frontend system](https://backstage.io/docs/frontend-system/).
+
+1. Import `grafanaPlugin` in your `App.tsx` and add it to your app's `features` array:
+
+```typescript
+import grafanaPlugin from '@backstage-community/plugin-grafana/alpha';
+
+// ...
+
+export const app = createApp({
+  features: [
+    // ...
+    grafanaPlugin,
+    // ...
+  ],
+});
+```
+
+2. Next, enable the desired extension in `app-config.yaml`. By default, the cards will only appear on entities
+   that are Components. You can override that behavior here by adding a config block, demonstrated below.
+
+```yaml
+app:
+  extensions:
+    - entity-card:grafana/alerts # can omit the config to keep the default behavior
+    - entity-card:grafana/alerts:
+        config:
+          filter: kind:component,api,group
+```

--- a/workspaces/grafana/plugins/grafana/docs/dashboards-on-component-page.md
+++ b/workspaces/grafana/plugins/grafana/docs/dashboards-on-component-page.md
@@ -67,3 +67,35 @@ Note that the `tags @> "my-service"` selector can be simplified as:
 annotations:
   grafana/dashboard-selector: my-service
 ```
+
+### Integrating with `EntityPage` (New Frontend System)
+
+Follow this section if you are using Backstage's [new frontend system](https://backstage.io/docs/frontend-system/).
+
+1. Import `grafanaPlugin` in your `App.tsx` and add it to your app's `features` array:
+
+```typescript
+import grafanaPlugin from '@backstage-community/plugin-grafana/alpha';
+
+// ...
+
+export const app = createApp({
+  features: [
+    // ...
+    grafanaPlugin,
+    // ...
+  ],
+});
+```
+
+2. Next, enable the desired extension in `app-config.yaml`. By default, the cards will only appear on entities
+   that are Components. You can override that behavior here by adding a config block, demonstrated below.
+
+```yaml
+app:
+  extensions:
+    - entity-card:grafana/dashboards # can omit the config to keep the default behavior
+    - entity-card:grafana/dashboards:
+        config:
+          filter: kind:component,api,group
+```

--- a/workspaces/grafana/plugins/grafana/docs/embed-dashboards-on-page.md
+++ b/workspaces/grafana/plugins/grafana/docs/embed-dashboards-on-page.md
@@ -53,3 +53,35 @@ spec:
 > This can be done by setting [`allow_embedding=true`](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#allow_embedding) and [`cookie_samesite=none`](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#cookie_samesite) in your `grafana.ini` configuration file.
 >
 > Only change these settings if you fully understand and accept the risks.
+
+### Integrating with `EntityPage` (New Frontend System)
+
+Follow this section if you are using Backstage's [new frontend system](https://backstage.io/docs/frontend-system/).
+
+1. Import `grafanaPlugin` in your `App.tsx` and add it to your app's `features` array:
+
+```typescript
+import grafanaPlugin from '@backstage-community/plugin-grafana/alpha';
+
+// ...
+
+export const app = createApp({
+  features: [
+    // ...
+    grafanaPlugin,
+    // ...
+  ],
+});
+```
+
+2. Next, enable the desired extension in `app-config.yaml`. By default, the cards will only appear on entities
+   that are Components. You can override that behavior here by adding a config block, demonstrated below.
+
+```yaml
+app:
+  extensions:
+    - entity-card:grafana/overview-dashboard # can omit the config to keep the default behavior
+    - entity-card:grafana/overview-dashboard:
+        config:
+          filter: kind:component,api,group
+```

--- a/workspaces/grafana/plugins/grafana/src/alpha/entityCards.tsx
+++ b/workspaces/grafana/plugins/grafana/src/alpha/entityCards.tsx
@@ -6,6 +6,7 @@ import { createEntityCardExtension } from '@backstage/plugin-catalog-react/alpha
  */
 export const entityGrafanaDashboardsCard = createEntityCardExtension({
   name: 'dashboards',
+  filter: 'kind:component',
   loader: () =>
     import('../components/DashboardsCard').then(m => <m.DashboardsCard />),
 });
@@ -15,6 +16,7 @@ export const entityGrafanaDashboardsCard = createEntityCardExtension({
  */
 export const entityGrafanaAlertsCard = createEntityCardExtension({
   name: 'alerts',
+  filter: 'kind:component',
   loader: () => import('../components/AlertsCard').then(m => <m.AlertsCard />),
 });
 
@@ -23,6 +25,7 @@ export const entityGrafanaAlertsCard = createEntityCardExtension({
  */
 export const entityGrafanaOverviewDashboardViewer = createEntityCardExtension({
   name: 'overview-dashboard',
+  filter: 'kind:component',
   loader: () =>
     import('../components/DashboardViewer').then(m => (
       <m.EntityDashboardViewer />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up from portal compatibility work, ensure the plugins using the [new FE system](https://backstage.io/docs/frontend-system/) include a filter to publish their entity cards/content to components only by default. This can be overridden.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
