### PR TITLE
chore(ci): ignore private repositories (esp. backstage app, backend) when release plugins

### DIFF
--- a/workspaces/keycloak/.changeset/config.json
+++ b/workspaces/keycloak/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }

--- a/workspaces/ocm/.changeset/config.json
+++ b/workspaces/ocm/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }

--- a/workspaces/rbac/.changeset/config.json
+++ b/workspaces/rbac/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/config.json
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/config.json
@@ -6,5 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "privatePackages": {
+    "tag": false,
+    "version": false
+  }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow-up on #1510

It adds the missing changeset option `privatePackages` to new plugins so that their packages (backstage app and backend) are ignored when new releases are published. 

```json
  "privatePackages": {
    "tag": false,
    "version": false
  }
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
