### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/curvy-garlics-flow.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/curvy-garlics-flow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/scaffolder-backend-module-regex': patch
----
-
-Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.2.2
+
+### Patch Changes
+
+- 6ca34c8: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+
 ## 2.2.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/scaffolder-backend-module-regex@2.2.2

### Patch Changes

-   6ca34c8: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
