### PR TITLE
chore(ga4): add configurable cookie flags

### DIFF
--- a/workspaces/analytics/.changeset/famous-eggs-notice.md
+++ b/workspaces/analytics/.changeset/famous-eggs-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-ga4': minor
+---
+
+Allow defining custom cookie flags and setting it to 'SameSite=Lax' by default to make every browser behave similarly.

--- a/workspaces/analytics/plugins/analytics-module-ga4/config.d.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/config.d.ts
@@ -55,6 +55,14 @@ export interface Config {
         debug?: boolean;
 
         /**
+         * Google Analytics cookie flags. Defaults to 'SameSite=Lax'
+         * More information https://developers.google.com/analytics/devguides/collection/ga4/reference/config#cookie_flags
+         *
+         * @visibility frontend
+         */
+        cookieFlags?: string;
+
+        /**
          * Whether to send default send_page_view event.
          * Defaults to false.
          *

--- a/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
+++ b/workspaces/analytics/plugins/analytics-module-ga4/src/apis/implementations/AnalyticsApi/GoogleAnalytics4.ts
@@ -53,6 +53,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
     measurementId: string;
     testMode: boolean;
     debug: boolean;
+    cookieFlags: string;
     enableSendPageView: boolean;
     contentGroupBy?: string;
     allowedContexts?: string[];
@@ -65,6 +66,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
       userIdTransform = 'sha-256',
       testMode,
       debug,
+      cookieFlags,
       enableSendPageView,
       contentGroupBy,
       allowedContexts,
@@ -74,9 +76,11 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
     ReactGA.initialize(measurementId, {
       testMode,
       gaOptions: {
+        cookieFlags: cookieFlags,
         debug_mode: debug,
       },
       gtagOptions: {
+        cookie_flags: cookieFlags,
         debug_mode: debug,
         send_page_view: enableSendPageView,
       },
@@ -121,6 +125,9 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
     const identity =
       config.getOptionalString('app.analytics.ga4.identity') || 'disabled';
     const debug = config.getOptionalBoolean('app.analytics.ga4.debug') ?? false;
+    const cookieFlags =
+      config.getOptionalString('app.analytics.ga4.cookieFlags') ??
+      'SameSite=Lax';
     const enableSendPageView =
       config.getOptionalBoolean('app.analytics.ga4.enableSendPageView') ??
       false;
@@ -150,6 +157,7 @@ export class GoogleAnalytics4 implements AnalyticsApi, NewAnalyticsApi {
       measurementId: measurementId,
       testMode,
       debug,
+      cookieFlags,
       enableSendPageView,
       contentGroupBy,
       allowedContexts,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Current default cookie flags produces the following warnings (Firefox 132):
![image](https://github.com/user-attachments/assets/1aa0db2d-8f7d-4276-be68-961aaf1a24a3)

This patch sets sane defaults for any browser silencing the above warning and allows users to override the flags via configuration for their environment. 

Sources:
- https://www.simoahava.com/analytics/cookieflags-field-google-analytics/
- https://github.com/codler/react-ga4/blob/d50684824f5d155c772721d93ff2be7ea65767bf/types/ga4.d.ts#L93
- https://developers.google.com/analytics/devguides/collection/ga4/reference/config#cookie_flags

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
