### PR TITLE
Fix tool provider extension point

### DIFF
--- a/workspaces/explore/.changeset/calm-dolphins-admire.md
+++ b/workspaces/explore/.changeset/calm-dolphins-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore-backend': patch
+---
+
+Fix tool provider extension point

--- a/workspaces/explore/plugins/explore-backend/src/plugin.ts
+++ b/workspaces/explore/plugins/explore-backend/src/plugin.ts
@@ -37,7 +37,7 @@ export const explorePlugin = createBackendPlugin({
 
     env.registerExtensionPoint(toolProviderExtensionPoint, {
       setToolProvider(provider) {
-        if (provider) {
+        if (toolProvider) {
           throw new Error('The tool provider has been already set');
         }
         toolProvider = provider;


### PR DESCRIPTION
Signed-off-by: Jonathan Mezach <jonathan.mezach@rr-wfm.com>

## Hey, I just made a Pull Request!

This fixes the tool provider extension point for the explore-backend plugin so that you can now actually change the tool provider.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [-] Tests for new functionality and regression tests for bug fixes
- [-] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
