### PR TITLE
lighthouse: remove support for custom old auth

### DIFF
--- a/workspaces/lighthouse/.changeset/tender-walls-pay.md
+++ b/workspaces/lighthouse/.changeset/tender-walls-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-lighthouse-backend': patch
+---
+
+Made the token manager optional. The new-backend module no longer injects custom token managers.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/api-report.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/api-report.md
@@ -27,7 +27,7 @@ export interface CreateLighthouseSchedulerOptions {
   // (undocumented)
   scheduler?: PluginTaskScheduler;
   // (undocumented)
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
 }
 
 // @public (undocumented)

--- a/workspaces/lighthouse/plugins/lighthouse-backend/src/plugin.ts
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/src/plugin.ts
@@ -36,7 +36,6 @@ export const lighthousePlugin = createBackendPlugin({
         config: coreServices.rootConfig,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
-        tokenManager: coreServices.tokenManager,
         discovery: coreServices.discovery,
         auth: coreServices.auth,
       },
@@ -45,7 +44,6 @@ export const lighthousePlugin = createBackendPlugin({
         config,
         logger,
         scheduler,
-        tokenManager,
         discovery,
         auth,
       }) {
@@ -54,7 +52,6 @@ export const lighthousePlugin = createBackendPlugin({
           config,
           logger,
           scheduler,
-          tokenManager,
           discovery,
           auth,
         });

--- a/workspaces/lighthouse/plugins/lighthouse-backend/src/service/createScheduler.ts
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/src/service/createScheduler.ts
@@ -37,7 +37,7 @@ export interface CreateLighthouseSchedulerOptions {
   discovery: DiscoveryService;
   scheduler?: PluginTaskScheduler;
   catalogClient: CatalogApi;
-  tokenManager: TokenManager;
+  tokenManager?: TokenManager;
   auth?: AuthService;
 }
 


### PR DESCRIPTION
coreServices.identity and coreServices.tokenManager were removed entirely in the 1.31 release of Backstage, so migrate away from that and instead to the new auth system.