### PR TITLE
Version Packages (airbrake)

### DIFF
--- a/workspaces/airbrake/.changeset/renovate-a22d50c.md
+++ b/workspaces/airbrake/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-airbrake-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
+++ b/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-airbrake-backend
 
+## 0.3.17
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.3.16
 
 ### Patch Changes

--- a/workspaces/airbrake/plugins/airbrake-backend/package.json
+++ b/workspaces/airbrake/plugins/airbrake-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-airbrake-backend",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-airbrake-backend@0.3.17

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.
