### PR TITLE
fix: cicd-statistics-module-buildkite README typos

### DIFF
--- a/workspaces/cicd-statistics/.changeset/large-guests-invite.md
+++ b/workspaces/cicd-statistics/.changeset/large-guests-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
+---
+
+Correct README typos surrounding plugin setup and configuration.

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/README.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/README.md
@@ -28,7 +28,7 @@ export const apis: AnyApiFactory[] = [
       fetchApiApi: fetchApiRef,
     },
     factory({ discoveryApi, fetchApi }) {
-      return new CicdStatisticsApiBuildkite(discoveryApi, fetchApi);
+      return new CicdStatisticsApiBuildkite({ discoveryApi, fetchApi });
     },
   }),
 ];
@@ -49,5 +49,5 @@ import { EntityCicdStatisticsContent } from '@backstage-community/plugin-cicd-st
 
 ```yaml
 annotations:
-  buildkite.com/pipeline-name: 'org-name/some-pipeline'
+  buildkite.com/pipeline: 'org-name/some-pipeline'
 ```


### PR DESCRIPTION
This corrects some `cicd-stastics-module-buildkite` `README` typos surrounding plugin setup and configuration.

Fixes issue #1200 and corrects some typos recently introduced in https://github.com/backstage/community-plugins/pull/865.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
