### PR TITLE
ci(release_workspace): ensure commit that triggered the workflow is f…

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -76,6 +76,10 @@ jobs:
       - name: Fetch previous commit for release check
         run: git fetch origin '${{ github.event.before }}'
 
+      - name: Fetch the commit that triggered the workflow (used by backstage/changesets-action)
+        run: git fetch origin ${{ github.sha }}
+        continue-on-error: true
+
       - name: Check if release
         id: release_check
         if: inputs.force_release != true


### PR DESCRIPTION
…etched

## Hey, I just made a Pull Request!

Should fix https://github.com/backstage/community-plugins/issues/1049#issuecomment-2312840489.

> For example, in the following failed run: https://github.com/backstage/community-plugins/actions/runs/10539750276/job/29203660661, the checkout action is checking out https://github.com/backstage/community-plugins/commit/588887c0f4869335428b22f402061ad68848d74a, but the changesets-action is trying to create a branch from https://github.com/backstage/community-plugins/commit/d5c3ebfaa90628f98f471d275f4b0b041bf32590, which seems to be the correct one.

The error is:
```console
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
/usr/bin/git checkout changesets-release/firehydrant
error: pathspec 'changesets-release/firehydrant' did not match any file(s) known to git
/usr/bin/git checkout -b changesets-release/firehydrant
Switched to a new branch 'changesets-release/firehydrant'
/usr/bin/git reset --hard d5c3ebfaa90628f98f471d275f4b0b041bf32590
fatal: Could not parse object 'd5c3ebfaa90628f98f471d275f4b0b041bf32590'.
```
Which I believe comes from the [`await gitUtils.reset(github.context.sha);`](https://github.com/backstage/changesets-action/blob/069a0a4ac972a361af23eb95b70c3e6681745549/src/run.ts#L202-L203) in `backstage/changesets-action`.

Adding an explicit fetch for `github.context.sha` should ensure we can always reset to the commit that triggered the workflow.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
