### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/tall-beds-repair.md
+++ b/workspaces/redhat-argocd/.changeset/tall-beds-repair.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-fetched argo resources timestamp from k8s object

--- a/workspaces/redhat-argocd/packages/app/CHANGELOG.md
+++ b/workspaces/redhat-argocd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [c829b80]
+  - @backstage-community/plugin-redhat-argocd@1.8.5
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.8.5
+
+### Patch Changes
+
+- c829b80: fetched argo resources timestamp from k8s object
+
 ## 1.8.4
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.8.5

### Patch Changes

-   c829b80: fetched argo resources timestamp from k8s object

## app@0.0.4

### Patch Changes

-   Updated dependencies [c829b80]
    -   @backstage-community/plugin-redhat-argocd@1.8.5
