### PR TITLE
Version Packages (gitops-profiles)

### DIFF
--- a/workspaces/gitops-profiles/.changeset/wet-jars-sneeze.md
+++ b/workspaces/gitops-profiles/.changeset/wet-jars-sneeze.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gitops-profiles': patch
----
-
-Fix broken link to docker image with binary of the plugin

--- a/workspaces/gitops-profiles/plugins/gitops-profiles/CHANGELOG.md
+++ b/workspaces/gitops-profiles/plugins/gitops-profiles/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gitops-profiles
 
+## 0.3.55
+
+### Patch Changes
+
+- 6cd4e02: Fix broken link to docker image with binary of the plugin
+
 ## 0.3.54
 
 ### Patch Changes

--- a/workspaces/gitops-profiles/plugins/gitops-profiles/package.json
+++ b/workspaces/gitops-profiles/plugins/gitops-profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gitops-profiles",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "description": "A Backstage plugin that helps you manage GitOps profiles",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gitops-profiles@0.3.55

### Patch Changes

-   6cd4e02: Fix broken link to docker image with binary of the plugin
