### PR TITLE
Version Packages (stack-overflow)

### DIFF
--- a/workspaces/stack-overflow/.changeset/eighty-llamas-beam.md
+++ b/workspaces/stack-overflow/.changeset/eighty-llamas-beam.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-stack-overflow-backend': patch
----
-
-Entire package has been deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-stack-overflow-backend
 
+## 0.2.25
+
+### Patch Changes
+
+- b61618b: Entire package has been deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead
+
 ## 0.2.24
 
 ### Patch Changes

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-stack-overflow-backend",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "description": "Deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead",
   "deprecated": "Deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead",
   "backstage": {


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-stack-overflow-backend@0.2.25

### Patch Changes

-   b61618b: Entire package has been deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead
