### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/renovate-a22d50c.md
+++ b/workspaces/code-coverage/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.2.34
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.2.33
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage-backend@0.2.34

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
