### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/happy-cars-mix.md
+++ b/workspaces/azure-sites/.changeset/happy-cars-mix.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-sites-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.3.11
+
+### Patch Changes
+
+- 2101453: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.10
 
 ### Patch Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites-backend@0.3.11

### Patch Changes

-   2101453: Deprecated `createRouter` and its router options in favour of the new backend system.
