### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/gold-files-flash.md
+++ b/workspaces/topology/.changeset/gold-files-flash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Resolved issues with the style-inject module path references in the npm package to ensure proper loading.

--- a/workspaces/topology/.changeset/little-forks-train.md
+++ b/workspaces/topology/.changeset/little-forks-train.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-topology-common': patch
-'@backstage-community/plugin-topology': patch
----
-
-Bump up share-react version to ^2.13.1 and updated supported-versions to ^1.28.4.

--- a/workspaces/topology/plugins/topology-common/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-topology-common [1.3.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-topology-common@1.2.2...@janus-idp/backstage-plugin-topology-common@1.3.0) (2024-07-26)
 
+## 1.4.3
+
+### Patch Changes
+
+- e77652d: Bump up share-react version to ^2.13.1 and updated supported-versions to ^1.28.4.
+
 ## 1.4.2
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology-common/package.json
+++ b/workspaces/topology/plugins/topology-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.29.1
+
+### Patch Changes
+
+- 833d4dd: Resolved issues with the style-inject module path references in the npm package to ensure proper loading.
+- e77652d: Bump up share-react version to ^2.13.1 and updated supported-versions to ^1.28.4.
+- Updated dependencies [e77652d]
+  - @backstage-community/plugin-topology-common@1.4.3
+
 ## 1.29.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.29.1

### Patch Changes

-   833d4dd: Resolved issues with the style-inject module path references in the npm package to ensure proper loading.
-   e77652d: Bump up share-react version to ^2.13.1 and updated supported-versions to ^1.28.4.
-   Updated dependencies [e77652d]
    -   @backstage-community/plugin-topology-common@1.4.3

## @backstage-community/plugin-topology-common@1.4.3

### Patch Changes

-   e77652d: Bump up share-react version to ^2.13.1 and updated supported-versions to ^1.28.4.
