### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/modern-books-give.md
+++ b/workspaces/jenkins/.changeset/modern-books-give.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.6.3
+
+### Patch Changes
+
+- 3500d71: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.6.2
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins-backend@0.6.3

### Patch Changes

-   3500d71: Deprecated `createRouter` and its router options in favour of the new backend system.
