### PR TITLE
chore(docs-update) update Feedback Plugin README.md file to include EntityFeedbackPage component

### DIFF
--- a/workspaces/feedback/.changeset/flat-points-lie.md
+++ b/workspaces/feedback/.changeset/flat-points-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-feedback': patch
+---
+
+chore(docs-update) update Feedback Plugin README.md file to include EntityFeedbackPage component

--- a/workspaces/feedback/plugins/feedback/README.md
+++ b/workspaces/feedback/plugins/feedback/README.md
@@ -115,9 +115,12 @@ It is dedicated to simplifying the process of gathering and managing user feedba
    )
    ```
 
-5. Add `EntityFeedbackPage` component to the **Component page, Api page** in `src/components/catalog/EntityPage.tsx`.
+5. Import the `EntityFeedbackPage` component and add it to the **Component page, Api page** in `src/components/catalog/EntityPage.tsx`.
 
    ```ts
+   import { EntityFeedbackPage } from '@backstage-community/plugin-feedback';
+   // ...
+   
    <EntityLayout.Route path="/feedback" title="Feedback">
      <EntityFeedbackPage />
    </EntityLayout.Route>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds the missing import declaration ` import { EntityFeedbackPage } from '@backstage-community/plugin-feedback';` on top of the `EntityPage.tsx` file for the feedback plugin. 

This issue was raised by  @fwiegerinck here: https://github.com/backstage/community-plugins/issues/1131 

I have tested the feedback plugin  and reproduced the error `EntityFeedbackPage is not defined`:

![Screenshot from 2024-09-04 14-21-33](https://github.com/user-attachments/assets/99e2a4ac-a240-41a1-88fa-70972bcae00b)

This is the plugin working perfectly now:
![Screenshot from 2024-09-04 14-20-58](https://github.com/user-attachments/assets/c0912c70-8012-4159-b9d9-32425892e523)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
