### PR TITLE
Version Packages (tech-radar)

### DIFF
--- a/workspaces/tech-radar/.changeset/cuddly-walls-try-one.md
+++ b/workspaces/tech-radar/.changeset/cuddly-walls-try-one.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-radar-common': major
----
-
-Initial release of the `tech-radar-common` plugin.

--- a/workspaces/tech-radar/.changeset/cuddly-walls-try-two.md
+++ b/workspaces/tech-radar/.changeset/cuddly-walls-try-two.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-radar-backend': major
----
-
-Initial release of the `tech-radar-backend` plugin.

--- a/workspaces/tech-radar/.changeset/proud-bikes-camp.md
+++ b/workspaces/tech-radar/.changeset/proud-bikes-camp.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-tech-radar': major
----
-
-The plugin now fetches data from the `@backstage-community/plugin-tech-radar-backend` plugin.
-
-If you are providing a custom API via `techRadarApiRef`, this change will not affect you. However, if you are using the default API with the default mocked data, you will need to install the `@backstage-community/plugin-tech-radar-backend` plugin.
-
-**BREAKING**: Additionally, several types have been moved to the `@backstage-community/plugin-tech-radar-common` plugin. If you are using `TechRadarLoaderResponse`, `RadarEntry`, `RadarQuadrant`, or `RadarRing`, you will need to import them from the `@backstage-community/plugin-tech-radar-common` plugin.

--- a/workspaces/tech-radar/packages/app-next/CHANGELOG.md
+++ b/workspaces/tech-radar/packages/app-next/CHANGELOG.md
@@ -1,5 +1,14 @@
 # app-next
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [e3ab8e9]
+- Updated dependencies [e5a9abf]
+  - @backstage-community/plugin-tech-radar-common@1.0.0
+  - @backstage-community/plugin-tech-radar@1.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/tech-radar/packages/app-next/package.json
+++ b/workspaces/tech-radar/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/tech-radar/packages/app/CHANGELOG.md
+++ b/workspaces/tech-radar/packages/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [e3ab8e9]
+- Updated dependencies [e5a9abf]
+  - @backstage-community/plugin-tech-radar-common@1.0.0
+  - @backstage-community/plugin-tech-radar@1.0.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/tech-radar/packages/app/package.json
+++ b/workspaces/tech-radar/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/tech-radar/packages/backend/CHANGELOG.md
+++ b/workspaces/tech-radar/packages/backend/CHANGELOG.md
@@ -1,0 +1,10 @@
+# backend
+
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [e3ab8e9]
+- Updated dependencies [e3ab8e9]
+  - @backstage-community/plugin-tech-radar-common@1.0.0
+  - @backstage-community/plugin-tech-radar-backend@1.0.0

--- a/workspaces/tech-radar/packages/backend/package.json
+++ b/workspaces/tech-radar/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/tech-radar/plugins/tech-radar-backend/CHANGELOG.md
+++ b/workspaces/tech-radar/plugins/tech-radar-backend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @backstage-community/plugin-tech-radar-backend
+
+## 1.0.0
+
+### Major Changes
+
+- e3ab8e9: Initial release of the `tech-radar-backend` plugin.
+
+### Patch Changes
+
+- Updated dependencies [e3ab8e9]
+  - @backstage-community/plugin-tech-radar-common@1.0.0

--- a/workspaces/tech-radar/plugins/tech-radar-backend/package.json
+++ b/workspaces/tech-radar/plugins/tech-radar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-radar-backend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/tech-radar/plugins/tech-radar-common/CHANGELOG.md
+++ b/workspaces/tech-radar/plugins/tech-radar-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-tech-radar-common
+
+## 1.0.0
+
+### Major Changes
+
+- e3ab8e9: Initial release of the `tech-radar-common` plugin.

--- a/workspaces/tech-radar/plugins/tech-radar-common/package.json
+++ b/workspaces/tech-radar/plugins/tech-radar-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-tech-radar-common",
   "description": "Common functionalities for the tech-radar plugins",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/tech-radar/plugins/tech-radar/CHANGELOG.md
+++ b/workspaces/tech-radar/plugins/tech-radar/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-tech-radar
 
+## 1.0.0
+
+### Major Changes
+
+- e5a9abf: The plugin now fetches data from the `@backstage-community/plugin-tech-radar-backend` plugin.
+
+  If you are providing a custom API via `techRadarApiRef`, this change will not affect you. However, if you are using the default API with the default mocked data, you will need to install the `@backstage-community/plugin-tech-radar-backend` plugin.
+
+  **BREAKING**: Additionally, several types have been moved to the `@backstage-community/plugin-tech-radar-common` plugin. If you are using `TechRadarLoaderResponse`, `RadarEntry`, `RadarQuadrant`, or `RadarRing`, you will need to import them from the `@backstage-community/plugin-tech-radar-common` plugin.
+
+### Patch Changes
+
+- Updated dependencies [e3ab8e9]
+  - @backstage-community/plugin-tech-radar-common@1.0.0
+
 ## 0.7.11
 
 ### Patch Changes

--- a/workspaces/tech-radar/plugins/tech-radar/package.json
+++ b/workspaces/tech-radar/plugins/tech-radar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-radar",
-  "version": "0.7.11",
+  "version": "1.0.0",
   "description": "A Backstage plugin that lets you display a Tech Radar for your organization",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-radar@1.0.0

### Major Changes

-   e5a9abf: The plugin now fetches data from the `@backstage-community/plugin-tech-radar-backend` plugin.

    If you are providing a custom API via `techRadarApiRef`, this change will not affect you. However, if you are using the default API with the default mocked data, you will need to install the `@backstage-community/plugin-tech-radar-backend` plugin.

    **BREAKING**: Additionally, several types have been moved to the `@backstage-community/plugin-tech-radar-common` plugin. If you are using `TechRadarLoaderResponse`, `RadarEntry`, `RadarQuadrant`, or `RadarRing`, you will need to import them from the `@backstage-community/plugin-tech-radar-common` plugin.

### Patch Changes

-   Updated dependencies [e3ab8e9]
    -   @backstage-community/plugin-tech-radar-common@1.0.0

## @backstage-community/plugin-tech-radar-backend@1.0.0

### Major Changes

-   e3ab8e9: Initial release of the `tech-radar-backend` plugin.

### Patch Changes

-   Updated dependencies [e3ab8e9]
    -   @backstage-community/plugin-tech-radar-common@1.0.0

## @backstage-community/plugin-tech-radar-common@1.0.0

### Major Changes

-   e3ab8e9: Initial release of the `tech-radar-common` plugin.

## app@0.0.3

### Patch Changes

-   Updated dependencies [e3ab8e9]
-   Updated dependencies [e5a9abf]
    -   @backstage-community/plugin-tech-radar-common@1.0.0
    -   @backstage-community/plugin-tech-radar@1.0.0

## app-next@0.0.3

### Patch Changes

-   Updated dependencies [e3ab8e9]
-   Updated dependencies [e5a9abf]
    -   @backstage-community/plugin-tech-radar-common@1.0.0
    -   @backstage-community/plugin-tech-radar@1.0.0

## backend@0.0.2

### Patch Changes

-   Updated dependencies [e3ab8e9]
-   Updated dependencies [e3ab8e9]
    -   @backstage-community/plugin-tech-radar-common@1.0.0
    -   @backstage-community/plugin-tech-radar-backend@1.0.0
