### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/renovate-3964424.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-3964424.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.6.3`.

--- a/workspaces/redhat-argocd/.changeset/renovate-6869e7f.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-6869e7f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@playwright/test` to `1.49.1`.

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.11.2
+
+### Patch Changes
+
+- 350250c: Updated dependency `@testing-library/jest-dom` to `6.6.3`.
+- 4eef4d1: Updated dependency `@playwright/test` to `1.49.1`.
+
 ## 1.11.1
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.11.2

### Patch Changes

-   350250c: Updated dependency `@testing-library/jest-dom` to `6.6.3`.
-   4eef4d1: Updated dependency `@playwright/test` to `1.49.1`.
