### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/thin-toys-drum.md
+++ b/workspaces/jfrog-artifactory/.changeset/thin-toys-drum.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-- Version update in `package.json` from `1.8.3` to `1.9.0`
-- Removed `export-dynamic` script and Janus CLI dependency in `package.json`

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.9.1
+
+### Patch Changes
+
+- 71aca1f: - Version update in `package.json` from `1.8.3` to `1.9.0`
+  - Removed `export-dynamic` script and Janus CLI dependency in `package.json`
+
 ## 1.8.3
 
 ### Patch Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.9.1

### Patch Changes

-   71aca1f: - Version update in `package.json` from `1.8.3` to `1.9.0`
    -   Removed `export-dynamic` script and Janus CLI dependency in `package.json`
