### PR TITLE
tech-insights: migrate away from the old auth services

### DIFF
--- a/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
+++ b/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-node': minor
+---
+
+**BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead.

--- a/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
+++ b/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-tech-insights-node': minor
+'@backstage-community/plugin-tech-insights-node': major
 ---
 
-**BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead.
+**BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead if you need to make backend requests.

--- a/workspaces/tech-insights/.changeset/tidy-paws-matter.md
+++ b/workspaces/tech-insights/.changeset/tidy-paws-matter.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-tech-insights-backend': minor
+'@backstage-community/plugin-tech-insights-backend': major
 ---
 
 **BREAKING**: The service no longer accepts the deprecated `TokenManager` instance, but instead the `AuthService` is now required where it used to be optional. If you are using the new backend system module, this does not affect you.

--- a/workspaces/tech-insights/.changeset/tidy-paws-matter.md
+++ b/workspaces/tech-insights/.changeset/tidy-paws-matter.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': minor
+---
+
+**BREAKING**: The service no longer accepts the deprecated `TokenManager` instance, but instead the `AuthService` is now required where it used to be optional. If you are using the new backend system module, this does not affect you.

--- a/workspaces/tech-insights/plugins/tech-insights-backend/api-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/api-report.md
@@ -22,7 +22,6 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { PersistenceContext as PersistenceContext_2 } from '@backstage-community/plugin-tech-insights-node';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { TechInsightCheck } from '@backstage-community/plugin-tech-insights-node';
-import { TokenManager } from '@backstage/backend-common';
 
 // @public
 export const buildTechInsightsContext: <
