### PR TITLE
Add query parameter to confluence collator plugin

### DIFF
--- a/workspaces/confluence/.changeset/khaki-lizards-tickle.md
+++ b/workspaces/confluence/.changeset/khaki-lizards-tickle.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Add query parameter that allows providing a CQL query that is combined with spaces to more finely select the documents to index

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -36,7 +36,7 @@ backend.start();
 
 Before you are able to start index confluence spaces to search, you need to go through the [search getting started guide](https://backstage.io/docs/features/search/getting-started).
 
-When you have your `packages/backend/src/plugins/search.ts` file ready to make modifications, add the following code snippet to add the `ConfluenceCollatorFactory`. Note that you can optionally modify the `spaces`, otherwise it will resolve and index **all** spaces authorized by the token.
+When you have your `packages/backend/src/plugins/search.ts` file ready to make modifications, add the following code snippet to add the `ConfluenceCollatorFactory`. Note that you can optionally modify the `spaces` or `query`, otherwise it will resolve and index **all** spaces and documents authorized by the token.
 
 ```ts
 indexBuilder.addCollator({
@@ -62,6 +62,7 @@ confluence:
   auth:
     token: '${CONFLUENCE_TOKEN}'
   spaces: [] # Warning, it is highly recommended to safely list the spaces that you want to index, either all documents will be indexed.
+  query: '' # If your spaces contain documents you don't want to index, you can use a CQL query to more precisely select them. This is combined with the spaces parameter above
 ```
 
 The sections below will go into more details about the Base URL and Auth Methods.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -57,6 +57,10 @@ export interface Config {
      */
     spaces?: string[];
     /**
+     * CQL query to select the pages to index. It is combined with spaces parameter above when finding documents.
+     */
+    query?: string;
+    /**
      * An abstract value that controls the concurrency level of the
      * collation process. Increasing this value will both increase the
      * number of entities fetched at a time from the catalog, as well as how


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In order to allow more precise selection of documents, introduce a `query` parameter that allows users to provide a CQL query to the plugin. When provided this parameter is combined with the `spaces` parameter to more accurately select the documents to index from a given confluence instance.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
