### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/many-spiders-doubt.md
+++ b/workspaces/github-actions/.changeset/many-spiders-doubt.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Use a consistent empty state in the workflow runs card regardless of the reason
-for the card being empty.

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-github-actions
 
+## 0.6.27
+
+### Patch Changes
+
+- ede35ca: Use a consistent empty state in the workflow runs card regardless of the reason
+  for the card being empty.
+
 ## 0.6.26
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.6.27

### Patch Changes

-   ede35ca: Use a consistent empty state in the workflow runs card regardless of the reason
    for the card being empty.
