### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/renovate-a22d50c.md
+++ b/workspaces/rollbar/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rollbar-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.1.65
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.1.64
 
 ### Patch Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar-backend@0.1.65

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
