### PR TITLE
chore(version-bump): add option to generate backstage version updates as either minor or patch updates

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,6 +20,7 @@ on:
         default: 'minor'
         type: choice
         options:
+          - 'major'
           - 'minor'
           - 'patch'
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       version-bump-type:
-        description: ': Specifies the type of version update to apply.'
+        description: 'Specifies the type of version update to apply.'
         required: true
         default: 'minor'
         type: choice

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,6 +14,14 @@ on:
         description: 'Workspace (this must be a JSON array)'
         required: true
         type: string
+      version-bump-type:
+        description: ': Specifies the type of version update to apply.'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - 'minor'
+          - 'patch'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -103,7 +111,7 @@ jobs:
       - name: 'Add changeset'
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         working-directory: ./workspaces/${{ matrix.workspace }}
-        run: node ../../scripts/ci/generate-version-bump-changeset.js ${{ steps.set_release_name.outputs.release_version }}
+        run: node ../../scripts/ci/generate-version-bump-changeset.js ${{ steps.set_release_name.outputs.release_version }} ${{ inputs.version-bump-type || 'minor' }}
       - name: 'Commit changes'
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         run: |

--- a/scripts/ci/generate-version-bump-changeset.js
+++ b/scripts/ci/generate-version-bump-changeset.js
@@ -18,7 +18,7 @@
 
 // This script assumes that it is being ran from the plugins workspace,
 // for example: `/workspaces/azure-devops` and would be called like this:
-// `node ../../scripts/ci/generate-version-bump-changeset.js 1.29.1`
+// `node ../../scripts/ci/generate-version-bump-changeset.js 1.29.1 minor`
 
 import fs from 'fs-extra';
 import { getPackages } from '@manypkg/get-packages';
@@ -26,9 +26,11 @@ import { join } from 'path';
 
 async function main() {
   // Get the releaseVersion
-  const [script, releaseVersion] = process.argv.slice(1);
+  const [script, releaseVersion, versionBumpType] = process.argv.slice(1);
   if (!releaseVersion) {
-    throw new Error(`Argument must be ${script} <release-version>`);
+    throw new Error(
+      `Argument must be ${script} <release-version> <version-bump-type>`,
+    );
   }
 
   const workspacePlugins = join(process.cwd(), 'plugins');
@@ -46,7 +48,7 @@ async function main() {
   const { packages } = await getPackages(workspacePlugins);
   const packageEntries = packages
     .filter(p => p.packageJson.name.includes('@backstage-community'))
-    .map(p => `'${p.packageJson.name}': patch`);
+    .map(p => `'${p.packageJson.name}': ${versionBumpType}`);
 
   // Populate the changeset contents
   const changeset = `---

--- a/scripts/ci/generate-version-bump-changeset.js
+++ b/scripts/ci/generate-version-bump-changeset.js
@@ -25,9 +25,10 @@ import { getPackages } from '@manypkg/get-packages';
 import { join } from 'path';
 
 async function main() {
-  // Get the releaseVersion
+  // Get the releaseVersion and versionBumpType
   const [script, releaseVersion, versionBumpType] = process.argv.slice(1);
-  if (!releaseVersion) {
+
+  if (!releaseVersion || !versionBumpType) {
     throw new Error(
       `Argument must be ${script} <release-version> <version-bump-type>`,
     );


### PR DESCRIPTION
This PR adds a `version-bump-type` variable to the `version-bump.yml` workflow to generate changesets for Backstage version updates as either patch or minor updates, with minor as default.

Also updated the `generate-version-bump-changeset.js` script to include the `versionBumpType` commandline arg.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
