### PR TITLE
Version Packages (bazaar)

### DIFF
--- a/workspaces/bazaar/.changeset/flat-eggs-joke.md
+++ b/workspaces/bazaar/.changeset/flat-eggs-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bazaar-backend': minor
----
-
-**BREAKING**: The backend has been migrated to the new backend system. The `createRouter` function now requires the new `auth` and `httpAuth` services to be passed in, instead of the removed `identity` service. If you are using the new backend system module, this does not affect you.

--- a/workspaces/bazaar/.changeset/version-bump-1-30-2.md
+++ b/workspaces/bazaar/.changeset/version-bump-1-30-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-bazaar': patch
-'@backstage-community/plugin-bazaar-backend': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/bazaar/plugins/bazaar-backend/CHANGELOG.md
+++ b/workspaces/bazaar/plugins/bazaar-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-bazaar-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- 40b046d: **BREAKING**: The backend has been migrated to the new backend system. The `createRouter` function now requires the new `auth` and `httpAuth` services to be passed in, instead of the removed `identity` service. If you are using the new backend system module, this does not affect you.
+
+### Patch Changes
+
+- 23c908d: Backstage version bump to v1.30.2
+
 ## 0.3.17
 
 ### Patch Changes

--- a/workspaces/bazaar/plugins/bazaar-backend/package.json
+++ b/workspaces/bazaar/plugins/bazaar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bazaar-backend",
-  "version": "0.3.17",
+  "version": "0.4.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "bazaar",

--- a/workspaces/bazaar/plugins/bazaar/CHANGELOG.md
+++ b/workspaces/bazaar/plugins/bazaar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-bazaar
 
+## 0.2.29
+
+### Patch Changes
+
+- 23c908d: Backstage version bump to v1.30.2
+
 ## 0.2.28
 
 ### Patch Changes

--- a/workspaces/bazaar/plugins/bazaar/package.json
+++ b/workspaces/bazaar/plugins/bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bazaar",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "bazaar",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-bazaar-backend@0.4.0

### Minor Changes

-   40b046d: **BREAKING**: The backend has been migrated to the new backend system. The `createRouter` function now requires the new `auth` and `httpAuth` services to be passed in, instead of the removed `identity` service. If you are using the new backend system module, this does not affect you.

### Patch Changes

-   23c908d: Backstage version bump to v1.30.2

## @backstage-community/plugin-bazaar@0.2.29

### Patch Changes

-   23c908d: Backstage version bump to v1.30.2
