### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/sixty-balloons-rush.md
+++ b/workspaces/adr/.changeset/sixty-balloons-rush.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': minor
----
-
-**BREAKING** Removed `TokenManager` as it has been removed from the upstream Backstage packages. `AuthService` is also now required. Please use the new backend system.

--- a/workspaces/adr/.changeset/version-bump-1-31-1.md
+++ b/workspaces/adr/.changeset/version-bump-1-31-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr-common': patch
-'@backstage-community/search-backend-module-adr': patch
----
-
-Backstage version bump to v1.31.1

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.4.25
+
+### Patch Changes
+
+- 5b56188: Backstage version bump to v1.31.1
+- Updated dependencies [5b56188]
+- Updated dependencies [5b56188]
+  - @backstage-community/search-backend-module-adr@0.2.0
+  - @backstage-community/plugin-adr-common@0.2.29
+
 ## 0.4.24
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.2.29
+
+### Patch Changes
+
+- 5b56188: Backstage version bump to v1.31.1
+
 ## 0.2.28
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.6.26
+
+### Patch Changes
+
+- 5b56188: Backstage version bump to v1.31.1
+- Updated dependencies [5b56188]
+  - @backstage-community/plugin-adr-common@0.2.29
+
 ## 0.6.25
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.6.25",
+  "version": "0.6.26",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.2.0
+
+### Minor Changes
+
+- 5b56188: **BREAKING** Removed `TokenManager` as it has been removed from the upstream Backstage packages. `AuthService` is also now required. Please use the new backend system.
+
+### Patch Changes
+
+- 5b56188: Backstage version bump to v1.31.1
+- Updated dependencies [5b56188]
+  - @backstage-community/plugin-adr-common@0.2.29
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/search-backend-module-adr@0.2.0

### Minor Changes

-   5b56188: **BREAKING** Removed `TokenManager` as it has been removed from the upstream Backstage packages. `AuthService` is also now required. Please use the new backend system.

### Patch Changes

-   5b56188: Backstage version bump to v1.31.1
-   Updated dependencies [5b56188]
    -   @backstage-community/plugin-adr-common@0.2.29

## @backstage-community/plugin-adr@0.6.26

### Patch Changes

-   5b56188: Backstage version bump to v1.31.1
-   Updated dependencies [5b56188]
    -   @backstage-community/plugin-adr-common@0.2.29

## @backstage-community/plugin-adr-backend@0.4.25

### Patch Changes

-   5b56188: Backstage version bump to v1.31.1
-   Updated dependencies [5b56188]
-   Updated dependencies [5b56188]
    -   @backstage-community/search-backend-module-adr@0.2.0
    -   @backstage-community/plugin-adr-common@0.2.29

## @backstage-community/plugin-adr-common@0.2.29

### Patch Changes

-   5b56188: Backstage version bump to v1.31.1
