### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
+++ b/workspaces/tech-insights/.changeset/cuddly-brooms-shake.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-node': major
----
-
-**BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead if you need to make backend requests.

--- a/workspaces/tech-insights/.changeset/tidy-paws-matter.md
+++ b/workspaces/tech-insights/.changeset/tidy-paws-matter.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': major
----
-
-**BREAKING**: The service no longer accepts the deprecated `TokenManager` instance, but instead the `AuthService` is now required where it used to be optional. If you are using the new backend system module, this does not affect you.

--- a/workspaces/tech-insights/packages/backend/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # backend
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [9871d0b]
+- Updated dependencies [9871d0b]
+  - @backstage-community/plugin-tech-insights-node@1.0.0
+  - @backstage-community/plugin-tech-insights-backend@1.0.0
+  - @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.57
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/tech-insights/packages/backend/package.json
+++ b/workspaces/tech-insights/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.57
+
+### Patch Changes
+
+- Updated dependencies [9871d0b]
+  - @backstage-community/plugin-tech-insights-node@1.0.0
+
 ## 0.1.56
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 1.0.0
+
+### Major Changes
+
+- 9871d0b: **BREAKING**: The service no longer accepts the deprecated `TokenManager` instance, but instead the `AuthService` is now required where it used to be optional. If you are using the new backend system module, this does not affect you.
+
+### Patch Changes
+
+- Updated dependencies [9871d0b]
+  - @backstage-community/plugin-tech-insights-node@1.0.0
+
 ## 0.6.3
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "0.6.3",
+  "version": "1.0.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-node
 
+## 1.0.0
+
+### Major Changes
+
+- 9871d0b: **BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead if you need to make backend requests.
+
 ## 0.6.7
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-node",
-  "version": "0.6.7",
+  "version": "1.0.0",
   "backstage": {
     "role": "node-library",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-backend@1.0.0

### Major Changes

-   9871d0b: **BREAKING**: The service no longer accepts the deprecated `TokenManager` instance, but instead the `AuthService` is now required where it used to be optional. If you are using the new backend system module, this does not affect you.

### Patch Changes

-   Updated dependencies [9871d0b]
    -   @backstage-community/plugin-tech-insights-node@1.0.0

## @backstage-community/plugin-tech-insights-node@1.0.0

### Major Changes

-   9871d0b: **BREAKING**: `FactRetrieverContext` no longer includes the deprecated `tokenManager`. Please use the `auth` field instead if you need to make backend requests.

## @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.57

### Patch Changes

-   Updated dependencies [9871d0b]
    -   @backstage-community/plugin-tech-insights-node@1.0.0

## backend@0.0.7

### Patch Changes

-   Updated dependencies [9871d0b]
-   Updated dependencies [9871d0b]
    -   @backstage-community/plugin-tech-insights-node@1.0.0
    -   @backstage-community/plugin-tech-insights-backend@1.0.0
    -   @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.57
