### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/five-eyes-suffer.md
+++ b/workspaces/tech-insights/.changeset/five-eyes-suffer.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': minor
----
-
-Adds fact to represent presence of the `backstage.io/techdocs-entity` annotation.

--- a/workspaces/tech-insights/.changeset/strange-peaches-compare.md
+++ b/workspaces/tech-insights/.changeset/strange-peaches-compare.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-Export component extensions instead of routable extensions when routes aren't required (or used). ResultCheckIcon can now wrap both React components and HTML elements for onClick handling of the popup menu with links.

--- a/workspaces/tech-insights/packages/app/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [42a2c31]
+  - @backstage-community/plugin-tech-insights@0.3.36
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/tech-insights/packages/app/package.json
+++ b/workspaces/tech-insights/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/tech-insights/packages/backend/CHANGELOG.md
+++ b/workspaces/tech-insights/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [fad299b]
+  - @backstage-community/plugin-tech-insights-backend@1.1.0
+  - app@0.0.8
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/tech-insights/packages/backend/package.json
+++ b/workspaces/tech-insights/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 1.1.0
+
+### Minor Changes
+
+- fad299b: Adds fact to represent presence of the `backstage.io/techdocs-entity` annotation.
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.3.36
+
+### Patch Changes
+
+- 42a2c31: Export component extensions instead of routable extensions when routes aren't required (or used). ResultCheckIcon can now wrap both React components and HTML elements for onClick handling of the popup menu with links.
+
 ## 0.3.35
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-backend@1.1.0

### Minor Changes

-   fad299b: Adds fact to represent presence of the `backstage.io/techdocs-entity` annotation.

## @backstage-community/plugin-tech-insights@0.3.36

### Patch Changes

-   42a2c31: Export component extensions instead of routable extensions when routes aren't required (or used). ResultCheckIcon can now wrap both React components and HTML elements for onClick handling of the popup menu with links.

## app@0.0.8

### Patch Changes

-   Updated dependencies [42a2c31]
    -   @backstage-community/plugin-tech-insights@0.3.36

## backend@0.0.8

### Patch Changes

-   Updated dependencies [fad299b]
    -   @backstage-community/plugin-tech-insights-backend@1.1.0
    -   app@0.0.8
