### PR TITLE
fix: jenkins plugin double set jobsTreeSpec limit 

### DIFF
--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -64,7 +64,7 @@ export class JenkinsApiImpl {
 
   private static readonly jobsTreeSpec = `jobs[
                    ${JenkinsApiImpl.jobTreeSpec}
-                 ]{0,50}`;
+                 ]`;
 
   private static readonly jobBuildsTreeSpec = `
                    name,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes bug from https://github.com/backstage/community-plugins/pull/796
With https://github.com/backstage/community-plugins/pull/796 the jobsTreeSpec is has a count limit {0,50} hardcoded on it and the new value. The resulting URL with two limites seems to trigger a 500 internal server error in Jenkins.
So in this fix the hardcoded count limit {0,50} has been removed

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
