### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/mighty-poets-approve.md
+++ b/workspaces/entity-feedback/.changeset/mighty-poets-approve.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': minor
----
-
-The `identity` service is now optional. It has been removed as a plugin dependency for
-the new backend system.

--- a/workspaces/entity-feedback/packages/backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [6ab3e6d]
+  - @backstage-community/plugin-entity-feedback-backend@0.3.0
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/entity-feedback/packages/backend/package.json
+++ b/workspaces/entity-feedback/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.3.0
+
+### Minor Changes
+
+- 6ab3e6d: The `identity` service is now optional. It has been removed as a plugin dependency for
+  the new backend system.
+
 ## 0.2.21
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.2.21",
+  "version": "0.3.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "entity-feedback",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback-backend@0.3.0

### Minor Changes

-   6ab3e6d: The `identity` service is now optional. It has been removed as a plugin dependency for
    the new backend system.

## backend@0.0.6

### Patch Changes

-   Updated dependencies [6ab3e6d]
    -   @backstage-community/plugin-entity-feedback-backend@0.3.0
