### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/brave-ladybugs-eat.md
+++ b/workspaces/analytics/.changeset/brave-ladybugs-eat.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-The `analytics-provider-segment` plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.10.2
+
+### Patch Changes
+
+- 059ecb2: The `analytics-provider-segment` plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
+
 ## 1.10.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-provider-segment@1.10.2

### Patch Changes

-   059ecb2: The `analytics-provider-segment` plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the community plugins. The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin)
