### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/giant-comics-remain.md
+++ b/workspaces/sonarqube/.changeset/giant-comics-remain.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': patch
----
-
-Removed usages and references of `@backstage/backend-common`
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.4
+
+### Patch Changes
+
+- Updated dependencies [f53852b]
+  - @backstage-community/plugin-sonarqube-backend@0.3.1
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.3.1
+
+### Patch Changes
+
+- f53852b: Removed usages and references of `@backstage/backend-common`
+
+  Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.3.1

### Patch Changes

-   f53852b: Removed usages and references of `@backstage/backend-common`

    Deprecated `createRouter` and its router options in favour of the new backend system.

## backend@0.0.4

### Patch Changes

-   Updated dependencies [f53852b]
    -   @backstage-community/plugin-sonarqube-backend@0.3.1
