### PR TITLE
chore(deps): update renovate.json - pin to typescript ~5.3.0, not 5.5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,10 @@
       "allowedVersions": "<3.0.0"
     },
     {
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "~5.3.0"
+    },
+    {
       "matchPackageNames": ["yn"],
       "allowedVersions": "<5.0.0"
     }


### PR DESCRIPTION
cc: @Rugvip

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

For context, this change is proposed based on [conversation in the Community SIG](https://docs.google.com/document/d/1lIHXi8fi3CDiUD8UhX7s1FWCKAiricQKnFR4OSHoaiY/edit) about rejecting this renovate update: https://github.com/backstage/community-plugins/pull/824
