### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/renovate-a22d50c.md
+++ b/workspaces/kafka/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kafka-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kafka-backend
 
+## 0.3.18
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.3.17
 
 ### Patch Changes

--- a/workspaces/kafka/plugins/kafka-backend/package.json
+++ b/workspaces/kafka/plugins/kafka-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka-backend",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "A Backstage backend plugin that integrates towards Kafka",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka-backend@0.3.18

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
