### PR TITLE
chore(azure-devops) remove some unused dependencies

### DIFF
--- a/workspaces/azure-devops/.changeset/shiny-items-learn.md
+++ b/workspaces/azure-devops/.changeset/shiny-items-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-backend': patch
+---
+
+remove unused dependencies: lodash and yn

--- a/workspaces/azure-devops/packages/app/knip-report.md
+++ b/workspaces/azure-devops/packages/app/knip-report.md
@@ -1,19 +1,17 @@
 # Knip report
 
-## Unused dependencies (4)
+## Unused dependencies (3)
 
 | Name                                     | Location     | Severity |
 | :--------------------------------------- | :----------- | :------- |
 | @backstage-community/plugin-azure-devops | package.json | error    |
 | react-router                             | package.json | error    |
 | react-use                                | package.json | error    |
-| history                                  | package.json | error    |
 
-## Unused devDependencies (4)
+## Unused devDependencies (3)
 
 | Name                        | Location     | Severity |
 | :-------------------------- | :----------- | :------- |
 | @testing-library/user-event | package.json | error    |
 | @backstage/test-utils       | package.json | error    |
 | @testing-library/dom        | package.json | error    |
-| cross-env                   | package.json | error    |

--- a/workspaces/azure-devops/packages/app/package.json
+++ b/workspaces/azure-devops/packages/app/package.json
@@ -45,7 +45,6 @@
     "@backstage/theme": "^0.6.3",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",
