### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/tricky-suits-admire.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/tricky-suits-admire.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
----
-
-update package to backstage 1.27.7 and bump version to a version number sematically larger than 1.1.x to replace the janus-idp package.

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 1.0.1
+
+### Patch Changes
+
+- 8288c9c: update package to backstage 1.27.7 and bump version to a version number sematically larger than 1.1.x to replace the janus-idp package.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@1.0.1

### Patch Changes

-   8288c9c: update package to backstage 1.27.7 and bump version to a version number sematically larger than 1.1.x to replace the janus-idp package.
