### PR TITLE
fix(nbs): removed some tokenmanager and identity usage

### DIFF
--- a/workspaces/adr/.changeset/fuzzy-onions-marry.md
+++ b/workspaces/adr/.changeset/fuzzy-onions-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/search-backend-module-adr': patch
+---
+
+Removed the dependency to the `tokenManager` when using the new backend system.

--- a/workspaces/adr/plugins/search-backend-module-adr/src/index.ts
+++ b/workspaces/adr/plugins/search-backend-module-adr/src/index.ts
@@ -89,7 +89,6 @@ export default createBackendModule({
         logger: coreServices.rootLogger,
         reader: coreServices.urlReader,
         scheduler: coreServices.scheduler,
-        tokenManager: coreServices.tokenManager,
         indexRegistry: searchIndexRegistryExtensionPoint,
         catalog: catalogServiceRef,
       },
@@ -101,7 +100,6 @@ export default createBackendModule({
         logger,
         reader,
         scheduler,
-        tokenManager,
         indexRegistry,
         catalog,
       }) {
@@ -116,7 +114,6 @@ export default createBackendModule({
             discovery,
             logger,
             reader,
-            tokenManager,
             adrFilePathFilterFn,
             parser,
             catalogClient: catalog,

--- a/workspaces/lighthouse/.changeset/tasty-fireants-tan.md
+++ b/workspaces/lighthouse/.changeset/tasty-fireants-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-lighthouse-backend': patch
+---
+
+The `tokenManager` service is now an optional dependency and is not used with the new backend system.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/api-report.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/api-report.md
@@ -27,7 +27,7 @@ export interface CreateLighthouseSchedulerOptions {
   // (undocumented)
   scheduler?: PluginTaskScheduler;
   // (undocumented)
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
 }
 
 // @public (undocumented)

--- a/workspaces/lighthouse/plugins/lighthouse-backend/src/plugin.ts
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/src/plugin.ts
@@ -36,7 +36,6 @@ export const lighthousePlugin = createBackendPlugin({
         config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
-        tokenManager: coreServices.tokenManager,
         discovery: coreServices.discovery,
         auth: coreServices.auth,
       },
@@ -45,7 +44,6 @@ export const lighthousePlugin = createBackendPlugin({
         config,
         logger,
         scheduler,
-        tokenManager,
         discovery,
         auth,
       }) {
@@ -54,7 +52,6 @@ export const lighthousePlugin = createBackendPlugin({
           config,
           logger,
           scheduler,
-          tokenManager,
           discovery,
           auth,
         });

--- a/workspaces/lighthouse/plugins/lighthouse-backend/src/service/createScheduler.ts
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/src/service/createScheduler.ts
@@ -37,7 +37,7 @@ export interface CreateLighthouseSchedulerOptions {
   discovery: DiscoveryService;
   scheduler?: PluginTaskScheduler;
   catalogClient: CatalogApi;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   auth?: AuthService;
 }
 

--- a/workspaces/playlist/.changeset/few-falcons-melt.md
+++ b/workspaces/playlist/.changeset/few-falcons-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-playlist-backend': patch
+---
+
+The `identity` service is now an optional dependency and is not used with the new backend system.

--- a/workspaces/playlist/plugins/playlist-backend/api-report.md
+++ b/workspaces/playlist/plugins/playlist-backend/api-report.md
@@ -98,7 +98,7 @@ export interface RouterOptions {
   // (undocumented)
   httpAuth?: HttpAuthService;
   // (undocumented)
-  identity: IdentityApi;
+  identity?: IdentityApi;
   // (undocumented)
   logger: LoggerService;
   // (undocumented)

--- a/workspaces/playlist/plugins/playlist-backend/src/plugin.ts
+++ b/workspaces/playlist/plugins/playlist-backend/src/plugin.ts
@@ -32,16 +32,14 @@ export const playlistPlugin = createBackendPlugin({
         http: coreServices.httpRouter,
         logger: coreServices.logger,
         database: coreServices.database,
-        identity: coreServices.identity,
         discovery: coreServices.discovery,
         permissions: coreServices.permissions,
       },
-      async init({ http, logger, database, identity, discovery, permissions }) {
+      async init({ http, logger, database, discovery, permissions }) {
         http.use(
           await createRouter({
             logger,
             database,
-            identity,
             discovery,
             permissions,
           }),

--- a/workspaces/playlist/plugins/playlist-backend/src/service/router.ts
+++ b/workspaces/playlist/plugins/playlist-backend/src/service/router.ts
@@ -53,7 +53,7 @@ import {
 export interface RouterOptions {
   database: PluginDatabaseManager;
   discovery: PluginEndpointDiscovery;
-  identity: IdentityApi;
+  identity?: IdentityApi;
   logger: LoggerService;
   permissions: PermissionsService;
   auth?: AuthService;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With the removal of the "tokenManager" and the "identity" service with the NBS v1.0 there are a few plugins that need to stop using these when using the new backend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
