### PR TITLE
fix(topology): fixed style-inject module path ref issue

### DIFF
--- a/workspaces/topology/.changeset/gold-files-flash.md
+++ b/workspaces/topology/.changeset/gold-files-flash.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-topology': minor
+'@backstage-community/plugin-topology': patch
 ---
 
 Resolved issues with the style-inject module path references in the npm package to ensure proper loading.

--- a/workspaces/topology/.changeset/gold-files-flash.md
+++ b/workspaces/topology/.changeset/gold-files-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': minor
+---
+
+Resolved issues with the style-inject module path references in the npm package to ensure proper loading.

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -19,7 +19,8 @@
     ]
   },
   "sideEffects": [
-    "./**/*.css"
+    "./**/*.css",
+    "./**/*.css.esm.js"
   ],
   "scripts": {
     "build": "backstage-cli package build",
@@ -30,7 +31,8 @@
     "prepack": "backstage-cli package prepack",
     "start": "backstage-cli package start",
     "test": "backstage-cli package test --passWithNoTests --coverage",
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "prepare": "node replace-style-injection-paths.js"
   },
   "dependencies": {
     "@backstage-community/plugin-topology-common": "workspace:^",
@@ -59,7 +61,8 @@
     "git-url-parse": "^13.1.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
-    "react-use": "^17.4.0"
+    "react-use": "^17.4.0",
+    "style-inject": "^0.3.0"
   },
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
@@ -80,6 +83,7 @@
     "@types/node": "18.19.34",
     "@types/react": "^18.3.11",
     "cross-fetch": "4.0.0",
+    "glob": "^11.0.0",
     "msw": "1.3.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -87,7 +91,6 @@
   },
   "files": [
     "dist",
-    "dist-scalprum",
     "app-config.backstage-community.yaml"
   ],
   "repository": {

--- a/workspaces/topology/plugins/topology/replace-style-injection-paths.js
+++ b/workspaces/topology/plugins/topology/replace-style-injection-paths.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const fs = require('fs');
+const glob = require('glob');
+
+const files = glob.sync('dist/**/*.css.esm.js');
+
+files.forEach(file => {
+  let content = fs.readFileSync(file, 'utf8');
+  content = content.replace(
+    /(\.\.\/)+node_modules\/style-inject\/dist\/style-inject\.es\.esm\.js/g,
+    'style-inject',
+  );
+  fs.writeFileSync(file, content, 'utf8');
+});

--- a/workspaces/topology/yarn.lock
+++ b/workspaces/topology/yarn.lock
@@ -2818,6 +2818,7 @@ __metadata:
     classnames: 2.x
     cross-fetch: 4.0.0
     git-url-parse: ^13.1.0
+    glob: ^11.0.0
     js-yaml: ^4.1.0
     lodash: ^4.17.21
     msw: 1.3.4
@@ -2825,6 +2826,7 @@ __metadata:
     react-dom: ^18.3.1
     react-router-dom: ^6.26.2
     react-use: ^17.4.0
+    style-inject: ^0.3.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -21338,6 +21340,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^4.0.1
+    minimatch: ^10.0.0
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^2.0.0
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 8a2dd914d5776987be5244624d9491bbcaf19f2387e06783737003ff696ebfd2264190c47014f8709c1c02d8bc892f17660cf986c587b107e194c0a3151ab333
+  languageName: node
+  linkType: hard
+
 "glob@npm:^8.0.1, glob@npm:^8.0.3, glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
@@ -23357,6 +23375,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "jackspeak@npm:4.0.2"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+  checksum: 210030029edfa1658328799ad88c3d0fc057c4cb8a069fc4137cc8d2cc4b65c9721c6e749e890f9ca77a954bb54f200f715b8896e50d330e5f3e902e72b40974
+  languageName: node
+  linkType: hard
+
 "javascript-natural-sort@npm:^0.7.1":
   version: 0.7.1
   resolution: "javascript-natural-sort@npm:0.7.1"
@@ -25165,6 +25192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "lru-cache@npm:11.0.2"
+  checksum: f9c27c58919a30f42834de9444de9f75bcbbb802c459239f96dd449ad880d8f9a42f51556d13659864dc94ab2dbded9c4a4f42a3e25a45b6da01bb86111224df
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^4.0.1":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
@@ -26192,6 +26226,15 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: f5b63c2f30606091a057c5f679b067f84a2cd0ffbd2dbc9143bda850afd353c7be81949ff11ae0c86988f07390eeca64efd7143ee05a0dab37f6c6b38a2ebb6c
   languageName: node
   linkType: hard
 
@@ -28029,6 +28072,16 @@ __metadata:
     lru-cache: ^10.2.0
     minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
   checksum: 890d5abcd593a7912dcce7cf7c6bf7a0b5648e3dee6caf0712c126ca0a65c7f3d7b9d769072a4d1baf370f61ce493ab5b038d59988688e0c5f3f646ee3c69023
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: ^11.0.0
+    minipass: ^7.1.2
+  checksum: 9953ce3857f7e0796b187a7066eede63864b7e1dfc14bf0484249801a5ab9afb90d9a58fc533ebb1b552d23767df8aa6a2c6c62caf3f8a65f6ce336a97bbb484
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Resolved issues with the style-inject module path references in the npm package to ensure proper loading.

This is a temporary workaround until a higher-level solution is implemented. The issue was that the reference path for `style-inject` pointed to `dist/node_modules/style-inject/` in the bundled `css.esm.js` style files, which is not included in the npm package per best practices.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
