### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-fbd1938.md
+++ b/workspaces/ocm/.changeset/renovate-fbd1938.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.15.3`.

--- a/workspaces/ocm/.changeset/unlucky-apples-fix.md
+++ b/workspaces/ocm/.changeset/unlucky-apples-fix.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
-'@backstage-community/plugin-ocm-common': patch
-'@backstage-community/plugin-ocm': patch
----
-
-Clean up api report warnings and remove unnecessary files

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 5.2.4
+
+### Patch Changes
+
+- 056a5ca: Updated dependency `@openapitools/openapi-generator-cli` to `2.15.3`.
+- 40f3226: Clean up api report warnings and remove unnecessary files
+- Updated dependencies [40f3226]
+  - @backstage-community/plugin-ocm-common@3.6.2
+
 ## 5.2.3
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.6.2
+
+### Patch Changes
+
+- 40f3226: Clean up api report warnings and remove unnecessary files
+
 ## 3.6.1
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.2.5
+
+### Patch Changes
+
+- 40f3226: Clean up api report warnings and remove unnecessary files
+- Updated dependencies [40f3226]
+  - @backstage-community/plugin-ocm-common@3.6.2
+
 ## 5.2.4
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.2.5

### Patch Changes

-   40f3226: Clean up api report warnings and remove unnecessary files
-   Updated dependencies [40f3226]
    -   @backstage-community/plugin-ocm-common@3.6.2

## @backstage-community/plugin-ocm-backend@5.2.4

### Patch Changes

-   056a5ca: Updated dependency `@openapitools/openapi-generator-cli` to `2.15.3`.
-   40f3226: Clean up api report warnings and remove unnecessary files
-   Updated dependencies [40f3226]
    -   @backstage-community/plugin-ocm-common@3.6.2

## @backstage-community/plugin-ocm-common@3.6.2

### Patch Changes

-   40f3226: Clean up api report warnings and remove unnecessary files
