### PR TITLE
noop: add missing postinstall script

### DIFF
--- a/workspaces/noop/package.json
+++ b/workspaces/noop/package.json
@@ -8,6 +8,7 @@
     "backstage-cli": "exit 0",
     "build:api-reports:only": "exit 0",
     "fix": "exit 0",
+    "postinstall": "cd ../../ && yarn install",
     "prettier:check": "exit 0",
     "tsc:full": "exit 0"
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a missing `postinstall` script to the `noop` workspace, which was causing the ci workflow to fail.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
