### PR TITLE
chore(rbac): use workspace dependencies

### DIFF
--- a/workspaces/rbac/.changeset/chilly-pillows-check.md
+++ b/workspaces/rbac/.changeset/chilly-pillows-check.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+'@backstage-community/plugin-rbac': patch
+---
+
+chore: use workspace dependencies

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -34,8 +34,8 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "^1.12.1",
-    "@backstage-community/plugin-rbac-node": "^1.8.1",
+    "@backstage-community/plugin-rbac-common": "workspace:^",
+    "@backstage-community/plugin-rbac-node": "workspace:^",
     "@backstage/backend-defaults": "^0.5.2",
     "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/catalog-client": "^1.7.1",

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -36,7 +36,7 @@
     "ui-test": "start-server-and-test start localhost:3000 'playwright test'"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "^1.12.1",
+    "@backstage-community/plugin-rbac-common": "workspace:^",
     "@backstage/catalog-model": "^1.7.0",
     "@backstage/core-components": "^0.15.1",
     "@backstage/core-plugin-api": "^1.10.0",

--- a/workspaces/rbac/yarn.lock
+++ b/workspaces/rbac/yarn.lock
@@ -2461,8 +2461,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-rbac-backend@workspace:plugins/rbac-backend"
   dependencies:
-    "@backstage-community/plugin-rbac-common": ^1.12.1
-    "@backstage-community/plugin-rbac-node": ^1.8.1
+    "@backstage-community/plugin-rbac-common": "workspace:^"
+    "@backstage-community/plugin-rbac-node": "workspace:^"
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/backend-test-utils": 1.0.2
@@ -2500,7 +2500,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage-community/plugin-rbac-common@^1.12.1, @backstage-community/plugin-rbac-common@workspace:plugins/rbac-common":
+"@backstage-community/plugin-rbac-common@workspace:^, @backstage-community/plugin-rbac-common@workspace:plugins/rbac-common":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-rbac-common@workspace:plugins/rbac-common"
   dependencies:
@@ -2515,7 +2515,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage-community/plugin-rbac-node@^1.8.1, @backstage-community/plugin-rbac-node@workspace:plugins/rbac-node":
+"@backstage-community/plugin-rbac-node@workspace:^, @backstage-community/plugin-rbac-node@workspace:plugins/rbac-node":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-rbac-node@workspace:plugins/rbac-node"
   dependencies:
@@ -2530,7 +2530,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-rbac@workspace:plugins/rbac"
   dependencies:
-    "@backstage-community/plugin-rbac-common": ^1.12.1
+    "@backstage-community/plugin-rbac-common": "workspace:^"
     "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": 0.28.2
     "@backstage/core-app-api": 1.15.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up on #1808: Use workspace dependencies from rbac and rbac-backend to rbac-common and rbac-node

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
