### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/fair-flies-guess.md
+++ b/workspaces/nexus-repository-manager/.changeset/fair-flies-guess.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.10.4
+
+### Patch Changes
+
+- 5e5c1a5: Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.
+
 ## 1.10.3
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.10.4

### Patch Changes

-   5e5c1a5: Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.
