### PR TITLE
Version Packages (feedback)

### DIFF
--- a/workspaces/feedback/.changeset/wicked-students-battle.md
+++ b/workspaces/feedback/.changeset/wicked-students-battle.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-feedback-backend': patch
-'@backstage-community/plugin-feedback': patch
----
-
-update backstage to 1.34.2 and replace `@spotify/prettier-config` by `@backstage/cli/config/prettier`

--- a/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-feedback-backend [1.7.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.6.0...@janus-idp/backstage-plugin-feedback-backend@1.7.0) (2024-07-26)
 
+## 1.7.11
+
+### Patch Changes
+
+- 4b2e17c: update backstage to 1.34.2 and replace `@spotify/prettier-config` by `@backstage/cli/config/prettier`
+
 ## 1.7.10
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-backend",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/feedback/plugins/feedback/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-feedback [1.6.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback@1.5.0...@janus-idp/backstage-plugin-feedback@1.6.0) (2024-07-26)
 
+## 1.6.14
+
+### Patch Changes
+
+- 4b2e17c: update backstage to 1.34.2 and replace `@spotify/prettier-config` by `@backstage/cli/config/prettier`
+
 ## 1.6.13
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback/package.json
+++ b/workspaces/feedback/plugins/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-feedback@1.6.14

### Patch Changes

-   4b2e17c: update backstage to 1.34.2 and replace `@spotify/prettier-config` by `@backstage/cli/config/prettier`

## @backstage-community/plugin-feedback-backend@1.7.11

### Patch Changes

-   4b2e17c: update backstage to 1.34.2 and replace `@spotify/prettier-config` by `@backstage/cli/config/prettier`
