### PR TITLE
Version Packages (feedback)

### DIFF
--- a/workspaces/feedback/.changeset/odd-clocks-study.md
+++ b/workspaces/feedback/.changeset/odd-clocks-study.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-feedback-backend': patch
-'@backstage-community/plugin-feedback': patch
----
-
-The feedback and feedback-backend plugins from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) repository was migrated to the community plugins, based on commit a8fe67c2. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

--- a/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-feedback-backend [1.7.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.6.0...@janus-idp/backstage-plugin-feedback-backend@1.7.0) (2024-07-26)
 
+## 1.7.1
+
+### Patch Changes
+
+- 4827a7f: The feedback and feedback-backend plugins from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) repository was migrated to the community plugins, based on commit a8fe67c2. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
+
 ### Features
 
 - **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-backend",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/feedback/plugins/feedback/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-feedback [1.6.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback@1.5.0...@janus-idp/backstage-plugin-feedback@1.6.0) (2024-07-26)
 
+## 1.6.1
+
+### Patch Changes
+
+- 4827a7f: The feedback and feedback-backend plugins from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) repository was migrated to the community plugins, based on commit a8fe67c2. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
+
 ### Features
 
 - **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))

--- a/workspaces/feedback/plugins/feedback/package.json
+++ b/workspaces/feedback/plugins/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-feedback@1.6.1

### Patch Changes

-   4827a7f: The feedback and feedback-backend plugins from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) repository was migrated to the community plugins, based on commit a8fe67c2. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

### Features

-   **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))

## @backstage-community/plugin-feedback-backend@1.7.1

### Patch Changes

-   4827a7f: The feedback and feedback-backend plugins from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) repository was migrated to the community plugins, based on commit a8fe67c2. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

### Features

-   **deps:** update to backstage 1.29 ([#1900](https://github.com/janus-idp/backstage-plugins/issues/1900)) ([f53677f](https://github.com/janus-idp/backstage-plugins/commit/f53677fb02d6df43a9de98c43a9f101a6db76802))
