### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/fast-ducks-peel.md
+++ b/workspaces/playlist/.changeset/fast-ducks-peel.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist-backend': minor
----
-
-**BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.
-
-Also, removed usages and references of `@backstage/backend-common`

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [8634a13]
+  - @backstage-community/plugin-playlist-backend@0.4.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- 8634a13: **BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.
+
+  Also, removed usages and references of `@backstage/backend-common`
+
 ## 0.3.28
 
 ### Patch Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.3.28",
+  "version": "0.4.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist-backend@0.4.0

### Minor Changes

-   8634a13: **BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.

    Also, removed usages and references of `@backstage/backend-common`

## backend@0.0.7

### Patch Changes

-   Updated dependencies [8634a13]
    -   @backstage-community/plugin-playlist-backend@0.4.0
