### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/curvy-ads-grab.md
+++ b/workspaces/confluence/.changeset/curvy-ads-grab.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Removed usages of `@backstage/backend-tasks`

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.3.2
+
+### Patch Changes
+
+- 18c36d8: Removed usages of `@backstage/backend-tasks`
+
 ## 0.3.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-search-backend-module-confluence-collator@0.3.2

### Patch Changes

-   18c36d8: Removed usages of `@backstage/backend-tasks`
