### PR TITLE
fix @backstage/repo-tools version in create-workspace

### DIFF
--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@backstage/cli": "^{{version '@backstage/cli'}}",
     "@backstage/e2e-test-utils": "^{{version '@backstage/e2e-test-utils'}}",
-    "@backstage/repo-tools": "^{{version '@backstage/repo-tools'}}",
+    "@backstage/repo-tools": "^0.10.0",
     "@changesets/cli": "^2.27.1",
     "@spotify/prettier-config": "^12.0.0",
     "node-gyp": "^9.0.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Since `@backstage/repo-tools` ins't mentioned in https://github.com/backstage/backstage/blob/master/packages/create-app/src/lib/versions.ts, we can't use `{{version '@backstage/repo-tools'}}`. This PR updates @backstage/repo-tools to use version 0.10.0.

Discord discussion: https://discord.com/channels/687207715902193673/1211692810294788126/1305415024927440957

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
