### PR TITLE
Version Packages (gocd)

### DIFF
--- a/workspaces/gocd/.changeset/version-bump-1-32-2.md
+++ b/workspaces/gocd/.changeset/version-bump-1-32-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gocd': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/gocd/plugins/gocd/CHANGELOG.md
+++ b/workspaces/gocd/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gocd
 
+## 0.1.46
+
+### Patch Changes
+
+- 7e64765: Backstage version bump to v1.32.2
+
 ## 0.1.45
 
 ### Patch Changes

--- a/workspaces/gocd/plugins/gocd/package.json
+++ b/workspaces/gocd/plugins/gocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gocd",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "A Backstage plugin that integrates towards GoCD",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gocd@0.1.46

### Patch Changes

-   7e64765: Backstage version bump to v1.32.2
