### PR TITLE
chore(shortcuts): cleanup changeset, added missing changelog entry

### DIFF
--- a/.changeset/forty-beds-bow.md
+++ b/.changeset/forty-beds-bow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugins': patch
----
-
-Adding emitting analytics event for removing shortcut.

--- a/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
+++ b/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 - 55969e3: Backstage version bump to v1.31.2
+- e6d92ee: Adding emitting analytics event for removing shortcut.
 
 ## 0.3.26
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes a left-over changelog and adds it to an existing changelog entry.

### History

The change was added in #1171 for the shortcuts workspace, but the changeset used the wrong package name (from the root package.json), so it was never picked up when running `yarn changeset version`.

But the latest release of `@backstage-community/plugin-shortcuts` (0.3.27) includes this change. It was released with PR #1451 after #1442 was merged.

* #1171
* #1442
* #1451

https://github.com/backstage/community-plugins/commits/main/workspaces/shortcuts

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
