### PR TITLE
Tech Insights icon and export fixes

### DIFF
--- a/workspaces/tech-insights/.changeset/strange-peaches-compare.md
+++ b/workspaces/tech-insights/.changeset/strange-peaches-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+Export component extensions instead of routable extensions when routes aren't required (or used). ResultCheckIcon can now wrap both React components and HTML elements for onClick handling of the popup menu with links.

--- a/workspaces/tech-insights/plugins/tech-insights/api-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights/api-report.md
@@ -11,16 +11,14 @@ import { BulkCheckResponse } from '@backstage-community/plugin-tech-insights-com
 import { Check as Check_2 } from '@backstage-community/plugin-tech-insights-common/client';
 import { CheckLink } from '@backstage-community/plugin-tech-insights-common';
 import { CheckResult } from '@backstage-community/plugin-tech-insights-common';
-import { ComponentProps } from 'react';
-import { ComponentType } from 'react';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
+import { ElementType } from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { FactSchema } from '@backstage-community/plugin-tech-insights-common';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { JsonValue } from '@backstage/types';
 import { JSX as JSX_2 } from 'react';
-import { ListItemSecondaryAction } from '@material-ui/core';
 import { MouseEventHandler } from 'react';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
@@ -74,15 +72,17 @@ export interface InsightFacts {
 export const jsonRulesEngineCheckResultRenderer: CheckResultRenderer;
 
 // @public (undocumented)
-export type ResultCheckIconBaseComponent = ComponentType<{
-  onClick?: MouseEventHandler | undefined;
+export type ResultCheckIconBaseComponentProps = PropsWithChildren<{
+  onClick?: MouseEventHandler;
 }>;
 
 // @public
-export interface ResultCheckIconProps<C extends ResultCheckIconBaseComponent> {
+export interface ResultCheckIconProps<
+  P extends ResultCheckIconBaseComponentProps,
+> {
   checkResultRenderer?: CheckResultRenderer;
-  component?: C;
-  componentProps?: Omit<ComponentProps<C>, 'onClick'>;
+  component?: ElementType<P>;
+  componentProps?: Omit<P, 'onClick' | 'children'>;
   disableLinksMenu?: boolean;
   entity?: Entity;
   missingRendererComponent?: ReactNode;
@@ -147,9 +147,9 @@ export const techInsightsApiRef: ApiRef<TechInsightsApi>;
 
 // @public (undocumented)
 export const TechInsightsCheckIcon: <
-  C extends ResultCheckIconBaseComponent = ListItemSecondaryAction,
+  P extends ResultCheckIconBaseComponentProps,
 >(
-  props: ResultCheckIconProps<C>,
+  props: ResultCheckIconProps<P>,
 ) => JSX_2.Element;
 
 // @public (undocumented)

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ResultCheckIcon/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ResultCheckIcon/index.ts
@@ -16,6 +16,6 @@
 
 export type {
   ResultCheckIconProps,
-  ResultCheckIconBaseComponent,
+  ResultCheckIconBaseComponentProps,
 } from './ResultCheckIcon';
 export { ResultCheckIcon } from './ResultCheckIcon';

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsList/ScorecardsList.tsx
@@ -18,6 +18,7 @@ import React from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import ListItemText from '@material-ui/core/ListItemText';
 import { makeStyles } from '@material-ui/core/styles';
 import { techInsightsApiRef } from '../../api';
@@ -70,6 +71,7 @@ export const ScorecardsList = (props: {
             <ResultCheckIcon
               result={result}
               entity={entity}
+              component={ListItemSecondaryAction}
               checkResultRenderer={checkResultRenderer}
             />
           </ListItem>

--- a/workspaces/tech-insights/plugins/tech-insights/src/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/index.ts
@@ -31,6 +31,6 @@ export { jsonRulesEngineCheckResultRenderer } from './components/CheckResultRend
 export type { CheckResultRenderer } from './components/CheckResultRenderer';
 export type {
   ResultCheckIconProps,
-  ResultCheckIconBaseComponent,
+  ResultCheckIconBaseComponentProps,
 } from './components/ResultCheckIcon';
 export type { ResultLinksMenuInfo } from './components/ResultLinksMenu';

--- a/workspaces/tech-insights/plugins/tech-insights/src/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/plugin.ts
@@ -15,6 +15,7 @@
  */
 import {
   createPlugin,
+  createComponentExtension,
   createRoutableExtension,
   createApiFactory,
   discoveryApiRef,
@@ -46,11 +47,12 @@ export const techInsightsPlugin = createPlugin({
  * @public
  */
 export const ScorecardInfo = techInsightsPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: 'ScorecardInfo',
-    component: () =>
-      import('./components/ScorecardsInfo').then(m => m.ScorecardInfo),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import('./components/ScorecardsInfo').then(m => m.ScorecardInfo),
+    },
   }),
 );
 
@@ -58,11 +60,12 @@ export const ScorecardInfo = techInsightsPlugin.provide(
  * @public
  */
 export const ScorecardsList = techInsightsPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: 'ScorecardsList',
-    component: () =>
-      import('./components/ScorecardsList').then(m => m.ScorecardsList),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import('./components/ScorecardsList').then(m => m.ScorecardsList),
+    },
   }),
 );
 
@@ -106,11 +109,12 @@ export const TechInsightsScorecardPage = techInsightsPlugin.provide(
  * @public
  */
 export const TechInsightsCheckIcon = techInsightsPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: 'TechInsightsCheckIcon',
-    component: () =>
-      import('./components/ResultCheckIcon').then(m => m.ResultCheckIcon),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import('./components/ResultCheckIcon').then(m => m.ResultCheckIcon),
+    },
   }),
 );
 
@@ -118,10 +122,11 @@ export const TechInsightsCheckIcon = techInsightsPlugin.provide(
  * @public
  */
 export const TechInsightsLinksMenu = techInsightsPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: 'TechInsightsLinksMenu',
-    component: () =>
-      import('./components/ResultLinksMenu').then(m => m.ResultLinksMenu),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () =>
+        import('./components/ResultLinksMenu').then(m => m.ResultLinksMenu),
+    },
   }),
 );


### PR DESCRIPTION
## Improve the ResultCheckIcon and exports

#1203 introduced a reusable ResultCheckIcon for Tech Insights' result icons.

This PR changes this slightly to not wrap any component by default (was `ListItemSecondaryAction`), and allow wrapping it with native HTML elements too (for the onClick handler of the popup menu with links). This makes it more generic (and less centric to the ScorecardsList).

Also, this PR changes how the (in #1203) added `ResultCheckIcon` and `TechInsightsLinksMenu`, but also the `ScorecardInfo` and `ScorecardsList` components are exported. They used to be exported through `createRoutableExtension` but are now instead through `createComponentExtension` as they don't require (or use) any routing. This makes it possible to render them anywhere.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
