### PR TITLE
Version Packages (blackduck)

### DIFF
--- a/workspaces/blackduck/.changeset/dirty-carrots-accept.md
+++ b/workspaces/blackduck/.changeset/dirty-carrots-accept.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-blackduck-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/blackduck/plugins/blackduck-backend/CHANGELOG.md
+++ b/workspaces/blackduck/plugins/blackduck-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-blackduck-backend
 
+## 0.0.8
+
+### Patch Changes
+
+- ca201c4: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.0.7
 
 ### Patch Changes

--- a/workspaces/blackduck/plugins/blackduck-backend/package.json
+++ b/workspaces/blackduck/plugins/blackduck-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-blackduck-backend",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-blackduck-backend@0.0.8

### Patch Changes

-   ca201c4: Deprecated `createRouter` and its router options in favour of the new backend system.
