### PR TITLE
chore(version bump): generate changesets as minor version bumps

### DIFF
--- a/scripts/ci/generate-version-bump-changeset.js
+++ b/scripts/ci/generate-version-bump-changeset.js
@@ -46,7 +46,7 @@ async function main() {
   const { packages } = await getPackages(workspacePlugins);
   const packageEntries = packages
     .filter(p => p.packageJson.name.includes('@backstage-community'))
-    .map(p => `'${p.packageJson.name}': patch`);
+    .map(p => `'${p.packageJson.name}': minor`);
 
   // Populate the changeset contents
   const changeset = `---


### PR DESCRIPTION
### What does this PR do?

chore(version bump): generate changesets for Backstage version updates as MINOR updates instead of just PATCH updates, so we have version space to apply security fixes to older plugins based on older backstage versions

Signed-off-by: rhdh-bot service account <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
See discussion in COmmunity Plugins SIG - https://docs.google.com/document/d/1lIHXi8fi3CDiUD8UhX7s1FWCKAiricQKnFR4OSHoaiY/edit#heading=h.e10g1evhtpzj 

This is only a partial solution based on the reqs raised in that call -- this does not allow the option to choose deliberately to apply only a patch update (passed in via a cmdline arg to the [GH action](https://github.com/backstage/community-plugins/actions/workflows/version-bump.yml) when running it). 

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.