### PR TITLE
fix(rbac): use loadPolicy to keep in sync enforcer for edit operations

### DIFF
--- a/workspaces/rbac/.changeset/red-glasses-reply.md
+++ b/workspaces/rbac/.changeset/red-glasses-reply.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-rbac-backend': major
+'@backstage-community/plugin-rbac-backend': patch
 ---
 
-Use loadPolicy to keep the enforcer in sync for edit operations. It should keep the RBAC plugin in sync when the Backstage instance is scaled to multiple deployment replicas.
+Use loadPolicy to keep the enforcer in sync for edit operations. It should keep the RBAC plugin in sync when the Backstage instance is scaled to multiple deployment replicas. Reuse the maximum database pool size value from the application configuration in the RBAC Casbin adapter.

--- a/workspaces/rbac/.changeset/red-glasses-reply.md
+++ b/workspaces/rbac/.changeset/red-glasses-reply.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': major
+---
+
+Use loadPolicy to keep the enforcer in sync for edit operations. It should keep the RBAC plugin in sync when the Backstage instance is scaled to multiple deployment replicas.

--- a/workspaces/rbac/plugins/rbac-backend/__fixtures__/test-utils.ts
+++ b/workspaces/rbac/plugins/rbac-backend/__fixtures__/test-utils.ts
@@ -140,7 +140,12 @@ export async function newEnforcerDelegate(
     await enf.addGroupingPolicies(storedGroupingPolicies);
   }
 
