### PR TITLE
chore(topology): add build in prepack to include necessary style-inject modules

### DIFF
--- a/workspaces/topology/.changeset/seven-houses-melt.md
+++ b/workspaces/topology/.changeset/seven-houses-melt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Add build command in prepack script so that style-inject modules will be properly included in package.

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -24,11 +24,10 @@
   "scripts": {
     "build": "backstage-cli package build",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place",
     "lint": "backstage-cli package lint",
     "postpack": "backstage-cli package postpack",
     "postversion": "yarn run export-dynamic",
-    "prepack": "backstage-cli package prepack",
+    "prepack": "backstage-cli package prepack && yarn build",
     "start": "backstage-cli package start",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "tsc": "tsc"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Before this change, topology plugin package misses the style-inject modules and couldn't be used as imported package. With this change, it packs with the required style-inject modules and it will be able to be used as a npm package.

Error when export topology from BCP as dynamic plugin in backstage-showcase before this change:
```
Module not found: Error: Can't resolve '../../node_modules/style-inject/dist/style-inject.es.esm.js' in ...
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
