### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/version-bump-1-30-2.md
+++ b/workspaces/adr/.changeset/version-bump-1-30-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr-common': patch
-'@backstage-community/search-backend-module-adr': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.23
+
+### Patch Changes
+
+- f18c579: Backstage version bump to v1.30.2
+- Updated dependencies [f18c579]
+  - @backstage-community/plugin-adr-common@0.2.28
+  - @backstage-community/search-backend-module-adr@0.1.3
+
 ## 0.4.22
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.2.28
+
+### Patch Changes
+
+- f18c579: Backstage version bump to v1.30.2
+
 ## 0.2.27
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.6.24
+
+### Patch Changes
+
+- f18c579: Backstage version bump to v1.30.2
+- Updated dependencies [f18c579]
+  - @backstage-community/plugin-adr-common@0.2.28
+
 ## 0.6.23
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.1.3
+
+### Patch Changes
+
+- f18c579: Backstage version bump to v1.30.2
+- Updated dependencies [f18c579]
+  - @backstage-community/plugin-adr-common@0.2.28
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.6.24

### Patch Changes

-   f18c579: Backstage version bump to v1.30.2
-   Updated dependencies [f18c579]
    -   @backstage-community/plugin-adr-common@0.2.28

## @backstage-community/plugin-adr-backend@0.4.23

### Patch Changes

-   f18c579: Backstage version bump to v1.30.2
-   Updated dependencies [f18c579]
    -   @backstage-community/plugin-adr-common@0.2.28
    -   @backstage-community/search-backend-module-adr@0.1.3

## @backstage-community/plugin-adr-common@0.2.28

### Patch Changes

-   f18c579: Backstage version bump to v1.30.2

## @backstage-community/search-backend-module-adr@0.1.3

### Patch Changes

-   f18c579: Backstage version bump to v1.30.2
-   Updated dependencies [f18c579]
    -   @backstage-community/plugin-adr-common@0.2.28
