### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/brown-clouds-call.md
+++ b/workspaces/topology/.changeset/brown-clouds-call.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-Migrated to MUI5

--- a/workspaces/topology/.changeset/seven-houses-melt.md
+++ b/workspaces/topology/.changeset/seven-houses-melt.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-- Fixed an issue with the topology node badge icon text color.
-- Updated the stylesheet link filter string to accommodate the new topology package name.
-- Removed `janus-idp/cli` from `devDependencies` as `export-dynamic` is no longer needed for the topology plugin package.

--- a/workspaces/topology/packages/app/CHANGELOG.md
+++ b/workspaces/topology/packages/app/CHANGELOG.md
@@ -1,5 +1,13 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [730359c]
+- Updated dependencies [694e163]
+  - @backstage-community/plugin-topology@1.29.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/topology/packages/app/package.json
+++ b/workspaces/topology/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "backstage": {

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.29.0
+
+### Minor Changes
+
+- 730359c: Migrated to MUI5
+
+### Patch Changes
+
+- 694e163: - Fixed an issue with the topology node badge icon text color.
+  - Updated the stylesheet link filter string to accommodate the new topology package name.
+  - Removed `janus-idp/cli` from `devDependencies` as `export-dynamic` is no longer needed for the topology plugin package.
+
 ## 1.28.4
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.28.4",
+  "version": "1.29.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.29.0

### Minor Changes

-   730359c: Migrated to MUI5

### Patch Changes

-   694e163: - Fixed an issue with the topology node badge icon text color.
    -   Updated the stylesheet link filter string to accommodate the new topology package name.
    -   Removed `janus-idp/cli` from `devDependencies` as `export-dynamic` is no longer needed for the topology plugin package.

## app@0.0.3

### Patch Changes

-   Updated dependencies [730359c]
-   Updated dependencies [694e163]
    -   @backstage-community/plugin-topology@1.29.0
