### PR TITLE
Update renovatebot/github-action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -74,10 +74,10 @@ jobs:
           # are different than the ones given after the cache is restored. We have to
           # change ownership to solve this. We also need to have correct permissions in
           # the entire /tmp/renovate tree, not just the section with the repo cache.
-          sudo chown -R runneradmin:root /tmp/renovate/
+          sudo chown -R 12021:0 /tmp/renovate/
           ls -R $cache_dir
 
-      - uses: renovatebot/github-action@v40.1.10
+      - uses: renovatebot/github-action@v41.0.2
         with:
           configurationFile: .github/renovate-action.json
           renovate-version: full


### PR DESCRIPTION
The `renovate.yaml` started failing a few weeks ago.

Updated the workflow as suggested by https://github.com/renovatebot/github-action?tab=readme-ov-file#persisting-the-repository-cache

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
