### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/green-pumpkins-sell.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/green-pumpkins-sell.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-regex': patch
----
-
-rename the plugin from @backstage-community/scaffolder-backend-module-regex to @backstage-community/plugin-scaffolder-backend-module-regex

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.2.3
+
+### Patch Changes
+
+- 70151fa: rename the plugin from @backstage-community/scaffolder-backend-module-regex to @backstage-community/plugin-scaffolder-backend-module-regex
+
 ## 2.2.2
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-regex@2.2.3

### Patch Changes

-   70151fa: rename the plugin from @backstage-community/scaffolder-backend-module-regex to @backstage-community/plugin-scaffolder-backend-module-regex
