### PR TITLE
Version Packages (lighthouse)

### DIFF
--- a/workspaces/lighthouse/.changeset/tender-walls-pay.md
+++ b/workspaces/lighthouse/.changeset/tender-walls-pay.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse-backend': patch
----
-
-Made the token manager optional. The new-backend module no longer injects custom token managers.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-lighthouse-backend
 
+## 0.4.14
+
+### Patch Changes
+
+- 149bcac: Made the token manager optional. The new-backend module no longer injects custom token managers.
+
 ## 0.4.13
 
 ### Patch Changes

--- a/workspaces/lighthouse/plugins/lighthouse-backend/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-backend",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-lighthouse-backend@0.4.14

### Patch Changes

-   149bcac: Made the token manager optional. The new-backend module no longer injects custom token managers.
