### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/lemon-geese-pump.md
+++ b/workspaces/azure-devops/.changeset/lemon-geese-pump.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Introduced the `azure:pipeline:run` scaffolder action

--- a/workspaces/azure-devops/packages/backend/CHANGELOG.md
+++ b/workspaces/azure-devops/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [28110f5]
+  - @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.1.1
+
 ## 0.0.11
 
 ### Patch Changes

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-scaffolder-backend-module-azure-devops
+
+## 0.1.1
+
+### Patch Changes
+
+- 28110f5: Introduced the `azure:pipeline:run` scaffolder action

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.1.1

### Patch Changes

-   28110f5: Introduced the `azure:pipeline:run` scaffolder action

## backend@0.0.12

### Patch Changes

-   Updated dependencies [28110f5]
    -   @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.1.1
