### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/olive-buttons-rest.md
+++ b/workspaces/cicd-statistics/.changeset/olive-buttons-rest.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
----
-
-remove unused dependencies: p-limit and luxon

--- a/workspaces/cicd-statistics/.changeset/twenty-donuts-travel.md
+++ b/workspaces/cicd-statistics/.changeset/twenty-donuts-travel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
----
-
-remove unused dependency: luxon

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.1.1
+
+### Patch Changes
+
+- 43cf7dc: remove unused dependencies: p-limit and luxon
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.2.1
+
+### Patch Changes
+
+- 43cf7dc: remove unused dependency: luxon
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.1.1

### Patch Changes

-   43cf7dc: remove unused dependencies: p-limit and luxon

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.2.1

### Patch Changes

-   43cf7dc: remove unused dependency: luxon
