### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/version-bump-1-34-2.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/version-bump-1-34-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-regex': minor
----
-
-Backstage version bump to v1.34.2

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.3.0
+
+### Minor Changes
+
+- b893377: Backstage version bump to v1.34.2
+
 ## 2.2.5
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-regex@2.3.0

### Minor Changes

-   b893377: Backstage version bump to v1.34.2
