### PR TITLE
Version Packages (scaffolder-backend-module-sonarqube)

### DIFF
--- a/workspaces/scaffolder-backend-module-sonarqube/.changeset/calm-jokes-explode.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/.changeset/calm-jokes-explode.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-sonarqube': patch
----
-
-The [scaffolder-backend-module-sonarqube](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `0e6bfd3f`.
-
-The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 2.2.2
+
+### Patch Changes
+
+- 3d1f1d8: The [scaffolder-backend-module-sonarqube](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `0e6bfd3f`.
+
+  The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).
+
 ## 2.2.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-sonarqube",
   "description": "The sonarqube module for @backstage/plugin-scaffolder-backend",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-sonarqube@2.2.2

### Patch Changes

-   3d1f1d8: The [scaffolder-backend-module-sonarqube](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/sonarqube-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `0e6bfd3f`.

    The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).
