### PR TITLE
Version Packages (lighthouse)

### DIFF
--- a/workspaces/lighthouse/.changeset/short-snails-boil.md
+++ b/workspaces/lighthouse/.changeset/short-snails-boil.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse-backend': patch
----
-
-Deprecated `createScheduler` and its options in favour of the new backend system.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-lighthouse-backend
 
+## 0.4.17
+
+### Patch Changes
+
+- fe5f938: Deprecated `createScheduler` and its options in favour of the new backend system.
+
 ## 0.4.16
 
 ### Patch Changes

--- a/workspaces/lighthouse/plugins/lighthouse-backend/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-backend",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-lighthouse-backend@0.4.17

### Patch Changes

-   fe5f938: Deprecated `createScheduler` and its options in favour of the new backend system.
