### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/version-bump-1-30-2.md
+++ b/workspaces/azure-sites/.changeset/version-bump-1-30-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-sites': patch
-'@backstage-community/plugin-azure-sites-backend': patch
-'@backstage-community/plugin-azure-sites-common': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.3.8
+
+### Patch Changes
+
+- 558cdfd: Backstage version bump to v1.30.2
+- Updated dependencies [558cdfd]
+  - @backstage-community/plugin-azure-sites-common@0.1.6
+
 ## 0.3.7
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-common
 
+## 0.1.6
+
+### Patch Changes
+
+- 558cdfd: Backstage version bump to v1.30.2
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-common/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-common",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Common functionalities for the azure plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites
 
+## 0.1.26
+
+### Patch Changes
+
+- 558cdfd: Backstage version bump to v1.30.2
+- Updated dependencies [558cdfd]
+  - @backstage-community/plugin-azure-sites-common@0.1.6
+
 ## 0.1.25
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-sites",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites@0.1.26

### Patch Changes

-   558cdfd: Backstage version bump to v1.30.2
-   Updated dependencies [558cdfd]
    -   @backstage-community/plugin-azure-sites-common@0.1.6

## @backstage-community/plugin-azure-sites-backend@0.3.8

### Patch Changes

-   558cdfd: Backstage version bump to v1.30.2
-   Updated dependencies [558cdfd]
    -   @backstage-community/plugin-azure-sites-common@0.1.6

## @backstage-community/plugin-azure-sites-common@0.1.6

### Patch Changes

-   558cdfd: Backstage version bump to v1.30.2
