### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/itchy-toes-perform.md
+++ b/workspaces/redhat-argocd/.changeset/itchy-toes-perform.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Fix CVE by upgrading kubernetes/client-node to v0.22.1

--- a/workspaces/redhat-argocd/packages/app/CHANGELOG.md
+++ b/workspaces/redhat-argocd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [3865528]
+  - @backstage-community/plugin-redhat-argocd@1.8.7
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.8.7
+
+### Patch Changes
+
+- 3865528: Fix CVE by upgrading kubernetes/client-node to v0.22.1
+
 ## 1.8.6
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.8.7

### Patch Changes

-   3865528: Fix CVE by upgrading kubernetes/client-node to v0.22.1

## app@0.0.6

### Patch Changes

-   Updated dependencies [3865528]
    -   @backstage-community/plugin-redhat-argocd@1.8.7
