### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/gentle-lies-warn.md
+++ b/workspaces/code-coverage/.changeset/gentle-lies-warn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': minor
----
-
-Updated the `pluginId` defined in `src/plugin.ts` from `codeCoverage` to `code-coverage` to be compatible with frontend.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.3.0
+
+### Minor Changes
+
+- 32da7b0: Updated the `pluginId` defined in `src/plugin.ts` from `codeCoverage` to `code-coverage` to be compatible with frontend.
+
 ## 0.2.35
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.2.35",
+  "version": "0.3.0",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage-backend@0.3.0

### Minor Changes

-   32da7b0: Updated the `pluginId` defined in `src/plugin.ts` from `codeCoverage` to `code-coverage` to be compatible with frontend.
