### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/version-bump-1-32-2.md
+++ b/workspaces/playlist/.changeset/version-bump-1-32-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist': patch
-'@backstage-community/plugin-playlist-backend': patch
-'@backstage-community/plugin-playlist-common': patch
----
-
-Backstage version bump to v1.32.2

--- a/workspaces/playlist/packages/app/CHANGELOG.md
+++ b/workspaces/playlist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [c69b919]
+  - @backstage-community/plugin-playlist@0.2.16
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/playlist/packages/app/package.json
+++ b/workspaces/playlist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [c69b919]
+  - @backstage-community/plugin-playlist-backend@0.3.28
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.3.28
+
+### Patch Changes
+
+- c69b919: Backstage version bump to v1.32.2
+- Updated dependencies [c69b919]
+  - @backstage-community/plugin-playlist-common@0.1.21
+
 ## 0.3.27
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",

--- a/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-common
 
+## 0.1.21
+
+### Patch Changes
+
+- c69b919: Backstage version bump to v1.32.2
+
 ## 0.1.20
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-common/package.json
+++ b/workspaces/playlist/plugins/playlist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-common",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Common functionalities for the playlist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist
 
+## 0.2.16
+
+### Patch Changes
+
+- c69b919: Backstage version bump to v1.32.2
+- Updated dependencies [c69b919]
+  - @backstage-community/plugin-playlist-common@0.1.21
+
 ## 0.2.15
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.2.16

### Patch Changes

-   c69b919: Backstage version bump to v1.32.2
-   Updated dependencies [c69b919]
    -   @backstage-community/plugin-playlist-common@0.1.21

## @backstage-community/plugin-playlist-backend@0.3.28

### Patch Changes

-   c69b919: Backstage version bump to v1.32.2
-   Updated dependencies [c69b919]
    -   @backstage-community/plugin-playlist-common@0.1.21

## @backstage-community/plugin-playlist-common@0.1.21

### Patch Changes

-   c69b919: Backstage version bump to v1.32.2

## app@0.0.6

### Patch Changes

-   Updated dependencies [c69b919]
    -   @backstage-community/plugin-playlist@0.2.16

## backend@0.0.6

### Patch Changes

-   Updated dependencies [c69b919]
    -   @backstage-community/plugin-playlist-backend@0.3.28
