### PR TITLE
Version Packages (grafana)

### DIFF
--- a/workspaces/grafana/.changeset/strong-numbers-turn.md
+++ b/workspaces/grafana/.changeset/strong-numbers-turn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': patch
----
-
-use new FE system syntax (replacing deprecated methods)

--- a/workspaces/grafana/.changeset/version-bump-1-30-2.md
+++ b/workspaces/grafana/.changeset/version-bump-1-30-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/grafana/plugins/grafana/CHANGELOG.md
+++ b/workspaces/grafana/plugins/grafana/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-grafana
 
+## 0.1.6
+
+### Patch Changes
+
+- 45fd620: use new FE system syntax (replacing deprecated methods)
+- c01b96c: Backstage version bump to v1.30.2
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-grafana",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A Backstage backend plugin that integrates towards Grafana",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-grafana@0.1.6

### Patch Changes

-   45fd620: use new FE system syntax (replacing deprecated methods)
-   c01b96c: Backstage version bump to v1.30.2
