### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/short-rules-guess.md
+++ b/workspaces/entity-feedback/.changeset/short-rules-guess.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': minor
----
-
-**BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.
-
-Also, removed usages and references of `@backstage/backend-common`

--- a/workspaces/entity-feedback/packages/backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [fcf6f84]
+  - @backstage-community/plugin-entity-feedback-backend@0.4.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/entity-feedback/packages/backend/package.json
+++ b/workspaces/entity-feedback/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- fcf6f84: **BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.
+
+  Also, removed usages and references of `@backstage/backend-common`
+
 ## 0.3.2
 
 ### Patch Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "entity-feedback",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback-backend@0.4.0

### Minor Changes

-   fcf6f84: **BREAKING** `auth`, `config`, and `httpAuth` are now required, please migrate to the new backend system as the best path forward for this change.

    Also, removed usages and references of `@backstage/backend-common`

## backend@0.0.9

### Patch Changes

-   Updated dependencies [fcf6f84]
    -   @backstage-community/plugin-entity-feedback-backend@0.4.0
