### PR TITLE
fix(github-issues): introduce multiple GitHub providers support

### DIFF
--- a/workspaces/github-issues/.changeset/happy-garlics-think.md
+++ b/workspaces/github-issues/.changeset/happy-garlics-think.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-github-issues': minor
+'@backstage-community/plugin-github-issues': patch
 ---
 
-Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If the entity does not provide this annotation, the first GitHub provider will be used.
+Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` or `backstage.io/managed-by-location` to determine the appropriate provider. If no provider matches the slug, the first GitHub provider will be selected, maintaining the previous behavior.

--- a/workspaces/github-issues/.changeset/happy-garlics-think.md
+++ b/workspaces/github-issues/.changeset/happy-garlics-think.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-issues': minor
+---
+
+**BREAKING**: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If you previously relied on the old behavior, please ensure that your entities include the location annotation.

--- a/workspaces/github-issues/.changeset/happy-garlics-think.md
+++ b/workspaces/github-issues/.changeset/happy-garlics-think.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-github-issues': minor
 ---
 
-**BREAKING**: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If you previously relied on the old behavior, please ensure that your entities include the location annotation.
+**BREAKING**: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If the entity does not provide this annotation, the default hostname `github.com` will be used. If you previously relied on the old behavior and are using a custom GitHub instance, please ensure that your entities include the location annotation.

--- a/workspaces/github-issues/.changeset/happy-garlics-think.md
+++ b/workspaces/github-issues/.changeset/happy-garlics-think.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-github-issues': minor
 ---
 
-**BREAKING**: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If the entity does not provide this annotation, the default hostname `github.com` will be used. If you previously relied on the old behavior and are using a custom GitHub instance, please ensure that your entities include the location annotation.
+Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` to determine the appropriate integration. If the entity does not provide this annotation, the first GitHub provider will be used.

