### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/itchy-cooks-cover.md
+++ b/workspaces/redhat-argocd/.changeset/itchy-cooks-cover.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-redhat-argocd: release 1.8.9 as 1.10.1

--- a/workspaces/redhat-argocd/packages/app/CHANGELOG.md
+++ b/workspaces/redhat-argocd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [9e73efd]
+  - @backstage-community/plugin-redhat-argocd@1.10.1
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.10.1
+
+### Patch Changes
+
+- 9e73efd: redhat-argocd: release 1.8.9 as 1.10.1
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.10.1

### Patch Changes

-   9e73efd: redhat-argocd: release 1.8.9 as 1.10.1

## app@0.0.9

### Patch Changes

-   Updated dependencies [9e73efd]
    -   @backstage-community/plugin-redhat-argocd@1.10.1
