### PR TITLE
Version Packages (periskop)

### DIFF
--- a/workspaces/periskop/.changeset/renovate-a22d50c.md
+++ b/workspaces/periskop/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-periskop-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
+++ b/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-periskop-backend
 
+## 0.2.18
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.2.17
 
 ### Patch Changes

--- a/workspaces/periskop/plugins/periskop-backend/package.json
+++ b/workspaces/periskop/plugins/periskop-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-periskop-backend",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "periskop",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-periskop-backend@0.2.18

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
