### PR TITLE
repo-tools: update @backstage/repo-tools version

### DIFF
--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@backstage/e2e-test-utils": "^{{version '@backstage/e2e-test-utils'}}",
-    "@backstage/repo-tools": "^0.10.0",
+    "@backstage/repo-tools": "^{{version '@backstage/repo-tools'}}",
     "@changesets/cli": "^2.27.1",
     "@spotify/prettier-config": "^12.0.0",
     "node-gyp": "^9.0.0",

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@backstage/e2e-test-utils": "^{{version '@backstage/e2e-test-utils'}}",
-    "@backstage/repo-tools": "^0.8.0",
+    "@backstage/repo-tools": "^0.10.0",
     "@changesets/cli": "^2.27.1",
     "@spotify/prettier-config": "^12.0.0",
     "node-gyp": "^9.0.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While creating a new workspace, I was running into an issue with generating api reports as they were being named as `api-report.md` instead of `report.api.md`. I was able to fix this by updating @backstage/repo-tools to version 0.10.0. 

Might also be worth looking and seeing if anything else in `workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs` needs to be updated

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
