### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/beige-cougars-smash.md
+++ b/workspaces/confluence/.changeset/beige-cougars-smash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-confluence': patch
----
-
-Adding support for the new frontend system, available at the `/alpha` export.

--- a/workspaces/confluence/.changeset/cool-plums-marry.md
+++ b/workspaces/confluence/.changeset/cool-plums-marry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Fix typo in readme

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-confluence
 
+## 0.1.4
+
+### Patch Changes
+
+- f4ea9a2: Adding support for the new frontend system, available at the `/alpha` export.
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.2.5
+
+### Patch Changes
+
+- f4ea9a2: Fix typo in readme
+
 ## 0.2.4
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.1.4

### Patch Changes

-   f4ea9a2: Adding support for the new frontend system, available at the `/alpha` export.

## @backstage-community/plugin-search-backend-module-confluence-collator@0.2.5

### Patch Changes

-   f4ea9a2: Fix typo in readme