-  return new EnforcerDelegate(enf, roleMetadataStorageMock, mockClientKnex);
+  return new EnforcerDelegate(
+    enf,
+    auditLogger(),
+    roleMetadataStorageMock,
+    mockClientKnex,
+  );
 }
 
 export async function newPermissionPolicy(

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -64,6 +64,7 @@
     "@backstage/types": "1.1.1",
     "@spotify/prettier-config": "^15.0.0",
     "@types/express": "4.17.21",
+    "@types/knex": "^0.16.1",
     "@types/lodash": "^4.14.151",
     "@types/node": "18.19.68",
     "@types/supertest": "2.0.16",

--- a/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
@@ -120,7 +120,7 @@ export const RBAC_BACKEND = 'rbac-backend';
 // Audit log stage for processing Role-Based Access Control (RBAC) data
 export const HANDLE_RBAC_DATA_STAGE = 'handleRBACData';
 
-// Audit log stageto refresh Role-Based Access Control (RBAC) data
+// Audit log stage to refresh Role-Based Access Control (RBAC) data
 export const FETCH_NEWER_PERMISSIONS_STAGE = 'fetchNewerPermissions';
 
 // Audit log stage for determining access rights based on user permissions and resource information

--- a/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
@@ -92,7 +92,7 @@ export type EvaluationAuditInfo = {
   decision?: PolicyDecision;
 };
 
-export const PolisiesData = {
+export const PoliciesData = {
   FAILED_TO_FETCH_NEWER_PERMISSIONS: 'FailedToFetchNewerPermissions',
 };
 

--- a/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/audit-log/audit-logger.ts
@@ -92,6 +92,10 @@ export type EvaluationAuditInfo = {
   decision?: PolicyDecision;
 };
 
+export const PolisiesData = {
+  FAILED_TO_FETCH_NEWER_PERMISSIONS: 'FailedToFetchNewerPermissions',
+};
+
 export const ConditionEvents = {
   CREATE_CONDITION: 'CreateCondition',
   UPDATE_CONDITION: 'UpdateCondition',
@@ -115,6 +119,9 @@ export const RBAC_BACKEND = 'rbac-backend';
 
 // Audit log stage for processing Role-Based Access Control (RBAC) data
 export const HANDLE_RBAC_DATA_STAGE = 'handleRBACData';
+
+// Audit log stageto refresh Role-Based Access Control (RBAC) data
+export const FETCH_NEWER_PERMISSIONS_STAGE = 'fetchNewerPermissions';
 
 // Audit log stage for determining access rights based on user permissions and resource information
 export const EVALUATE_PERMISSION_ACCESS_STAGE = 'evaluatePermissionAccess';

--- a/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -54,6 +54,7 @@ export class CasbinDBAdapterFactory {
         ssl,
         database: dbName,
         schema: schema,
+        poolSize: databaseConfig?.getOptionalNumber('knexConfig.pool.max'),
       });
     }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
@@ -180,7 +180,12 @@ describe('CSVFileWatcher', () => {
 
     const knex = Knex.knex({ client: MockClient });
 
-    enforcerDelegate = new EnforcerDelegate(enf, roleMetadataStorageMock, knex);
+    enforcerDelegate = new EnforcerDelegate(
+      enf,
+      auditLoggerMock,
+      roleMetadataStorageMock,
+      knex,
+    );
 
     auditLoggerMock.auditLog.mockReset();
     (roleMetadataStorageMock.updateRoleMetadata as jest.Mock).mockClear();

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1750,6 +1750,7 @@ describe('Policy checks for conditional policies', () => {
 
     const enfDelegate = new EnforcerDelegate(
       enf,
+      auditLoggerMock,
       roleMetadataStorageMock,
       mockClientKnex,
     );
@@ -2173,7 +2174,12 @@ async function newEnforcerDelegate(
     await enf.addGroupingPolicies(storedGroupingPolicies);
   }
 
-  return new EnforcerDelegate(enf, roleMetadataStorageMock, mockClientKnex);
+  return new EnforcerDelegate(
+    enf,
+    auditLoggerMock,
+    roleMetadataStorageMock,
+    mockClientKnex,
+  );
 }
 
 async function newPermissionPolicy(

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -216,6 +216,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       }
 
       const permissionName = request.permission.name;
+      await this.enforcer.loadPolicy();
       const roles = await this.enforcer.getRolesForUser(userEntityRef);
 
       if (isResourcePermission(request.permission)) {

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -184,7 +184,12 @@ describe('Connection', () => {
 
     const knex = Knex.knex({ client: MockClient });
 
-    enforcerDelegate = new EnforcerDelegate(enf, roleMetadataStorageMock, knex);
+    enforcerDelegate = new EnforcerDelegate(
+      enf,
+      auditLoggerMock,
+      roleMetadataStorageMock,
+      knex,
+    );
 
     await enforcerDelegate.addGroupingPolicy(
       roleToBeRemoved,
@@ -478,6 +483,7 @@ describe('connectRBACProviders', () => {
 
     const enforcerDelegate = new EnforcerDelegate(
       enf,
+      auditLoggerMock,
       roleMetadataStorageMock,
       knex,
     );

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -67,6 +67,7 @@ export class Connection implements RBACProviderConnection {
 
     const providerRoles = await this.getProviderRoles();
 
+    await this.enforcer.loadPolicy();
     // Get the roles for this provider coming from rbac plugin
     for (const providerRole of providerRoles) {
       providerRolesforRemoval.push(
@@ -95,6 +96,7 @@ export class Connection implements RBACProviderConnection {
 
     const providerRoles = await this.getProviderRoles();
 
+    await this.enforcer.loadPolicy();
     // Get the roles for this provider coming from rbac plugin
     for (const providerRole of providerRoles) {
       providerPermissions.push(

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -27,6 +27,7 @@ import {
 import { BackstageRoleManager } from '../role-manager/role-manager';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { MODEL } from './permission-model';
+import { auditLoggerMock } from '../../__fixtures__/mock-utils';
 
 // TODO: Move to 'catalogServiceMock' from '@backstage/plugin-catalog-node/testUtils'
 // once '@backstage/plugin-catalog-node' is upgraded
@@ -179,7 +180,12 @@ describe('EnforcerDelegate', () => {
       await enf.addGroupingPolicies(groupingPolicies);
     }
 
-    return new EnforcerDelegate(enf, roleMetadataStorageMock, knex);
+    return new EnforcerDelegate(
+      enf,
+      auditLoggerMock,
+      roleMetadataStorageMock,
+      knex,
+    );
   }
 
   describe('hasPolicy', () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -336,6 +336,10 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
     }
 
     const addGroupingPoliciesOperation = (async () => {
+      if (policies.length === 0) {
+        return;
+      }
+
       const trx = externalTrx ?? (await this.knex.transaction());
 
       try {
@@ -386,6 +390,7 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
     newRoleMetadata: RoleMetadataDao,
   ): Promise<void> {
     const oldRoleName = oldRole.at(0)?.at(1)!;
+
     const trx = await this.knex.transaction();
     try {
       const currentMetadata = await this.roleMetadataStorage.findRoleMetadata(

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -28,7 +28,7 @@ import { MODEL } from './permission-model';
 import { AuditLogger } from '@janus-idp/backstage-plugin-audit-log-node';
 import {
   FETCH_NEWER_PERMISSIONS_STAGE,
-  PolisiesData,
+  PoliciesData,
 } from '../audit-log/audit-logger';
 
 export type RoleEvents = 'roleAdded';
@@ -71,7 +71,7 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
       } catch (err) {
         this.auditLogger.auditLog({
           message: 'Failed to load newer policies from database',
-          eventName: PolisiesData.FAILED_TO_FETCH_NEWER_PERMISSIONS,
+          eventName: PoliciesData.FAILED_TO_FETCH_NEWER_PERMISSIONS,
           stage: FETCH_NEWER_PERMISSIONS_STAGE,
           status: 'failed',
           errors: [err],

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -92,11 +92,16 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   async execOperation<T>(operation: Promise<T>): Promise<T> {
     this.editOperationsQueue.push(operation);
 
-    const result = await operation;
-
-    const index = this.editOperationsQueue.indexOf(operation);
-    if (index !== -1) {
-      this.editOperationsQueue.splice(index, 1);
+    let result;
+    try {
+      result = await operation;
+    } catch (err) {
+      throw err;
+    } finally {
+      const index = this.editOperationsQueue.indexOf(operation);
+      if (index !== -1) {
+        this.editOperationsQueue.splice(index, 1);
+      }
     }
 
     return result;

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
@@ -125,17 +125,17 @@ export class PolicyBuilder {
     const conditionStorage = new DataBaseConditionalStorage(databaseClient);
 
     const roleMetadataStorage = new DataBaseRoleMetadataStorage(databaseClient);
-    const enforcerDelegate = new EnforcerDelegate(
-      enf,
-      roleMetadataStorage,
-      databaseClient,
-    );
-
     const defAuditLog = new DefaultAuditLogger({
       logger: env.logger,
       authService: env.auth,
       httpAuthService: env.httpAuth,
     });
+    const enforcerDelegate = new EnforcerDelegate(
+      enf,
+      defAuditLog,
+      roleMetadataStorage,
+      databaseClient,
+    );
 
     if (rbacProviders) {
       await connectRBACProviders(

--- a/workspaces/rbac/yarn.lock
+++ b/workspaces/rbac/yarn.lock
@@ -2696,6 +2696,7 @@ __metadata:
     "@janus-idp/backstage-plugin-audit-log-node": ^1.7.1
     "@spotify/prettier-config": ^15.0.0
     "@types/express": 4.17.21
+    "@types/knex": ^0.16.1
     "@types/lodash": ^4.14.151
     "@types/node": 18.19.68
     "@types/supertest": 2.0.16
@@ -13091,6 +13092,15 @@ __metadata:
   dependencies:
     keyv: "*"
   checksum: 8713da9382b9346d664866a6cab2f91b0fd479f61379af891303a618e9a2abad6f347adc38a0850540e3f2dad278427de24e7555339264fddb04d1d17d3b50e0
+  languageName: node
+  linkType: hard
+
+"@types/knex@npm:^0.16.1":
+  version: 0.16.1
+  resolution: "@types/knex@npm:0.16.1"
+  dependencies:
+    knex: "*"
+  checksum: daf16bef279e68a11c74ad5d351237c6667ea9921ebe73e613d24b26acc25ba86b40fdc9d8adddfe1a0d234f20336adde6e4a2d062ae7ebe74a2c288ac6ccdc5
   languageName: node
   linkType: hard
 
@@ -24005,7 +24015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3, knex@npm:^3.0.0":
+"knex@npm:*, knex@npm:3, knex@npm:^3.0.0":
   version: 3.1.0
   resolution: "knex@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fast fix: Use loadPolicy to keep in sync enforcer for edit operations

### What does this pull request fix:

https://issues.redhat.com/browse/RHIDP-5259

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
