### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/rare-taxis-boil.md
+++ b/workspaces/topology/.changeset/rare-taxis-boil.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Fix CVE by upgrading kubernetes-client to v0.22.1

--- a/workspaces/topology/.changeset/version-bump-1-32-2.md
+++ b/workspaces/topology/.changeset/version-bump-1-32-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
-'@backstage-community/plugin-topology-common': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/topology/packages/app/CHANGELOG.md
+++ b/workspaces/topology/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [3865528]
+- Updated dependencies [62a2d24]
+  - @backstage-community/plugin-topology@1.28.4
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/topology/packages/app/package.json
+++ b/workspaces/topology/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "backstage": {

--- a/workspaces/topology/plugins/topology-common/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-topology-common [1.3.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-topology-common@1.2.2...@janus-idp/backstage-plugin-topology-common@1.3.0) (2024-07-26)
 
+## 1.4.2
+
+### Patch Changes
+
+- 62a2d24: Backstage version bump to v1.32.2
+
 ## 1.4.1
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology-common/package.json
+++ b/workspaces/topology/plugins/topology-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.28.4
+
+### Patch Changes
+
+- 3865528: Fix CVE by upgrading kubernetes-client to v0.22.1
+- 62a2d24: Backstage version bump to v1.32.2
+- Updated dependencies [62a2d24]
+  - @backstage-community/plugin-topology-common@1.4.2
+
 ## 1.28.3
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.28.4

### Patch Changes

-   3865528: Fix CVE by upgrading kubernetes-client to v0.22.1
-   62a2d24: Backstage version bump to v1.32.2
-   Updated dependencies [62a2d24]
    -   @backstage-community/plugin-topology-common@1.4.2

## @backstage-community/plugin-topology-common@1.4.2

### Patch Changes

-   62a2d24: Backstage version bump to v1.32.2

## app@0.0.2

### Patch Changes

-   Updated dependencies [3865528]
-   Updated dependencies [62a2d24]
    -   @backstage-community/plugin-topology@1.28.4
