### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/shiny-toys-decide.md
+++ b/workspaces/redhat-argocd/.changeset/shiny-toys-decide.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated reference to `@backstage-community/plugin-redhat-argocd-common` in the frontend plugin to use the `workspace:^` version

--- a/workspaces/redhat-argocd/packages/app/CHANGELOG.md
+++ b/workspaces/redhat-argocd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [ef55b90]
+  - @backstage-community/plugin-redhat-argocd@1.8.9
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-argocd [1.5.7](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-argocd@1.5.6...@janus-idp/backstage-plugin-argocd@1.5.7) (2024-08-02)
 
+## 1.8.9
+
+### Patch Changes
+
+- ef55b90: Updated reference to `@backstage-community/plugin-redhat-argocd-common` in the frontend plugin to use the `workspace:^` version
+
 ## 1.8.8
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.8.9

### Patch Changes

-   ef55b90: Updated reference to `@backstage-community/plugin-redhat-argocd-common` in the frontend plugin to use the `workspace:^` version

## app@0.0.8

### Patch Changes

-   Updated dependencies [ef55b90]
    -   @backstage-community/plugin-redhat-argocd@1.8.9
