### PR TITLE
Version Packages (graphiql)

### DIFF
--- a/workspaces/graphiql/.changeset/unlucky-fans-applaud.md
+++ b/workspaces/graphiql/.changeset/unlucky-fans-applaud.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-graphiql': patch
----
-
-Updated the declaration of the `GraphiQLIcon` to pass through all `SvgIcon` props.

--- a/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
+++ b/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-graphiql
 
+## 0.3.11
+
+### Patch Changes
+
+- 3ef985a: Updated the declaration of the `GraphiQLIcon` to pass through all `SvgIcon` props.
+
 ## 0.3.10
 
 ### Patch Changes

--- a/workspaces/graphiql/plugins/graphiql/package.json
+++ b/workspaces/graphiql/plugins/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-graphiql",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Backstage plugin for browsing GraphQL APIs",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-graphiql@0.3.11

### Patch Changes

-   3ef985a: Updated the declaration of the `GraphiQLIcon` to pass through all `SvgIcon` props.
