### PR TITLE
Remove use of `useId` hook to allow compatibility with react 17

### DIFF
--- a/workspaces/tech-insights/.changeset/famous-birds-buy.md
+++ b/workspaces/tech-insights/.changeset/famous-birds-buy.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+Remove use of react 18 `useId` hook to maintain compatibility with react 17.

--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ResultLinksMenu/ResultLinksMenu.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ResultLinksMenu/ResultLinksMenu.tsx
@@ -18,7 +18,6 @@ import React, {
   PropsWithChildren,
   useCallback,
   useEffect,
-  useId,
   useMemo,
 } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
@@ -26,7 +25,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import { techInsightsApiRef } from '../../api';
 import { CheckResult } from '@backstage-community/plugin-tech-insights-common';
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 
 /**
  * TechInsightsLinksMenu setMenu receiver.
@@ -66,7 +65,9 @@ export const ResultLinksMenu = (
     [api, result, entity],
   );
 
-  const menuId = `menu-${useId()}`;
+  const menuId = `menu-${result.check.id}-${
+    entity ? stringifyEntityRef(entity) : 'unknown'
+  }`;
 
   const [anchorEl, setAnchorEl] = React.useState<Element | undefined>(
     undefined,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove use of `useId` hook to allow compatibility with react 17

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
