### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/nervous-worms-fold.md
+++ b/workspaces/confluence/.changeset/nervous-worms-fold.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Make `parallelismLimit` configuration field optional.
-
-This field is already treated as optional in the package code, and the default
-value is already mentioned in the description. As such we can safely mark it as
-optional and treat configuration which omits it as valid.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.2.4
+
+### Patch Changes
+
+- 3211478: Make `parallelismLimit` configuration field optional.
+
+  This field is already treated as optional in the package code, and the default
+  value is already mentioned in the description. As such we can safely mark it as
+  optional and treat configuration which omits it as valid.
+
 ## 0.2.3
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-search-backend-module-confluence-collator@0.2.4

### Patch Changes

-   3211478: Make `parallelismLimit` configuration field optional.

    This field is already treated as optional in the package code, and the default
    value is already mentioned in the description. As such we can safely mark it as
    optional and treat configuration which omits it as valid.
