### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/lovely-suns-allow.md
+++ b/workspaces/playlist/.changeset/lovely-suns-allow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-playlist-backend': patch
----
-
-Updated auth system support - the router no longer requires an identity API, and optionally accepts an auth and httpAuth API

--- a/workspaces/playlist/.changeset/version-bump-1-30-2.md
+++ b/workspaces/playlist/.changeset/version-bump-1-30-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist': patch
-'@backstage-community/plugin-playlist-backend': patch
-'@backstage-community/plugin-playlist-common': patch
----
-
-Backstage version bump to v1.30.2

--- a/workspaces/playlist/packages/app/CHANGELOG.md
+++ b/workspaces/playlist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [22de8f4]
+  - @backstage-community/plugin-playlist@0.2.14
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/playlist/packages/app/package.json
+++ b/workspaces/playlist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [cba33e9]
+- Updated dependencies [22de8f4]
+  - @backstage-community/plugin-playlist-backend@0.3.26
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.3.26
+
+### Patch Changes
+
+- cba33e9: Updated auth system support - the router no longer requires an identity API, and optionally accepts an auth and httpAuth API
+- 22de8f4: Backstage version bump to v1.30.2
+- Updated dependencies [22de8f4]
+  - @backstage-community/plugin-playlist-common@0.1.19
+
 ## 0.3.25
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",

--- a/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-common
 
+## 0.1.19
+
+### Patch Changes
+
+- 22de8f4: Backstage version bump to v1.30.2
+
 ## 0.1.18
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-common/package.json
+++ b/workspaces/playlist/plugins/playlist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-common",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Common functionalities for the playlist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist
 
+## 0.2.14
+
+### Patch Changes
+
+- 22de8f4: Backstage version bump to v1.30.2
+- Updated dependencies [22de8f4]
+  - @backstage-community/plugin-playlist-common@0.1.19
+
 ## 0.2.13
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.2.14

### Patch Changes

-   22de8f4: Backstage version bump to v1.30.2
-   Updated dependencies [22de8f4]
    -   @backstage-community/plugin-playlist-common@0.1.19

## @backstage-community/plugin-playlist-backend@0.3.26

### Patch Changes

-   cba33e9: Updated auth system support - the router no longer requires an identity API, and optionally accepts an auth and httpAuth API
-   22de8f4: Backstage version bump to v1.30.2
-   Updated dependencies [22de8f4]
    -   @backstage-community/plugin-playlist-common@0.1.19

## @backstage-community/plugin-playlist-common@0.1.19

### Patch Changes

-   22de8f4: Backstage version bump to v1.30.2

## app@0.0.4

### Patch Changes

-   Updated dependencies [22de8f4]
    -   @backstage-community/plugin-playlist@0.2.14

## backend@0.0.4

### Patch Changes

-   Updated dependencies [cba33e9]
-   Updated dependencies [22de8f4]
    -   @backstage-community/plugin-playlist-backend@0.3.26
