### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/popular-horses-relax.md
+++ b/workspaces/nexus-repository-manager/.changeset/popular-horses-relax.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-The [nexus-repository-manager](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository is migrated to the [community plugins](https://github.com/backstage/community-plugins/tree/main).
-
-The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.10.1
+
+### Patch Changes
+
+- 2a9ec07: The [nexus-repository-manager](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository is migrated to the [community plugins](https://github.com/backstage/community-plugins/tree/main).
+
+  The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).
+
 - **@janus-idp/shared-react:** upgraded to 2.11.0
 - **@janus-idp/cli:** upgraded to 1.14.0
 

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.10.1

### Patch Changes

-   2a9ec07: The [nexus-repository-manager](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/nexus-repository-manager) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository is migrated to the [community plugins](https://github.com/backstage/community-plugins/tree/main).

    The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).

-   **@janus-idp/shared-react:** upgraded to 2.11.0

-   **@janus-idp/cli:** upgraded to 1.14.0

### Dependencies

-   **@janus-idp/cli:** upgraded to 1.13.2

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.3

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.2

### Dependencies

-   **@janus-idp/shared-react:** upgraded to 2.10.1

### Dependencies

-   **@janus-idp/cli:** upgraded to 1.13.1
