### PR TITLE
playlist: better support the new auth system

### DIFF
--- a/workspaces/playlist/.changeset/lovely-suns-allow.md
+++ b/workspaces/playlist/.changeset/lovely-suns-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-playlist-backend': patch
+---
+
+Updated auth system support - the router no longer requires an identity API, and optionally accepts an auth and httpAuth API

--- a/workspaces/playlist/plugins/playlist-backend/api-report.md
+++ b/workspaces/playlist/plugins/playlist-backend/api-report.md
@@ -98,7 +98,7 @@ export interface RouterOptions {
   // (undocumented)
   httpAuth?: HttpAuthService;
   // (undocumented)
-  identity: IdentityApi;
+  identity?: IdentityApi;
   // (undocumented)
   logger: LoggerService;
   // (undocumented)

--- a/workspaces/playlist/plugins/playlist-backend/src/plugin.ts
+++ b/workspaces/playlist/plugins/playlist-backend/src/plugin.ts
@@ -32,18 +32,28 @@ export const playlistPlugin = createBackendPlugin({
         http: coreServices.httpRouter,
         logger: coreServices.logger,
         database: coreServices.database,
-        identity: coreServices.identity,
         discovery: coreServices.discovery,
         permissions: coreServices.permissions,
+        auth: coreServices.auth,
+        httpAuth: coreServices.httpAuth,
       },
-      async init({ http, logger, database, identity, discovery, permissions }) {
+      async init({
+        http,
+        logger,
+        database,
+        discovery,
+        permissions,
+        auth,
+        httpAuth,
+      }) {
         http.use(
           await createRouter({
             logger,
             database,
-            identity,
             discovery,
             permissions,
+            auth,
+            httpAuth,
           }),
         );
       },

--- a/workspaces/playlist/plugins/playlist-backend/src/service/router.ts
+++ b/workspaces/playlist/plugins/playlist-backend/src/service/router.ts
@@ -53,7 +53,7 @@ import {
 export interface RouterOptions {
   database: PluginDatabaseManager;
   discovery: PluginEndpointDiscovery;
-  identity: IdentityApi;
+  identity?: IdentityApi;
   logger: LoggerService;
   permissions: PermissionsService;
   auth?: AuthService;


### PR DESCRIPTION
coreServices.identity and coreServices.tokenManager were removed entirely in the 1.31 release of Backstage, so migrate away from that and instead to the new auth system.