### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/breezy-ducks-joke.md
+++ b/workspaces/tech-insights/.changeset/breezy-ducks-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': minor
----
-
-Allow tech insights backend to schedule a single job.

--- a/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
+++ b/workspaces/tech-insights/.changeset/eighty-brooms-repeat.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': major
-'@backstage-community/plugin-tech-insights-node': major
----
-
-In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-tech-insights-backend-module-jsonfc
 
+## 0.1.61
+
+### Patch Changes
+
+- Updated dependencies [c3bbe0f]
+  - @backstage-community/plugin-tech-insights-node@2.0.0
+
 ## 0.1.60
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend-module-jsonfc",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "backstage": {
     "role": "backend-plugin-module",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 2.0.0
+
+### Major Changes
+
+- c3bbe0f: In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.
+
+### Minor Changes
+
+- 306121a: Allow tech insights backend to schedule a single job.
+
+### Patch Changes
+
+- Updated dependencies [c3bbe0f]
+  - @backstage-community/plugin-tech-insights-node@2.0.0
+
 ## 1.2.3
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-node
 
+## 2.0.0
+
+### Major Changes
+
+- c3bbe0f: In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.
+
 ## 1.0.3
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-node/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-node",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "backstage": {
     "role": "node-library",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-backend@2.0.0

### Major Changes

-   c3bbe0f: In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.

### Minor Changes

-   306121a: Allow tech insights backend to schedule a single job.

### Patch Changes

-   Updated dependencies [c3bbe0f]
    -   @backstage-community/plugin-tech-insights-node@2.0.0

## @backstage-community/plugin-tech-insights-node@2.0.0

### Major Changes

-   c3bbe0f: In order to use UrlReaderService in fact retrievers, UrlReaderService has been added to FactRetrieverContext.

## @backstage-community/plugin-tech-insights-backend-module-jsonfc@0.1.61

### Patch Changes

-   Updated dependencies [c3bbe0f]
    -   @backstage-community/plugin-tech-insights-node@2.0.0
