### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/version-bump-1-32-2.md
+++ b/workspaces/linkerd/.changeset/version-bump-1-32-2.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linkerd': patch
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/linkerd/packages/app/CHANGELOG.md
+++ b/workspaces/linkerd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [e564ebe]
+  - @backstage-community/plugin-linkerd@0.3.7
+
 ## 0.0.9
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/app/package.json
+++ b/workspaces/linkerd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.11
+
+### Patch Changes
+
+- Updated dependencies [e564ebe]
+  - @backstage-community/plugin-linkerd-backend@0.3.6
+  - app@0.0.10
+
 ## 0.0.10
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.3.6
+
+### Patch Changes
+
+- e564ebe: Backstage version bump to v1.32.2
+
 ## 0.3.5
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd
 
+## 0.3.7
+
+### Patch Changes
+
+- e564ebe: Backstage version bump to v1.32.2
+
 ## 0.3.6
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd/package.json
+++ b/workspaces/linkerd/plugins/linkerd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd@0.3.7

### Patch Changes

-   e564ebe: Backstage version bump to v1.32.2

## @backstage-community/plugin-linkerd-backend@0.3.6

### Patch Changes

-   e564ebe: Backstage version bump to v1.32.2

## app@0.0.10

### Patch Changes

-   Updated dependencies [e564ebe]
    -   @backstage-community/plugin-linkerd@0.3.7

## backend@0.0.11

### Patch Changes

-   Updated dependencies [e564ebe]
    -   @backstage-community/plugin-linkerd-backend@0.3.6
    -   app@0.0.10
