### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/five-laws-learn.md
+++ b/workspaces/sonarqube/.changeset/five-laws-learn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

--- a/workspaces/sonarqube/packages/app-next/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app-next/CHANGELOG.md
@@ -1,0 +1,8 @@
+# app-next
+
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [f257398]
+  - @backstage-community/plugin-sonarqube@0.8.2

--- a/workspaces/sonarqube/packages/app-next/package.json
+++ b/workspaces/sonarqube/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/packages/app/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app/CHANGELOG.md
@@ -1,0 +1,8 @@
+# app
+
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [f257398]
+  - @backstage-community/plugin-sonarqube@0.8.2

--- a/workspaces/sonarqube/packages/app/package.json
+++ b/workspaces/sonarqube/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.8.2
+
+### Patch Changes
+
+- f257398: adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
+
 ## 0.8.1
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.8.2

### Patch Changes

-   f257398: adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

## app@0.0.3

### Patch Changes

-   Updated dependencies [f257398]
    -   @backstage-community/plugin-sonarqube@0.8.2

## app-next@0.0.2

### Patch Changes

-   Updated dependencies [f257398]
    -   @backstage-community/plugin-sonarqube@0.8.2
