### PR TITLE
fix(rbac): update roleRef in metadata and policies

### DIFF
--- a/workspaces/rbac/.changeset/itchy-dots-compare.md
+++ b/workspaces/rbac/.changeset/itchy-dots-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Fixed a bug where updating a role name via the `PUT </api/permission/roles/:kind/:namespace/:name>` endpoint did not propagate changes to metadata and permissions, leaving them mapped to the old role name.

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
@@ -94,6 +94,7 @@ export const useAdminsFromConfig = async (
     await enf.addGroupingPolicies(
       addedRoleMembers,
       getAdminRoleMetadata(),
+      undefined,
       trx,
     );
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -777,6 +777,7 @@ describe('EnforcerDelegate', () => {
 
     it('should update grouping policies: role should be renamed', async () => {
       const oldRoleName = 'role:default/dev-team';
+      const newRoleName = 'role:default/new-team-name';
       roleMetadataStorageMock.findRoleMetadata = jest
         .fn()
         .mockImplementation(
@@ -798,12 +799,20 @@ describe('EnforcerDelegate', () => {
           },
         );
 
+      const secondGroupingPolicyWithOldRole = ['user:default/tim', oldRoleName];
+      const firstRolePolicy = [oldRoleName, 'policy-entity', 'read', 'allow'];
+      const secondRolePolicy = [oldRoleName, 'policy-entity', 'write', 'allow'];
+      const expectedPolicies = [
+        policy,
+        [newRoleName, 'policy-entity', 'read', 'allow'],
+        [newRoleName, 'policy-entity', 'write', 'allow'],
+      ];
+
       const enfDelegate = await createEnfDelegate(
-        [],
-        [groupingPolicy, secondGroupingPolicy],
+        [policy, firstRolePolicy, secondRolePolicy],
+        [groupingPolicy, secondGroupingPolicyWithOldRole],
       );
 
-      const newRoleName = 'role:default/new-team-name';
       const groupingPolicyWithRenamedRole = ['user:default/tom', newRoleName];
       const secondGroupingPolicyWithRenamedRole = [
         'user:default/tim',
@@ -816,7 +825,7 @@ describe('EnforcerDelegate', () => {
         modifiedBy,
       };
       await enfDelegate.updateGroupingPolicies(
-        [groupingPolicy, secondGroupingPolicy],
+        [groupingPolicy, secondGroupingPolicyWithOldRole],
         [groupingPolicyWithRenamedRole, secondGroupingPolicyWithRenamedRole],
         roleMetadataDao,
       );
@@ -828,7 +837,7 @@ describe('EnforcerDelegate', () => {
 
       expect(enfRemoveGroupingPoliciesSpy).toHaveBeenCalledWith([
         groupingPolicy,
-        secondGroupingPolicy,
+        secondGroupingPolicyWithOldRole,
       ]);
       expect(enfAddGroupingPoliciesSpy).toHaveBeenCalledWith([
         groupingPolicyWithRenamedRole,
@@ -846,6 +855,7 @@ describe('EnforcerDelegate', () => {
       expect(metadata.modifiedBy).toEqual(modifiedBy);
       expect(metadata.roleEntityRef).toEqual(newRoleName);
       expect(metadata.source).toEqual('rest');
+      expect(await enfDelegate.getPolicy()).toEqual(expectedPolicies);
     });
 
     it('should update grouping policies: should be updated role description and source', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -779,16 +779,24 @@ describe('EnforcerDelegate', () => {
       const oldRoleName = 'role:default/dev-team';
       roleMetadataStorageMock.findRoleMetadata = jest
         .fn()
-        .mockImplementation(async (): Promise<RoleMetadataDao> => {
-          return {
-            source: 'rest',
-            roleEntityRef: oldRoleName,
-            author: modifiedBy,
-            modifiedBy,
-            description: 'Role for dev engineers',
-            createdAt: '2024-03-01 00:23:41+00',
-          };
-        });
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+            _trx: Knex.Knex.Transaction,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === oldRoleName) {
+              return {
+                source: 'rest',
+                roleEntityRef: oldRoleName,
+                author: modifiedBy,
+                modifiedBy,
+                description: 'Role for dev engineers',
+                createdAt: '2024-03-01 00:23:41+00',
+              };
+            }
+            return undefined;
+          },
+        );
 
       const enfDelegate = await createEnfDelegate(
         [],

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -252,8 +252,8 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   async addGroupingPolicies(
     policies: string[][],
     roleMetadata: RoleMetadataDao,
-    externalTrx?: Knex.Transaction,
     oldRoleEntityRef?: string,
+    externalTrx?: Knex.Transaction,
   ): Promise<void> {
     if (policies.length === 0) {
       return;
@@ -322,8 +322,8 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
       await this.addGroupingPolicies(
         newRole,
         newRoleMetadata,
-        trx,
         currentMetadata.roleEntityRef,
+        trx,
       );
 
       // Role name changed -> update roleEntityRef in policies


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When role name is updated using RBAC API: `PUT </api/permission/roles/:kind/:namespace/:name>`
it is correctly updated for group policies, but it is not updated for any existing permissions which stay mapped to the old role name. Metadata are also not updated correctly.

### How to test
Please change `user:default/dzemanov` to your user in the following queries.

1. Create role `viewer`:

`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences":  [ "user:default/dzemanov" ], "name": "role:default/viewer" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

2. Add permissions to viewer

`curl -X POST "http://localhost:7007/api/permission/policies" -d '[{"entityReference": "role:default/viewer", "permission": "catalog-entity", "policy": "read", "effect":"allow"}]' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

`curl -X POST "http://localhost:7007/api/permission/policies" -d '[{"entityReference": "role:default/viewer", "permission": "catalog-entity", "policy": "delete", "effect":"allow"}]' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

3. Rename role

`curl -X PUT "http://localhost:7007/api/permission/roles/role/default/viewer" -d '{ "oldRole": { "memberReferences":  [ "user:default/dzemanov" ], "name": "role:default/viewer" }, "newRole": { "memberReferences": [ "user:default/dzemanov" ], "name": "role:default/viewer2" } }' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

4. Confirm, that `roleEntityRef` is correctly updated not only for group policies, but also for permissions and metadata.

#### Fixes
[RHIDP-5153](https://issues.redhat.com/browse/RHIDP-5153)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
