### PR TITLE
Version Packages (mta)

### DIFF
--- a/workspaces/mta/.changeset/spicy-dingos-burn.md
+++ b/workspaces/mta/.changeset/spicy-dingos-burn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Deprecated `createRouter` and its router options in favour of the new backend system.

--- a/workspaces/mta/plugins/mta-backend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-mta-backend
 
+## 0.2.2
+
+### Patch Changes
+
+- 9004ac1: Deprecated `createRouter` and its router options in favour of the new backend system.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/workspaces/mta/plugins/mta-backend/package.json
+++ b/workspaces/mta/plugins/mta-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-backend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/backstage-plugin-mta-backend@0.2.2

### Patch Changes

-   9004ac1: Deprecated `createRouter` and its router options in favour of the new backend system.
