### PR TITLE
Version Packages (github-pull-requests-board)

### DIFF
--- a/workspaces/github-pull-requests-board/.changeset/afraid-sloths-punch.md
+++ b/workspaces/github-pull-requests-board/.changeset/afraid-sloths-punch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': patch
----
-
-Adding support for the new frontend system, available at the `/alpha` export.

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-pull-requests-board
 
+## 0.2.7
+
+### Patch Changes
+
+- afefe93: Adding support for the new frontend system, available at the `/alpha` export.
+
 ## 0.2.6
 
 ### Patch Changes

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-pull-requests-board",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-pull-requests-board@0.2.7

### Patch Changes

-   afefe93: Adding support for the new frontend system, available at the `/alpha` export.
