### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/version-bump-1-30-2.md
+++ b/workspaces/cicd-statistics/.changeset/version-bump-1-30-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics': patch
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.1.33
+
+### Patch Changes
+
+- 8662d09: Backstage version bump to v1.30.2
+- Updated dependencies [8662d09]
+  - @backstage-community/plugin-cicd-statistics@0.1.39
+
 ## 0.1.32
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.1.39
+
+### Patch Changes
+
+- 8662d09: Backstage version bump to v1.30.2
+
 ## 0.1.38
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.1.39

### Patch Changes

-   8662d09: Backstage version bump to v1.30.2

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.33

### Patch Changes

-   8662d09: Backstage version bump to v1.30.2
-   Updated dependencies [8662d09]
    -   @backstage-community/plugin-cicd-statistics@0.1.39
