### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/migrate-1730331331411.md
+++ b/workspaces/ocm/.changeset/migrate-1730331331411.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
-'@backstage-community/plugin-ocm-backend': patch
-'@backstage-community/plugin-ocm-common': patch
----
-
-Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.2.1
+
+### Patch Changes
+
+- 22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+- Updated dependencies [22a79d1]
+  - @backstage-community/plugin-ocm-common@3.6.1
+
 ## 5.2.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -45,7 +45,7 @@
   },
   "configSchema": "config.d.ts",
   "dependencies": {
-    "@backstage-community/plugin-ocm-common": "^3.6.0",
+    "@backstage-community/plugin-ocm-common": "^3.6.1",
     "@backstage/backend-defaults": "^0.5.2",
     "@backstage/backend-openapi-utils": "^0.2.0",
     "@backstage/backend-plugin-api": "^1.0.1",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.6.1
+
+### Patch Changes
+
+- 22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+
 ## 3.6.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.2.1
+
+### Patch Changes
+
+- 22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+- Updated dependencies [22a79d1]
+  - @backstage-community/plugin-ocm-common@3.6.1
+
 ## 5.2.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -34,7 +34,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-ocm-common": "^3.6.0",
+    "@backstage-community/plugin-ocm-common": "^3.6.1",
     "@backstage/catalog-model": "^1.7.0",
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",

--- a/workspaces/ocm/yarn.lock
+++ b/workspaces/ocm/yarn.lock
@@ -2472,7 +2472,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-ocm-backend@workspace:plugins/ocm-backend"
   dependencies:
-    "@backstage-community/plugin-ocm-common": ^3.6.0
+    "@backstage-community/plugin-ocm-common": ^3.6.1
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-dynamic-feature-service": 0.4.3
     "@backstage/backend-openapi-utils": ^0.2.0
@@ -2499,7 +2499,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage-community/plugin-ocm-common@^3.6.0, @backstage-community/plugin-ocm-common@workspace:plugins/ocm-common":
+"@backstage-community/plugin-ocm-common@^3.6.1, @backstage-community/plugin-ocm-common@workspace:plugins/ocm-common":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-ocm-common@workspace:plugins/ocm-common"
   dependencies:
@@ -2516,7 +2516,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-ocm@workspace:plugins/ocm"
   dependencies:
-    "@backstage-community/plugin-ocm-common": ^3.6.0
+    "@backstage-community/plugin-ocm-common": ^3.6.1
     "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": 0.28.2
     "@backstage/core-app-api": 1.15.1


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.2.1

### Patch Changes

-   22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
-   Updated dependencies [22a79d1]
    -   @backstage-community/plugin-ocm-common@3.6.1

## @backstage-community/plugin-ocm-backend@5.2.1

### Patch Changes

-   22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
-   Updated dependencies [22a79d1]
    -   @backstage-community/plugin-ocm-common@3.6.1

## @backstage-community/plugin-ocm-common@3.6.1

### Patch Changes

-   22a79d1: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
