### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/version-bump-1-30-2.md
+++ b/workspaces/azure-devops/.changeset/version-bump-1-30-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [b6515fa]
+  - @backstage-community/plugin-azure-devops@0.4.9
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [b6515fa]
+  - @backstage-community/plugin-azure-devops-backend@0.6.12
+  - @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.0.4
+  - app@0.0.5
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.6.12
+
+### Patch Changes
+
+- b6515fa: Backstage version bump to v1.30.2
+- Updated dependencies [b6515fa]
+  - @backstage-community/plugin-azure-devops-common@0.4.7
+
 ## 0.6.11
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.4.7
+
+### Patch Changes
+
+- b6515fa: Backstage version bump to v1.30.2
+
 ## 0.4.6
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.4.9
+
+### Patch Changes
+
+- b6515fa: Backstage version bump to v1.30.2
+- Updated dependencies [b6515fa]
+  - @backstage-community/plugin-azure-devops-common@0.4.7
+
 ## 0.4.8
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.0.4
+
+### Patch Changes
+
+- b6515fa: Backstage version bump to v1.30.2
+- Updated dependencies [b6515fa]
+  - @backstage-community/plugin-azure-devops-common@0.4.7
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.4.9

### Patch Changes

-   b6515fa: Backstage version bump to v1.30.2
-   Updated dependencies [b6515fa]
    -   @backstage-community/plugin-azure-devops-common@0.4.7

## @backstage-community/plugin-azure-devops-backend@0.6.12

### Patch Changes

-   b6515fa: Backstage version bump to v1.30.2
-   Updated dependencies [b6515fa]
    -   @backstage-community/plugin-azure-devops-common@0.4.7

## @backstage-community/plugin-azure-devops-common@0.4.7

### Patch Changes

-   b6515fa: Backstage version bump to v1.30.2

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.0.4

### Patch Changes

-   b6515fa: Backstage version bump to v1.30.2
-   Updated dependencies [b6515fa]
    -   @backstage-community/plugin-azure-devops-common@0.4.7

## app@0.0.5

### Patch Changes

-   Updated dependencies [b6515fa]
    -   @backstage-community/plugin-azure-devops@0.4.9

## backend@0.0.7

### Patch Changes

-   Updated dependencies [b6515fa]
    -   @backstage-community/plugin-azure-devops-backend@0.6.12
    -   @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.0.4
    -   app@0.0.5
