### PR TITLE
Removing Private Flag from Jenkins-Scaffolder

### DIFF
--- a/workspaces/jenkins/plugins/jenkins-scaffolder/package.json
+++ b/workspaces/jenkins/plugins/jenkins-scaffolder/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When merging the PR https://github.com/backstage/community-plugins/pull/1481, I forgot to remove the private flag in order to allow the plugin to be used.

This PR simply removes the <code>private</code> flag from the plugin's <code>package.json</code>

Thanks @vinzscam for the suggestion

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
