### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/version-bump-1-30-2.md
+++ b/workspaces/linguist/.changeset/version-bump-1-30-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
-'@backstage-community/plugin-linguist': patch
-'@backstage-community/plugin-linguist-backend': patch
-'@backstage-community/plugin-linguist-common': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [6021ae7]
+  - @backstage-community/plugin-linguist@0.1.25
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [6021ae7]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.5
+  - @backstage-community/plugin-linguist-backend@0.5.23
+  - app@0.0.5
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.1.5
+
+### Patch Changes
+
+- 6021ae7: Backstage version bump to v1.30.2
+- Updated dependencies [6021ae7]
+  - @backstage-community/plugin-linguist-common@0.1.8
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.5.23
+
+### Patch Changes
+
+- 6021ae7: Backstage version bump to v1.30.2
+- Updated dependencies [6021ae7]
+  - @backstage-community/plugin-linguist-common@0.1.8
+
 ## 0.5.22
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.1.8
+
+### Patch Changes
+
+- 6021ae7: Backstage version bump to v1.30.2
+
 ## 0.1.7
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist
 
+## 0.1.25
+
+### Patch Changes
+
+- 6021ae7: Backstage version bump to v1.30.2
+- Updated dependencies [6021ae7]
+  - @backstage-community/plugin-linguist-common@0.1.8
+
 ## 0.1.24
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.5

### Patch Changes

-   6021ae7: Backstage version bump to v1.30.2
-   Updated dependencies [6021ae7]
    -   @backstage-community/plugin-linguist-common@0.1.8

## @backstage-community/plugin-linguist@0.1.25

### Patch Changes

-   6021ae7: Backstage version bump to v1.30.2
-   Updated dependencies [6021ae7]
    -   @backstage-community/plugin-linguist-common@0.1.8

## @backstage-community/plugin-linguist-backend@0.5.23

### Patch Changes

-   6021ae7: Backstage version bump to v1.30.2
-   Updated dependencies [6021ae7]
    -   @backstage-community/plugin-linguist-common@0.1.8

## @backstage-community/plugin-linguist-common@0.1.8

### Patch Changes

-   6021ae7: Backstage version bump to v1.30.2

## app@0.0.5

### Patch Changes

-   Updated dependencies [6021ae7]
    -   @backstage-community/plugin-linguist@0.1.25

## backend@0.0.8

### Patch Changes

-   Updated dependencies [6021ae7]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.1.5
    -   @backstage-community/plugin-linguist-backend@0.5.23
    -   app@0.0.5
