### PR TITLE
Update README.md

### DIFF
--- a/workspaces/sonarqube/.changeset/sixty-tables-admire.md
+++ b/workspaces/sonarqube/.changeset/sixty-tables-admire.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-sonarqube': minor
+'@backstage-community/plugin-sonarqube': patch
 ---
 
 Updating missingAnnotationReadMoreUrl attribute on documentation

--- a/workspaces/sonarqube/.changeset/sixty-tables-admire.md
+++ b/workspaces/sonarqube/.changeset/sixty-tables-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': minor
+---
+
+Updating missingAnnotationReadMoreUrl attribute on documentation

--- a/workspaces/sonarqube/plugins/sonarqube/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube/README.md
@@ -49,7 +49,7 @@ The "Read more" link that shows in the MissingAnnotationEmptyState is also confi
        <EntityAboutCard variant="gridItem" />
      </Grid>
 +    <Grid item md={6}>
-+      <EntitySonarQubeCard variant="gridItem" readMoreUrl={MISSING_ANNOTATION_READ_MORE_URL} />
++      <EntitySonarQubeCard variant="gridItem" missingAnnotationReadMoreUrl={MISSING_ANNOTATION_READ_MORE_URL} />
 +    </Grid>
    </Grid>
  );


### PR DESCRIPTION
Changing from readMoreUrl to missingAnnotationReadMoreUrl attribute on README.md

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Changing old attribute readMoreURL to missingAnnotationReadMoreUrl on README.md 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
