### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/renovate-a22d50c.md
+++ b/workspaces/linkerd/.changeset/renovate-a22d50c.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [ae2ee8a]
+  - @backstage-community/plugin-linkerd-backend@0.3.3
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.3.3
+
+### Patch Changes
+
+- ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
+  Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd-backend@0.3.3

### Patch Changes

-   ae2ee8a: Updated dependency `@types/supertest` to `^6.0.0`.
    Updated dependency `supertest` to `^7.0.0`.

## backend@0.0.8

### Patch Changes

-   Updated dependencies [ae2ee8a]
    -   @backstage-community/plugin-linkerd-backend@0.3.3
