### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/version-bump-1-33-5.md
+++ b/workspaces/linguist/.changeset/version-bump-1-33-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': minor
-'@backstage-community/plugin-linguist': minor
-'@backstage-community/plugin-linguist-backend': minor
-'@backstage-community/plugin-linguist-common': minor
----
-
-Backstage version bump to v1.33.5

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [067af9a]
+  - @backstage-community/plugin-linguist@0.2.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.15
+
+### Patch Changes
+
+- Updated dependencies [067af9a]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.3.0
+  - @backstage-community/plugin-linguist-backend@0.8.0
+  - app@0.0.9
+
 ## 0.0.14
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.3.0
+
+### Minor Changes
+
+- 067af9a: Backstage version bump to v1.33.5
+
+### Patch Changes
+
+- Updated dependencies [067af9a]
+  - @backstage-community/plugin-linguist-common@0.2.0
+
 ## 0.2.2
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.8.0
+
+### Minor Changes
+
+- 067af9a: Backstage version bump to v1.33.5
+
+### Patch Changes
+
+- Updated dependencies [067af9a]
+  - @backstage-community/plugin-linguist-common@0.2.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.2.0
+
+### Minor Changes
+
+- 067af9a: Backstage version bump to v1.33.5
+
 ## 0.1.10
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist
 
+## 0.2.0
+
+### Minor Changes
+
+- 067af9a: Backstage version bump to v1.33.5
+
+### Patch Changes
+
+- Updated dependencies [067af9a]
+  - @backstage-community/plugin-linguist-common@0.2.0
+
 ## 0.1.28
 
 ### Patch Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.1.28",
+  "version": "0.2.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.3.0

### Minor Changes

-   067af9a: Backstage version bump to v1.33.5

### Patch Changes

-   Updated dependencies [067af9a]
    -   @backstage-community/plugin-linguist-common@0.2.0

## @backstage-community/plugin-linguist@0.2.0

### Minor Changes

-   067af9a: Backstage version bump to v1.33.5

### Patch Changes

-   Updated dependencies [067af9a]
    -   @backstage-community/plugin-linguist-common@0.2.0

## @backstage-community/plugin-linguist-backend@0.8.0

### Minor Changes

-   067af9a: Backstage version bump to v1.33.5

### Patch Changes

-   Updated dependencies [067af9a]
    -   @backstage-community/plugin-linguist-common@0.2.0

## @backstage-community/plugin-linguist-common@0.2.0

### Minor Changes

-   067af9a: Backstage version bump to v1.33.5

## app@0.0.9

### Patch Changes

-   Updated dependencies [067af9a]
    -   @backstage-community/plugin-linguist@0.2.0

## backend@0.0.15

### Patch Changes

-   Updated dependencies [067af9a]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.3.0
    -   @backstage-community/plugin-linguist-backend@0.8.0
    -   app@0.0.9
