### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/chilly-readers-own.md
+++ b/workspaces/linguist/.changeset/chilly-readers-own.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
----
-
-Marked `createRouter`, `createRouterFromConfig`, `RouterOptions`, and `PluginOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [932d9e6]
+  - @backstage-community/plugin-linguist-backend@0.6.1
+
 ## 0.0.9
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.6.1
+
+### Patch Changes
+
+- 932d9e6: Marked `createRouter`, `createRouterFromConfig`, `RouterOptions`, and `PluginOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist-backend@0.6.1

### Patch Changes

-   932d9e6: Marked `createRouter`, `createRouterFromConfig`, `RouterOptions`, and `PluginOptions` as deprecated, to be removed soon after the Backstage `1.32.0` release in October

## backend@0.0.10

### Patch Changes

-   Updated dependencies [932d9e6]
    -   @backstage-community/plugin-linguist-backend@0.6.1
