### PR TITLE
Version Packages (nomad)

### DIFF
--- a/workspaces/nomad/.changeset/perfect-birds-fly.md
+++ b/workspaces/nomad/.changeset/perfect-birds-fly.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-nomad-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/nomad/plugins/nomad-backend/CHANGELOG.md
+++ b/workspaces/nomad/plugins/nomad-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-nomad-backend
 
+## 0.1.26
+
+### Patch Changes
+
+- 75644d9: Removed usages and references of `@backstage/backend-common`
+
+  Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.1.25
 
 ### Patch Changes

--- a/workspaces/nomad/plugins/nomad-backend/package.json
+++ b/workspaces/nomad/plugins/nomad-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nomad-backend",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "nomad",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nomad-backend@0.1.26

### Patch Changes

-   75644d9: Removed usages and references of `@backstage/backend-common`

    Deprecated `createRouter` and its router options in favour of the new backend system.
