### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/beige-papayas-approve.md
+++ b/workspaces/rollbar/.changeset/beige-papayas-approve.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-rollbar-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.1.70
+
+### Patch Changes
+
+- 3a74e4b: Removed usages and references of `@backstage/backend-common`
+
+  Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.1.69
 
 ### Patch Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar-backend@0.1.70

### Patch Changes

-   3a74e4b: Removed usages and references of `@backstage/backend-common`

    Deprecated `createRouter` and its router options in favour of the new backend system.
