### PR TITLE
Version Packages (airbrake)

### DIFF
--- a/workspaces/airbrake/.changeset/great-ligers-check.md
+++ b/workspaces/airbrake/.changeset/great-ligers-check.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-airbrake-backend': minor
----
-
-Removed usages and references of `@backstage/backend-common`
-Removed deprecated exports for createRouter and RouterOptions

--- a/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
+++ b/workspaces/airbrake/plugins/airbrake-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-airbrake-backend
 
+## 0.5.0
+
+### Minor Changes
+
+- 99ac249: Removed usages and references of `@backstage/backend-common`
+  Removed deprecated exports for createRouter and RouterOptions
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/airbrake/plugins/airbrake-backend/package.json
+++ b/workspaces/airbrake/plugins/airbrake-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-airbrake-backend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-airbrake-backend@0.5.0

### Minor Changes

-   99ac249: Removed usages and references of `@backstage/backend-common`
    Removed deprecated exports for createRouter and RouterOptions
