### PR TITLE
fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114

### DIFF
--- a/workspaces/redhat-argocd/.changeset/modern-buttons-hug.md
+++ b/workspaces/redhat-argocd/.changeset/modern-buttons-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-redhat-argocd': patch
+---
+
+fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -33,7 +33,7 @@
     "ui-test": "yarn playwright test"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd-common": "1.0.3",
+    "@backstage-community/plugin-redhat-argocd-common": "^1.0.3",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/core-components": "^0.14.10",
     "@backstage/core-plugin-api": "^1.9.3",


### PR DESCRIPTION
### What does this PR do?

fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.