### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/proud-mice-switch.md
+++ b/workspaces/cicd-statistics/.changeset/proud-mice-switch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
----
-
-An initial release implementation of a Buildkite `CicdStatisticsApi` for use in using the existing [cicd-statistics](https://github.com/backstage/community-plugins/tree/main/workspaces/cicd-statistics/plugins/cicd-statistics) plugin with [Buildkite](https://buildkite.com/).

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,1 +1,7 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
+
+## 0.0.1
+
+### Patch Changes
+
+- 87d6273: An initial release implementation of a Buildkite `CicdStatisticsApi` for use in using the existing [cicd-statistics](https://github.com/backstage/community-plugins/tree/main/workspaces/cicd-statistics/plugins/cicd-statistics) plugin with [Buildkite](https://buildkite.com/).

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.0.1

### Patch Changes

-   87d6273: An initial release implementation of a Buildkite `CicdStatisticsApi` for use in using the existing [cicd-statistics](https://github.com/backstage/community-plugins/tree/main/workspaces/cicd-statistics/plugins/cicd-statistics) plugin with [Buildkite](https://buildkite.com/).
