### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/empty-starfishes-bow.md
+++ b/workspaces/tech-insights/.changeset/empty-starfishes-bow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-common': patch
----
-
-Cache identical API calls for a few seconds. This prevents fetching the same checks multiple times when having several Scorecards with the same (or all) checks, although with different filters.

--- a/workspaces/tech-insights/.changeset/gold-ways-talk.md
+++ b/workspaces/tech-insights/.changeset/gold-ways-talk.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-Added optional `filter` prop to `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` for easier and more flexible filtering of what checks to display.

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.60
+
+### Patch Changes
+
+- Updated dependencies [331daba]
+  - @backstage-community/plugin-tech-insights-common@0.2.21
+  - @backstage-community/plugin-tech-insights-node@1.0.3
+
 ## 0.1.59
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 1.2.3
+
+### Patch Changes
+
+- Updated dependencies [331daba]
+  - @backstage-community/plugin-tech-insights-common@0.2.21
+  - @backstage-community/plugin-tech-insights-node@1.0.3
+
 ## 1.2.2
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-common
 
+## 0.2.21
+
+### Patch Changes
+
+- 331daba: Cache identical API calls for a few seconds. This prevents fetching the same checks multiple times when having several Scorecards with the same (or all) checks, although with different filters.
+
 ## 0.2.20
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-common/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-common",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "backstage": {
     "role": "common-library",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-tech-insights-node
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [331daba]
+  - @backstage-community/plugin-tech-insights-common@0.2.21
+
 ## 1.0.2
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-node",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "backstage": {
     "role": "node-library",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.3.40
+
+### Patch Changes
+
+- 331daba: Added optional `filter` prop to `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` for easier and more flexible filtering of what checks to display.
+- Updated dependencies [331daba]
+  - @backstage-community/plugin-tech-insights-common@0.2.21
+
 ## 0.3.39
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights@0.3.40

### Patch Changes

-   331daba: Added optional `filter` prop to `EntityTechInsightsScorecardContent` and `EntityTechInsightsScorecardCard` for easier and more flexible filtering of what checks to display.
-   Updated dependencies [331daba]
    -   @backstage-community/plugin-tech-insights-common@0.2.21

## @backstage-community/plugin-tech-insights-backend@1.2.3

### Patch Changes

-   Updated dependencies [331daba]
    -   @backstage-community/plugin-tech-insights-common@0.2.21
    -   @backstage-community/plugin-tech-insights-node@1.0.3

## @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.60

### Patch Changes

-   Updated dependencies [331daba]
    -   @backstage-community/plugin-tech-insights-common@0.2.21
    -   @backstage-community/plugin-tech-insights-node@1.0.3

## @backstage-community/plugin-tech-insights-common@0.2.21

### Patch Changes

-   331daba: Cache identical API calls for a few seconds. This prevents fetching the same checks multiple times when having several Scorecards with the same (or all) checks, although with different filters.

## @backstage-community/plugin-tech-insights-node@1.0.3

### Patch Changes

-   Updated dependencies [331daba]
    -   @backstage-community/plugin-tech-insights-common@0.2.21
