### PR TITLE
fix(tekton): workaround to resolve style-inject imports in packed *.css.esm.js files

### DIFF
--- a/workspaces/tekton/.changeset/eighty-vans-notice.md
+++ b/workspaces/tekton/.changeset/eighty-vans-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Fixed `style-inject` imports in packed \*.css.esm.js files until a new version of `@backstage/cli` is released that includes https://github.com/backstage/backstage/pull/27547.

--- a/workspaces/tekton/plugins/tekton/fix-style-inject-imports.sh
+++ b/workspaces/tekton/plugins/tekton/fix-style-inject-imports.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Copyright 2024 The Backstage Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+glob='*.css.esm.js'
+replace="import styleInject from '\.\.\/\.\.\/node_modules\/style-inject\/dist\/style-inject\.es\.esm\.js';"
+with="import styleInject from 'style-inject';"
+
+find dist -name "$glob" -exec sed -i "s/$replace/$with/" {} \;

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -30,7 +30,8 @@
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack"
+    "postpack": "backstage-cli package postpack",
+    "prepublish": "./fix-style-inject-imports.sh"
   },
   "dependencies": {
     "@aonic-ui/pipelines": "^1.1.1",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add workaround when building a plugin based on the release tekton plugin. Error:

```
Error: Failed to compile '../../../node_modules/@backstage-community/plugin-tekton/dist/components/PipelineRunList/PipelineRunRow.css.esm.js':
  Module not found: Error: Can't resolve '../../node_modules/style-inject/dist/style-inject.es.esm.js' in 'node_modules/@backstage-community/plugin-tekton/dist/components/PipelineRunList'
```

This solution is developed by @ciiay and is working already added to the topology plugin.

Related issues and PRs:

* https://github.com/backstage/community-plugins/pull/1723
* https://github.com/backstage/community-plugins/pull/1827
* https://github.com/backstage/community-plugins/pull/1878
* https://github.com/backstage/community-plugins/pull/1880
* https://github.com/backstage/community-plugins/pull/1882
* https://github.com/backstage/backstage/issues/27506
* https://github.com/backstage/backstage/pull/27547

Might reverse this fix when merged PR #27547 is published.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
