### PR TITLE
Version Packages (scaffolder-backend-module-kubernetes)

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/forty-dogs-marry.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/forty-dogs-marry.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': patch
----
-
-The [scaffolder-backend-module-kubernetes](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `9671df5d`.
-
-The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 2.2.2
+
+### Patch Changes
+
+- 599be1e: The [scaffolder-backend-module-kubernetes](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `9671df5d`.
+
+  The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).
+
 ## 2.2.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.2.2

### Patch Changes

-   599be1e: The [scaffolder-backend-module-kubernetes](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/kubernetes-actions) plugin from the [janus-idp/backstage-plugins](https://github.com/janus-idp/backstage-plugins) repository was migrated to the [community plugins](https://github.com/backstage/community-plugins), based on commit `9671df5d`.

    The migration was performed by following the manual migration steps outlined in the [Community Plugins CONTRIBUTING guide](https://github.com/backstage/community-plugins/blob/main/CONTRIBUTING.md#migrating-a-plugin).
