### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/renovate-87e49d2.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-87e49d2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@redhat-developer/red-hat-developer-hub-theme` to `0.2.0`.

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.8.1
+
+### Patch Changes
+
+- 7dc8618: Updated dependency `@redhat-developer/red-hat-developer-hub-theme` to `0.2.0`.
+
 ## 1.8.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.8.1

### Patch Changes

-   7dc8618: Updated dependency `@redhat-developer/red-hat-developer-hub-theme` to `0.2.0`.
