### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/tough-starfishes-deliver.md
+++ b/workspaces/rbac/.changeset/tough-starfishes-deliver.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-- fix: remove empty summary row
-- fix: remove `@janus-idp/cli` / `scalprum` configuration from `package.json`. Users that build and install the plugin from the source code must change their app-config.yaml from `janus-idp.backstage-plugin-rbac` to `backstage-community.plugin-rbac` and drop the module parameter. This matches now other plugins we migrated from the Janus IDP community to the Backstage community plugin and was missed before.

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.33.2
+
+### Patch Changes
+
+- c3fe880: - fix: remove empty summary row
+  - fix: remove `@janus-idp/cli` / `scalprum` configuration from `package.json`. Users that build and install the plugin from the source code must change their app-config.yaml from `janus-idp.backstage-plugin-rbac` to `backstage-community.plugin-rbac` and drop the module parameter. This matches now other plugins we migrated from the Janus IDP community to the Backstage community plugin and was missed before.
+
 ## 1.33.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.33.2

### Patch Changes

-   c3fe880: - fix: remove empty summary row
    -   fix: remove `@janus-idp/cli` / `scalprum` configuration from `package.json`. Users that build and install the plugin from the source code must change their app-config.yaml from `janus-idp.backstage-plugin-rbac` to `backstage-community.plugin-rbac` and drop the module parameter. This matches now other plugins we migrated from the Janus IDP community to the Backstage community plugin and was missed before.