@@ -112,7 +111,7 @@ export interface TechInsightsOptions<
   CheckResultType extends CheckResult,
 > {
   // (undocumented)
-  auth?: AuthService;
+  auth: AuthService;
   // (undocumented)
   config: Config;
   // (undocumented)
@@ -127,8 +126,6 @@ export interface TechInsightsOptions<
   persistenceContext?: PersistenceContext_2;
   // (undocumented)
   scheduler: SchedulerService;
-  // (undocumented)
-  tokenManager: TokenManager;
 }
 
 // @public

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
@@ -100,7 +100,6 @@ export const techInsightsPlugin = createBackendPlugin({
         httpRouter: coreServices.httpRouter,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
-        tokenManager: coreServices.tokenManager,
         auth: coreServices.auth,
       },
       async init({
@@ -110,7 +109,6 @@ export const techInsightsPlugin = createBackendPlugin({
         httpRouter,
         logger,
         scheduler,
-        tokenManager,
         auth,
       }) {
         const factRetrievers: FactRetrieverRegistration[] = Object.entries(
@@ -135,7 +133,6 @@ export const techInsightsPlugin = createBackendPlugin({
           logger,
           persistenceContext,
           scheduler,
-          tokenManager,
           auth,
         });
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
@@ -26,7 +26,6 @@ import {
   DefaultFactRetrieverEngine,
   FactRetrieverEngine,
 } from './FactRetrieverEngine';
-import { ServerTokenManager } from '@backstage/backend-common';
 import { DatabaseManager } from '@backstage/backend-defaults/database';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -142,7 +141,6 @@ describe('FactRetrieverEngine', () => {
       factRetrieverContext: {
         logger,
         config: ConfigReader.fromConfigs([]),
-        tokenManager: ServerTokenManager.noop(),
         auth: mockServices.auth(),
         discovery: {
           getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.test.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { buildTechInsightsContext } from './techInsightsContextBuilder';
 import { createRouter } from './router';
-import { ServerTokenManager } from '@backstage/backend-common';
 import { ConfigReader } from '@backstage/config';
 import request from 'supertest';
 import express from 'express';
@@ -75,7 +75,7 @@ describe('Tech Insights router tests', () => {
         getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
         getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
       },
-      tokenManager: ServerTokenManager.noop(),
+      auth: mockServices.auth(),
     });
 
     const router = await createRouter({

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { buildTechInsightsContext } from './techInsightsContextBuilder';
-import { ServerTokenManager } from '@backstage/backend-common';
-import { DatabaseManager } from '@backstage/backend-defaults/database';
 import { ConfigReader } from '@backstage/config';
 import { DefaultSchedulerService } from '@backstage/backend-defaults/scheduler';
 import { DefaultFactRetrieverRegistry } from './fact/FactRetrieverRegistry';
@@ -34,7 +33,7 @@ jest.mock('./fact/FactRetrieverEngine', () => ({
 
 describe('buildTechInsightsContext', () => {
   const logger = mockServices.logger.mock();
-  const pluginDatabase: DatabaseService = {
+  const database: DatabaseService = {
     getClient: () => {
       return Promise.resolve({
         migrate: {
@@ -43,11 +42,6 @@ describe('buildTechInsightsContext', () => {
       }) as unknown as Promise<Knex>;
     },
   };
-  const databaseManager: Partial<DatabaseManager> = {
-    forPlugin: () => pluginDatabase,
-  };
-  const manager = databaseManager as DatabaseManager;
-  const database = manager.forPlugin('tech-insights');
   const discoveryMock = {
     getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
     getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
@@ -60,13 +54,13 @@ describe('buildTechInsightsContext', () => {
 
   it('constructs the default FactRetrieverRegistry if factRetrievers but no factRetrieverRegistry are passed', () => {
     buildTechInsightsContext({
-      database: pluginDatabase,
+      database,
       logger,
       factRetrievers: [],
-      scheduler: scheduler,
+      scheduler,
       config: ConfigReader.fromConfigs([]),
       discovery: discoveryMock,
-      tokenManager: ServerTokenManager.noop(),
+      auth: mockServices.auth(),
     });
     expect(DefaultFactRetrieverRegistry).toHaveBeenCalledTimes(1);
   });
@@ -75,14 +69,14 @@ describe('buildTechInsightsContext', () => {
     const factRetrieverRegistryMock = {} as DefaultFactRetrieverRegistry;
 
     buildTechInsightsContext({
-      database: pluginDatabase,
+      database,
       logger,
       factRetrievers: [],
       factRetrieverRegistry: factRetrieverRegistryMock,
-      scheduler: scheduler,
+      scheduler,
       config: ConfigReader.fromConfigs([]),
       discovery: discoveryMock,
-      tokenManager: ServerTokenManager.noop(),
+      auth: mockServices.auth(),
     });
     expect(DefaultFactRetrieverRegistry).not.toHaveBeenCalled();
   });

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
@@ -21,10 +21,6 @@ import {
 import { DefaultFactRetrieverRegistry } from './fact/FactRetrieverRegistry';
 import { Config } from '@backstage/config';
 import {
-  createLegacyAuthAdapters,
-  TokenManager,
-} from '@backstage/backend-common';
-import {
   FactChecker,
   FactCheckerFactory,
   FactRetrieverRegistration,
@@ -85,8 +81,7 @@ export interface TechInsightsOptions<
   discovery: DiscoveryService;
   database: DatabaseService;
   scheduler: SchedulerService;
-  tokenManager: TokenManager;
-  auth?: AuthService;
+  auth: AuthService;
 }
 
 /**
@@ -129,7 +124,7 @@ export const buildTechInsightsContext = async <
     database,
     logger,
     scheduler,
-    tokenManager,
+    auth,
   } = options;
 
   const buildFactRetrieverRegistry = (): FactRetrieverRegistry => {
@@ -152,12 +147,6 @@ export const buildTechInsightsContext = async <
       logger,
     }));
 
-  const { auth } = createLegacyAuthAdapters({
-    auth: options.auth,
-    tokenManager,
-    discovery,
-  });
-
   const factRetrieverEngine = await DefaultFactRetrieverEngine.create({
     scheduler,
     repository: persistenceContext.techInsightsStore,
@@ -166,7 +155,6 @@ export const buildTechInsightsContext = async <
       config,
       discovery,
       logger,
-      tokenManager,
       auth,
     },
   });

--- a/workspaces/tech-insights/plugins/tech-insights-node/api-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/api-report.md
@@ -17,7 +17,6 @@ import { FactSchema } from '@backstage-community/plugin-tech-insights-common';
 import { HumanDuration } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import { TokenManager } from '@backstage/backend-common';
 
 // @public
 export type CheckValidationResponse = {
@@ -68,7 +67,6 @@ export type FactRetrieverContext = {
   config: Config;
   discovery: DiscoveryService;
   logger: LoggerService;
-  tokenManager: TokenManager;
   auth: AuthService;
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@backstage-community/plugin-tech-insights-common": "workspace:^",
-    "@backstage/backend-common": "^0.24.0",
     "@backstage/backend-plugin-api": "^0.8.0",
     "@backstage/catalog-model": "^1.6.0",
     "@backstage/config": "^1.2.0",

--- a/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { DateTime, Duration, DurationLike } from 'luxon';
 import { Config } from '@backstage/config';
 import { HumanDuration, JsonValue } from '@backstage/types';
-import { TokenManager } from '@backstage/backend-common';
 import { FactSchema } from '@backstage-community/plugin-tech-insights-common';
 import {
   AuthService,
@@ -92,7 +92,6 @@ export type FactRetrieverContext = {
   config: Config;
   discovery: DiscoveryService;
   logger: LoggerService;
-  tokenManager: TokenManager;
   auth: AuthService;
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -2857,7 +2857,6 @@ __metadata:
   resolution: "@backstage-community/plugin-tech-insights-node@workspace:plugins/tech-insights-node"
   dependencies:
     "@backstage-community/plugin-tech-insights-common": "workspace:^"
-    "@backstage/backend-common": ^0.24.0
     "@backstage/backend-plugin-api": ^0.8.0
     "@backstage/catalog-model": ^1.6.0
     "@backstage/cli": ^0.27.0


### PR DESCRIPTION
Fixes #1237

`coreServices.identity` and `coreServices.tokenManager` were removed entirely in the 1.31 release of Backstage, so migrate away from that and instead to the new auth system. I chose to NOT do a gradual migration, because it's hard to both have the cookie and eat it - the goal of the PR is to avoid depending on `coreServices.tokenManager` in the plugin itself, and at the end of the day that type leaked all the way out into the context being passed to fact retrievers. We can't really reliably make a fake `TokenManager` either, since if the target plugins are on the new backend system we can't just make any ol' legacy token to pass to them.

This does have the effect that if a user wants to update to a new tech-insights version, they'll need to have done the auth migration first.