### PR TITLE
Version Packages (badges)

### DIFF
--- a/workspaces/badges/.changeset/two-ears-train.md
+++ b/workspaces/badges/.changeset/two-ears-train.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-badges-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/badges/plugins/badges-backend/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges-backend
 
+## 0.5.4
+
+### Patch Changes
+
+- 1f907f2: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.5.3
 
 ### Patch Changes

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges-backend",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A Backstage backend plugin that generates README badges for your entities",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-badges-backend@0.5.4

### Patch Changes

-   1f907f2: Deprecated `createRouter` and its router options in favour of the new backend system.
