### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/dry-teachers-tap.md
+++ b/workspaces/linguist/.changeset/dry-teachers-tap.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': minor
----
-
-**BREAKING** Removed support for what is known as the legacy backend, please use the New Backend System.

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies [9602620]
+  - @backstage-community/plugin-linguist-backend@0.7.0
+
 ## 0.0.13
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- 9602620: **BREAKING** Removed support for what is known as the legacy backend, please use the New Backend System.
+
 ## 0.6.4
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist-backend@0.7.0

### Minor Changes

-   9602620: **BREAKING** Removed support for what is known as the legacy backend, please use the New Backend System.

## backend@0.0.14

### Patch Changes

-   Updated dependencies [9602620]
    -   @backstage-community/plugin-linguist-backend@0.7.0
