### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/version-bump-1-32-0.md
+++ b/workspaces/cicd-statistics/.changeset/version-bump-1-32-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
-'@backstage-community/plugin-cicd-statistics': patch
----
-
-Backstage version bump to v1.32.0

--- a/workspaces/cicd-statistics/packages/app-next/CHANGELOG.md
+++ b/workspaces/cicd-statistics/packages/app-next/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app-next
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [a624400]
+  - @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.35
+  - @backstage-community/plugin-cicd-statistics@0.1.41
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/packages/app-next/package.json
+++ b/workspaces/cicd-statistics/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/cicd-statistics/packages/app/CHANGELOG.md
+++ b/workspaces/cicd-statistics/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [a624400]
+  - @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.35
+  - @backstage-community/plugin-cicd-statistics@0.1.41
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/packages/app/package.json
+++ b/workspaces/cicd-statistics/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.0.4
+
+### Patch Changes
+
+- a624400: Backstage version bump to v1.32.0
+- Updated dependencies [a624400]
+  - @backstage-community/plugin-cicd-statistics@0.1.41
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.1.35
+
+### Patch Changes
+
+- a624400: Backstage version bump to v1.32.0
+- Updated dependencies [a624400]
+  - @backstage-community/plugin-cicd-statistics@0.1.41
+
 ## 0.1.34
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.1.41
+
+### Patch Changes
+
+- a624400: Backstage version bump to v1.32.0
+
 ## 0.1.40
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.1.41

### Patch Changes

-   a624400: Backstage version bump to v1.32.0

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.0.4

### Patch Changes

-   a624400: Backstage version bump to v1.32.0
-   Updated dependencies [a624400]
    -   @backstage-community/plugin-cicd-statistics@0.1.41

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.35

### Patch Changes

-   a624400: Backstage version bump to v1.32.0
-   Updated dependencies [a624400]
    -   @backstage-community/plugin-cicd-statistics@0.1.41

## app@0.0.6

### Patch Changes

-   Updated dependencies [a624400]
    -   @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.35
    -   @backstage-community/plugin-cicd-statistics@0.1.41

## app-next@0.0.6

### Patch Changes

-   Updated dependencies [a624400]
    -   @backstage-community/plugin-cicd-statistics-module-gitlab@0.1.35
    -   @backstage-community/plugin-cicd-statistics@0.1.41
