### PR TITLE
chore: add additional codeowners for acr, ocm and rbac workspaces

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ yarn.lock                                           @backstage/community-plugins
 */yarn.lock                                         @backstage/community-plugins-maintainers @backstage-service
 
 /workspaces/3scale                                  @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr
-/workspaces/acr                                     @backstage/community-plugins-maintainers  @invincibleJai
+/workspaces/acr                                     @backstage/community-plugins-maintainers  @christoph-jerolimov @invincibleJai
 /workspaces/adr                                     @backstage/community-plugins-maintainers  @kuangp
 /workspaces/analytics                               @backstage/community-plugins-maintainers  @jmezach
 /workspaces/azure-devops                            @backstage/community-plugins-maintainers  @awanlin
@@ -33,11 +33,11 @@ yarn.lock                                           @backstage/community-plugins
 /workspaces/mta                                     @backstage/community-plugins-maintainers  @ibolton336
 /workspaces/nexus-repository-manager                @backstage/community-plugins-maintainers  @schultzp2020
 /workspaces/npm                                     @backstage/community-plugins-maintainers  @christoph-jerolimov @karthikjeeyar
-/workspaces/ocm                                     @backstage/community-plugins-maintainers  @debsmita1
+/workspaces/ocm                                     @backstage/community-plugins-maintainers  @christoph-jerolimov @debsmita1
 /workspaces/octopus-deploy                          @backstage/community-plugins-maintainers  @jmezach
 /workspaces/pingidentity                            @backstage/community-plugins-maintainers  @jessicajhee
 /workspaces/playlist                                @backstage/community-plugins-maintainers  @kuangp
-/workspaces/rbac                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @PatAKnight
+/workspaces/rbac                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @divyanshiGupta @PatAKnight
 /workspaces/redhat-argocd                           @backstage/community-plugins-maintainers  @karthikjeeyar @rohitkrai03 @Eswaraiahsapram
 /workspaces/redhat-resource-optimization            @backstage/community-plugins-maintainers  @christoph-jerolimov @04kash
 /workspaces/report-portal                           @backstage/community-plugins-maintainers  @yashoswalyo


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds additional codeowners for plugins we (Red Hat) converted/migrated the last month from Janus IDP to this Backstage community-plugins repo

1. @christoph-jerolimov / myself for the acr workspace (Azure Container Registry) where just @invincibleJai is a codeowner at the moment who is not part of the Backstage org yet. Jai, maybe you can approve that PR anyway to show your acknowledge on this.
   
   I worked already on some acr improvements and have some more local changes:

   * https://github.com/backstage/community-plugins/pull/1791
   * https://github.com/backstage/community-plugins/pull/1783
2. @christoph-jerolimov / myself also for the ocm (Open Cluster Management) workspace where just @debsmita1 is a codeowner at the moment who is not part of the Backstage org yet. Debsmita, maybe you can approve that PR anyway to show your acknowledge on this.

   Until now, I have raised just this small PR on that workspace.

   * https://github.com/backstage/community-plugins/pull/1823

3. @divyanshiGupta to the rbac workspace as she was responsible for the RBAC frontend plugin in the past.

   * https://github.com/backstage/community-plugins/pull/1847
   * https://github.com/janus-idp/backstage-plugins/pulls?q=is%3Apr+author%3AdivyanshiGupta+is%3Aclosed+rbac

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
