### PR TITLE
Version Packages (periskop)

### DIFF
--- a/workspaces/periskop/.changeset/brave-emus-ring.md
+++ b/workspaces/periskop/.changeset/brave-emus-ring.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-periskop-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
+++ b/workspaces/periskop/plugins/periskop-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-periskop-backend
 
+## 0.2.22
+
+### Patch Changes
+
+- fdcc96d: Removed usages and references of `@backstage/backend-common`
+
+  Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.2.21
 
 ### Patch Changes

--- a/workspaces/periskop/plugins/periskop-backend/package.json
+++ b/workspaces/periskop/plugins/periskop-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-periskop-backend",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "periskop",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-periskop-backend@0.2.22

### Patch Changes

-   fdcc96d: Removed usages and references of `@backstage/backend-common`

    Deprecated `createRouter` and its router options in favour of the new backend system.
