### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/silly-yaks-protect.md
+++ b/workspaces/confluence/.changeset/silly-yaks-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-confluence': patch
----
-
-Truncate confluence search result item text to 290 characters, which will include the highlighted section if found.

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-confluence
 
+## 0.2.1
+
+### Patch Changes
+
+- 6757d87: Truncate confluence search result item text to 290 characters, which will include the highlighted section if found.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.2.1

### Patch Changes

-   6757d87: Truncate confluence search result item text to 290 characters, which will include the highlighted section if found.
