### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/violet-foxes-clean.md
+++ b/workspaces/npm/.changeset/violet-foxes-clean.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': patch
----
-
-export deprecated card components to be backward compatible

--- a/workspaces/npm/packages/app/CHANGELOG.md
+++ b/workspaces/npm/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [fa1521c]
+  - @backstage-community/plugin-npm@1.0.2
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/npm/packages/app/package.json
+++ b/workspaces/npm/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm
 
+## 1.0.2
+
+### Patch Changes
+
+- fa1521c: export deprecated card components to be backward compatible
+
 ## 1.0.1
 
 ### Patch Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.0.2

### Patch Changes

-   fa1521c: export deprecated card components to be backward compatible

## app@0.0.3

### Patch Changes

-   Updated dependencies [fa1521c]
    -   @backstage-community/plugin-npm@1.0.2
