### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/orange-cups-switch.md
+++ b/workspaces/linguist/.changeset/orange-cups-switch.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': minor
-'@backstage-community/plugin-linguist-backend': minor
----
-
-**BREAKING** This change removes the deprecated `LinguistTagsProcessor` from `@backstage-community/plugin-linguist-backend`. It also removes the export of `LinguistTagsProcessor` from `@backstage-community/plugin-catalog-backend-module-linguist-tags-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor#setup), which is now the default.

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [3a4d799]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.2.0
+  - @backstage-community/plugin-linguist-backend@0.6.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.2.0
+
+### Minor Changes
+
+- 3a4d799: **BREAKING** This change removes the deprecated `LinguistTagsProcessor` from `@backstage-community/plugin-linguist-backend`. It also removes the export of `LinguistTagsProcessor` from `@backstage-community/plugin-catalog-backend-module-linguist-tags-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor#setup), which is now the default.
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- 3a4d799: **BREAKING** This change removes the deprecated `LinguistTagsProcessor` from `@backstage-community/plugin-linguist-backend`. It also removes the export of `LinguistTagsProcessor` from `@backstage-community/plugin-catalog-backend-module-linguist-tags-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor#setup), which is now the default.
+
 ## 0.5.23
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.5.23",
+  "version": "0.6.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.2.0

### Minor Changes

-   3a4d799: **BREAKING** This change removes the deprecated `LinguistTagsProcessor` from `@backstage-community/plugin-linguist-backend`. It also removes the export of `LinguistTagsProcessor` from `@backstage-community/plugin-catalog-backend-module-linguist-tags-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor#setup), which is now the default.

## @backstage-community/plugin-linguist-backend@0.6.0

### Minor Changes

-   3a4d799: **BREAKING** This change removes the deprecated `LinguistTagsProcessor` from `@backstage-community/plugin-linguist-backend`. It also removes the export of `LinguistTagsProcessor` from `@backstage-community/plugin-catalog-backend-module-linguist-tags-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor#setup), which is now the default.

## backend@0.0.9

### Patch Changes

-   Updated dependencies [3a4d799]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.2.0
    -   @backstage-community/plugin-linguist-backend@0.6.0
