### PR TITLE
Version Packages (azure-storage-explorer)

### DIFF
--- a/workspaces/azure-storage-explorer/.changeset/selfish-nails-develop.md
+++ b/workspaces/azure-storage-explorer/.changeset/selfish-nails-develop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-storage-explorer-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/azure-storage-explorer/plugins/azure-storage-backend/CHANGELOG.md
+++ b/workspaces/azure-storage-explorer/plugins/azure-storage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-storage-explorer-backend
 
+## 0.0.8
+
+### Patch Changes
+
+- 8e1d040: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/azure-storage-explorer/plugins/azure-storage-backend/package.json
+++ b/workspaces/azure-storage-explorer/plugins/azure-storage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-storage-explorer-backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-storage-explorer-backend@0.0.8

### Patch Changes

-   8e1d040: Deprecated `createRouter` and its router options in favour of the new backend system.
