### PR TITLE
fix: add using buildAnnouncementsContext back to plugin

### DIFF
--- a/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
@@ -18,9 +18,9 @@ import {
   coreServices,
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './router';
-import { initializePersistenceContext } from './service/persistence/persistenceContext';
 import { signalsServiceRef } from '@backstage/plugin-signals-node';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
+import { buildAnnouncementsContext } from './service';
 
 /**
  * A backend for the announcements plugin.
@@ -50,17 +50,19 @@ export const announcementsPlugin = createBackendPlugin({
         events,
         signals,
       }) {
-        http.use(
-          await createRouter({
-            permissions,
-            logger,
-            config,
-            persistenceContext: await initializePersistenceContext(database),
-            httpAuth,
-            events,
-            signals,
-          }),
-        );
+        const context = await buildAnnouncementsContext({
+          events,
+          logger,
+          config,
+          database,
+          permissions,
+          signals,
+          httpAuth,
+        });
+
+        const router = await createRouter(context);
+
+        http.use(router);
       },
     });
   },

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -17,7 +17,6 @@ import express from 'express';
 import { DateTime } from 'luxon';
 import request from 'supertest';
 import { AnnouncementsContext } from './service/announcementsContextBuilder';
-import { AnnouncementModel } from './service/model';
 import { AnnouncementsDatabase } from './service/persistence/AnnouncementsDatabase';
 import { PersistenceContext } from './service/persistence/persistenceContext';
 import { createRouter } from './router';
@@ -90,7 +89,7 @@ describe('createRouter', () => {
           publisher: 'user:default/name',
           created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         },
-      ] as AnnouncementModel[]);
+      ]);
 
       const response = await request(app).get('/announcements');
 

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -37,16 +37,8 @@ import {
   EVENTS_ACTION_DELETE_CATEGORY,
 } from '@backstage-community/plugin-announcements-common';
 import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
-import {
-  HttpAuthService,
-  LoggerService,
-  PermissionsService,
-  RootConfigService,
-} from '@backstage/backend-plugin-api';
-import { PersistenceContext } from './service/persistence/persistenceContext';
-import { EventsService } from '@backstage/plugin-events-node';
 import { signalAnnouncement } from './service/signal';
-import { SignalsService } from '@backstage/plugin-signals-node';
+import { AnnouncementsContext } from './service';
 
 interface AnnouncementRequest {
   publisher: string;
@@ -61,16 +53,6 @@ interface CategoryRequest {
   title: string;
 }
 
-type RouterOptions = {
-  httpAuth: HttpAuthService;
-  config: RootConfigService;
-  logger: LoggerService;
-  permissions: PermissionsService;
-  persistenceContext: PersistenceContext;
-  events?: EventsService;
-  signals?: SignalsService;
-};
-
 type GetAnnouncementsQueryParams = {
   category?: string;
   page?: number;
@@ -79,7 +61,7 @@ type GetAnnouncementsQueryParams = {
 };
 
 export async function createRouter(
-  options: RouterOptions,
+  options: AnnouncementsContext,
 ): Promise<express.Router> {
   const {
     persistenceContext,
@@ -114,10 +96,6 @@ export async function createRouter(
   router.use(express.json());
   router.use(permissionIntegrationRouter);
 
-  // eslint-disable-next-line spaced-comment
-  /*****************
-   * Announcements *
-   ****************/
   router.get(
     '/announcements',
     async (req: Request<{}, {}, {}, GetAnnouncementsQueryParams>, res) => {
@@ -262,10 +240,6 @@ export async function createRouter(
     },
   );
 
-  // eslint-disable-next-line spaced-comment
-  /**************
-   * Categories *
-   **************/
   router.get('/categories', async (_req, res) => {
     const results = await persistenceContext.categoriesStore.categories();
 

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
@@ -20,6 +20,8 @@ import {
   HttpAuthService,
   PermissionsService,
 } from '@backstage/backend-plugin-api';
+import { EventsService } from '@backstage/plugin-events-node/index';
+import { SignalsService } from '@backstage/plugin-signals-node/index';
 
 jest.mock('./persistence/persistenceContext', () => ({
   initializePersistenceContext: jest.fn(),
@@ -42,12 +44,23 @@ describe('buildAnnouncementsContext', () => {
       issueUserCookie: jest.fn(),
     };
 
+    const events: EventsService = {
+      publish: jest.fn(),
+      subscribe: jest.fn(),
+    };
+
+    const signals: SignalsService = {
+      publish: jest.fn(),
+    };
+
     const context = await buildAnnouncementsContext({
       logger,
       config,
       database,
       permissions,
       httpAuth,
+      events,
+      signals,
     });
 
     expect(context).toStrictEqual({

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { EventsService } from '@backstage/plugin-events-node/index';
 import {
   initializePersistenceContext,
   PersistenceContext,
@@ -24,19 +25,7 @@ import {
   PermissionsService,
   RootConfigService,
 } from '@backstage/backend-plugin-api';
-
-/**
- * Options to build the context for the announcements plugin.
- *
- * @public
- */
-export type AnnouncementsContextOptions = {
-  logger: LoggerService;
-  config: RootConfigService;
-  database: DatabaseService;
-  permissions: PermissionsService;
-  httpAuth: HttpAuthService;
-};
+import { SignalsService } from '@backstage/plugin-signals-node/index';
 
 /**
  * Context for the announcements plugin.
@@ -49,6 +38,20 @@ export type AnnouncementsContext = {
   persistenceContext: PersistenceContext;
   permissions: PermissionsService;
   httpAuth: HttpAuthService;
+  events?: EventsService;
+  signals?: SignalsService;
+};
+
+/**
+ * Options to build the context for the announcements plugin.
+ *
+ * @public
+ */
+export type AnnouncementsContextOptions = Omit<
+  AnnouncementsContext,
+  'persistenceContext'
+> & {
+  database: DatabaseService;
 };
 
 /**
@@ -62,6 +65,8 @@ export const buildAnnouncementsContext = async ({
   database,
   permissions,
   httpAuth,
+  events,
+  signals,
 }: AnnouncementsContextOptions): Promise<AnnouncementsContext> => {
   return {
     logger,
@@ -69,5 +74,7 @@ export const buildAnnouncementsContext = async ({
     persistenceContext: await initializePersistenceContext(database),
     permissions,
     httpAuth,
+    events,
+    signals,
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `buildAnnouncementsContext` is not being used. I'm not sure why, but this PR adds it back.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
