### PR TITLE
Version Packages (todo)

### DIFF
--- a/workspaces/todo/.changeset/fluffy-phones-tie.md
+++ b/workspaces/todo/.changeset/fluffy-phones-tie.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-todo-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/todo/plugins/todo-backend/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-todo-backend
 
+## 0.3.22
+
+### Patch Changes
+
+- b23745f: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.21
 
 ### Patch Changes

--- a/workspaces/todo/plugins/todo-backend/package.json
+++ b/workspaces/todo/plugins/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo-backend",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-todo-backend@0.3.22

### Patch Changes

-   b23745f: Deprecated `createRouter` and its router options in favour of the new backend system.
