### PR TITLE
Bazaar: Adding a completed status for Bazaar Projects

### DIFF
--- a/workspaces/bazaar/.changeset/hungry-stingrays-obey.md
+++ b/workspaces/bazaar/.changeset/hungry-stingrays-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-bazaar': minor
+---
+
+Adding Completion Capabilities

--- a/workspaces/bazaar/plugins/bazaar/dev/__fixtures__/get-projects-response.json
+++ b/workspaces/bazaar/plugins/bazaar/dev/__fixtures__/get-projects-response.json
@@ -9,7 +9,7 @@
       "status": "proposed",
       "updated_at": "2023-03-10T12:41:41.941Z",
       "community": "",
-      "size": "medium",
+      "size": "small",
       "start_date": null,
       "end_date": null,
       "responsible": "Responsible Adult 1",
@@ -21,7 +21,7 @@
       "entity_ref": null,
       "title": "Lorem ipsum 2",
       "description": "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud",
-      "status": "proposed",
+      "status": "ongoing",
       "updated_at": "2023-03-09T12:41:41.941Z",
       "community": "",
       "size": "medium",
@@ -30,6 +30,21 @@
       "responsible": "Responsible Adult 2",
       "docs": null,
       "members_count": "5"
+    },
+    {
+      "id": 12,
+      "entity_ref": null,
+      "title": "Lorem ipsum 3",
+      "description": "sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit",
+      "status": "completed",
+      "updated_at": "2024-09-09T12:41:41.941Z",
+      "community": "",
+      "size": "large",
+      "start_date": null,
+      "end_date": null,
+      "responsible": "Responsible Adult 3",
+      "docs": null,
+      "members_count": "15"
     }
   ]
 }

--- a/workspaces/bazaar/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
+++ b/workspaces/bazaar/plugins/bazaar/src/components/ProjectDialog/ProjectDialog.tsx
@@ -111,7 +111,7 @@ export const ProjectDialog = ({
           <InputSelector
             control={control}
             name="status"
-            options={['proposed', 'ongoing']}
+            options={['proposed', 'ongoing', 'completed']}
           />
 
           <InputSelector

--- a/workspaces/bazaar/plugins/bazaar/src/components/StatusTag/StatusTag.tsx
+++ b/workspaces/bazaar/plugins/bazaar/src/components/StatusTag/StatusTag.tsx
@@ -15,7 +15,11 @@
  */
 
 import React from 'react';
-import { StatusOK, StatusWarning } from '@backstage/core-components';
+import {
+  StatusOK,
+  StatusPending,
+  StatusWarning,
+} from '@backstage/core-components';
 import { Status } from '../../types';
 
 interface StatusComponent {
@@ -24,7 +28,8 @@ interface StatusComponent {
 
 const statuses: StatusComponent = {
   proposed: <StatusWarning>proposed</StatusWarning>,
-  ongoing: <StatusOK>ongoing</StatusOK>,
+  ongoing: <StatusPending>ongoing</StatusPending>,
+  completed: <StatusOK>completed</StatusOK>,
 };
 
 type Props = {

--- a/workspaces/bazaar/plugins/bazaar/src/types.ts
+++ b/workspaces/bazaar/plugins/bazaar/src/types.ts
@@ -22,7 +22,7 @@ export type Member = {
   userRef?: string;
 };
 
-export type Status = 'ongoing' | 'proposed';
+export type Status = 'ongoing' | 'proposed' | 'completed';
 
 export type Size = 'small' | 'medium' | 'large';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In order to address #1209 I've added a completed status. In the future, perhaps this ends up with a richer workflow; however, projects should be able to be marked as completed.  This would allow for sorting and filtering in the future. 
Adjusting default fixtures for more coverage
I also adjusted which statuses were used for certain project phases.  
![Screenshot 2024-10-01 064041](https://github.com/user-attachments/assets/43dde665-25f2-4946-87a3-eba816195ffa)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
