### PR TITLE
Version Packages (3scale)

### DIFF
--- a/workspaces/3scale/.changeset/renovate-58a3982.md
+++ b/workspaces/3scale/.changeset/renovate-58a3982.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-3scale-backend': patch
----
-
-Updated dependency `@types/supertest` to `6.0.2`.
-Updated dependency `supertest` to `7.0.0`.

--- a/workspaces/3scale/.changeset/version-bump-1-30-2.md
+++ b/workspaces/3scale/.changeset/version-bump-1-30-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-3scale-backend': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
+++ b/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @janus-idp/backstage-plugin-3scale-backend [1.8.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-3scale-backend@1.7.1...@janus-idp/backstage-plugin-3scale-backend@1.8.0) (2024-07-25)
 
+## 1.8.3
+
+### Patch Changes
+
+- 235f5f4: Updated dependency `@types/supertest` to `6.0.2`.
+  Updated dependency `supertest` to `7.0.0`.
+- 0df0ae0: Backstage version bump to v1.30.2
+
 ## 1.8.2
 
 ### Patch Changes

--- a/workspaces/3scale/plugins/3scale-backend/package.json
+++ b/workspaces/3scale/plugins/3scale-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-3scale-backend",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-3scale-backend@1.8.3

### Patch Changes

-   235f5f4: Updated dependency `@types/supertest` to `6.0.2`.
    Updated dependency `supertest` to `7.0.0`.
-   0df0ae0: Backstage version bump to v1.30.2
