### PR TITLE
fix: acceptance rate now uses suggestion/acceptance count

### DIFF
--- a/workspaces/copilot/.changeset/neat-years-taste.md
+++ b/workspaces/copilot/.changeset/neat-years-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': minor
+---
+
+Fix incorrectly reporting acceptance rate

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/DashboardCards.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/DashboardCards.tsx
@@ -42,8 +42,8 @@ export const DashboardCards = ({
     data.reduce((acc, item) => acc + (item[property] || 0), 0);
 
   const calculateAcceptanceRate = (metricsData: Metric[]) => {
-    const totalSuggested = sumProperty(metricsData, 'total_lines_suggested');
-    const totalAccepted = sumProperty(metricsData, 'total_lines_accepted');
+    const totalSuggested = sumProperty(metricsData, 'total_suggestions_count');
+    const totalAccepted = sumProperty(metricsData, 'total_acceptances_count');
     return totalSuggested > 0
       ? ((totalAccepted / totalSuggested) * 100).toFixed(2).concat('%')
       : 'N/A';


### PR DESCRIPTION
## Fix acceptance rate calculation

We are migrating from https://github.com/github-copilot-resources/copilot-metrics-viewer/issues to the Backstage plugin, and noticed one critical difference in our metrics: The "Acceptance Rate Average".

The copilot plugin reports acceptance rate incorrectly, using the lines metrics rather than acceptance/suggestion count.

The GitHub API will respond with the following:
```json
[
  {
    "total_suggestions_count": 600,
    "total_acceptances_count": 200,
    "total_lines_suggested": 2500,
    "total_lines_accepted": 500,
    ...
```

In this case, we expect acceptance rate to be 33%, not 20%, as the Backstage plugin reports.

For reference, here is how copilot-metrics-viewer does it: https://github.com/github-copilot-resources/copilot-metrics-viewer/blob/223cb4fc9f73bd6e7263f8246d9a701aca1983cf/src/components/MetricsViewer.vue#L276-L280

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
