### PR TITLE
ci: fix renovate changesets git issues

### DIFF
--- a/.github/workflows/automate_renovate_changesets.yml
+++ b/.github/workflows/automate_renovate_changesets.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
         with:
-          fetch-depth: 2
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 

--- a/scripts/ci/generate-bump-changesets.js
+++ b/scripts/ci/generate-bump-changesets.js
@@ -57,7 +57,7 @@ async function main() {
     await exec(`git add ${fileName}`);
   }
   await exec('git commit --amend --no-edit');
-  await exec('git push');
+  await exec('git push -f');
   console.log(`Added changeset for commit ${shortHash.trim()}`);
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `automate_renovate_changesets.yaml` workflow is currently failing when invoking `git push`. This should hopefully fix the issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
