### PR TITLE
Version Packages (gcalendar)

### DIFF
--- a/workspaces/gcalendar/.changeset/version-bump-1-30-2.md
+++ b/workspaces/gcalendar/.changeset/version-bump-1-30-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gcalendar': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
+++ b/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gcalendar
 
+## 0.3.30
+
+### Patch Changes
+
+- 43850c7: Backstage version bump to v1.30.2
+
 ## 0.3.29
 
 ### Patch Changes

--- a/workspaces/gcalendar/plugins/gcalendar/package.json
+++ b/workspaces/gcalendar/plugins/gcalendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gcalendar",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gcalendar@0.3.30

### Patch Changes

-   43850c7: Backstage version bump to v1.30.2
