### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/version-bump-1-32-2.md
+++ b/workspaces/azure-devops/.changeset/version-bump-1-32-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/azure-devops/packages/app/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [dab2f81]
+  - @backstage-community/plugin-azure-devops@0.6.1
+
 ## 0.0.9
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.11
+
+### Patch Changes
+
+- Updated dependencies [dab2f81]
+  - @backstage-community/plugin-azure-devops-backend@0.7.3
+  - @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.2
+  - app@0.0.10
+
 ## 0.0.10
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.7.3
+
+### Patch Changes
+
+- dab2f81: Backstage version bump to v1.32.2
+- Updated dependencies [dab2f81]
+  - @backstage-community/plugin-azure-devops-common@0.4.9
+
 ## 0.7.2
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.4.9
+
+### Patch Changes
+
+- dab2f81: Backstage version bump to v1.32.2
+
 ## 0.4.8
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.6.1
+
+### Patch Changes
+
+- dab2f81: Backstage version bump to v1.32.2
+- Updated dependencies [dab2f81]
+  - @backstage-community/plugin-azure-devops-common@0.4.9
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.1.2
+
+### Patch Changes
+
+- dab2f81: Backstage version bump to v1.32.2
+- Updated dependencies [dab2f81]
+  - @backstage-community/plugin-azure-devops-common@0.4.9
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.6.1

### Patch Changes

-   dab2f81: Backstage version bump to v1.32.2
-   Updated dependencies [dab2f81]
    -   @backstage-community/plugin-azure-devops-common@0.4.9

## @backstage-community/plugin-azure-devops-backend@0.7.3

### Patch Changes

-   dab2f81: Backstage version bump to v1.32.2
-   Updated dependencies [dab2f81]
    -   @backstage-community/plugin-azure-devops-common@0.4.9

## @backstage-community/plugin-azure-devops-common@0.4.9

### Patch Changes

-   dab2f81: Backstage version bump to v1.32.2

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.2

### Patch Changes

-   dab2f81: Backstage version bump to v1.32.2
-   Updated dependencies [dab2f81]
    -   @backstage-community/plugin-azure-devops-common@0.4.9

## app@0.0.10

### Patch Changes

-   Updated dependencies [dab2f81]
    -   @backstage-community/plugin-azure-devops@0.6.1

## backend@0.0.11

### Patch Changes

-   Updated dependencies [dab2f81]
    -   @backstage-community/plugin-azure-devops-backend@0.7.3
    -   @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.1.2
    -   app@0.0.10
