### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/fifty-cherries-share.md
+++ b/workspaces/code-coverage/.changeset/fifty-cherries-share.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage': patch
----
-
-Prevent divide by zero error when rendering codecoverage lines on empty files.

--- a/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage
 
+## 0.2.33
+
+### Patch Changes
+
+- ff7bf93: Prevent divide by zero error when rendering codecoverage lines on empty files.
+
 ## 0.2.32
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage@0.2.33

### Patch Changes

-   ff7bf93: Prevent divide by zero error when rendering codecoverage lines on empty files.
