### PR TITLE
Add config visibility to the frontend

### DIFF
--- a/workspaces/sonarqube/.changeset/tasty-moose-promise.md
+++ b/workspaces/sonarqube/.changeset/tasty-moose-promise.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': patch
+---
+
+Add config visibility to the frontend

--- a/workspaces/sonarqube/plugins/sonarqube/config.d.ts
+++ b/workspaces/sonarqube/plugins/sonarqube/config.d.ts
@@ -22,5 +22,37 @@ export interface Config {
      * @visibility frontend
      */
     baseUrl?: string;
+
+    /**
+     * The external url of the sonarqube installation.
+     * Use this if you want to use a different url for the frontend than the backend.
+     * @visibility frontend
+     */
+    externalBaseUrl?: string;
+
+    /**
+     * The optional sonarqube instances.
+     * @visibility frontend
+     */
+    instances?: Array<{
+      /**
+       * The name of the sonarqube instance.
+       * @visibility frontend
+       */
+      name: string;
+
+      /**
+       * The base url of the sonarqube instance.
+       * @visibility frontend
+       */
+      baseUrl: string;
+
+      /**
+       * The external url of the sonarqube instance.
+       * Use this if you want to use a different url for the frontend than the backend.
+       * @visibility frontend
+       */
+      externalBaseUrl?: string;
+    }>;
   };
 }


### PR DESCRIPTION
## SonarQube config visible in the frontend

We need to get the urls to the instances in the frontend, but they're not visible, despite being `@visibility frontend` in the config - although the _backend_ config. I saw that there's a shadow config in the frontend package for the `baseUrl`, but this only works if you don't have multiple instances.

This PR adds the config values of the `baseUrl` (and other non-sensitive fields) to the frontend for multi-instance configurations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
