### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/slimy-mangos-drum.md
+++ b/workspaces/sonarqube/.changeset/slimy-mangos-drum.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': minor
----
-
-**BREAKING** Added error logging when API calls fail. With this change your will need to include the `logger` when using the `DefaultSonarqubeInfoProvider.fromConfig()` like this: `DefaultSonarqubeInfoProvider.fromConfig(config, logger)`

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [ddc377c]
+  - @backstage-community/plugin-sonarqube-backend@0.3.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.3.0
+
+### Minor Changes
+
+- ddc377c: **BREAKING** Added error logging when API calls fail. With this change your will need to include the `logger` when using the `DefaultSonarqubeInfoProvider.fromConfig()` like this: `DefaultSonarqubeInfoProvider.fromConfig(config, logger)`
+
 ## 0.2.25
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.2.25",
+  "version": "0.3.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.3.0

### Minor Changes

-   ddc377c: **BREAKING** Added error logging when API calls fail. With this change your will need to include the `logger` when using the `DefaultSonarqubeInfoProvider.fromConfig()` like this: `DefaultSonarqubeInfoProvider.fromConfig(config, logger)`

## backend@0.0.3

### Patch Changes

-   Updated dependencies [ddc377c]
    -   @backstage-community/plugin-sonarqube-backend@0.3.0
