### PR TITLE
Version Packages (acr)

### DIFF
--- a/workspaces/acr/.changeset/clean-squids-fix.md
+++ b/workspaces/acr/.changeset/clean-squids-fix.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': minor
----
-
-add support for the new frontend-system (alpha)

--- a/workspaces/acr/.changeset/cold-horses-design.md
+++ b/workspaces/acr/.changeset/cold-horses-design.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': minor
----
-
-Aligned the exported component names with other plugins and the Backstage recommendations. Please use the exported `AcrImagesEntityContent` component instead of `AcrPage`. `AcrPage` is still exported, but deprecated and might be removed in the future.

--- a/workspaces/acr/plugins/acr/CHANGELOG.md
+++ b/workspaces/acr/plugins/acr/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.9.0
+
+### Minor Changes
+
+- 0c1e93a: add support for the new frontend-system (alpha)
+- 0c1e93a: Aligned the exported component names with other plugins and the Backstage recommendations. Please use the exported `AcrImagesEntityContent` component instead of `AcrPage`. `AcrPage` is still exported, but deprecated and might be removed in the future.
+
 ## 1.8.8
 
 ### Patch Changes

--- a/workspaces/acr/plugins/acr/package.json
+++ b/workspaces/acr/plugins/acr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-acr",
   "description": "A Backstage plugin that displays information about your container images available in the Azure Container Registry",
-  "version": "1.8.8",
+  "version": "1.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acr@1.9.0

### Minor Changes

-   0c1e93a: add support for the new frontend-system (alpha)
-   0c1e93a: Aligned the exported component names with other plugins and the Backstage recommendations. Please use the exported `AcrImagesEntityContent` component instead of `AcrPage`. `AcrPage` is still exported, but deprecated and might be removed in the future.