--- a/workspaces/github-issues/plugins/github-issues/README.md
+++ b/workspaces/github-issues/plugins/github-issues/README.md
@@ -3,6 +3,7 @@
 Welcome to the GitHub Issues plugin!
 
 Based on the [well-known GitHub slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations#githubcomproject-slug) associated with the Entity, it renders the list of Open issues in GitHub.
+The plugin will attempt to determine the source code location using the [well-known Source location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) associated with the Entity.
 
 The plugin is designed to work with four Entity kinds, and it behaves a bit differently depending on that kind:
 

--- a/workspaces/github-issues/plugins/github-issues/README.md
+++ b/workspaces/github-issues/plugins/github-issues/README.md
@@ -3,7 +3,7 @@
 Welcome to the GitHub Issues plugin!
 
 Based on the [well-known GitHub slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations#githubcomproject-slug) associated with the Entity, it renders the list of Open issues in GitHub.
-The plugin will attempt to determine the source code location using the [well-known Source location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) associated with the Entity.
+The plugin will attempt to determine the source code location using the [well-known Source location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) associated with the Entity. If the slug is not provided, it will default to `github.com`.
 
 The plugin is designed to work with four Entity kinds, and it behaves a bit differently depending on that kind:
 

--- a/workspaces/github-issues/plugins/github-issues/README.md
+++ b/workspaces/github-issues/plugins/github-issues/README.md
@@ -3,7 +3,8 @@
 Welcome to the GitHub Issues plugin!
 
 Based on the [well-known GitHub slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations#githubcomproject-slug) associated with the Entity, it renders the list of Open issues in GitHub.
-The plugin will attempt to determine the source code location using the [well-known Source location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) associated with the Entity. If the slug is not provided, it will default to `github.com`.
+The plugin will attempt to determine the source code location using the [well-known Source location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiosource-location) or [Managed by location slug annotation](https://backstage.io/docs/features/software-catalog/well-known-annotations/#backstageiomanaged-by-location) associated with the Entity.
+If no configured Github provider will match, the first one will be used.
 
 The plugin is designed to work with four Entity kinds, and it behaves a bit differently depending on that kind:
 

--- a/workspaces/github-issues/plugins/github-issues/package.json
+++ b/workspaces/github-issues/plugins/github-issues/package.json
@@ -41,6 +41,7 @@
     "@backstage/core-plugin-api": "^1.9.3",
     "@backstage/errors": "^1.2.4",
     "@backstage/integration": "^1.14.0",
+    "@backstage/integration-react": "^1.1.30",
     "@backstage/plugin-catalog-react": "^1.12.3",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.9.1",

--- a/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -116,7 +116,7 @@ describe('githubIssuesApi', () => {
 
     beforeEach(() => {
       api = githubIssuesApi(
-        { getCredentials: jest.fn().mockReturnValue({ token: mockToken }) },
+        { getCredentials: jest.fn().mockResolvedValue({ token: mockToken }) },
         {
           getOptionalConfigArray: jest.fn(),
         } as unknown as ConfigApi,
@@ -306,7 +306,7 @@ describe('githubIssuesApi', () => {
     );
 
     const api = githubIssuesApi(
-      { getCredentials: jest.fn().mockReturnValue({ token: mockToken }) },
+      { getCredentials: jest.fn().mockResolvedValue({ token: mockToken }) },
       {
         getOptionalConfigArray: jest.fn(),
       } as unknown as ConfigApi,
@@ -376,7 +376,7 @@ describe('githubIssuesApi', () => {
     );
 
     const api = githubIssuesApi(
-      { getCredentials: jest.fn().mockReturnValue({ token: mockToken }) },
+      { getCredentials: jest.fn().mockResolvedValue({ token: mockToken }) },
       {
         getOptionalConfigArray: jest.fn(),
       } as unknown as ConfigApi,
@@ -417,7 +417,7 @@ describe('githubIssuesApi', () => {
     const mockErrorApi = { post: jest.fn() };
 
     const api = githubIssuesApi(
-      { getCredentials: jest.fn().mockReturnValue({ token: mockToken }) },
+      { getCredentials: jest.fn().mockResolvedValue({ token: mockToken }) },
       {
         getOptionalConfigArray: jest.fn(),
       } as unknown as ConfigApi,

--- a/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -42,21 +42,6 @@ function entityRepository(
 function getFragment(
   filterBy = '',
   orderBy = 'field: UPDATED_AT, direction: DESC',
-  query = '    query {\n' +
-    '      \n' +
-    '        yoyo: repository(name: "yo-yo", owner: "mrwolny") {\n' +
-    '          ...issues\n' +
-    '        }\n' +
-    '      ,\n' +
-    '        yoyox: repository(name: "yoyo", owner: "mrwolny") {\n' +
-    '          ...issues\n' +
-    '        }\n' +
-    '      ,\n' +
-    '        yoyoxx: repository(name: "yo.yo", owner: "mrwolny") {\n' +
-    '          ...issues\n' +
-    '        }\n' +
-    '      \n' +
-    '    }\n',
 ) {
   return (
     '\n' +
@@ -101,7 +86,21 @@ function getFragment(
     '    }\n' +
     '  \n' +
     '\n' +
-    `${query}` +
+    '    query {\n' +
+    '      \n' +
+    '        yoyo: repository(name: "yo-yo", owner: "mrwolny") {\n' +
+    '          ...issues\n' +
+    '        }\n' +
+    '      ,\n' +
+    '        yoyox: repository(name: "yoyo", owner: "mrwolny") {\n' +
+    '          ...issues\n' +
+    '        }\n' +
+    '      ,\n' +
+    '        yoyoxx: repository(name: "yo.yo", owner: "mrwolny") {\n' +
+    '          ...issues\n' +
+    '        }\n' +
+    '      \n' +
+    '    }\n' +
     '  '
   );
 }
@@ -147,14 +146,14 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
         ],
         10,
-        'github.com',
+        'github.com', // entity location
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
       expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
     });
 
-    it('should only fetch data for entities hosted in the same GitHub instance as is entity location that differs from github.com', async () => {
+    it("should only fetch data for entities hosted in the same GitHub instance as the plugin's first config", async () => {
       await api.fetchIssuesByRepoFromGithub(
         [
           entityRepository('mrwolny/yo-yo'),
@@ -163,33 +162,7 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
         ],
         10,
-        'enterprise.github.com',
-      );
-
-      const query =
-        '    query {\n' +
-        '      \n' +
-        '        anotherrepo: repository(name: "another-repo", owner: "mrwolny") {\n' +
-        '          ...issues\n' +
-        '        }\n' +
-        '      \n' +
-        '    }\n';
-
-      expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
-      expect(mockGraphQLQuery).toHaveBeenCalledWith(
-        getFragment('', 'field: UPDATED_AT, direction: DESC', query),
-      );
-    });
-
-    it('should only fetch data for entities hosted in the github.com if entity does not define location', async () => {
-      await api.fetchIssuesByRepoFromGithub(
-        [
-          entityRepository('mrwolny/yo-yo'),
-          entityRepository('mrwolny/yoyo'),
-          entityRepository('mrwolny/yo.yo'),
-          entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
-        ],
-        10,
+        undefined,
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
@@ -204,7 +177,7 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/yo.yo'),
         ],
         10,
-        undefined,
+        'github.com',
         {
           filterBy: {
             labels: ['bug'],

--- a/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -131,6 +131,7 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/yo.yo'),
         ],
         10,
+        'github.com',
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
@@ -146,14 +147,14 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
         ],
         10,
-        'github.com', // entity location
+        'github.com',
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
       expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
     });
 
-    it("should only fetch data for entities hosted in the same GitHub instance as the plugin's first config", async () => {
+    it("should only fetch data for entities hosted in the same GitHub instance as the plugin's first config if no config matches", async () => {
       await api.fetchIssuesByRepoFromGithub(
         [
           entityRepository('mrwolny/yo-yo'),
@@ -162,7 +163,7 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
         ],
         10,
-        undefined,
+        'enterprise.github.com',
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
@@ -289,6 +290,7 @@ describe('githubIssuesApi', () => {
     const data = await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/yo-yo'), entityRepository('mrwolny/notfound')],
       10,
+      'github.com',
     );
 
     expect(data).toEqual({
@@ -359,6 +361,7 @@ describe('githubIssuesApi', () => {
     const data = await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/notfound')],
       10,
+      'github.com',
     );
 
     expect(data).toEqual({});
@@ -400,6 +403,7 @@ describe('githubIssuesApi', () => {
     await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/notfound')],
       10,
+      'github.com',
     );
 
     expect(mockErrorApi.post).toHaveBeenCalledTimes(1);

--- a/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -114,14 +114,13 @@ export const githubIssuesApi = (
   configApi: ConfigApi,
   errorApi: ErrorApi,
 ) => {
-  const getOctokit = async (hostname: string | undefined = undefined) => {
+  const getOctokit = async (hostname: string) => {
     const configs = readGithubIntegrationConfigs(
       configApi.getOptionalConfigArray('integrations.github') ?? [],
     );
 
-    const githubIntegrationConfig = hostname
-      ? configs.find(v => v.host === hostname)
-      : configs[0];
+    const githubIntegrationConfig =
+      configs.find(v => v.host === hostname) ?? configs[0];
 
     const host = githubIntegrationConfig?.host;
     const { token } = await scmAuthApi.getCredentials({
@@ -140,7 +139,7 @@ export const githubIssuesApi = (
   const fetchIssuesByRepoFromGithub = async (
     repos: Array<Repository>,
     itemsPerRepo: number,
-    hostname?: string,
+    hostname: string,
     {
       filterBy,
       orderBy = {

--- a/workspaces/github-issues/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
@@ -30,11 +30,9 @@ export const getProjectNameFromEntity = (entity: Entity): string => {
   return entity?.metadata.annotations?.[GITHUB_PROJECT_SLUG_ANNOTATION] ?? '';
 };
 
-export const getHostnameFromEntity = (entity: Entity): string | undefined => {
-  const sourceLocation = getEntitySourceLocation(entity);
-  return sourceLocation === undefined
-    ? undefined
-    : new URL(sourceLocation.target).hostname;
+export const getHostnameFromEntity = (entity: Entity): string => {
+  const { target } = getEntitySourceLocation(entity);
+  return new URL(target).hostname;
 };
 
 export function useEntityGithubRepositories() {
@@ -51,7 +49,7 @@ export function useEntityGithubRepositories() {
         setRepositories([
           {
             name: entityName,
-            locationHostname: locationHostname || 'github.com',
+            locationHostname,
           },
         ]);
       }
@@ -77,7 +75,7 @@ export function useEntityGithubRepositories() {
         ) {
           acc.push({
             name: entityName,
-            locationHostname: entityLocationHostname || 'github.com',
+            locationHostname: entityLocationHostname,
           });
         }
         return acc;

--- a/workspaces/github-issues/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/hooks/useEntityGithubRepositories.ts
@@ -30,9 +30,11 @@ export const getProjectNameFromEntity = (entity: Entity): string => {
   return entity?.metadata.annotations?.[GITHUB_PROJECT_SLUG_ANNOTATION] ?? '';
 };
 
-export const getHostnameFromEntity = (entity: Entity): string => {
-  const { target } = getEntitySourceLocation(entity);
-  return new URL(target).hostname;
+export const getHostnameFromEntity = (entity: Entity): string | undefined => {
+  const sourceLocation = getEntitySourceLocation(entity);
+  return sourceLocation === undefined
+    ? undefined
+    : new URL(sourceLocation.target).hostname;
 };
 
 export function useEntityGithubRepositories() {
@@ -49,7 +51,7 @@ export function useEntityGithubRepositories() {
         setRepositories([
           {
             name: entityName,
-            locationHostname,
+            locationHostname: locationHostname || 'github.com',
           },
         ]);
       }
@@ -75,7 +77,7 @@ export function useEntityGithubRepositories() {
         ) {
           acc.push({
             name: entityName,
-            locationHostname: entityLocationHostname,
+            locationHostname: entityLocationHostname || 'github.com',
           });
         }
         return acc;

--- a/workspaces/github-issues/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
@@ -21,6 +21,8 @@ import {
   githubIssuesApiRef,
   GithubIssuesByRepoOptions,
 } from '../api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { getHostnameFromEntity } from './useEntityGithubRepositories';
 
 export const useGetIssuesByRepoFromGithub = (
   repos: Array<Repository>,
@@ -28,6 +30,8 @@ export const useGetIssuesByRepoFromGithub = (
   options?: GithubIssuesByRepoOptions,
 ) => {
   const githubIssuesApi = useApi(githubIssuesApiRef);
+  const { entity } = useEntity();
+  const hostname = getHostnameFromEntity(entity);
 
   const {
     value: issues,
@@ -38,6 +42,7 @@ export const useGetIssuesByRepoFromGithub = (
       return await githubIssuesApi.fetchIssuesByRepoFromGithub(
         repos,
         itemsPerRepo,
+        hostname,
         options,
       );
     }

--- a/workspaces/github-issues/plugins/github-issues/src/plugin.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/plugin.ts
@@ -21,8 +21,8 @@ import {
   createRoutableExtension,
   configApiRef,
   errorApiRef,
-  githubAuthApiRef,
 } from '@backstage/core-plugin-api';
+import { scmAuthApiRef } from '@backstage/integration-react';
 import { githubIssuesApi, githubIssuesApiRef } from './api';
 import { rootRouteRef } from './routes';
 
@@ -34,11 +34,11 @@ export const githubIssuesPlugin = createPlugin({
       api: githubIssuesApiRef,
       deps: {
         configApi: configApiRef,
-        githubAuthApi: githubAuthApiRef,
+        scmAuthApi: scmAuthApiRef,
         errorApi: errorApiRef,
       },
-      factory: ({ configApi, githubAuthApi, errorApi }) =>
-        githubIssuesApi(githubAuthApi, configApi, errorApi),
+      factory: ({ configApi, scmAuthApi, errorApi }) =>
+        githubIssuesApi(scmAuthApi, configApi, errorApi),
     }),
   ],
   routes: {

--- a/workspaces/github-issues/yarn.lock
+++ b/workspaces/github-issues/yarn.lock
@@ -2523,6 +2523,7 @@ __metadata:
     "@backstage/dev-utils": ^1.0.37
     "@backstage/errors": ^1.2.4
     "@backstage/integration": ^1.14.0
+    "@backstage/integration-react": ^1.1.30
     "@backstage/plugin-catalog-react": ^1.12.3
     "@backstage/test-utils": ^1.5.10
     "@material-ui/core": ^4.12.4


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Description
Introduces support for multiple github providers. Plugin uses slug annotation `backstage.io/source-location` or  `backstage.io/managed-by-location` to determine the appropriate github integration to use for the entity. If no Github provider matches, it uses the first one.

Before:
![Pasted image](https://github.com/user-attachments/assets/b841524d-6e66-487b-9e13-469781bff2d2)

After:
![Screenshot from 2024-09-16 18-37-57](https://github.com/user-attachments/assets/cee89608-31e6-4274-be00-62fb3c91d042)
![Screenshot from 2024-09-16 18-38-27](https://github.com/user-attachments/assets/3f4dd876-5d4e-4986-a42c-1c503d62b1c4)

## How to test
1. Create a github repo with issues and a github app with permissions to view issues on that repository or generate token (make it on github.com)
2. Install the github issues plugin
3. Add at least 2 different github hosts in the github integrations (put the github.com host as the 2nd integration in the list)
```
integrations: 
  github: 
    - host: github.company.com
      apiBaseUrl: https://github.company.com/api/v3
    - host: github.com
      apps / token:
```
4. Ingest a component with a github slug pointing to the newly created github repo
5. Navigate to the tab containing the issues component

-> Error when it tries to query the github.company.com host instead of the expected github.com host is fixed
-> Add slug `backstage.io/source-location` to the ingested entity info, plugin still successfully fetches issues

## Fixes
#550 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
