### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/young-peaches-carry.md
+++ b/workspaces/adr/.changeset/young-peaches-carry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': patch
----
-
-Removed usages of `@backstage/backend-tasks`

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [9e92818]
+  - @backstage-community/search-backend-module-adr@0.3.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.3.1
+
+### Patch Changes
+
+- 9e92818: Removed usages of `@backstage/backend-tasks`
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.5.1

### Patch Changes

-   Updated dependencies [9e92818]
    -   @backstage-community/search-backend-module-adr@0.3.1

## @backstage-community/search-backend-module-adr@0.3.1

### Patch Changes

-   9e92818: Removed usages of `@backstage/backend-tasks`
