### PR TITLE
Copilot: add support for private tokens

### DIFF
--- a/workspaces/copilot/.changeset/stupid-cooks-walk.md
+++ b/workspaces/copilot/.changeset/stupid-cooks-walk.md
@@ -1,0 +1,19 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+Added support for specifying private GitHub tokens dedicated to the Copilot plugin. This is useful if you don't want to use the same token for both the Copilot backend and other GitHub integrations. To do this, you can specify a new GitHub integration using a string as the host:
+
+```diff
+  integrations:
+    github:
+      - host: github.com
+        token: your_token
++     - host: your_copilot_private_token
++       token: your_super_token
++       apiBaseUrl: https://api.github.com
+  copilot:
+-   host: github.com
++   host: your_copilot_private_token
+    enterprise: your_enterprise
+```

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
@@ -15,11 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
-import {
-  DefaultGithubCredentialsProvider,
-  GithubCredentials,
-  ScmIntegrations,
-} from '@backstage/integration';
+import { GithubCredentials, ScmIntegrations } from '@backstage/integration';
 
 export type GithubInfo = {
   credentials: GithubCredentials;
@@ -29,8 +25,6 @@ export type GithubInfo = {
 
 export const getGithubInfo = async (config: Config): Promise<GithubInfo> => {
   const integrations = ScmIntegrations.fromConfig(config);
-  const credentialsProvider =
-    DefaultGithubCredentialsProvider.fromIntegrations(integrations);
 
   const host = config.getString('copilot.host');
   const enterprise = config.getString('copilot.enterprise');
@@ -53,13 +47,11 @@ export const getGithubInfo = async (config: Config): Promise<GithubInfo> => {
 
   const apiBaseUrl = githubConfig.apiBaseUrl ?? 'https://api.github.com';
 
-  const credentials = await credentialsProvider.getCredentials({
-    url: apiBaseUrl,
-  });
-
-  if (!credentials.headers) {
-    throw new Error('Failed to retrieve credentials headers.');
-  }
+  const credentials: GithubCredentials = {
+    type: 'token',
+    headers: { Authorization: `Bearer ${githubConfig.token}` },
+    token: githubConfig.token,
+  };
 
   return {
     apiBaseUrl,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for specifying private GitHub tokens dedicated to the Copilot plugin. This is useful if you don't want to use the same token for both the Copilot backend and other GitHub integrations.

This is an alternative approach to: https://github.com/backstage/community-plugins/pull/1260

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
