### PR TITLE
Version Packages (github-issues)

### DIFF
--- a/workspaces/github-issues/.changeset/happy-garlics-think.md
+++ b/workspaces/github-issues/.changeset/happy-garlics-think.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-issues': patch
----
-
-Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` or `backstage.io/managed-by-location` to determine the appropriate provider. If no provider matches the slug, the first GitHub provider will be selected, maintaining the previous behavior.

--- a/workspaces/github-issues/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github-issues/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-issues
 
+## 0.4.5
+
+### Patch Changes
+
+- db0dc8d: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` or `backstage.io/managed-by-location` to determine the appropriate provider. If no provider matches the slug, the first GitHub provider will be selected, maintaining the previous behavior.
+
 ## 0.4.4
 
 ### Patch Changes

--- a/workspaces/github-issues/plugins/github-issues/package.json
+++ b/workspaces/github-issues/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "github-issues",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-issues@0.4.5

### Patch Changes

-   db0dc8d: Introduces support for multiple GitHub integrations. The previous behavior of using the first GitHub provider has been changed to use the well-known entity slug annotation `backstage.io/source-location` or `backstage.io/managed-by-location` to determine the appropriate provider. If no provider matches the slug, the first GitHub provider will be selected, maintaining the previous behavior.
