### PR TITLE
fix(topology): add prepublish script to fix style-inject module path …

### DIFF
--- a/workspaces/topology/.changeset/chilled-laws-appear.md
+++ b/workspaces/topology/.changeset/chilled-laws-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Added `prepublish` script to correct `style-inject` module path references in packed files, ensuring proper resolution and avoiding runtime errors in the published package. And reverted `build` script.

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -23,8 +23,8 @@
     "./**/*.css.esm.js"
   ],
   "scripts": {
-    "build": "backstage-cli package build && node replace-style-injection-paths.js",
-    "prepublish": "yarn prepare",
+    "build": "backstage-cli package build",
+    "prepublish": "node replace-style-injection-paths.js",
     "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
     "postpack": "backstage-cli package postpack",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Added `prepublish` script to correct `style-inject` module path references in packed files, ensuring proper resolution and avoiding runtime errors in the published package. And revert `build` script.

This `prepublish` script will be removed when [this Backstage issue](https://github.com/backstage/backstage/issues/27506) is resolved.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
