### PR TITLE
announcements - Exported missing items to match documentation

### DIFF
--- a/workspaces/announcements/.changeset/clever-wolves-learn.md
+++ b/workspaces/announcements/.changeset/clever-wolves-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Exported missing items to match documentation

--- a/workspaces/announcements/plugins/announcements/report.api.md
+++ b/workspaces/announcements/plugins/announcements/report.api.md
@@ -8,14 +8,59 @@
 import { AnnouncementsApi as AnnouncementsApi_2 } from '@backstage-community/plugin-announcements-react';
 import { ApiRef } from '@backstage/core-plugin-api/index';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import { IndexableDocument } from '@backstage/plugin-search-common';
+import { InfoCardVariants } from '@backstage/core-components/index';
 import { JSX as JSX_2 } from 'react';
+import { ResultHighlight } from '@backstage/plugin-search-common';
 import { RouteRef } from '@backstage/core-plugin-api';
+import { SearchResultListItemExtensionProps } from '@backstage/plugin-search-react';
+
+// @public (undocumented)
+export const AnnouncementsAdminPortal: (
+  props?:
+    | {
+        themeId?: string | undefined;
+        title?: string | undefined;
+        subtitle?: string | undefined;
+      }
+    | undefined,
+) => JSX_2.Element;
 
 // @public @deprecated (undocumented)
 export type AnnouncementsApi = AnnouncementsApi_2;
 
 // @public @deprecated (undocumented)
 export const announcementsApiRef: ApiRef<AnnouncementsApi_2>;
+
+// @public (undocumented)
+export const AnnouncementsCard: ({
+  title,
+  max,
+  category,
+  active,
+  variant,
+}: {
+  title?: string | undefined;
+  max?: number | undefined;
+  category?: string | undefined;
+  active?: boolean | undefined;
+  variant?: InfoCardVariants | undefined;
+}) => JSX_2.Element;
+
+// @public (undocumented)
+export const AnnouncementSearchResultListItem: (
+  props: SearchResultListItemExtensionProps<AnnouncementSearchResultProps>,
+) => JSX.Element | null;
+
+// @public (undocumented)
+export interface AnnouncementSearchResultProps {
+  // (undocumented)
+  highlight?: ResultHighlight;
+  // (undocumented)
+  rank?: number;
+  // (undocumented)
+  result?: IndexableDocument;
+}
 
 // @public (undocumented)
 export const AnnouncementsPage: (props: {
@@ -45,6 +90,30 @@ export const announcementsPlugin: BackstagePlugin<
   {},
   {}
 >;
+
+// @public (undocumented)
+export const AnnouncementsTimeline: ({
+  maxResults,
+  timelineAlignment,
+  timelineMinWidth,
+  hideInactive,
+}: AnnouncementsTimelineProps) => JSX_2.Element;
+
+// @public
+export type AnnouncementsTimelineProps = {
+  maxResults?: number;
+  timelineAlignment?: 'left' | 'right' | 'alternate';
+  timelineMinWidth?: string;
+  hideInactive?: boolean;
+};
+
+// @public (undocumented)
+export const NewAnnouncementBanner: (props: {
+  variant?: 'block' | 'floating' | undefined;
+  max?: number | undefined;
+  category?: string | undefined;
+  active?: boolean | undefined;
+}) => JSX_2.Element | null;
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
@@ -51,6 +51,7 @@ type IndexableAnnouncement = IndexableDocument & {
   createdAt: string;
 };
 
+/** @public */
 export interface AnnouncementSearchResultProps {
   result?: IndexableDocument;
   highlight?: ResultHighlight;

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsTimeline/AnnouncementsTimeline.tsx
@@ -37,6 +37,8 @@ import Stack from '@mui/material/Stack';
 
 /**
  * Props for the AnnouncementsTimeline component.
+ *
+ * @public
  */
 export type AnnouncementsTimelineProps = {
   /**

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsTimeline/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsTimeline/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { AnnouncementsTimeline } from './AnnouncementsTimeline';
+export type { AnnouncementsTimelineProps } from './AnnouncementsTimeline';

--- a/workspaces/announcements/plugins/announcements/src/components/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/components/index.ts
@@ -15,3 +15,5 @@
  */
 export * from './AnnouncementsTimeline';
 export { AdminPortal, AnnouncementsContent } from './Admin';
+export type { AnnouncementsTimelineProps } from './AnnouncementsTimeline';
+export type { AnnouncementSearchResultProps } from './AnnouncementSearchResultListItem';

--- a/workspaces/announcements/plugins/announcements/src/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { announcementsPlugin, AnnouncementsPage } from './plugin';
+export * from './plugin';
 
 import {
   announcementsApiRef as announcementsApiRef_,
@@ -31,3 +31,6 @@ export type AnnouncementsApi = AnnouncementsApi_;
  * @deprecated Use `announcementsApiRef` from `@backstage-community/plugin-announcements-react` instead
  */
 export const announcementsApiRef = announcementsApiRef_;
+
+export type { AnnouncementsTimelineProps } from './components';
+export type { AnnouncementSearchResultProps } from './components';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Exported missing items to match documentation. This follows what was done in the archived source repo:

https://github.com/procore-oss/backstage-plugin-announcements/blob/0a756f2b1413594d26300d5b8503c1bbb320c6cb/plugins/announcements/src/index.ts#L14

Closes #2419

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
