### PR TITLE
chore(cicd-statistics): remove some unused dependencies

### DIFF
--- a/workspaces/cicd-statistics/.changeset/olive-buttons-rest.md
+++ b/workspaces/cicd-statistics/.changeset/olive-buttons-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
+---
+
+remove unused dependencies: p-limit and luxon

--- a/workspaces/cicd-statistics/.changeset/twenty-donuts-travel.md
+++ b/workspaces/cicd-statistics/.changeset/twenty-donuts-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
+---
+
+remove unused dependency: luxon

--- a/workspaces/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/package.json
@@ -25,6 +25,7 @@
     "new": "backstage-cli new --scope @backstage-community",
     "build:api-reports": "yarn build:api-reports:only",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags",
+    "build:knip-reports": "backstage-repo-tools knip-reports",
     "postinstall": "cd ../../ && yarn install"
   },
   "workspaces": {

--- a/workspaces/cicd-statistics/packages/app-next/knip-report.md
+++ b/workspaces/cicd-statistics/packages/app-next/knip-report.md
@@ -1,0 +1,28 @@
+# Knip report
+
+## Unused dependencies (13)
+
+| Name                                                      | Location     | Severity |
+| :-------------------------------------------------------- | :----------- | :------- |
+| @backstage-community/plugin-cicd-statistics-module-gitlab | package.json | error    |
+| @backstage-community/plugin-cicd-statistics               | package.json | error    |
+| @backstage/plugin-catalog-common                          | package.json | error    |
+| @backstage/plugin-catalog-graph                           | package.json | error    |
+| @backstage/plugin-catalog-react                           | package.json | error    |
+| @backstage/frontend-app-api                               | package.json | error    |
+| @backstage/catalog-model                                  | package.json | error    |
+| @backstage/app-defaults                                   | package.json | error    |
+| @backstage/plugin-org                                     | package.json | error    |
+| @material-ui/core                                         | package.json | error    |
+| styled-components                                         | package.json | error    |
+| react-router-dom                                          | package.json | error    |
+| react-use                                                 | package.json | error    |
+
+## Unused devDependencies (4)
+
+| Name                        | Location     | Severity |
+| :-------------------------- | :----------- | :------- |
+| @testing-library/user-event | package.json | error    |
+| @testing-library/react      | package.json | error    |
+| @testing-library/dom        | package.json | error    |
+| @playwright/test            | package.json | error    |

--- a/workspaces/cicd-statistics/packages/app-next/package.json
+++ b/workspaces/cicd-statistics/packages/app-next/package.json
@@ -43,7 +43,6 @@
     "@backstage/theme": "^0.6.3",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",
@@ -58,8 +57,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "@types/react-dom": "*",
-    "cross-env": "^7.0.0"
+    "@types/react-dom": "*"
   },
   "browserslist": {
     "production": [

--- a/workspaces/cicd-statistics/packages/app/knip-report.md
+++ b/workspaces/cicd-statistics/packages/app/knip-report.md
@@ -1,0 +1,21 @@
+# Knip report
+
+## Unused dependencies (6)
+
+| Name                                                      | Location     | Severity |
+| :-------------------------------------------------------- | :----------- | :------- |
+| @backstage-community/plugin-cicd-statistics-module-gitlab | package.json | error    |
+| @backstage-community/plugin-cicd-statistics               | package.json | error    |
+| @backstage/plugin-catalog-react                           | package.json | error    |
+| @backstage/catalog-model                                  | package.json | error    |
+| react-router                                              | package.json | error    |
+| react-use                                                 | package.json | error    |
+
+## Unused devDependencies (4)
+
+| Name                        | Location     | Severity |
+| :-------------------------- | :----------- | :------- |
+| @testing-library/user-event | package.json | error    |
+| @backstage/test-utils       | package.json | error    |
+| @testing-library/dom        | package.json | error    |
+| @playwright/test            | package.json | error    |

--- a/workspaces/cicd-statistics/packages/app/package.json
+++ b/workspaces/cicd-statistics/packages/app/package.json
@@ -40,7 +40,6 @@
     "@backstage/theme": "^0.6.3",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",
@@ -54,8 +53,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "@types/react-dom": "*",
-    "cross-env": "^7.0.0"
+    "@types/react-dom": "*"
   },
   "browserslist": {
     "production": [

--- a/workspaces/cicd-statistics/packages/backend/knip-report.md
+++ b/workspaces/cicd-statistics/packages/backend/knip-report.md
@@ -1,0 +1,18 @@
+# Knip report
+
+## Unused dependencies (12)
+
+| Name                          | Location     | Severity |
+| :---------------------------- | :----------- | :------- |
+| @backstage/backend-plugin-api | package.json | error    |
+| @backstage/plugin-auth-node   | package.json | error    |
+| @backstage/backend-common     | package.json | error    |
+| @backstage/backend-tasks      | package.json | error    |
+| @backstage/catalog-model      | package.json | error    |
+| @backstage/config             | package.json | error    |
+| better-sqlite3                | package.json | error    |
+| dockerode                     | package.json | error    |
+| node-gyp                      | package.json | error    |
+| winston                       | package.json | error    |
+| app                           | package.json | error    |
+| pg                            | package.json | error    |

--- a/workspaces/cicd-statistics/packages/backend/package.json
+++ b/workspaces/cicd-statistics/packages/backend/package.json
@@ -42,11 +42,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.29.4",
-    "@types/dockerode": "^3.3.0",
-    "@types/express": "^4.17.6",
-    "@types/express-serve-static-core": "^4.17.5",
-    "@types/luxon": "^2.0.4"
+    "@backstage/cli": "^0.29.4"
   },
   "files": [
     "dist"

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/knip-report.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/knip-report.md
@@ -1,10 +1,12 @@
 # Knip report
 
-## Unused dependencies (1)
+## Unused dependencies (3)
 
 | Name                                        | Location     | Severity |
 | :------------------------------------------ | :----------- | :------- |
 | @backstage-community/plugin-cicd-statistics | package.json | error    |
+| @gitbeaker/browser                          | package.json | error    |
+| @gitbeaker/core                             | package.json | error    |
 
 ## Unused devDependencies (5)
 

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -45,9 +45,7 @@
     "@backstage/test-utils": "^1.7.3",
     "@gitbeaker/browser": "^35.6.0",
     "@gitbeaker/core": "^35.6.0",
-    "@roadiehq/backstage-plugin-buildkite": "^2.3.1",
-    "luxon": "^3.0.0",
-    "p-limit": "^3.1.0"
+    "@roadiehq/backstage-plugin-buildkite": "^2.3.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.29.4",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -58,7 +58,6 @@
     "@backstage/frontend-plugin-api": "^0.9.3",
     "@gitbeaker/browser": "^35.6.0",
     "@gitbeaker/core": "^35.6.0",
-    "luxon": "^3.0.0",
     "p-limit": "^3.1.0"
   },
   "devDependencies": {

--- a/workspaces/cicd-statistics/yarn.lock
+++ b/workspaces/cicd-statistics/yarn.lock
@@ -2706,8 +2706,6 @@ __metadata:
     "@roadiehq/backstage-plugin-buildkite": ^2.3.1
     "@types/react": ^16.13.1 || ^17.0.0
     "@types/react-dom": ^18.2.19
-    luxon: ^3.0.0
-    p-limit: ^3.1.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
@@ -2731,7 +2729,6 @@ __metadata:
     "@gitbeaker/core": ^35.6.0
     "@types/react": ^16.13.1 || ^17.0.0
     "@types/react-dom": ^18.2.19
-    luxon: ^3.0.0
     p-limit: ^3.1.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -11583,13 +11580,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^2.0.4":
-  version: 2.4.0
-  resolution: "@types/luxon@npm:2.4.0"
-  checksum: eeb16a1bfe5440464c1a9635700d103cd18d3cd8da6063a1938478e435cfba6ab8e893aa80c95a407e541187c1e997c3e4481322726bc1258551cb8606d0e5ad
-  languageName: node
-  linkType: hard
-
 "@types/luxon@npm:^3.0.0, @types/luxon@npm:~3.4.0":
   version: 3.4.2
   resolution: "@types/luxon@npm:3.4.2"
@@ -12866,8 +12856,6 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     "@types/react-dom": "*"
-    cross-env: ^7.0.0
-    history: ^5.0.0
     react: ^18.0.2
     react-dom: ^18.0.2
     react-router: ^6.3.0
@@ -12915,8 +12903,6 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     "@types/react-dom": "*"
-    cross-env: ^7.0.0
-    history: ^5.0.0
     react: ^18.0.2
     react-dom: ^18.0.2
     react-router: ^6.3.0
@@ -13546,10 +13532,6 @@ __metadata:
     "@backstage/plugin-auth-node": ^0.5.5
     "@backstage/plugin-catalog-backend": ^1.29.0
     "@backstage/plugin-proxy-backend": ^0.5.9
-    "@types/dockerode": ^3.3.0
-    "@types/express": ^4.17.6
-    "@types/express-serve-static-core": ^4.17.5
-    "@types/luxon": ^2.0.4
     app: "link:../app"
     better-sqlite3: ^9.0.0
     dockerode: ^3.3.1
@@ -15284,18 +15266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: ^7.0.1
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
 "cross-fetch@npm:^3.1.5":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -15334,7 +15304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The automated PR #2232 tries to update the unused dependency `@types/express-serve-static-core`.

This PR instead removes multiple unused devDependencies from `packages/backend/package.json`.

⚠️ **It also removes 2 dependencies from `@backstage-community/plugin-cicd-statistics-module-buildkite`!**

⚠️ **It also removes 1 dependency from `@backstage-community/plugin-cicd-statistics-module-gitlab`!**

I also added a script to run `yarn build:knip-reports` to rebuild the knip reports.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