@@ -59,8 +58,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "@types/react-dom": "*",
-    "cross-env": "^7.0.0"
+    "@types/react-dom": "*"
   },
   "browserslist": {
     "production": [

--- a/workspaces/azure-devops/packages/backend/knip-report.md
+++ b/workspaces/azure-devops/packages/backend/knip-report.md
@@ -5,6 +5,7 @@
 | Name                                                                                | Location     | Severity |
 | :---------------------------------------------------------------------------------- | :----------- | :------- |
 | @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor | package.json | error    |
+| @backstage-community/plugin-scaffolder-backend-module-azure-devops                  | package.json | error    |
 | @backstage-community/plugin-azure-devops-backend                                    | package.json | error    |
 | @backstage/plugin-search-backend-node                                               | package.json | error    |
 | @backstage/plugin-permission-common                                                 | package.json | error    |
@@ -18,12 +19,3 @@
 | winston                                                                             | package.json | error    |
 | app                                                                                 | package.json | error    |
 | pg                                                                                  | package.json | error    |
-
-## Unused devDependencies (4)
-
-| Name                             | Location     | Severity |
-| :------------------------------- | :----------- | :------- |
-| @types/express-serve-static-core | package.json | error    |
-| @types/dockerode                 | package.json | error    |
-| @types/express                   | package.json | error    |
-| @types/luxon                     | package.json | error    |

--- a/workspaces/azure-devops/packages/backend/package.json
+++ b/workspaces/azure-devops/packages/backend/package.json
@@ -52,11 +52,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.29.4",
-    "@types/dockerode": "^3.3.0",
-    "@types/express": "^4.17.6",
-    "@types/express-serve-static-core": "^4.17.5",
-    "@types/luxon": "^2.0.4"
+    "@backstage/cli": "^0.29.4"
   },
   "files": [
     "dist"

--- a/workspaces/azure-devops/plugins/azure-devops-backend/knip-report.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/knip-report.md
@@ -1,9 +1,11 @@
 # Knip report
 
-## Unused dependencies (3)
+## Unused dependencies (5)
 
 | Name                                            | Location     | Severity |
 | :---------------------------------------------- | :----------- | :------- |
 | @backstage-community/plugin-azure-devops-common | package.json | error    |
+| @backstage/plugin-catalog-common                | package.json | error    |
+| @backstage/plugin-catalog-node                  | package.json | error    |
 | @backstage/plugin-auth-node                     | package.json | error    |
-| yn                                              | package.json | error    |
+| @backstage/catalog-model                        | package.json | error    |

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -50,10 +50,8 @@
     "azure-devops-node-api": "^13.0.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "lodash": "^4.17.21",
     "mime-types": "^2.1.27",
-    "p-limit": "^3.1.0",
-    "yn": "^4.0.0"
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.2.0",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/knip-report.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/knip-report.md
@@ -1,6 +1,6 @@
 # Knip report
 
-## Unused dependencies (2)
+## Unused dependencies (1)
 
 | Name                                            | Location     | Severity |
 | :---------------------------------------------- | :----------- | :------- |

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/knip-report.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/knip-report.md
@@ -1,0 +1,1 @@
+# Knip report

--- a/workspaces/azure-devops/yarn.lock
+++ b/workspaces/azure-devops/yarn.lock
@@ -2682,11 +2682,9 @@ __metadata:
     azure-devops-node-api: ^13.0.0
     express: ^4.17.1
     express-promise-router: ^4.1.0
-    lodash: ^4.17.21
     mime-types: ^2.1.27
     p-limit: ^3.1.0
     supertest: ^7.0.0
-    yn: ^4.0.0
   languageName: unknown
   linkType: soft
 
@@ -12708,9 +12706,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:^4.14.151":
-  version: 4.17.12
-  resolution: "@types/lodash@npm:4.17.12"
-  checksum: 7b564e4114f09ce5ae31a2e9493592baf20bb498507f3705c5d91cf838c2298b4f6a06f2d6c8dc608fcac63e210a2b7b13388c7a5e220e15688f813521030127
+  version: 4.17.13
+  resolution: "@types/lodash@npm:4.17.13"
+  checksum: d0bf8fbd950be71946e0076b30fd40d492293baea75f05931b6b5b906fd62583708c6229abdb95b30205ad24ce1ed2f48bc9d419364f682320edd03405cc0c7e
   languageName: node
   linkType: hard
 
@@ -12725,13 +12723,6 @@ __metadata:
   version: 2.3.7
   resolution: "@types/lunr@npm:2.3.7"
   checksum: 188a18f035e042f4c23e807ae752bfdb0076a0446ff8285b3c10572008fb00282dfeebdbbd566bfcf65dbb073daf552477a0ccbf426ebaa5ce88c0088a860924
-  languageName: node
-  linkType: hard
-
-"@types/luxon@npm:^2.0.4":
-  version: 2.4.0
-  resolution: "@types/luxon@npm:2.4.0"
-  checksum: eeb16a1bfe5440464c1a9635700d103cd18d3cd8da6063a1938478e435cfba6ab8e893aa80c95a407e541187c1e997c3e4481322726bc1258551cb8606d0e5ad
   languageName: node
   linkType: hard
 
@@ -14126,8 +14117,6 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     "@types/react-dom": "*"
-    cross-env: ^7.0.0
-    history: ^5.0.0
     react: ^18.0.2
     react-dom: ^18.0.2
     react-router: ^6.3.0
@@ -14852,10 +14841,6 @@ __metadata:
     "@backstage/plugin-search-backend-module-techdocs": ^0.3.4
     "@backstage/plugin-search-backend-node": ^1.3.6
     "@backstage/plugin-techdocs-backend": ^1.11.4
-    "@types/dockerode": ^3.3.0
-    "@types/express": ^4.17.6
-    "@types/express-serve-static-core": ^4.17.5
-    "@types/luxon": ^2.0.4
     app: "link:../app"
     better-sqlite3: ^9.0.0
     dockerode: ^3.3.1
@@ -16668,18 +16653,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: ^7.0.1
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
 "cross-fetch@npm:^3.1.5":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -16718,7 +16691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The automated PR #2232 tries to update the unused dependency `@types/express-serve-static-core`.

This PR instead removes multiple unused devDependencies from `packages/backend/package.json`.

:warning: **It also removes two dependencies from `@backstage-community/plugin-azure-devops-backend`!**

I also run `yarn build:knip-reports` to rebuild the knip reports.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
