### PR TITLE
adr: remove support for custom old auth

### DIFF
--- a/workspaces/adr/.changeset/lucky-apes-repair.md
+++ b/workspaces/adr/.changeset/lucky-apes-repair.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/search-backend-module-adr': patch
+---
+
+Made the token manager optional. The new-backend module no longer injects custom token managers.

--- a/workspaces/adr/plugins/search-backend-module-adr/src/index.ts
+++ b/workspaces/adr/plugins/search-backend-module-adr/src/index.ts
@@ -89,7 +89,6 @@ export default createBackendModule({
         logger: coreServices.rootLogger,
         reader: coreServices.urlReader,
         scheduler: coreServices.scheduler,
-        tokenManager: coreServices.tokenManager,
         indexRegistry: searchIndexRegistryExtensionPoint,
         catalog: catalogServiceRef,
       },
@@ -101,7 +100,6 @@ export default createBackendModule({
         logger,
         reader,
         scheduler,
-        tokenManager,
         indexRegistry,
         catalog,
       }) {
@@ -116,7 +114,6 @@ export default createBackendModule({
             discovery,
             logger,
             reader,
-            tokenManager,
             adrFilePathFilterFn,
             parser,
             catalogClient: catalog,


### PR DESCRIPTION
coreServices.identity and coreServices.tokenManager were removed entirely in the 1.31 release of Backstage, so migrate away from that and instead to the new auth system.