### PR TITLE
fix(entity-feedback-backend): make the identity service optional

### DIFF
--- a/workspaces/entity-feedback/.changeset/mighty-poets-approve.md
+++ b/workspaces/entity-feedback/.changeset/mighty-poets-approve.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-entity-feedback-backend': minor
+---
+
+The `identity` service is now optional. It has been removed as a plugin dependency for
+the new backend system.

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/api-report.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/api-report.md
@@ -5,12 +5,12 @@
 ```ts
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackendFeatureCompat } from '@backstage/backend-plugin-api';
+import { DatabaseService } from '@backstage/backend-plugin-api';
+import { DiscoveryService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { HttpAuthService } from '@backstage/backend-plugin-api';
 import { IdentityApi } from '@backstage/plugin-auth-node';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { PluginDatabaseManager } from '@backstage/backend-common';
-import { PluginEndpointDiscovery } from '@backstage/backend-common';
 
 // @public (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
@@ -24,13 +24,13 @@ export interface RouterOptions {
   // (undocumented)
   auth?: AuthService;
   // (undocumented)
-  database: PluginDatabaseManager;
+  database: DatabaseService;
   // (undocumented)
-  discovery: PluginEndpointDiscovery;
+  discovery: DiscoveryService;
   // (undocumented)
   httpAuth?: HttpAuthService;
   // (undocumented)
-  identity: IdentityApi;
+  identity?: IdentityApi;
   // (undocumented)
   logger: LoggerService;
 }

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/src/plugin.ts
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/src/plugin.ts
@@ -30,31 +30,21 @@ export const entityFeedbackPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        discovery: coreServices.discovery,
-        database: coreServices.database,
-        identity: coreServices.identity,
-        logger: coreServices.logger,
-        httpRouter: coreServices.httpRouter,
         auth: coreServices.auth,
+        database: coreServices.database,
+        discovery: coreServices.discovery,
         httpAuth: coreServices.httpAuth,
+        httpRouter: coreServices.httpRouter,
+        logger: coreServices.logger,
       },
-      async init({
-        database,
-        discovery,
-        identity,
-        logger,
-        httpRouter,
-        auth,
-        httpAuth,
-      }) {
+      async init({ database, discovery, logger, httpRouter, auth, httpAuth }) {
         httpRouter.use(
           await createRouter({
+            auth,
             database,
             discovery,
-            identity,
-            logger,
-            auth,
             httpAuth,
+            logger,
           }),
         );
       },

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/router.ts
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/router.ts
@@ -17,11 +17,11 @@
 import {
   createLegacyAuthAdapters,
   errorHandler,
-  PluginDatabaseManager,
-  PluginEndpointDiscovery,
 } from '@backstage/backend-common';
 import {
   AuthService,
+  DatabaseService,
+  DiscoveryService,
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
@@ -42,9 +42,9 @@ import { DatabaseHandler } from './DatabaseHandler';
  * @public
  */
 export interface RouterOptions {
-  database: PluginDatabaseManager;
-  discovery: PluginEndpointDiscovery;
-  identity: IdentityApi;
+  database: DatabaseService;
+  discovery: DiscoveryService;
+  identity?: IdentityApi;
   logger: LoggerService;
   auth?: AuthService;
   httpAuth?: HttpAuthService;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The identity service dependency is now an optional dependency. Since "identity"
is not a part of the "coreServices" any more it this plugin is not possible to use with
the recent "next" releases of backstage.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
