### PR TITLE
Version Packages (badges)

### DIFF
--- a/workspaces/badges/.changeset/grumpy-coats-walk.md
+++ b/workspaces/badges/.changeset/grumpy-coats-walk.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-badges-backend': patch
----
-
-Removed deprecated `tokenManager` and `identity` in favor of new auth services

--- a/workspaces/badges/plugins/badges-backend/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges-backend
 
+## 0.5.1
+
+### Patch Changes
+
+- bdf5b08: Removed deprecated `tokenManager` and `identity` in favor of new auth services
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Backstage backend plugin that generates README badges for your entities",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-badges-backend@0.5.1

### Patch Changes

-   bdf5b08: Removed deprecated `tokenManager` and `identity` in favor of new auth services
