### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/rotten-starfishes-marry.md
+++ b/workspaces/azure-devops/.changeset/rotten-starfishes-marry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
----
-
-Removed code marked as deprecated in the upstream Backstage project

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [968258f]
+  - @backstage-community/plugin-azure-devops-backend@0.6.10
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.6.10
+
+### Patch Changes
+
+- 968258f: Removed code marked as deprecated in the upstream Backstage project
+
 ## 0.6.9
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops-backend@0.6.10

### Patch Changes

-   968258f: Removed code marked as deprecated in the upstream Backstage project

## backend@0.0.5

### Patch Changes

-   Updated dependencies [968258f]
    -   @backstage-community/plugin-azure-devops-backend@0.6.10
