### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/silly-birds-clean.md
+++ b/workspaces/github-actions/.changeset/silly-birds-clean.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Make entity cards/content appear on Components only by default in new FE system

--- a/workspaces/github-actions/packages/app-next/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app-next
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [a0591d5]
+  - @backstage-community/plugin-github-actions@0.6.21
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/github-actions/packages/app-next/package.json
+++ b/workspaces/github-actions/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/packages/app/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [a0591d5]
+  - @backstage-community/plugin-github-actions@0.6.21
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/github-actions/packages/app/package.json
+++ b/workspaces/github-actions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.6.21
+
+### Patch Changes
+
+- a0591d5: Make entity cards/content appear on Components only by default in new FE system
+
 ## 0.6.20
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.6.21

### Patch Changes

-   a0591d5: Make entity cards/content appear on Components only by default in new FE system

## app@0.0.4

### Patch Changes

-   Updated dependencies [a0591d5]
    -   @backstage-community/plugin-github-actions@0.6.21

## app-next@0.0.4

### Patch Changes

-   Updated dependencies [a0591d5]
    -   @backstage-community/plugin-github-actions@0.6.21
