### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/version-bump-1-31-1.md
+++ b/workspaces/confluence/.changeset/version-bump-1-31-1.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-confluence': patch
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Backstage version bump to v1.31.1

--- a/workspaces/confluence/packages/app/CHANGELOG.md
+++ b/workspaces/confluence/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [8efbeed]
+  - @backstage-community/plugin-confluence@0.1.2
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/confluence/packages/app/package.json
+++ b/workspaces/confluence/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/confluence/packages/backend/CHANGELOG.md
+++ b/workspaces/confluence/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [8efbeed]
+  - @backstage-community/plugin-search-backend-module-confluence-collator@0.2.1
+  - app@0.0.3
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/confluence/packages/backend/package.json
+++ b/workspaces/confluence/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-confluence
 
+## 0.1.2
+
+### Patch Changes
+
+- 8efbeed: Backstage version bump to v1.31.1
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.2.1
+
+### Patch Changes
+
+- 8efbeed: Backstage version bump to v1.31.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.1.2

### Patch Changes

-   8efbeed: Backstage version bump to v1.31.1

## @backstage-community/plugin-search-backend-module-confluence-collator@0.2.1

### Patch Changes

-   8efbeed: Backstage version bump to v1.31.1

## app@0.0.3

### Patch Changes

-   Updated dependencies [8efbeed]
    -   @backstage-community/plugin-confluence@0.1.2

## backend@0.0.3

### Patch Changes

-   Updated dependencies [8efbeed]
    -   @backstage-community/plugin-search-backend-module-confluence-collator@0.2.1
    -   app@0.0.3
