### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/dirty-kangaroos-listen.md
+++ b/workspaces/linkerd/.changeset/dirty-kangaroos-listen.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd': patch
----
-
-Add support for New Frontend System under `/alpha`

--- a/workspaces/linkerd/.changeset/tidy-sloths-argue.md
+++ b/workspaces/linkerd/.changeset/tidy-sloths-argue.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd': patch
----
-
-Extensions of same kind need a unique name

--- a/workspaces/linkerd/packages/app/CHANGELOG.md
+++ b/workspaces/linkerd/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [fc44b73]
+- Updated dependencies [fc44b73]
+  - @backstage-community/plugin-linkerd@0.3.6
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/app/package.json
+++ b/workspaces/linkerd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-linkerd
 
+## 0.3.6
+
+### Patch Changes
+
+- fc44b73: Add support for New Frontend System under `/alpha`
+- fc44b73: Extensions of same kind need a unique name
+
 ## 0.3.5
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd/package.json
+++ b/workspaces/linkerd/plugins/linkerd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd@0.3.6

### Patch Changes

-   fc44b73: Add support for New Frontend System under `/alpha`
-   fc44b73: Extensions of same kind need a unique name

## app@0.0.9

### Patch Changes

-   Updated dependencies [fc44b73]
-   Updated dependencies [fc44b73]
    -   @backstage-community/plugin-linkerd@0.3.6
