### PR TITLE
Fixed broken root lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,9 +1647,7 @@ __metadata:
   resolution: "@backstage-community/plugins@workspace:."
   dependencies:
     "@backstage-community/cli": "portal:./workspaces/repo-tools/packages/cli"
-    "@backstage/catalog-model": ^1.5.0
     "@backstage/cli-node": ^0.2.2
-    "@backstage/config": ^1.2.0
     "@changesets/parse": ^0.4.0
     "@manypkg/get-packages": ^2.2.2
     "@octokit/rest": ^20.1.1
@@ -1680,22 +1678,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "@backstage/catalog-model@npm:1.5.0"
-  dependencies:
-    "@backstage/errors": ^1.2.4
-    "@backstage/types": ^1.1.1
-    ajv: ^8.10.0
-    lodash: ^4.17.21
-  checksum: 545873625afbb25a2142af9f8c701547b448fe8b822c9ed699c86a9c385571014115a2c3105a3dca2bc2ac63b837b093dba39a973c2f9e23521d427a0328ba12
-  languageName: node
-  linkType: hard
-
 "@backstage/cli-common@npm:^0.1.14":
   version: 0.1.14
   resolution: "@backstage/cli-common@npm:0.1.14"
   checksum: 6c5031ae31f08b405e5e59105d98e43dc6d865f960e5d016067267ecabccd5a892ab65d59d5b9e31850dccddb9eb29e06bf360ab6be8f7949991561ddb163fcb
+  languageName: node
+  linkType: hard
 
 "@backstage/cli-node@npm:^0.2.2, @backstage/cli-node@npm:^0.2.7":
   version: 0.2.7


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed broken root lock file which was causing build to fail with the following error:

```text
Type Error: Cannot read properties of undefined (reading 'toUpperCase')
    at ze.setupResolutions (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:439:793)
    at async ze.find (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:436:1[5](https://github.com/backstage/community-plugins/actions/runs/10603824313/job/29389095079#step:4:6)33)
    at async gm.execute (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:499:12090)
    at async gm.validateAndExecute (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:345:[6](https://github.com/backstage/community-plugins/actions/runs/10603824313/job/29389095079#step:4:7)73)
    at async Bs.run (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:359:208[7](https://github.com/backstage/community-plugins/actions/runs/10603824313/job/29389095079#step:4:8))
    at async Bs.runExit (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:359:2271)
    at async i (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:446:12696)
    at async t (/home/runner/work/community-plugins/community-plugins/.yarn/releases/yarn-3.2.3.cjs:446:10[9](https://github.com/backstage/community-plugins/actions/runs/10603824313/job/29389095079#step:4:10)14)
```

Looks like it was modified in this commit by mistake: https://github.com/backstage/community-plugins/commit/87a7392a676994eadfa86b52fff2fc155fd027c5

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
