### PR TITLE
fix(rbac): remove empty summary row, align bundle with other plugins

### DIFF
--- a/workspaces/rbac/plugins/rbac/app-config.dynamic.yaml
+++ b/workspaces/rbac/plugins/rbac/app-config.dynamic.yaml
@@ -4,10 +4,8 @@ dynamicPlugins:
       appIcons:
         - name: rbacIcon
           importName: RbacIcon
-          module: RbacPlugin
       dynamicRoutes:
         - path: /rbac
-          module: RbacPlugin
           importName: RbacPage
           menuItem:
             icon: rbacIcon

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -85,16 +85,9 @@
     "react-router-dom": "^6.0.0",
     "start-server-and-test": "2.0.8"
   },
-  "scalprum": {
-    "name": "janus-idp.backstage-plugin-rbac",
-    "exposedModules": {
-      "RbacPlugin": "./src/index.ts"
-    }
-  },
   "files": [
-    "dist",
-    "dist-scalprum",
-    "app-config.yaml"
+    "app-config.dynamic.yaml",
+    "dist"
   ],
   "repository": {
     "type": "git",

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -27,7 +27,7 @@ import CardContent from '@mui/material/CardContent';
 import { policyEntityUpdatePermission } from '@backstage-community/plugin-rbac-common';
 
 import { MembersInfo } from '../../hooks/useMembers';
-import { MembersData } from '../../types';
+import { filterTableData } from '../../utils/filter-table-data';
 import { getMembers } from '../../utils/rbac-utils';
 import EditRole from '../EditRole';
 import { columns } from './MembersListColumns';
@@ -53,7 +53,7 @@ const getEditIcon = (isAllowed: boolean, roleName: string) => {
 
 export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
   const { data, loading, retry, error, canReadUsersAndGroups } = membersInfo;
-  const [members, setMembers] = React.useState<MembersData[]>();
+  const [searchText, setSearchText] = React.useState<string>();
   const policyEntityPermissionResult = usePermission({
     permission: policyEntityUpdatePermission,
     resourceRef: policyEntityUpdatePermission.resourceType,
@@ -84,9 +84,10 @@ export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
     },
   ];
 
-  const onSearchResultsChange = (searchResults: MembersData[]) => {
-    setMembers(searchResults);
-  };
+  const filteredData = React.useMemo(
+    () => filterTableData({ data, columns, searchText }),
+    [data, searchText],
+  );
 
   return (
     <Card>
@@ -103,11 +104,10 @@ export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
         <Table
           title={
             !loading && data?.length
-              ? `Users and groups (${getMembers(members || data)})`
+              ? `Users and groups (${getMembers(filteredData)})`
               : 'Users and groups'
           }
           actions={actions}
-          renderSummaryRow={summary => onSearchResultsChange(summary.data)}
           options={{ padding: 'default', search: true, paging: true }}
           data={data ?? []}
           isLoading={loading}
@@ -120,6 +120,7 @@ export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
               No records found
             </Box>
           }
+          onSearchChange={setSearchText}
         />
       </CardContent>
     </Card>

--- a/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
@@ -23,7 +23,7 @@ import Box from '@mui/material/Box';
 import { useCheckIfLicensePluginEnabled } from '../../hooks/useCheckIfLicensePluginEnabled';
 import { useLocationToast } from '../../hooks/useLocationToast';
 import { useRoles } from '../../hooks/useRoles';
-import { RolesData } from '../../types';
+import { filterTableData } from '../../utils/filter-table-data';
 import DownloadCSVLink from '../DownloadUserStatistics';
 import { SnackbarAlert } from '../SnackbarAlert';
 import { useToast } from '../ToastContext';
@@ -35,7 +35,7 @@ export const RolesList = () => {
   const { toastMessage, setToastMessage } = useToast();
   const { openDialog, setOpenDialog, deleteComponent } = useDeleteDialog();
   useLocationToast(setToastMessage);
-  const [roles, setRoles] = React.useState<number | undefined>();
+  const [searchText, setSearchText] = React.useState<string>();
   const { loading, data, retry, createRoleAllowed, createRoleLoading, error } =
     useRoles();
 
@@ -48,9 +48,10 @@ export const RolesList = () => {
   const onAlertClose = () => {
     setToastMessage('');
   };
-  const onSearchResultsChange = (searchResults: RolesData[]) => {
-    setRoles(searchResults.length);
-  };
+  const filteredRoles = React.useMemo(
+    () => filterTableData({ data, columns, searchText }),
+    [data, searchText],
+  );
 
   const getErrorWarning = () => {
     const errorTitleBase = 'Something went wrong while fetching the';
@@ -100,14 +101,13 @@ export const RolesList = () => {
       <Table
         title={
           !loading && data?.length
-            ? `All roles (${roles ?? data.length})`
+            ? `All roles (${filteredRoles.length})`
             : `All roles`
         }
         options={{ padding: 'default', search: true, paging: true }}
         data={data}
         isLoading={loading}
         columns={columns}
-        renderSummaryRow={summary => onSearchResultsChange(summary.data)}
         emptyContent={
           <Box
             data-testid="roles-table-empty"
@@ -116,6 +116,7 @@ export const RolesList = () => {
             No records found
           </Box>
         }
+        onSearchChange={setSearchText}
       />
       {isLicensePluginEnabled.isEnabled && <DownloadCSVLink />}
       {openDialog && (

--- a/workspaces/rbac/plugins/rbac/src/utils/filter-table-data.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/filter-table-data.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TableColumn } from '@backstage/core-components';
+
+import { filterTableData } from './filter-table-data';
+
+type Row = { name: string; value: string };
+
+const data: Row[] = [
+  { name: 'UPPER', value: 'CASE' },
+  { name: 'lower', value: 'case' },
+];
+
+const columns: TableColumn<Row>[] = [{ field: 'name' }, { field: 'value' }];
+
+describe('filterTableData', () => {
+  it('should return an empty array if no data are passed', () => {
+    expect(
+      filterTableData({
+        data: [],
+        columns,
+        searchText: 'search',
+      }),
+    ).toEqual([]);
+    expect(
+      filterTableData({
+        data: null as any as [],
+        columns,
+        searchText: 'search',
+      }),
+    ).toEqual([]);
+    expect(
+      filterTableData({
+        data: undefined as any as [],
+        columns,
+        searchText: 'search',
+      }),
+    ).toEqual([]);
+  });
+
+  it('should return the input data when no columns are passed', () => {
+    expect(
+      filterTableData({
+        data,
+        columns: [],
+        searchText: 'search',
+      }),
+    ).toEqual(data);
+  });
+
+  it('should return the input data when search string is empty', () => {
+    expect(
+      filterTableData({
+        data,
+        columns,
+        searchText: '',
+      }),
+    ).toEqual(data);
+  });
+
+  it('should filter the right properties based on the column field', () => {
+    expect(
+      filterTableData({
+        data,
+        columns,
+        searchText: 'UPPER',
+      }),
+    ).toEqual([data[0]]);
+  });
+
+  it('should ignore upper and lower case when filtering', () => {
+    expect(
+      filterTableData({
+        data,
+        columns,
+        searchText: 'LOWER',
+      }),
+    ).toEqual([data[1]]);
+  });
+
+  it('should return all data when neccesarry', () => {
+    expect(
+      filterTableData({
+        data,
+        columns,
+        searchText: 'case',
+      }),
+    ).toEqual(data);
+  });
+});

--- a/workspaces/rbac/plugins/rbac/src/utils/filter-table-data.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/filter-table-data.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TableColumn } from '@backstage/core-components';
+
+/**
+ * Filter the given `data` rows with the Backstage TableColumn `columns` configuration
+ * and the `search` string.
+ *
+ * It ignores upper/lower case similar to the underlaying @material-table/core implementation:
+ * https://github.com/material-table-core/core/blob/v3.2.5/src/utils/data-manager.js#L808-L811
+ */
+export const filterTableData = <T extends Record<string, any>>({
+  data,
+  columns,
+  searchText,
+}: {
+  data: T[];
+  columns: TableColumn<T>[];
+  searchText?: string | null;
+}): T[] => {
+  if (!data || !data.length || !columns || !columns.length || !searchText) {
+    return data || [];
+  }
+
+  const upperCaseSearch = searchText.toLocaleUpperCase('en-US');
+
+  return data.filter(row => {
+    const fieldValues = columns.map(column =>
+      column.field ? row[column.field] : null,
+    );
+
+    return fieldValues.some(fieldValue =>
+      fieldValue
+        ?.toString()
+        .toLocaleUpperCase('en-US')
+        .includes(upperCaseSearch),
+    );
+  });
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. fix: remove empty summary row from the UI by adding a `filterTableData` util that filters the table rows similar to `@material-table/core` (the implementation behind Backstage Table)
2. remove `@janus-idp/cli` / `scalprum` configuration from `package.json`
3. Rename `app-config.yaml` to `app-config.dynamic.yaml` to align it with other plugins and make it clear that is actually no real/full app-config.

I installed the RBAC plugin with this command into my local RHDH:

```
cd workspaces/rbac/plugins/rbac

npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/git/janus-idp/backstage-showcase/dynamic-plugins-root --dev
```

Removing the scalprum configuration requires that I changed my RHDH config from:

```yaml
dynamicPlugins:
  frontend:
    janus-idp.backstage-plugin-rbac:
      appIcons:
        - name: rbacIcon
          importName: RbacIcon
          module: RbacPlugin
      dynamicRoutes:
        - path: /rbac
          module: RbacPlugin
          importName: RbacPage
          menuItem:
            icon: rbacIcon
            text: RBAC3
      menuItems:
        rbac:
          parent: admin
          icon: rbacIcon
          priority: 10

```

to

```yaml

dynamicPlugins:
  frontend:
    backstage-community.plugin-rbac:
      appIcons:
        - name: rbacIcon
          importName: RbacIcon
      dynamicRoutes:
        - path: /rbac
          importName: RbacPage
          menuItem:
            icon: rbacIcon
            text: RBAC1-X
      menuItems:
        rbac:
          parent: admin
          icon: rbacIcon
```

So the expected plugin id and no need to define the module anymore.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
