### PR TITLE
Version Packages (todo)

### DIFF
--- a/workspaces/todo/.changeset/renovate-a22d50c.md
+++ b/workspaces/todo/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-todo-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/todo/plugins/todo-backend/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-todo-backend
 
+## 0.3.19
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.3.18
 
 ### Patch Changes

--- a/workspaces/todo/plugins/todo-backend/package.json
+++ b/workspaces/todo/plugins/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo-backend",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-todo-backend@0.3.19

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
