### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/olive-apples-matter.md
+++ b/workspaces/announcements/.changeset/olive-apples-matter.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': patch
----
-
-An internal refactor to create the announcements context with persistence via the `buildAnnouncementsContext` function.

--- a/workspaces/announcements/.changeset/strong-flowers-remain.md
+++ b/workspaces/announcements/.changeset/strong-flowers-remain.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': patch
-'@backstage-community/plugin-announcements-common': patch
-'@backstage-community/plugin-announcements-react': patch
-'@backstage-community/plugin-announcements': patch
----
-
-Minor improvements to README documentation

--- a/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-announcements-backend
 
+## 0.1.3
+
+### Patch Changes
+
+- 22fd3a1: An internal refactor to create the announcements context with persistence via the `buildAnnouncementsContext` function.
+- e282a2d: Minor improvements to README documentation
+- Updated dependencies [e282a2d]
+  - @backstage-community/plugin-announcements-common@0.1.3
+  - @backstage-community/plugin-search-backend-module-announcements@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements-backend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-common
 
+## 0.1.3
+
+### Patch Changes
+
+- e282a2d: Minor improvements to README documentation
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-common/package.json
+++ b/workspaces/announcements/plugins/announcements-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-common",
   "description": "Common functionalities for the announcements plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements-node
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [e282a2d]
+  - @backstage-community/plugin-announcements-common@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-node/package.json
+++ b/workspaces/announcements/plugins/announcements-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-node",
   "description": "Node.js library for the announcements plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.1.3
+
+### Patch Changes
+
+- e282a2d: Minor improvements to README documentation
+- Updated dependencies [e282a2d]
+  - @backstage-community/plugin-announcements-common@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-announcements
 
+## 0.1.4
+
+### Patch Changes
+
+- e282a2d: Minor improvements to README documentation
+- Updated dependencies [e282a2d]
+  - @backstage-community/plugin-announcements-common@0.1.3
+  - @backstage-community/plugin-announcements-react@0.1.3
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [e282a2d]
+  - @backstage-community/plugin-announcements-common@0.1.3
+  - @backstage-community/plugin-announcements-node@0.1.3
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/search-backend-module-announcements/package.json
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-announcements",
   "description": "The announcements backend module for the search plugin.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.1.4

### Patch Changes

-   e282a2d: Minor improvements to README documentation
-   Updated dependencies [e282a2d]
    -   @backstage-community/plugin-announcements-common@0.1.3
    -   @backstage-community/plugin-announcements-react@0.1.3

## @backstage-community/plugin-announcements-backend@0.1.3

### Patch Changes

-   22fd3a1: An internal refactor to create the announcements context with persistence via the `buildAnnouncementsContext` function.
-   e282a2d: Minor improvements to README documentation
-   Updated dependencies [e282a2d]
    -   @backstage-community/plugin-announcements-common@0.1.3
    -   @backstage-community/plugin-search-backend-module-announcements@0.1.3

## @backstage-community/plugin-announcements-common@0.1.3

### Patch Changes

-   e282a2d: Minor improvements to README documentation

## @backstage-community/plugin-announcements-node@0.1.3

### Patch Changes

-   Updated dependencies [e282a2d]
    -   @backstage-community/plugin-announcements-common@0.1.3

## @backstage-community/plugin-announcements-react@0.1.3

### Patch Changes

-   e282a2d: Minor improvements to README documentation
-   Updated dependencies [e282a2d]
    -   @backstage-community/plugin-announcements-common@0.1.3

## @backstage-community/plugin-search-backend-module-announcements@0.1.3

### Patch Changes

-   Updated dependencies [e282a2d]
    -   @backstage-community/plugin-announcements-common@0.1.3
    -   @backstage-community/plugin-announcements-node@0.1.3
