### PR TITLE
chore(redhat-argocd): update dev page and rhdh theme (dev dependency)

### DIFF
--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -50,7 +50,7 @@
     "@mui/icons-material": "^5.15.16",
     "@mui/material": "^5.15.16",
     "@mui/styles": "^5.15.16",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
+    "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router": "^6.23.0",

--- a/workspaces/redhat-argocd/plugins/argocd/dev/index.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/dev/index.tsx
@@ -18,11 +18,12 @@ import React from 'react';
 import { Entity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import { configApiRef } from '@backstage/core-plugin-api';
+import { Page, Header, TabbedLayout } from '@backstage/core-components';
 import { createDevApp } from '@backstage/dev-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { KubernetesApi } from '@backstage/plugin-kubernetes-react';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
-import { MockPermissionApi, TestApiProvider } from '@backstage/test-utils';
+import { mockApis, TestApiProvider } from '@backstage/test-utils';
 
 import { Box } from '@material-ui/core';
 import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
@@ -71,7 +72,7 @@ const mockEntity: Entity = {
     owner: 'user:guest',
   },
 };
-const mockPermissionApi = new MockPermissionApi();
+
 export class MockArgoCDApiClient implements ArgoCDApi {
   async listApps(_options: listAppsOptions): Promise<any> {
     return {
@@ -194,7 +195,7 @@ createDevApp()
           [kubernetesApiRef, new MockKubernetesClient(mockArgoResources)],
           [configApiRef, new ConfigReader(mockArgocdConfig)],
           [argoCDApiRef, new MockArgoCDApiClient()],
-          [permissionApiRef, mockPermissionApi],
+          [permissionApiRef, mockApis.permission()],
         ]}
       >
         <EntityProvider entity={mockEntity}>
@@ -217,7 +218,14 @@ createDevApp()
         ]}
       >
         <EntityProvider entity={mockEntity}>
-          <ArgocdDeploymentSummary />
+          <Page themeId="service">
+            <Header type="component — service" title="quarkus-app" />
+            <TabbedLayout>
+              <TabbedLayout.Route path="/" title="CI/CD">
+                <ArgocdDeploymentSummary />
+              </TabbedLayout.Route>
+            </TabbedLayout>
+          </Page>
         </EntityProvider>
       </TestApiProvider>
     ),

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -67,7 +67,7 @@
     "@backstage/test-utils": "^1.7.0",
     "@janus-idp/cli": "1.13.1",
     "@playwright/test": "1.48.2",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.2.0",
+    "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
     "@testing-library/jest-dom": "6.6.2",
     "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.5.2",

--- a/workspaces/redhat-argocd/yarn.lock
+++ b/workspaces/redhat-argocd/yarn.lock
@@ -2862,7 +2862,7 @@ __metadata:
     "@patternfly/react-icons": ^5.1.1
     "@patternfly/react-tokens": ^5.1.2
     "@playwright/test": 1.48.2
-    "@redhat-developer/red-hat-developer-hub-theme": 0.2.0
+    "@redhat-developer/red-hat-developer-hub-theme": 0.4.0
     "@testing-library/jest-dom": 6.6.2
     "@testing-library/react": 14.3.1
     "@testing-library/user-event": 14.5.2
@@ -10963,9 +10963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhat-developer/red-hat-developer-hub-theme@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.2.0"
+"@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0"
   peerDependencies:
     "@backstage/theme": ^0.5.2
     "@emotion/react": ^11.11.1
@@ -10974,7 +10974,7 @@ __metadata:
     "@material-ui/icons": ^4.11.3
     "@mui/icons-material": ^5.14.19
     "@mui/material": ^5.14.20
-  checksum: 2a5d52e2ba31c5a6ff2cfe75d78b1de1afa00690b522875e52d8ddc8805a3ccc5c202414a0304790efe0ed0ea2c570b9c8bf7472c7895d4bbe416c6541435196
+  checksum: 8684f8faa2fe87100dba2c19f1e1a306e808cf98bc65da829c3203a325ea6520a93e54c174e25a220ccf8280ecc2750a178a0d18b12f5ba354c7c415e8a9dc7b
   languageName: node
   linkType: hard
 
@@ -15449,7 +15449,7 @@ __metadata:
     "@mui/icons-material": ^5.15.16
     "@mui/material": ^5.15.16
     "@mui/styles": ^5.15.16
-    "@redhat-developer/red-hat-developer-hub-theme": 0.2.0
+    "@redhat-developer/red-hat-developer-hub-theme": 0.4.0
     "@testing-library/jest-dom": 6.6.2
     "@testing-library/react": 14.3.1
     "@types/node": 18.19.34


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi, a small change while I tested different dev pages with the latest rhdh theme:

1. Added a catalog entity-like page around the argocd deployment test
2. Changed from deprecated `MockPermissionApi` to `mockApis.permission()`
3. Updated the rhdh-theme (that is just used as a dev dependency) 

I don't added a changeset because it doesn't update the plugin itself.

**Dev page before:**

![Screenshot From 2024-11-06 19-53-09](https://github.com/user-attachments/assets/c38be042-6eac-48db-8e5f-70629d762c9e)

**Dev page with this PR:**

![Screenshot From 2024-11-06 19-52-22](https://github.com/user-attachments/assets/abf80d0c-7306-4c1e-8499-6c3a40dab099)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
