### PR TITLE
WIP: Add multi-project support for Jenkins plugin

### DIFF
--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
@@ -151,7 +151,7 @@ export class JenkinsBuilder {
           if (err.errors) {
             throw new Error(
               `Unable to fetch projects, for ${
-                jenkinsInfo.jobFullName
+                jenkinsInfo.fullJobNames
               }: ${stringifyError(err.errors)}`,
             );
           }
@@ -172,7 +172,7 @@ export class JenkinsBuilder {
             namespace,
             name,
           },
-          jobFullName,
+          fullJobNames: [jobFullName],
           credentials: await httpAuth.credentials(request),
         });
 
@@ -199,7 +199,7 @@ export class JenkinsBuilder {
             namespace,
             name,
           },
-          jobFullName,
+          fullJobNames: [jobFullName],
           credentials: await httpAuth.credentials(request),
         });
 
@@ -222,7 +222,7 @@ export class JenkinsBuilder {
             namespace,
             name,
           },
-          jobFullName,
+          fullJobNames: [jobFullName],
           credentials: await httpAuth.credentials(request),
         });
 
@@ -252,7 +252,7 @@ export class JenkinsBuilder {
             namespace,
             name,
           },
-          jobFullName,
+          fullJobNames: [jobFullName],
           credentials: await httpAuth.credentials(request),
         });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsApi.ts
