### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/two-chefs-fix.md
+++ b/workspaces/azure-devops/.changeset/two-chefs-fix.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': minor
-'@backstage-community/plugin-azure-devops-backend': minor
-'@backstage-community/plugin-azure-devops': minor
----
-
-**BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [c6f00d3]
+  - @backstage-community/plugin-azure-devops@0.5.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [c6f00d3]
+  - @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.0
+  - @backstage-community/plugin-azure-devops-backend@0.7.0
+  - app@0.0.7
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.
+
 ## 0.6.12
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.6.12",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.5.0
+
+### Minor Changes
+
+- c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.
+
 ## 0.4.10
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.4.10",
+  "version": "0.5.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.1.0
+
+### Minor Changes
+
+- c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.
+
 ## 0.0.4
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.5.0

### Minor Changes

-   c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.

## @backstage-community/plugin-azure-devops-backend@0.7.0

### Minor Changes

-   c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.0

### Minor Changes

-   c6f00d3: **BREAKING** This change removes the deprecated `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-azure-devops-backend`. It also removes the export of `AzureDevOpsAnnotatorProcessor` from `@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor`. Please install this processor using [the New Backend System setup](https://github.com/backstage/community-plugins/tree/main/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor#setup), which is now the default.

## app@0.0.7

### Patch Changes

-   Updated dependencies [c6f00d3]
    -   @backstage-community/plugin-azure-devops@0.5.0

## backend@0.0.8

### Patch Changes

-   Updated dependencies [c6f00d3]
    -   @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.0
    -   @backstage-community/plugin-azure-devops-backend@0.7.0
    -   app@0.0.7
