### PR TITLE
Tech-Insights: Add UrlReaderService to FactRetrieverContext

### DIFF
--- a/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
+++ b/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
@@ -1,6 +1,6 @@
 ---
-'@backstage-community/plugin-tech-insights-backend': patch
-'@backstage-community/plugin-tech-insights-node': patch
+'@backstage-community/plugin-tech-insights-backend': major
+'@backstage-community/plugin-tech-insights-node': major
 ---
 
 In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.

--- a/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
+++ b/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+'@backstage-community/plugin-tech-insights-node': patch
+---
+
+In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.

--- a/workspaces/tech-insights/plugins/tech-insights-backend/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/report.api.md
@@ -22,6 +22,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { PersistenceContext as PersistenceContext_2 } from '@backstage-community/plugin-tech-insights-node';
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { TechInsightCheck } from '@backstage-community/plugin-tech-insights-node';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public
 export const buildTechInsightsContext: <
@@ -126,6 +127,8 @@ export interface TechInsightsOptions<
   persistenceContext?: PersistenceContext_2;
   // (undocumented)
   scheduler: SchedulerService;
+  // (undocumented)
+  urlReader: UrlReaderService;
 }
 
 // @public

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.test.ts
@@ -28,6 +28,7 @@ describe('techInsightsPlugin', () => {
         httpRouterMock.factory,
         mockServices.database.factory(),
         mockServices.logger.factory(),
+        mockServices.urlReader.factory(),
         mockServices.rootConfig.factory({
           data: {
             techInsights: {

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
@@ -101,6 +101,7 @@ export const techInsightsPlugin = createBackendPlugin({
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
         auth: coreServices.auth,
+        urlReader: coreServices.urlReader,
       },
       async init({
         config,
@@ -110,6 +111,7 @@ export const techInsightsPlugin = createBackendPlugin({
         logger,
         scheduler,
         auth,
+        urlReader,
       }) {
         const factRetrievers: FactRetrieverRegistration[] = Object.entries(
           addedFactRetrievers,
@@ -134,6 +136,7 @@ export const techInsightsPlugin = createBackendPlugin({
           persistenceContext,
           scheduler,
           auth,
+          urlReader,
         });
 
         httpRouter.use(

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/FactRetrieverEngine.test.ts
@@ -135,6 +135,7 @@ describe('FactRetrieverEngine', () => {
     };
     const manager = databaseManager as DatabaseManager;
     const logger = mockServices.logger.mock();
+    const urlReader = mockServices.urlReader.mock();
     const lifecycle = mockServices.lifecycle.mock();
     const database = manager.forPlugin('tech-insights', { logger, lifecycle });
     const scheduler = DefaultSchedulerService.create({ database, logger });
@@ -143,6 +144,7 @@ describe('FactRetrieverEngine', () => {
         logger,
         config: ConfigReader.fromConfigs([]),
         auth: mockServices.auth(),
+        urlReader,
         discovery: {
           getBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
           getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.test.ts
@@ -102,6 +102,7 @@ const handlerContext = {
   discovery,
   logger: mockServices.logger.mock(),
   auth: mockServices.auth(),
+  urlReader: mockServices.urlReader.mock(),
   config: ConfigReader.fromConfigs([]),
 };
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.test.ts
@@ -102,6 +102,7 @@ const handlerContext = {
   discovery,
   logger: mockServices.logger.mock(),
   auth: mockServices.auth(),
+  urlReader: mockServices.urlReader.mock(),
   config: ConfigReader.fromConfigs([]),
 };
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.test.ts
@@ -103,6 +103,7 @@ const handlerContext = {
   discovery,
   logger: mockServices.logger.mock(),
   auth: mockServices.auth(),
+  urlReader: mockServices.urlReader.mock(),
   config: ConfigReader.fromConfigs([]),
 };
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.test.ts
@@ -51,6 +51,7 @@ describe('Tech Insights router tests', () => {
       migrations: { skip: true },
     });
     const logger = mockServices.logger.mock();
+    const urlReader = mockServices.urlReader.mock();
     const techInsightsContext = await buildTechInsightsContext({
       database,
       logger,
@@ -62,6 +63,7 @@ describe('Tech Insights router tests', () => {
         getExternalBaseUrl: (_: string) => Promise.resolve('http://mock.url'),
       },
       auth: mockServices.auth(),
+      urlReader,
     });
 
     const router = await createRouter({

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.test.ts
@@ -33,6 +33,7 @@ jest.mock('./fact/FactRetrieverEngine', () => ({
 
 describe('buildTechInsightsContext', () => {
   const logger = mockServices.logger.mock();
+  const urlReader = mockServices.urlReader.mock();
   const database: DatabaseService = {
     getClient: () => {
       return Promise.resolve({
@@ -61,6 +62,7 @@ describe('buildTechInsightsContext', () => {
       config: ConfigReader.fromConfigs([]),
       discovery: discoveryMock,
       auth: mockServices.auth(),
+      urlReader,
     });
     expect(DefaultFactRetrieverRegistry).toHaveBeenCalledTimes(1);
   });
@@ -77,6 +79,7 @@ describe('buildTechInsightsContext', () => {
       config: ConfigReader.fromConfigs([]),
       discovery: discoveryMock,
       auth: mockServices.auth(),
+      urlReader,
     });
     expect(DefaultFactRetrieverRegistry).not.toHaveBeenCalled();
   });

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/techInsightsContextBuilder.ts
@@ -36,6 +36,7 @@ import {
   DiscoveryService,
   LoggerService,
   SchedulerService,
+  UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
 /**
@@ -82,6 +83,7 @@ export interface TechInsightsOptions<
   database: DatabaseService;
   scheduler: SchedulerService;
   auth: AuthService;
+  urlReader: UrlReaderService;
 }
 
 /**
@@ -125,6 +127,7 @@ export const buildTechInsightsContext = async <
     logger,
     scheduler,
     auth,
+    urlReader,
   } = options;
 
   const buildFactRetrieverRegistry = (): FactRetrieverRegistry => {
@@ -156,6 +159,7 @@ export const buildTechInsightsContext = async <
       discovery,
       logger,
       auth,
+      urlReader,
     },
   });
 

--- a/workspaces/tech-insights/plugins/tech-insights-node/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/report.api.md
@@ -17,6 +17,7 @@ import { FactSchema } from '@backstage-community/plugin-tech-insights-common';
 import { HumanDuration } from '@backstage/types';
 import { JsonValue } from '@backstage/types';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public
 export type CheckValidationResponse = {
@@ -68,6 +69,7 @@ export type FactRetrieverContext = {
   discovery: DiscoveryService;
   logger: LoggerService;
   auth: AuthService;
+  urlReader: UrlReaderService;
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
     | Record<string, string | symbol | (string | symbol)[]>;

--- a/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
@@ -22,6 +22,7 @@ import {
   AuthService,
   DiscoveryService,
   LoggerService,
+  UrlReaderService,
 } from '@backstage/backend-plugin-api';
 
 /**
@@ -93,6 +94,7 @@ export type FactRetrieverContext = {
   discovery: DiscoveryService;
   logger: LoggerService;
   auth: AuthService;
+  urlReader: UrlReaderService;
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
     | Record<string, string | symbol | (string | symbol)[]>;


### PR DESCRIPTION
## Add UrlReaderService to FactRetrieverContext in Tech-Insights backend plugin

In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
