### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/renovate-a22d50c.md
+++ b/workspaces/adr/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.22
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.4.21
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.4.22

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
