### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/quick-toys-study.md
+++ b/workspaces/quay/.changeset/quick-toys-study.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-Clean up api report warnings and remove unnecessary files

--- a/workspaces/quay/.changeset/renovate-86e99ec.md
+++ b/workspaces/quay/.changeset/renovate-86e99ec.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@playwright/test` to `1.49.0`.

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.2.3
+
+### Patch Changes
+
+- 1af220c: Clean up api report warnings and remove unnecessary files
+
 ## 2.2.2
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.3.4
+
+### Patch Changes
+
+- 1af220c: Clean up api report warnings and remove unnecessary files
+
 ## 1.3.3
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.14.6
+
+### Patch Changes
+
+- 1af220c: Clean up api report warnings and remove unnecessary files
+- aa02f04: Updated dependency `@playwright/test` to `1.49.0`.
+- Updated dependencies [1af220c]
+  - @backstage-community/plugin-quay-common@1.3.4
+
 ## 1.14.5
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.14.6

### Patch Changes

-   1af220c: Clean up api report warnings and remove unnecessary files
-   aa02f04: Updated dependency `@playwright/test` to `1.49.0`.
-   Updated dependencies [1af220c]
    -   @backstage-community/plugin-quay-common@1.3.4

## @backstage-community/plugin-scaffolder-backend-module-quay@2.2.3

### Patch Changes

-   1af220c: Clean up api report warnings and remove unnecessary files

## @backstage-community/plugin-quay-common@1.3.4

### Patch Changes

-   1af220c: Clean up api report warnings and remove unnecessary files
