### PR TITLE
Bumped renovate-changesets version

### DIFF
--- a/.github/workflows/automate_renovate_changesets.yml
+++ b/.github/workflows/automate_renovate_changesets.yml
@@ -28,6 +28,6 @@ jobs:
           git config --global user.name 'Github changeset workflow'
 
       - name: Generate feedback
-        uses: backstage/actions/renovate-changesets@v0.6.10
+        uses: backstage/actions/renovate-changesets@v0.6.13
         with:
           multiple-workspaces: true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumped renovate-changesets version as this newer version will not add changesets to private packages like `app` and `backend` that some of the workspaces have for their example app.

Here's an example this update would help us avoid: https://github.com/backstage/community-plugins/pull/830

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
