### PR TITLE
feat(Copilot): Update average card formula

### DIFF
--- a/workspaces/copilot/.changeset/beige-scissors-remember.md
+++ b/workspaces/copilot/.changeset/beige-scissors-remember.md
@@ -2,6 +2,6 @@
 '@backstage-community/plugin-copilot': patch
 ---
 
--Acceptance Rate Average card now show acceptance/suggestion rate instead of lines/days
+- Acceptance Rate Average card now show acceptance/suggestion rate instead of lines/days
 
 - Languages breakdown table had the wrong title for column "Total suggestions"

--- a/workspaces/copilot/.changeset/beige-scissors-remember.md
+++ b/workspaces/copilot/.changeset/beige-scissors-remember.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+-Acceptance Rate Average card now show acceptance/suggestion rate instead of lines/days
+
+- Languages breakdown table had the wrong title for column "Total suggestions"

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/EnterpriseCards.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/EnterpriseCards.tsx
@@ -32,14 +32,6 @@ export const EnterpriseCards = ({
   startDate,
   endDate,
 }: PropsWithChildren<CardsProps>) => {
-  const lines_suggested = metrics.reduce((acc, m) => {
-    const rate =
-      m.total_lines_suggested !== 0
-        ? m.total_lines_accepted / m.total_lines_suggested
-        : 0;
-    return acc + rate;
-  }, 0);
-
   const total_suggestions_count = metrics.reduce((acc, m) => {
     return acc + m.total_suggestions_count;
   }, 0);
@@ -59,7 +51,7 @@ export const EnterpriseCards = ({
           title="Acceptance Rate Average"
           value={
             metrics.length
-              ? ((lines_suggested / metrics.length) * 100)
+              ? ((total_acceptances_count / total_suggestions_count) * 100)
                   .toFixed(2)
                   .concat('%')
               : 'N/A'

--- a/workspaces/copilot/plugins/copilot/src/components/Table/LanguagesBreakdownTable.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Table/LanguagesBreakdownTable.tsx
@@ -91,7 +91,7 @@ const headCells: HeadCell[] = [
     id: 'totalSuggestions',
     numeric: true,
     disablePadding: false,
-    label: 'Accepted Lines of Code',
+    label: 'Total Suggestions',
   },
   {
     id: 'acceptanceRate',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR updates the formula of the Acceptance Rate Average card. The current formula is using the total lines of code accepted over the number of days. This would represent the rate of lines accepted per day.
To keep the acceptance rate consistent across all the plugin, this change now uses total_acceptances_count / total_suggestions_count (Same formula as the languages breakdown table uses)

![Captura de Tela 2024-10-09 às 16 31 18](https://github.com/user-attachments/assets/e3548b19-e9d0-4f6f-b493-bc172f0cd33e)

The language breakdown table also has a minor change. Previously the column that shows the total suggestions of a given language had the title "Accepted Lines of Code", this title is now "Total Suggestions"

![Captura de Tela 2024-10-09 às 16 31 07](https://github.com/user-attachments/assets/694c0981-0d7e-4ef3-82d7-e8ca1d8dc07e)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
