### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/version-bump-1-31-2.md
+++ b/workspaces/cost-insights/.changeset/version-bump-1-31-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': patch
-'@backstage-community/plugin-cost-insights-common': patch
----
-
-Backstage version bump to v1.31.2

--- a/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights-common
 
+## 0.1.6
+
+### Patch Changes
+
+- f3d4849: Backstage version bump to v1.31.2
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights-common/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights-common",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Common functionalities for the cost-insights plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.12.28
+
+### Patch Changes
+
+- f3d4849: Backstage version bump to v1.31.2
+- Updated dependencies [f3d4849]
+  - @backstage-community/plugin-cost-insights-common@0.1.6
+
 ## 0.12.27
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.12.27",
+  "version": "0.12.28",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.12.28

### Patch Changes

-   f3d4849: Backstage version bump to v1.31.2
-   Updated dependencies [f3d4849]
    -   @backstage-community/plugin-cost-insights-common@0.1.6

## @backstage-community/plugin-cost-insights-common@0.1.6

### Patch Changes

-   f3d4849: Backstage version bump to v1.31.2
