### PR TITLE
Use workspace version

### DIFF
--- a/workspaces/redhat-argocd/.changeset/shiny-toys-decide.md
+++ b/workspaces/redhat-argocd/.changeset/shiny-toys-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-redhat-argocd': patch
+---
+
+Updated reference to `@backstage-community/plugin-redhat-argocd-common` in the frontend plugin to use the `workspace:^` version

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -32,7 +32,7 @@
     "ui-test": "yarn playwright test"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd-common": "^1.0.7",
+    "@backstage-community/plugin-redhat-argocd-common": "workspace:^",
     "@backstage/catalog-model": "^1.7.0",
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",

--- a/workspaces/redhat-argocd/yarn.lock
+++ b/workspaces/redhat-argocd/yarn.lock
@@ -2823,7 +2823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-redhat-argocd-common@^1.0.7, @backstage-community/plugin-redhat-argocd-common@workspace:plugins/argocd-common":
+"@backstage-community/plugin-redhat-argocd-common@workspace:^, @backstage-community/plugin-redhat-argocd-common@workspace:plugins/argocd-common":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-redhat-argocd-common@workspace:plugins/argocd-common"
   dependencies:
@@ -2836,7 +2836,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-redhat-argocd@workspace:plugins/argocd"
   dependencies:
-    "@backstage-community/plugin-redhat-argocd-common": ^1.0.7
+    "@backstage-community/plugin-redhat-argocd-common": "workspace:^"
     "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": ^0.28.0
     "@backstage/config": ^1.2.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated reference to `@backstage-community/plugin-redhat-argocd-common` in the frontend plugin to use the `workspace:^` version

While doing the version bump of this plugin, the [Version Package PR ](https://github.com/backstage/community-plugins/pull/1679)failed as the `yarn.lock` file had changes, this should address that long term.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
