### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/chatty-otters-work.md
+++ b/workspaces/code-coverage/.changeset/chatty-otters-work.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.3.3
+
+### Patch Changes
+
+- 37bd870: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage-backend@0.3.3

### Patch Changes

-   37bd870: Deprecated `createRouter` and its router options in favour of the new backend system.
