### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/new-actors-beam.md
+++ b/workspaces/kafka/.changeset/new-actors-beam.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-kafka-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-kafka-backend
 
+## 0.3.22
+
+### Patch Changes
+
+- 179ee02: Removed usages and references of `@backstage/backend-common`
+
+  Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.21
 
 ### Patch Changes

--- a/workspaces/kafka/plugins/kafka-backend/package.json
+++ b/workspaces/kafka/plugins/kafka-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka-backend",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "A Backstage backend plugin that integrates towards Kafka",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka-backend@0.3.22

### Patch Changes

-   179ee02: Removed usages and references of `@backstage/backend-common`

    Deprecated `createRouter` and its router options in favour of the new backend system.
