### PR TITLE
Version Packages (matomo)

### DIFF
--- a/workspaces/matomo/.changeset/empty-rabbits-drop.md
+++ b/workspaces/matomo/.changeset/empty-rabbits-drop.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-matomo-backend': minor
-'@backstage-community/plugin-matomo': minor
----
-
-The matomo and matomo-backend plugins from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) are migrated to community-plugins. The migrations is performed using manual steps.

--- a/workspaces/matomo/plugins/matomo-backend/CHANGELOG.md
+++ b/workspaces/matomo/plugins/matomo-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.12.0
+
+### Minor Changes
+
+- a522528: The matomo and matomo-backend plugins from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) are migrated to community-plugins. The migrations is performed using manual steps.
+
 ## 1.11.1
 
 ### Patch Changes

--- a/workspaces/matomo/plugins/matomo-backend/package.json
+++ b/workspaces/matomo/plugins/matomo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-matomo-backend",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/matomo/plugins/matomo/CHANGELOG.md
+++ b/workspaces/matomo/plugins/matomo/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.11.0
+
+### Minor Changes
+
+- a522528: The matomo and matomo-backend plugins from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) are migrated to community-plugins. The migrations is performed using manual steps.
+
 ## 1.10.1
 
 ### Patch Changes

--- a/workspaces/matomo/plugins/matomo/package.json
+++ b/workspaces/matomo/plugins/matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-matomo",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-matomo@1.11.0

### Minor Changes

-   a522528: The matomo and matomo-backend plugins from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) are migrated to community-plugins. The migrations is performed using manual steps.

## @backstage-community/plugin-matomo-backend@1.12.0

### Minor Changes

-   a522528: The matomo and matomo-backend plugins from [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/) are migrated to community-plugins. The migrations is performed using manual steps.
