### PR TITLE
Version Packages (airbrake)

### DIFF
--- a/workspaces/airbrake/.changeset/healthy-apples-collect.md
+++ b/workspaces/airbrake/.changeset/healthy-apples-collect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-airbrake-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
+++ b/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-airbrake-backend
 
+## 0.3.21
+
+### Patch Changes
+
+- 14a35d5: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.20
 
 ### Patch Changes

--- a/workspaces/airbrake/plugins/airbrake-backend/package.json
+++ b/workspaces/airbrake/plugins/airbrake-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-airbrake-backend",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-airbrake-backend@0.3.21

### Patch Changes

-   14a35d5: Deprecated `createRouter` and its router options in favour of the new backend system.
