### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/calm-forks-join.md
+++ b/workspaces/linkerd/.changeset/calm-forks-join.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [0555e21]
+  - @backstage-community/plugin-linkerd-backend@0.3.7
+
 ## 0.0.11
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.3.7
+
+### Patch Changes
+
+- 0555e21: Removed usages and references of `@backstage/backend-common`
+
 ## 0.3.6
 
 ### Patch Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd-backend@0.3.7

### Patch Changes

-   0555e21: Removed usages and references of `@backstage/backend-common`

## backend@0.0.12

### Patch Changes

-   Updated dependencies [0555e21]
    -   @backstage-community/plugin-linkerd-backend@0.3.7