@@ -84,54 +84,71 @@ export class JenkinsApiImpl {
    */
   async getProjects(jenkinsInfo: JenkinsInfo, branches?: string[]) {
     const client = await JenkinsApiImpl.getClient(jenkinsInfo);
-    const projects: BackstageProject[] = [];
 
     if (branches) {
-      // Assume jenkinsInfo.jobFullName is a MultiBranch Pipeline project which contains one job per branch.
+      // Assume jenkinsInfo.fullJobNames are one or more MultiBranch Pipeline projects which contain one job per branch.
       // TODO: extract a strategy interface for this
-      const job = await Promise.any(
-        branches.map(branch =>
-          client.job.get({
-            name: `${jenkinsInfo.jobFullName}/${encodeURIComponent(branch)}`,
-            tree: JenkinsApiImpl.jobTreeSpec.replace(/\s/g, ''),
-          }),
-        ),
-      );
-      projects.push(this.augmentProject(job));
-    } else {
-      // We aren't filtering
-      // Assume jenkinsInfo.jobFullName is either
-      // a MultiBranch Pipeline (folder with one job per branch) project
-      // a Pipeline (standalone) project
-
-      // Add count limit to projects
-      // If limit is set in the config, use it, otherwise use the default limit of 50
-      const limitedJobsTreeSpec: string = `${JenkinsApiImpl.jobsTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`;
-
-      const project = await client.job.get({
-        name: jenkinsInfo.jobFullName,
-        // Filter only be the information we need, instead of loading all fields.
-        // Whitespaces are only included for readability here and stripped out
-        // before sending to Jenkins
-        tree: limitedJobsTreeSpec.replace(/\s/g, ''),
-      });
-
-      const isStandaloneProject = !project.jobs;
-      if (isStandaloneProject) {
-        const limitedStandaloneJobTreeSpec = `${JenkinsApiImpl.jobTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`;
-        const standaloneProject = await client.job.get({
-          name: jenkinsInfo.jobFullName,
-          tree: limitedStandaloneJobTreeSpec.replace(/\s/g, ''),
-        });
-        projects.push(this.augmentProject(standaloneProject));
-        return projects;
-      }
-      for (const jobDetails of project.jobs) {
-        // for each branch (we assume)
-        projects.push(this.augmentProject(jobDetails));
-      }
+      return this.fetchBranchSpecificProjects(client, jenkinsInfo, branches);
     }
-    return projects;
+
+    return this.fetchAllProjects(client, jenkinsInfo);
+  }
+
+  private async fetchBranchSpecificProjects(
+    client: any,
+    jenkinsInfo: JenkinsInfo,
+    branches: string[],
+  ) {
+    const projects: Promise<BackstageProject>[] = jenkinsInfo.fullJobNames.map(
+      jobName =>
+        Promise.any(
+          branches.map(branch =>
+            client.job.get({
+              name: `${jobName}/${encodeURIComponent(branch)}`,
+              tree: JenkinsApiImpl.jobTreeSpec.replace(/\s/g, ''),
+            }),
+          ),
+        ).then(job => this.augmentProject(job)),
+    );
+
+    return Promise.all(projects);
+  }
+
+  private async fetchAllProjects(client: any, jenkinsInfo: JenkinsInfo) {
+    const limitedJobsTreeSpec: string =
+      `${JenkinsApiImpl.jobsTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`.replace(
+        /\s/g,
+        '',
+      );
+    const limitedStandaloneJobTreeSpec =
+      `${JenkinsApiImpl.jobTreeSpec}{0,${jenkinsInfo.projectCountLimit}}`.replace(
+        /\s/g,
+        '',
+      );
+
+    const projects: Promise<BackstageProject>[] = jenkinsInfo.fullJobNames.map(
+      async jobName => {
+        const project = await client.job.get({
+          name: jobName,
+          tree: limitedJobsTreeSpec,
+        });
+
+        if (!project.jobs) {
+          // Standalone project
+          const standaloneProject = await client.job.get({
+            name: jobName,
+            tree: limitedStandaloneJobTreeSpec,
+          });
+          return [this.augmentProject(standaloneProject)];
+        }
+
+        // Multi-branch project
+        return project.jobs.map(jobDetails => this.augmentProject(jobDetails));
+      },
+    );
+
+    const nestedProjects = await Promise.all(projects);
+    return nestedProjects.flat();
   }
 
   /**

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -38,9 +38,9 @@ export interface JenkinsInfoProvider {
      */
     entityRef: CompoundEntityRef;
     /**
-     * A specific job to get. This is only passed in when we know about a job name we are interested in.
+     * Specific job(s) to get. This is only passed in when we know the job name(s) we are interested in.
      */
-    jobFullName?: string;
+    fullJobNames?: string[];
 
     credentials?: BackstageCredentials;
     logger?: LoggerService;
@@ -51,7 +51,7 @@ export interface JenkinsInfoProvider {
 export interface JenkinsInfo {
   baseUrl: string;
   headers?: Record<string, string | string[]>;
-  jobFullName: string; // TODO: make this an array
+  fullJobNames: string[];
   projectCountLimit: number;
   crumbIssuer?: boolean;
 }
@@ -230,7 +230,7 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
 
   async getInstance(opt: {
     entityRef: CompoundEntityRef;
-    jobFullName?: string;
+    fullJobNames?: string[];
     credentials?: BackstageCredentials;
   }): Promise<JenkinsInfo> {
     // default limitation of projects
@@ -252,9 +252,9 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
     }
 
     // lookup `[jenkinsName#]jobFullName` from entity annotation
-    const jenkinsAndJobName =
+    const jenkinsAndJobNames =
       DefaultJenkinsInfoProvider.getEntityAnnotationValue(entity);
-    if (!jenkinsAndJobName) {
+    if (!jenkinsAndJobNames || jenkinsAndJobNames.length === 0) {
       throw new Error(
         `Couldn't find jenkins annotation (${
           DefaultJenkinsInfoProvider.NEW_JENKINS_ANNOTATION
@@ -262,21 +262,21 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
       );
     }
 
-    let jobFullName;
+    const fullJobNames: string[] = [];
     let jenkinsName: string | undefined;
-    const splitIndex = jenkinsAndJobName.indexOf(':');
-    if (splitIndex === -1) {
-      // no jenkinsName specified, use default
-      jobFullName = jenkinsAndJobName;
-    } else {
-      // There is a jenkinsName specified
-      jenkinsName = jenkinsAndJobName.substring(0, splitIndex);
-      jobFullName = jenkinsAndJobName.substring(
-        splitIndex + 1,
-        jenkinsAndJobName.length,
-      );
-    }
+    jenkinsAndJobNames.forEach(name => {
+      const splitIndex = name.indexOf(':');
+      if (splitIndex === -1) {
+        // no jenkinsName specified, use default
+        fullJobNames.push(name);
+      } else {
+        // There is a jenkinsName specified
+        jenkinsName = name.substring(0, splitIndex);
+        fullJobNames.push(name.substring(splitIndex + 1));
+      }
+    });
 
+    // TODO: Update since we're allowing multiple project names now.
     // lookup baseURL + creds from config
     const instanceConfig = this.config.getInstanceConfig(jenkinsName);
 
@@ -306,7 +306,7 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
         Authorization: `Basic ${creds}`,
         ...instanceConfig.extraRequestHeaders,
       },
-      jobFullName,
+      fullJobNames,
       projectCountLimit:
         instanceConfig.projectCountLimit ?? DEFAULT_LIMITATION_OF_PROJECTS,
       crumbIssuer: instanceConfig.crumbIssuer,
@@ -314,14 +314,21 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
   }
 
   private static getEntityAnnotationValue(entity: Entity) {
-    return (
+    const oldAnnotation =
       entity.metadata.annotations?.[
         DefaultJenkinsInfoProvider.OLD_JENKINS_ANNOTATION
-      ] ||
+      ];
+    const newAnnotation =
       entity.metadata.annotations?.[
         DefaultJenkinsInfoProvider.NEW_JENKINS_ANNOTATION
-      ]
-    );
+      ];
+
+    if (oldAnnotation) return [oldAnnotation];
+    if (newAnnotation) {
+      return newAnnotation.replaceAll(' ', '').split(',');
+    }
+
+    return [];
   }
 
   private static getEntityOverrideURL(entity: Entity) {

--- a/workspaces/jenkins/plugins/jenkins/README.md
+++ b/workspaces/jenkins/plugins/jenkins/README.md
@@ -93,7 +93,7 @@ metadata:
   description: 'a description'
   annotations:
     jenkins.io/github-folder: 'folder-name/project-name' # deprecated
-    jenkins.io/job-full-name: 'folder-name/project-name' # use this instead
+    jenkins.io/job-full-name: 'folder-name/project-name, folder-name/project-name' # use this instead
 
 spec:
   type: service


### PR DESCRIPTION
**Work in progress**

## Hey, I just made a Pull Request!
- Adds multi-project support to the Jenkins plugin.
- Uses the original `jenkins.io/job-full-name` annotation but now it can accept multiple values.

Fixes #2469 

**Screenshots**:

![image](https://github.com/user-attachments/assets/f4920165-6ed4-4c83-93a9-ae8a0bb0c4f7)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
