### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/old-mirrors-attend.md
+++ b/workspaces/azure-devops/.changeset/old-mirrors-attend.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': minor
----
-
-Fixed a link to azure-devops-backend plugin in Readme.

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [904a6a2]
+  - @backstage-community/plugin-azure-devops@0.6.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.6.0
+
+### Minor Changes
+
+- 904a6a2: Fixed a link to azure-devops-backend plugin in Readme.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.6.0

### Minor Changes

-   904a6a2: Fixed a link to azure-devops-backend plugin in Readme.

## app@0.0.9

### Patch Changes

-   Updated dependencies [904a6a2]
    -   @backstage-community/plugin-azure-devops@0.6.0
