### PR TITLE
Version Packages (explore)

### DIFF
--- a/workspaces/explore/.changeset/lemon-elephants-provide.md
+++ b/workspaces/explore/.changeset/lemon-elephants-provide.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-explore-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/explore/plugins/explore-backend/CHANGELOG.md
+++ b/workspaces/explore/plugins/explore-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-explore-backend
 
+## 0.1.8
+
+### Patch Changes
+
+- 00f3ac0: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.1.7
 
 ### Patch Changes

--- a/workspaces/explore/plugins/explore-backend/package.json
+++ b/workspaces/explore/plugins/explore-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-explore-backend",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "explore",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-explore-backend@0.1.8

### Patch Changes

-   00f3ac0: Deprecated `createRouter` and its router options in favour of the new backend system.
