### PR TITLE
feat(tech-insights): ScorecardInfo description supports markdown syntax

### DIFF
--- a/workspaces/tech-insights/.changeset/mighty-worms-fold.md
+++ b/workspaces/tech-insights/.changeset/mighty-worms-fold.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-tech-insights': patch
 ---
 
-ScorecardInfo description supports markdown syntax
+`ScorecardInfo` description now supports markdown syntax

--- a/workspaces/tech-insights/.changeset/mighty-worms-fold.md
+++ b/workspaces/tech-insights/.changeset/mighty-worms-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+ScorecardInfo description supports markdown syntax

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsInfo/ScorecardInfo.tsx
@@ -28,6 +28,7 @@ import AccordionSummary from '@material-ui/core/AccordionSummary';
 import { useApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { techInsightsApiRef } from '../../api';
+import { MarkdownContent } from '@backstage/core-components';
 
 const useStyles = makeStyles(theme => ({
   subheader: {
@@ -76,7 +77,7 @@ const infoCard = (
                 variant="body1"
                 gutterBottom
               >
-                {description}
+                <MarkdownContent content={description} />
               </Typography>
             </Grid>
           )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds in support for ScorecardInfo's description to support markdown syntax. It is useful for linking to external doc etc.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
