### PR TITLE
confluence-collator: make parallelismLimit optional

### DIFF
--- a/workspaces/confluence/.changeset/nervous-worms-fold.md
+++ b/workspaces/confluence/.changeset/nervous-worms-fold.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Make `parallelismLimit` configuration field optional.
+
+This field is already treated as optional in the package code, and the default
+value is already mentioned in the description. As such we can safely mark it as
+optional and treat configuration which omits it as valid.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -83,6 +83,6 @@ export interface Config {
      *
      * Defaults to `15`.
      */
-    parallelismLimit: number;
+    parallelismLimit?: number;
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since this field already has a default value in code (cf. [read](https://github.com/backstage/community-plugins/blob/91731e018caee077f78603ef592a4c7f68428603/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts#L165-L167), [usage](https://github.com/backstage/community-plugins/blob/91731e018caee077f78603ef592a4c7f68428603/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts#L211)), it seems reasonable to mark it as optional in the schema. This allows people to skip setting it, and rely on the default value, which is already included in the field description.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
