### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/two-wombats-complain.md
+++ b/workspaces/github-actions/.changeset/two-wombats-complain.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-use new FE system syntax (replacing deprecated methods)

--- a/workspaces/github-actions/.changeset/version-bump-1-30-2.md
+++ b/workspaces/github-actions/.changeset/version-bump-1-30-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/github-actions/packages/app-next/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app-next
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [45fd620]
+- Updated dependencies [59b34f5]
+  - @backstage-community/plugin-github-actions@0.6.22
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/github-actions/packages/app-next/package.json
+++ b/workspaces/github-actions/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/packages/app/CHANGELOG.md
+++ b/workspaces/github-actions/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [45fd620]
+- Updated dependencies [59b34f5]
+  - @backstage-community/plugin-github-actions@0.6.22
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/github-actions/packages/app/package.json
+++ b/workspaces/github-actions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-github-actions
 
+## 0.6.22
+
+### Patch Changes
+
+- 45fd620: use new FE system syntax (replacing deprecated methods)
+- 59b34f5: Backstage version bump to v1.30.2
+
 ## 0.6.21
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.6.22

### Patch Changes

-   45fd620: use new FE system syntax (replacing deprecated methods)
-   59b34f5: Backstage version bump to v1.30.2

## app@0.0.5

### Patch Changes

-   Updated dependencies [45fd620]
-   Updated dependencies [59b34f5]
    -   @backstage-community/plugin-github-actions@0.6.22

## app-next@0.0.5

### Patch Changes

-   Updated dependencies [45fd620]
-   Updated dependencies [59b34f5]
    -   @backstage-community/plugin-github-actions@0.6.22
