### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-86e99ec.md
+++ b/workspaces/rbac/.changeset/renovate-86e99ec.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@playwright/test` to `1.49.0`.

--- a/workspaces/rbac/.changeset/renovate-97b9dfd.md
+++ b/workspaces/rbac/.changeset/renovate-97b9dfd.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `qs` to `6.13.1`.

--- a/workspaces/rbac/.changeset/violet-waves-film.md
+++ b/workspaces/rbac/.changeset/violet-waves-film.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac-common': patch
-'@backstage-community/plugin-rbac-node': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Clean up api report warnings and remove unnecessary files

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 5.2.7
+
+### Patch Changes
+
+- 7843798: Updated dependency `qs` to `6.13.1`.
+- 4b3653a: Clean up api report warnings and remove unnecessary files
+- Updated dependencies [4b3653a]
+  - @backstage-community/plugin-rbac-common@1.12.3
+  - @backstage-community/plugin-rbac-node@1.8.3
+
 ## 5.2.6
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "5.2.6",
+  "version": "5.2.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.12.3
+
+### Patch Changes
+
+- 4b3653a: Clean up api report warnings and remove unnecessary files
+
 ## 1.12.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.8.3
+
+### Patch Changes
+
+- 4b3653a: Clean up api report warnings and remove unnecessary files
+
 ## 1.8.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.33.3
+
+### Patch Changes
+
+- aa02f04: Updated dependency `@playwright/test` to `1.49.0`.
+- 4b3653a: Clean up api report warnings and remove unnecessary files
+- Updated dependencies [4b3653a]
+  - @backstage-community/plugin-rbac-common@1.12.3
+
 ## 1.33.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.33.3

### Patch Changes

-   aa02f04: Updated dependency `@playwright/test` to `1.49.0`.
-   4b3653a: Clean up api report warnings and remove unnecessary files
-   Updated dependencies [4b3653a]
    -   @backstage-community/plugin-rbac-common@1.12.3

## @backstage-community/plugin-rbac-backend@5.2.7

### Patch Changes

-   7843798: Updated dependency `qs` to `6.13.1`.
-   4b3653a: Clean up api report warnings and remove unnecessary files
-   Updated dependencies [4b3653a]
    -   @backstage-community/plugin-rbac-common@1.12.3
    -   @backstage-community/plugin-rbac-node@1.8.3

## @backstage-community/plugin-rbac-common@1.12.3

### Patch Changes

-   4b3653a: Clean up api report warnings and remove unnecessary files

## @backstage-community/plugin-rbac-node@1.8.3

### Patch Changes

-   4b3653a: Clean up api report warnings and remove unnecessary files
