### PR TITLE
chore(npm): remove unused dev dependencies

### DIFF
--- a/workspaces/npm/package.json
+++ b/workspaces/npm/package.json
@@ -17,6 +17,7 @@
     "build:all": "backstage-cli repo build --all",
     "build:api-reports": "yarn build:api-reports:only --tsc",
     "build:api-reports:only": "backstage-repo-tools api-reports -o ae-wrong-input-file-type,ae-undocumented --validate-release-tags",
+    "build:knip-reports": "backstage-repo-tools knip-reports",
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",

--- a/workspaces/npm/packages/app/knip-report.md
+++ b/workspaces/npm/packages/app/knip-report.md
@@ -1,19 +1,8 @@
 # Knip report
 
-## Unused dependencies (4)
+## Unused dependencies (2)
 
 | Name                            | Location     | Severity |
 | :------------------------------ | :----------- | :------- |
 | @backstage-community/plugin-npm | package.json | error    |
 | react-router                    | package.json | error    |
-| react-use                       | package.json | error    |
-| history                         | package.json | error    |
-
-## Unused devDependencies (4)
-
-| Name                        | Location     | Severity |
-| :-------------------------- | :----------- | :------- |
-| @testing-library/user-event | package.json | error    |
-| @backstage/test-utils       | package.json | error    |
-| @testing-library/dom        | package.json | error    |
-| cross-env                   | package.json | error    |

--- a/workspaces/npm/packages/app/package.json
+++ b/workspaces/npm/packages/app/package.json
@@ -45,22 +45,16 @@
     "@backstage/theme": "^0.6.0",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "history": "^5.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0",
-    "react-use": "^17.2.4"
+    "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
-    "@backstage/test-utils": "^1.7.0",
     "@playwright/test": "^1.32.3",
-    "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.0.0",
-    "@types/react-dom": "*",
-    "cross-env": "^7.0.0"
+    "@types/react-dom": "*"
   },
   "browserslist": {
     "production": [

--- a/workspaces/npm/packages/backend/knip-report.md
+++ b/workspaces/npm/packages/backend/knip-report.md
@@ -15,11 +15,3 @@
 | winston                                               | package.json | error    |
 | app                                                   | package.json | error    |
 | pg                                                    | package.json | error    |
-
-## Unused devDependencies (3)
-
-| Name                             | Location     | Severity |
-| :------------------------------- | :----------- | :------- |
-| @types/express-serve-static-core | package.json | error    |
-| @types/express                   | package.json | error    |
-| @types/luxon                     | package.json | error    |

--- a/workspaces/npm/packages/backend/package.json
+++ b/workspaces/npm/packages/backend/package.json
@@ -50,10 +50,7 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.28.0",
-    "@types/express": "^4.17.6",
-    "@types/express-serve-static-core": "^4.17.5",
-    "@types/luxon": "^2.0.4"
+    "@backstage/cli": "^0.28.0"
   },
   "files": [
     "dist"

--- a/workspaces/npm/plugins/npm/knip-report.md
+++ b/workspaces/npm/plugins/npm/knip-report.md
@@ -1,11 +1,9 @@
 # Knip report
 
-## Unused devDependencies (5)
+## Unused devDependencies (3)
 
 | Name                        | Location     | Severity |
 | :-------------------------- | :----------- | :------- |
 | @testing-library/user-event | package.json | error    |
-| @backstage/core-app-api     | package.json | error    |
 | @testing-library/react      | package.json | error    |
 | @backstage/test-utils       | package.json | error    |
-| msw                         | package.json | error    |

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -44,13 +44,11 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.28.0",
-    "@backstage/core-app-api": "^1.15.1",
     "@backstage/dev-utils": "^1.1.2",
     "@backstage/test-utils": "^1.7.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
-    "msw": "^1.0.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "files": [

--- a/workspaces/npm/yarn.lock
+++ b/workspaces/npm/yarn.lock
@@ -2712,7 +2712,6 @@ __metadata:
   dependencies:
     "@backstage/catalog-model": ^1.7.0
     "@backstage/cli": ^0.28.0
-    "@backstage/core-app-api": ^1.15.1
     "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
     "@backstage/dev-utils": ^1.1.2
@@ -2724,7 +2723,6 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.0.0
     luxon: ^3.5.0
-    msw: ^1.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-use: ^17.2.4
   peerDependencies:
@@ -12453,13 +12451,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/luxon@npm:^2.0.4":
-  version: 2.4.0
-  resolution: "@types/luxon@npm:2.4.0"
-  checksum: eeb16a1bfe5440464c1a9635700d103cd18d3cd8da6063a1938478e435cfba6ab8e893aa80c95a407e541187c1e997c3e4481322726bc1258551cb8606d0e5ad
-  languageName: node
-  linkType: hard
-
 "@types/luxon@npm:^3.0.0, @types/luxon@npm:~3.4.0":
   version: 3.4.2
   resolution: "@types/luxon@npm:3.4.2"
@@ -13839,23 +13830,17 @@ __metadata:
     "@backstage/plugin-techdocs-module-addons-contrib": ^1.1.16
     "@backstage/plugin-techdocs-react": ^1.2.9
     "@backstage/plugin-user-settings": ^0.8.14
-    "@backstage/test-utils": ^1.7.0
     "@backstage/theme": ^0.6.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@playwright/test": ^1.32.3
-    "@testing-library/dom": ^9.0.0
     "@testing-library/jest-dom": ^6.0.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/user-event": ^14.0.0
     "@types/react-dom": "*"
-    cross-env: ^7.0.0
-    history: ^5.0.0
     react: ^18.0.2
     react-dom: ^18.0.2
     react-router: ^6.3.0
     react-router-dom: ^6.3.0
-    react-use: ^17.2.4
   languageName: unknown
   linkType: soft
 
@@ -14516,9 +14501,6 @@ __metadata:
     "@backstage/plugin-search-backend-module-techdocs": ^0.3.1
     "@backstage/plugin-search-backend-node": ^1.3.4
     "@backstage/plugin-techdocs-backend": ^1.11.1
-    "@types/express": ^4.17.6
-    "@types/express-serve-static-core": ^4.17.5
-    "@types/luxon": ^2.0.4
     app: "link:../app"
     better-sqlite3: ^9.0.0
     node-gyp: ^10.0.0
@@ -16322,18 +16304,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^7.0.0":
-  version: 7.0.3
-  resolution: "cross-env@npm:7.0.3"
-  dependencies:
-    cross-spawn: ^7.0.1
-  bin:
-    cross-env: src/bin/cross-env.js
-    cross-env-shell: src/bin/cross-env-shell.js
-  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
-  languageName: node
-  linkType: hard
-
 "cross-fetch@npm:^3.1.5":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -16372,7 +16342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The automated PR #2232 tries to update the unused dependency `@types/express-serve-static-core`.

This PR instead removes multiple unused devDependencies from app and backend package and the plugin itself.

I also added a script to run `yarn build:knip-reports` to rebuild the knip reports.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
