### PR TITLE
[Version Bump] Refactor set release name

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: 'Set release name'
         id: set_release_name
-        run: node scripts/ci/set-release-name.js ${{ matrix.workspace }}
+        run: node scripts/ci/set-release-name.js ${{ matrix.workspace }} ${{ inputs.release_line || 'main' }}
       - name: 'Configure git'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/.eslintrc.cjs
+++ b/scripts/.eslintrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+  rules: {
+    'no-console': 0,
+    'no-restricted-imports': 0,
+  },
+};

--- a/scripts/ci/set-release-name.js
+++ b/scripts/ci/set-release-name.js
@@ -26,7 +26,7 @@ async function getBackstageVersion(workspace) {
   if (!fs.exists(rootPath)) {
     return 'N/A';
   }
-  return fs.readJson(rootPath).then((_) => _.version);
+  return fs.readJson(rootPath).then(_ => _.version);
 }
 
 async function getLatestRelease() {
@@ -43,7 +43,7 @@ async function getLatestPreRelease() {
   );
   const json = await response.json();
 
-  const preReleasesOnly = json.filter((release) => {
+  const preReleasesOnly = json.filter(release => {
     return release.prerelease === true;
   });
 
@@ -55,10 +55,10 @@ async function getLatestPreRelease() {
 }
 
 async function main() {
-  // Get the workspace
-  const [script, workspace] = process.argv.slice(1);
-  if (!workspace) {
-    throw new Error(`Argument must be ${script} <workspace>`);
+  // Get the workspace and release line
+  const [script, workspace, releaseLine] = process.argv.slice(1);
+  if (!workspace || !releaseLine) {
+    throw new Error(`Argument must be ${script} <workspace> <releaseLine>`);
   }
 
   // Get the current Backstage version from the backstage.json file
@@ -81,10 +81,17 @@ async function main() {
   const latestPreReleaseDate = new Date(
     latestPreRelease.published_at,
   ).getTime();
-  if (latestReleaseDate > latestPreReleaseDate) {
-    console.log(
-      `Latest Release is newer than latest Pre-release, using Latest Release name ${latestRelease.name}`,
-    );
+  if (releaseLine === 'main' || latestReleaseDate > latestPreReleaseDate) {
+    if (releaseLine === 'main') {
+      console.log(
+        `Selected release line is 'main', using Latest Release name ${latestRelease.name}`,
+      );
+    } else {
+      console.log(
+        `Latest Release is newer than latest Pre-release, using Latest Release name ${latestRelease.name}`,
+      );
+    }
+
     console.log();
 
     await fs.appendFile(
@@ -109,7 +116,7 @@ async function main() {
   );
 }
 
-main().catch((error) => {
+main().catch(error => {
   console.error(error.stack);
   process.exit(1);
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Refactor set release name so that it uses the release line. Currently if you were to tun the version bump using main it would do the correct version bump but the branch and PR would have the details from the current next release which is confusion and not correct.

Note: added the `.eslintrc.cjs` file to resolve the "Parsing error: The keyword 'import' is reserved eslint" error that the script was hitting when I would try and commit my changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
