### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/eighty-vans-notice.md
+++ b/workspaces/tekton/.changeset/eighty-vans-notice.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Fixed `style-inject` imports in packed \*.css.esm.js files until a new version of `@backstage/cli` is released that includes https://github.com/backstage/backstage/pull/27547.

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 3.16.1
+
+### Patch Changes
+
+- 9b803bb: Fixed `style-inject` imports in packed \*.css.esm.js files until a new version of `@backstage/cli` is released that includes https://github.com/backstage/backstage/pull/27547.
+
 ## 3.16.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.16.1

### Patch Changes

-   9b803bb: Fixed `style-inject` imports in packed \*.css.esm.js files until a new version of `@backstage/cli` is released that includes <https://github.com/backstage/backstage/pull/27547>.
