### PR TITLE
Fact to represent presence of the `backstage.io/techdocs-entity` annotation

### DIFF
--- a/workspaces/tech-insights/.changeset/five-eyes-suffer.md
+++ b/workspaces/tech-insights/.changeset/five-eyes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+---
+
+Adds fact to represent presence of the `backstage.io/techdocs-entity` annotation.

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
@@ -45,6 +45,7 @@ const defaultEntityListResponse: GetEntitiesResponse = {
         tags: ['a-tag'],
         annotations: {
           'backstage.io/techdocs-ref': 'dir:.',
+          'backstage.io/techdocs-entity': 'component:default/techdocs-entity',
         },
       },
       kind: 'Component',
@@ -127,6 +128,7 @@ describe('techdocsFactRetriever', () => {
           ).toMatchObject({
             facts: {
               hasAnnotationBackstageIoTechdocsRef: true,
+              hasAnnotationBackstageIoTechdocsEntity: true,
             },
           });
         });
@@ -139,6 +141,7 @@ describe('techdocsFactRetriever', () => {
           ).toMatchObject({
             facts: {
               hasAnnotationBackstageIoTechdocsRef: false,
+              hasAnnotationBackstageIoTechdocsEntity: false,
             },
           });
         });

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.ts
@@ -23,8 +23,12 @@ import { Entity } from '@backstage/catalog-model';
 import { entityHasAnnotation, generateAnnotationFactName } from './utils';
 
 const techdocsAnnotation = 'backstage.io/techdocs-ref';
+const techdocsEntityAnnotation = 'backstage.io/techdocs-entity';
 const techdocsAnnotationFactName =
   generateAnnotationFactName(techdocsAnnotation);
+const techdocsEntityAnnotationFactName = generateAnnotationFactName(
+  techdocsEntityAnnotation,
+);
 
 /**
  * Generates facts related to the completeness of techdocs configuration for entities.
@@ -41,6 +45,10 @@ export const techdocsFactRetriever: FactRetriever = {
     [techdocsAnnotationFactName]: {
       type: 'boolean',
       description: 'The entity has a TechDocs reference annotation',
+    },
+    [techdocsEntityAnnotationFactName]: {
+      type: 'boolean',
+      description: 'The entity has a TechDocs entity annotation',
     },
   },
   handler: async ({ discovery, entityFilter, auth }: FactRetrieverContext) => {
@@ -67,6 +75,10 @@ export const techdocsFactRetriever: FactRetriever = {
           [techdocsAnnotationFactName]: entityHasAnnotation(
             entity,
             techdocsAnnotation,
+          ),
+          [techdocsEntityAnnotationFactName]: entityHasAnnotation(
+            entity,
+            techdocsEntityAnnotation,
           ),
         },
       };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In systems where you might have multiple entities for example a System with a Website and an API, when served from a Monorepo you might want to keep the TechDocs in one location in the repository.

In this case you might be using the `backstage.io/techdocs-entity` annotation to point to the owners entityRef and use its TechDocs.

This pull request allows tech insights checks to be aware of these cases.

This is a check you might write with this new fact:

```yaml
      techDocsCheck:
        type: json-rules-engine
        name: TechDocs Check
        description: Verifies that TechDocs has been enabled for this entity
        factIds:
          - techdocsFactRetriever
        rule:
          conditions:
            any:
              - fact: hasAnnotationBackstageIoTechdocsRef
                operator: equal
                value: true
              - fact: hasAnnotationBackstageIoTechdocsEntity
                operator: equal
                value: true
  ```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
