### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/silver-carrots-enjoy.md
+++ b/workspaces/topology/.changeset/silver-carrots-enjoy.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Updated the `build` script to correct `style-inject` module path references in packed files, ensuring proper resolution and avoiding runtime errors in the published package.

--- a/workspaces/topology/.changeset/sour-poems-share.md
+++ b/workspaces/topology/.changeset/sour-poems-share.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Added `build:all` script to trigger `prepare` script in release process and removed `postversion` script.

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.29.3
+
+### Patch Changes
+
+- a2c5a0a: Updated the `build` script to correct `style-inject` module path references in packed files, ensuring proper resolution and avoiding runtime errors in the published package.
+- a2c5a0a: Added `build:all` script to trigger `prepare` script in release process and removed `postversion` script.
+
 ## 1.29.2
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.29.3

### Patch Changes

-   a2c5a0a: Updated the `build` script to correct `style-inject` module path references in packed files, ensuring proper resolution and avoiding runtime errors in the published package.
-   a2c5a0a: Added `build:all` script to trigger `prepare` script in release process and removed `postversion` script.
