### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/gold-bugs-enjoy.md
+++ b/workspaces/redhat-argocd/.changeset/gold-bugs-enjoy.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
-'@backstage-community/plugin-redhat-argocd-common': patch
----
-
-regen yarn.lock

--- a/workspaces/redhat-argocd/.changeset/modern-buttons-hug.md
+++ b/workspaces/redhat-argocd/.changeset/modern-buttons-hug.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.0.5
+
+### Patch Changes
+
+- 38d858e: regen yarn.lock
+
 ## 1.0.4
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.6.9
+
+### Patch Changes
+
+- 38d858e: regen yarn.lock
+- 4431964: fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114
+- Updated dependencies [38d858e]
+  - @backstage-community/plugin-redhat-argocd-common@1.0.5
+
 ## 1.6.8
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -33,7 +33,7 @@
     "ui-test": "yarn playwright test"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd-common": "^1.0.3",
+    "@backstage-community/plugin-redhat-argocd-common": "^1.0.5",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/core-components": "^0.14.10",
     "@backstage/core-plugin-api": "^1.9.3",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.6.9

### Patch Changes

-   38d858e: regen yarn.lock
-   4431964: fix version range for dependency @backstage-community/plugin-redhat-argocd-common so we can bump to 1.0.4 without the tests failing at <https://github.com/backstage/community-plugins/actions/runs/10603150719/job/29386810871?pr=1114>
-   Updated dependencies [38d858e]
    -   @backstage-community/plugin-redhat-argocd-common@1.0.5

## @backstage-community/plugin-redhat-argocd-common@1.0.5

### Patch Changes

-   38d858e: regen yarn.lock
