### PR TITLE
Remove Portuguese from the README

### DIFF
--- a/workspaces/copilot/.changeset/mighty-chairs-mix.md
+++ b/workspaces/copilot/.changeset/mighty-chairs-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+Removes Portuguese from the README

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -1,7 +1,3 @@
-Aqui está o README ajustado, agora incluindo a nova funcionalidade para selecionar um time e comparar suas métricas com os dados gerais:
-
----
-
 # GitHub Copilot Plugin
 
 Welcome to the GitHub Copilot Plugin!


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes Portuguese from the README, originally made me suspicious of the package hosted on NPM (https://www.npmjs.com/package/@backstage-community/plugin-copilot?activeTab=readme) but it looks accidental.

![Screenshot 2025-01-13 at 09 34 11](https://github.com/user-attachments/assets/77482890-47e8-4297-8c3e-74ef3d6f48d7)

https://github.com/backstage/community-plugins/blame/7f17c9f54e8032af01e70e488b32fd6a0670f49c/workspaces/copilot/plugins/copilot/README.md  ([commit](https://github.com/backstage/community-plugins/commit/7f17c9f54e8032af01e70e488b32fd6a0670f49c))

Google Translates this to:

```
Here is the adjusted README, now including the new functionality to select a team and compare its metrics with general data:
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
