### PR TITLE
fix(topology): add missing permission mock so that dev page shows the topology graph again

### DIFF
--- a/workspaces/topology/.changeset/unlucky-flies-sniff.md
+++ b/workspaces/topology/.changeset/unlucky-flies-sniff.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Update topology dev pages (requires an additional permission dependency). This should not affect users.

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -43,6 +43,7 @@
     "@backstage/plugin-kubernetes": "^0.11.16",
     "@backstage/plugin-kubernetes-common": "^0.8.3",
     "@backstage/plugin-kubernetes-react": "^0.4.4",
+    "@backstage/plugin-permission-common": "^0.8.1",
     "@backstage/plugin-permission-react": "^0.4.27",
     "@backstage/theme": "^0.6.0",
     "@janus-idp/shared-react": "^2.13.1",

--- a/workspaces/topology/yarn.lock
+++ b/workspaces/topology/yarn.lock
@@ -2792,6 +2792,7 @@ __metadata:
     "@backstage/plugin-kubernetes": ^0.11.16
     "@backstage/plugin-kubernetes-common": ^0.8.3
     "@backstage/plugin-kubernetes-react": ^0.4.4
+    "@backstage/plugin-permission-common": ^0.8.1
     "@backstage/plugin-permission-react": ^0.4.27
     "@backstage/test-utils": ^1.7.0
     "@backstage/theme": ^0.6.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. Fixed the topology dev page which shows always "Permission required" error due a missing permission mock.
2. Wrapped the topology dev page in a "catalog entity"-like page with a tab
3. Added a 2nd test page for the permission error*

*there is an issue with the topology page that it doesn't show the latest content when switching between this dev pages. It's rendered correctly when I switch to another browser tab and back. I guess there is some kind of memorize that updates the content when the focus changed.

**Before:**

![Screenshot From 2024-11-06 20-40-59](https://github.com/user-attachments/assets/0fd06699-baa8-4204-8fbd-f675f91aead1)

**With this PR:**

![Screenshot From 2024-11-06 20-40-28](https://github.com/user-attachments/assets/130d40b7-3127-4a5b-81fd-f30b2c1bedcd)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
