### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/nasty-monkeys-smile.md
+++ b/workspaces/redhat-argocd/.changeset/nasty-monkeys-smile.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-common': patch
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-chore: update supported-versions to 1.29.2

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.0.4
+
+### Patch Changes
+
+- 576a2d1: chore: update supported-versions to 1.29.2
+
 ## 1.0.3
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.6.8
+
+### Patch Changes
+
+- 576a2d1: chore: update supported-versions to 1.29.2
+- Updated dependencies [576a2d1]
+  - @backstage-community/plugin-redhat-argocd-common@1.0.4
+
 ## 1.6.7
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -33,7 +33,7 @@
     "ui-test": "yarn playwright test"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd-common": "1.0.3",
+    "@backstage-community/plugin-redhat-argocd-common": "1.0.4",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/core-components": "^0.14.10",
     "@backstage/core-plugin-api": "^1.9.3",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.6.8

### Patch Changes

-   576a2d1: chore: update supported-versions to 1.29.2
-   Updated dependencies [576a2d1]
    -   @backstage-community/plugin-redhat-argocd-common@1.0.4

## @backstage-community/plugin-redhat-argocd-common@1.0.4

### Patch Changes

-   576a2d1: chore: update supported-versions to 1.29.2
