### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/lucky-apes-repair.md
+++ b/workspaces/adr/.changeset/lucky-apes-repair.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': patch
----
-
-Made the token manager optional. The new-backend module no longer injects custom token managers.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.24
+
+### Patch Changes
+
+- Updated dependencies [f43e557]
+  - @backstage-community/search-backend-module-adr@0.1.4
+
 ## 0.4.23
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.1.4
+
+### Patch Changes
+
+- f43e557: Made the token manager optional. The new-backend module no longer injects custom token managers.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.4.24

### Patch Changes

-   Updated dependencies [f43e557]
    -   @backstage-community/search-backend-module-adr@0.1.4

## @backstage-community/search-backend-module-adr@0.1.4

### Patch Changes

-   f43e557: Made the token manager optional. The new-backend module no longer injects custom token managers.
