### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/migrate-1731420924280.md
+++ b/workspaces/quay/.changeset/migrate-1731420924280.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
-'@backstage-community/plugin-quay-common': patch
----
-
-Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.3.2
+
+### Patch Changes
+
+- 00c79ed: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+
 ## 1.3.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.14.2
+
+### Patch Changes
+
+- 00c79ed: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
+- Updated dependencies [00c79ed]
+  - @backstage-community/plugin-quay-common@1.3.2
+
 ## 1.14.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.14.2

### Patch Changes

-   00c79ed: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
-   Updated dependencies [00c79ed]
    -   @backstage-community/plugin-quay-common@1.3.2

## @backstage-community/plugin-quay-common@1.3.2

### Patch Changes

-   00c79ed: Migrated from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins).
