### PR TITLE
Version Packages (acr)

### DIFF
--- a/workspaces/acr/.changeset/few-peaches-compete.md
+++ b/workspaces/acr/.changeset/few-peaches-compete.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': patch
----
-
-The acr from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

--- a/workspaces/acr/plugins/acr/CHANGELOG.md
+++ b/workspaces/acr/plugins/acr/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.8.1
+
+### Patch Changes
+
+- e72af66: The acr from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
+
 - **@janus-idp/cli:** upgraded to 1.13.2
 
 ### Dependencies

--- a/workspaces/acr/plugins/acr/package.json
+++ b/workspaces/acr/plugins/acr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-acr",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acr@1.8.1

### Patch Changes

-   e72af66: The acr from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/acr) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

-   **@janus-idp/cli:** upgraded to 1.13.2

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.3

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.2

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.1

### Dependencies

-   **@janus-idp/cli:** upgraded to 1.13.1
