### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/version-bump-1-32-2.md
+++ b/workspaces/azure-sites/.changeset/version-bump-1-32-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-sites': patch
-'@backstage-community/plugin-azure-sites-backend': patch
-'@backstage-community/plugin-azure-sites-common': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.3.10
+
+### Patch Changes
+
+- 58c28d3: Backstage version bump to v1.32.2
+- Updated dependencies [58c28d3]
+  - @backstage-community/plugin-azure-sites-common@0.1.8
+
 ## 0.3.9
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-common
 
+## 0.1.8
+
+### Patch Changes
+
+- 58c28d3: Backstage version bump to v1.32.2
+
 ## 0.1.7
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-common/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-common",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Common functionalities for the azure plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-sites
 
+## 0.1.28
+
+### Patch Changes
+
+- 58c28d3: Backstage version bump to v1.32.2
+- Updated dependencies [58c28d3]
+  - @backstage-community/plugin-azure-sites-common@0.1.8
+
 ## 0.1.27
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-sites",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites@0.1.28

### Patch Changes

-   58c28d3: Backstage version bump to v1.32.2
-   Updated dependencies [58c28d3]
    -   @backstage-community/plugin-azure-sites-common@0.1.8

## @backstage-community/plugin-azure-sites-backend@0.3.10

### Patch Changes

-   58c28d3: Backstage version bump to v1.32.2
-   Updated dependencies [58c28d3]
    -   @backstage-community/plugin-azure-sites-common@0.1.8

## @backstage-community/plugin-azure-sites-common@0.1.8

### Patch Changes

-   58c28d3: Backstage version bump to v1.32.2
