### PR TITLE
Version Packages (pingidentity)

### DIFF
--- a/workspaces/pingidentity/.changeset/weak-moles-jog.md
+++ b/workspaces/pingidentity/.changeset/weak-moles-jog.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
----
-
-Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-pingidentity
 
+## 0.1.5
+
+### Patch Changes
+
+- cf437a2: Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-pingidentity",
   "description": "The pingidentity backend module for the catalog plugin.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-pingidentity@0.1.5

### Patch Changes

-   cf437a2: Removed `export-dynamic` script and Janus IDP cli from the build process and npm release.
