### PR TITLE
Introduce `pluginsWithPermission` information

### DIFF
--- a/workspaces/rbac/.changeset/orange-kings-invite.md
+++ b/workspaces/rbac/.changeset/orange-kings-invite.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+'@backstage-community/plugin-rbac': patch
+---
+
+Update documentation information about `pluginsWithPermission` setting. In order for the RBAC UI to display available permissions provided by installed plugins, this setting needs to be configured.

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -106,7 +106,7 @@ permission:
         - name: group:default/admins
 ```
 
-For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](./docs/permissions.md).
+For more information on the available permissions, refer to the [RBAC permissions documentation](./docs/permissions.md).
 
 ### Configuring policies via file
 
@@ -148,7 +148,7 @@ permission:
     policyFileReload: true
 ```
 
-For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](./docs/permissions.md).
+For more information on the available permissions, refer to the [RBAC permissions documentation](./docs/permissions.md).
 
 We also have a fairly strict validation for permission policies and roles based on the originating role's source information, refer to the [api documentation](./docs/apis.md).
 

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -85,6 +85,28 @@ permission:
 
 For more information on the available API endpoints accessible to the policy administrators, refer to the [API documentation](./docs/apis.md).
 
+### Configure plugins with permission
+
+In order for the RBAC UI to display available permissions provided by installed plugins, the corresponding
+plugin IDs must be added to the `app-config.yaml`.
+
+You can specify the plugins with permission in your application configuration as follows:
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    pluginsWithPermission:
+      - catalog
+      - scaffolder
+    admin:
+      users:
+        - name: user:default/alice
+        - name: group:default/admins
+```
+
+For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](./docs/permissions.md).
+
 ### Configuring policies via file
 
 The RBAC plugin also allows you to import policies from an external file. These policies are defined in the [Casbin rules format](https://casbin.org/docs/category/the-basics), known for its simplicity and clarity. For a quick start, please refer to the format details in the provided link.

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -99,6 +99,7 @@ permission:
     pluginsWithPermission:
       - catalog
       - scaffolder
+      - permission
     admin:
       users:
         - name: user:default/alice

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -87,8 +87,8 @@ For more information on the available API endpoints accessible to the policy adm
 
 ### Configure plugins with permission
 
-In order for the RBAC UI to display available permissions provided by installed plugins, the corresponding
-plugin IDs must be added to the `app-config.yaml`.
+In order for the RBAC UI to display available permissions provided by installed plugins, add the corresponding
+plugin IDs to the `app-config.yaml`.
 
 You can specify the plugins with permission in your application configuration as follows:
 

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -107,8 +107,8 @@ permission:
 
 ### Configure plugins with permission
 
-In order for the RBAC UI to display available permissions provided by installed plugins, the corresponding
-plugin IDs must be added to the `app-config.yaml`.
+In order for the RBAC UI to display available permissions provided by installed plugins, add the corresponding
+plugin IDs to the `app-config.yaml`.
 
 You can specify the plugins with permission in your application configuration as follows:
 

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -104,3 +104,25 @@ permission:
      ```
 
    - Integrate the [`SignIn`](https://backstage.io/docs/auth/#sign-in-configuration) component to be able to sign-in to the Backstage instance.
+
+### Configure plugins with permission
+
+In order for the RBAC UI to display available permissions provided by installed plugins, the corresponding
+plugin IDs must be added to the `app-config.yaml`.
+
+You can specify the plugins with permission in your application configuration as follows:
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    admin:
+      users:
+        - name: user:default/alice
+        - name: group:default/admins
+    pluginsWithPermission:
+      - catalog
+      - scaffolder
+```
+
+For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](../rbac-backend/docs/permissions.md).

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -126,4 +126,4 @@ permission:
       - permission
 ```
 
-For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](../rbac-backend/docs/permissions.md).
+For more information on the available permissions, refer to the [RBAC permissions documentation](../rbac-backend/docs/permissions.md).

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -123,6 +123,7 @@ permission:
     pluginsWithPermission:
       - catalog
       - scaffolder
+      - permission
 ```
 
 For more information on the available permissions within Showcase and RHDH, refer to the [permissions documentation](../rbac-backend/docs/permissions.md).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It would be useful to add information about configuring `pluginsWithPermission` in `app-config.yaml` since without it, available permissions will not be displayed by RBAC UI.

## Fixes
[RHIDP-4490](https://issues.redhat.com/browse/RHIDP-4490)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
