### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/chilly-pillows-check.md
+++ b/workspaces/rbac/.changeset/chilly-pillows-check.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-chore: use workspace dependencies

--- a/workspaces/rbac/.changeset/violet-squids-compete.md
+++ b/workspaces/rbac/.changeset/violet-squids-compete.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac-common': patch
-'@backstage-community/plugin-rbac-node': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated supported-versions to ^1.28.4.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 5.2.4
+
+### Patch Changes
+
+- dd0e2b4: chore: use workspace dependencies
+- b7c2fa1: Updated supported-versions to ^1.28.4.
+- Updated dependencies [b7c2fa1]
+  - @backstage-community/plugin-rbac-common@1.12.2
+  - @backstage-community/plugin-rbac-node@1.8.2
+
 ## 5.2.3
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.12.2
+
+### Patch Changes
+
+- b7c2fa1: Updated supported-versions to ^1.28.4.
+
 ## 1.12.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.8.2
+
+### Patch Changes
+
+- b7c2fa1: Updated supported-versions to ^1.28.4.
+
 ## 1.8.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.32.3
+
+### Patch Changes
+
+- dd0e2b4: chore: use workspace dependencies
+- b7c2fa1: Updated supported-versions to ^1.28.4.
+- Updated dependencies [b7c2fa1]
+  - @backstage-community/plugin-rbac-common@1.12.2
+
 ## 1.32.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.32.3

### Patch Changes

-   dd0e2b4: chore: use workspace dependencies
-   b7c2fa1: Updated supported-versions to ^1.28.4.
-   Updated dependencies [b7c2fa1]
    -   @backstage-community/plugin-rbac-common@1.12.2

## @backstage-community/plugin-rbac-backend@5.2.4

### Patch Changes

-   dd0e2b4: chore: use workspace dependencies
-   b7c2fa1: Updated supported-versions to ^1.28.4.
-   Updated dependencies [b7c2fa1]
    -   @backstage-community/plugin-rbac-common@1.12.2
    -   @backstage-community/plugin-rbac-node@1.8.2

## @backstage-community/plugin-rbac-common@1.12.2

### Patch Changes

-   b7c2fa1: Updated supported-versions to ^1.28.4.

## @backstage-community/plugin-rbac-node@1.8.2

### Patch Changes

-   b7c2fa1: Updated supported-versions to ^1.28.4.
