### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/polite-houses-flow.md
+++ b/workspaces/npm/.changeset/polite-houses-flow.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-npm-backend': minor
-'@backstage-community/plugin-npm-common': minor
-'@backstage-community/plugin-npm': minor
----
-
-Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.

--- a/workspaces/npm/plugins/npm-backend/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-backend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @backstage-community/plugin-npm-backend
+
+## 1.2.0
+
+### Minor Changes
+
+- 2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.
+
+### Patch Changes
+
+- Updated dependencies [2816eb6]
+  - @backstage-community/plugin-npm-common@1.2.0

--- a/workspaces/npm/plugins/npm-backend/package.json
+++ b/workspaces/npm/plugins/npm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-npm-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm-common/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-npm-common
+
+## 1.2.0
+
+### Minor Changes
+
+- 2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.

--- a/workspaces/npm/plugins/npm-common/package.json
+++ b/workspaces/npm/plugins/npm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm-common",
   "description": "Common functionalities for the npm plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-npm
 
+## 1.2.0
+
+### Minor Changes
+
+- 2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.
+
+### Patch Changes
+
+- Updated dependencies [2816eb6]
+  - @backstage-community/plugin-npm-common@1.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.2.0

### Minor Changes

-   2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.

### Patch Changes

-   Updated dependencies [2816eb6]
    -   @backstage-community/plugin-npm-common@1.2.0

## @backstage-community/plugin-npm-backend@1.2.0

### Minor Changes

-   2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.

### Patch Changes

-   Updated dependencies [2816eb6]
    -   @backstage-community/plugin-npm-common@1.2.0

## @backstage-community/plugin-npm-common@1.2.0

### Minor Changes

-   2816eb6: Added support for custom and private npm registries like GitHub and GitLab via a new backend plugin. Other npm registries that works with the npm cli should work as well.
