### PR TITLE
sonarqube - Removed usages and references of `@backstage/backend-common`

### DIFF
--- a/workspaces/sonarqube/.changeset/giant-comics-remain.md
+++ b/workspaces/sonarqube/.changeset/giant-comics-remain.md
@@ -3,3 +3,5 @@
 ---
 
 Removed usages and references of `@backstage/backend-common`
+
+Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/sonarqube/.changeset/giant-comics-remain.md
+++ b/workspaces/sonarqube/.changeset/giant-comics-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube-backend': patch
+---
+
+Removed usages and references of `@backstage/backend-common`

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@backstage-community/plugin-sonarqube-backend": "workspace:^",
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-defaults": "^0.5.2",
     "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/backend-tasks": "^0.6.1",

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -38,7 +38,6 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-defaults": "^0.5.2",
     "@backstage/backend-plugin-api": "^1.0.1",
     "@backstage/config": "^1.2.0",

--- a/workspaces/sonarqube/plugins/sonarqube-backend/report.api.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/report.api.md
@@ -8,7 +8,7 @@ import { Config } from '@backstage/config';
 import express from 'express';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
-// @public
+// @public @deprecated (undocumented)
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
@@ -27,7 +27,7 @@ export class DefaultSonarqubeInfoProvider implements SonarqubeInfoProvider {
   }): Promise<SonarqubeFindings | undefined>;
 }
 
-// @public
+// @public @deprecated (undocumented)
 export interface RouterOptions {
   logger: LoggerService;
   sonarqubeInfoProvider: SonarqubeInfoProvider;

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/router.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/router.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { getVoidLogger } from '@backstage/backend-common';
 import express from 'express';
 import request from 'supertest';
 
 import { createRouter } from './router';
 import { SonarqubeFindings } from './sonarqubeInfoProvider';
+import { mockServices } from '@backstage/backend-test-utils';
 
 describe('createRouter', () => {
   let app: express.Express;
@@ -39,7 +39,7 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     const router = await createRouter({
-      logger: getVoidLogger(),
+      logger: mockServices.rootLogger(),
       sonarqubeInfoProvider: {
         getBaseUrl: getBaseUrlMock,
         getFindings: getFindingsMock,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/router.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/router.ts
@@ -21,6 +21,8 @@ import { InputError } from '@backstage/errors';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ *
  * Dependencies needed by the router
  * @public
  */
@@ -36,6 +38,8 @@ export interface RouterOptions {
 }
 
 /**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ *
  * @public
  *
  * Constructs a sonarqube router.

--- a/workspaces/sonarqube/yarn.lock
+++ b/workspaces/sonarqube/yarn.lock
@@ -2637,7 +2637,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-sonarqube-backend@workspace:plugins/sonarqube-backend"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/backend-test-utils": ^1.0.2
@@ -13414,7 +13413,6 @@ __metadata:
   resolution: "backend@workspace:packages/backend"
   dependencies:
     "@backstage-community/plugin-sonarqube-backend": "workspace:^"
-    "@backstage/backend-common": ^0.25.0
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/backend-tasks": ^0.6.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed usages and references of `@backstage/backend-common`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
