### PR TITLE
[Azure DevOps] Marked `createRouter` and `RouterOptions` as deprecated

### DIFF
--- a/workspaces/azure-devops/.changeset/ninety-jobs-sing.md
+++ b/workspaces/azure-devops/.changeset/ninety-jobs-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-backend': patch
+---
+
+Marked `createRouter` and `RouterOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October

--- a/workspaces/azure-devops/plugins/azure-devops-backend/api-report.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/api-report.md
@@ -151,10 +151,10 @@ export class AzureDevOpsApi {
 const azureDevOpsPlugin: BackendFeatureCompat;
 export default azureDevOpsPlugin;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export interface RouterOptions {
   // (undocumented)
   azureDevOpsApi?: AzureDevOpsApi;

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
@@ -48,7 +48,10 @@ import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 const DEFAULT_TOP = 10;
 
-/** @public */
+/**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ * @public
+ * */
 export interface RouterOptions {
   azureDevOpsApi?: AzureDevOpsApi;
   logger: LoggerService;
@@ -59,7 +62,10 @@ export interface RouterOptions {
   httpAuth?: HttpAuthService;
 }
 
-/** @public */
+/**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ * @public
+ * */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Marked `createRouter` and `RouterOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
