### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/tidy-ducks-share.md
+++ b/workspaces/sonarqube/.changeset/tidy-ducks-share.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-Removed `@microsoft/api-extractor` resolution as it is no longer needed

--- a/workspaces/sonarqube/packages/app-next/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app-next
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [2d16371]
+  - @backstage-community/plugin-sonarqube@0.8.6
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app-next/package.json
+++ b/workspaces/sonarqube/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/packages/app/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [2d16371]
+  - @backstage-community/plugin-sonarqube@0.8.6
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app/package.json
+++ b/workspaces/sonarqube/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.8.6
+
+### Patch Changes
+
+- 2d16371: Removed `@microsoft/api-extractor` resolution as it is no longer needed
+
 ## 0.8.5
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.8.6

### Patch Changes

-   2d16371: Removed `@microsoft/api-extractor` resolution as it is no longer needed

## app@0.0.7

### Patch Changes

-   Updated dependencies [2d16371]
    -   @backstage-community/plugin-sonarqube@0.8.6

## app-next@0.0.6

### Patch Changes

-   Updated dependencies [2d16371]
    -   @backstage-community/plugin-sonarqube@0.8.6
