### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/tender-jobs-hope.md
+++ b/workspaces/cicd-statistics/.changeset/tender-jobs-hope.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
-'@backstage-community/plugin-cicd-statistics': patch
----
-
-Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

--- a/workspaces/cicd-statistics/packages/app-next/CHANGELOG.md
+++ b/workspaces/cicd-statistics/packages/app-next/CHANGELOG.md
@@ -1,0 +1,9 @@
+# app-next
+
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [52fcd76]
+  - @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.34
+  - @backstage-community/plugin-cicd-statistics@0.1.40

--- a/workspaces/cicd-statistics/packages/app-next/package.json
+++ b/workspaces/cicd-statistics/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/cicd-statistics/packages/app/CHANGELOG.md
+++ b/workspaces/cicd-statistics/packages/app/CHANGELOG.md
@@ -1,0 +1,9 @@
+# app
+
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [52fcd76]
+  - @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.34
+  - @backstage-community/plugin-cicd-statistics@0.1.40

--- a/workspaces/cicd-statistics/packages/app/package.json
+++ b/workspaces/cicd-statistics/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [52fcd76]
+  - @backstage-community/plugin-cicd-statistics@0.1.40
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.1.34
+
+### Patch Changes
+
+- 52fcd76: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
+- Updated dependencies [52fcd76]
+  - @backstage-community/plugin-cicd-statistics@0.1.40
+
 ## 0.1.33
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.1.40
+
+### Patch Changes
+
+- 52fcd76: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
+
 ## 0.1.39
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.1.40

### Patch Changes

-   52fcd76: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.0.2

### Patch Changes

-   Updated dependencies [52fcd76]
    -   @backstage-community/plugin-cicd-statistics@0.1.40

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.34

### Patch Changes

-   52fcd76: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
-   Updated dependencies [52fcd76]
    -   @backstage-community/plugin-cicd-statistics@0.1.40

## app@0.0.5

### Patch Changes

-   Updated dependencies [52fcd76]
    -   @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.34
    -   @backstage-community/plugin-cicd-statistics@0.1.40

## app-next@0.0.5

### Patch Changes

-   Updated dependencies [52fcd76]
    -   @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.34
    -   @backstage-community/plugin-cicd-statistics@0.1.40
