### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/short-bikes-camp.md
+++ b/workspaces/adr/.changeset/short-bikes-camp.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': patch
----
-
-Fixed backend-plugin-api import that caused an error at backend startup

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [03913ac]
+  - @backstage-community/search-backend-module-adr@0.3.2
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.3.2
+
+### Patch Changes
+
+- 03913ac: Fixed backend-plugin-api import that caused an error at backend startup
+
 ## 0.3.1
 
 ### Patch Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.5.2

### Patch Changes

-   Updated dependencies [03913ac]
    -   @backstage-community/search-backend-module-adr@0.3.2

## @backstage-community/search-backend-module-adr@0.3.2

### Patch Changes

-   03913ac: Fixed backend-plugin-api import that caused an error at backend startup
