### PR TITLE
Version Packages (mend)

### DIFF
--- a/workspaces/mend/.changeset/good-sloths-hunt.md
+++ b/workspaces/mend/.changeset/good-sloths-hunt.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mend-backend': patch
----
-
-Updated dependency `path-to-regexp` to `^8.0.0`

--- a/workspaces/mend/.changeset/shy-knives-walk.md
+++ b/workspaces/mend/.changeset/shy-knives-walk.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mend-backend': minor
----
-
-Initial release of the `@backstage-community/plugin-mend-backend` plugin.

--- a/workspaces/mend/.changeset/tame-pumas-raise.md
+++ b/workspaces/mend/.changeset/tame-pumas-raise.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mend': minor
----
-
-Initial release of the `@backstage-community/plugin-mend` plugin.

--- a/workspaces/mend/plugins/mend-backend/CHANGELOG.md
+++ b/workspaces/mend/plugins/mend-backend/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @backstage-community/plugin-mend-backend
+
+## 0.1.0
+
+### Minor Changes
+
+- 898b5f1: Initial release of the `@backstage-community/plugin-mend-backend` plugin.
+
+### Patch Changes
+
+- 49378e1: Updated dependency `path-to-regexp` to `^8.0.0`

--- a/workspaces/mend/plugins/mend-backend/package.json
+++ b/workspaces/mend/plugins/mend-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mend-backend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mend/plugins/mend/CHANGELOG.md
+++ b/workspaces/mend/plugins/mend/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-mend
+
+## 0.1.0
+
+### Minor Changes
+
+- 898b5f1: Initial release of the `@backstage-community/plugin-mend` plugin.

--- a/workspaces/mend/plugins/mend/package.json
+++ b/workspaces/mend/plugins/mend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mend@0.1.0

### Minor Changes

-   898b5f1: Initial release of the `@backstage-community/plugin-mend` plugin.

## @backstage-community/plugin-mend-backend@0.1.0

### Minor Changes

-   898b5f1: Initial release of the `@backstage-community/plugin-mend-backend` plugin.

### Patch Changes

-   49378e1: Updated dependency `path-to-regexp` to `^8.0.0`
