### PR TITLE
Version Packages (scaffolder-backend-module-sonarqube)

### DIFF
--- a/workspaces/scaffolder-backend-module-sonarqube/.changeset/renovate-47d5b11.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/.changeset/renovate-47d5b11.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-sonarqube': patch
----
-
-Updated dependency `prettier` to `3.4.2`.

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.2.4
+
+### Patch Changes
+
+- 0f5c451: Updated dependency `prettier` to `3.4.2`.
+
 ## 2.2.3
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-sonarqube",
   "description": "The sonarqube module for @backstage/plugin-scaffolder-backend",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-sonarqube@2.2.4

### Patch Changes

-   0f5c451: Updated dependency `prettier` to `3.4.2`.
