### PR TITLE
doc: add note on updating plugin directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Visit the [Package Metadata documentation](https://backstage.io/docs/tooling/pac
 
 10. Create a new pull request from your branch.
 
-11. Update external references to the old plugin location such as documentation to point to the new location in the `backstage/community-plugins` repository.
+11. Update external references to the old plugin location such as documentation to point to the new location in the `backstage/community-plugins` repository. If applicable, update the [Backstage Plugin directory](https://backstage.io/plugins/) to reflect the new location ([example](https://github.com/backstage/backstage/pull/28502)).
 
 12. In the original repository, update the plugin to indicate that it has been moved to the `backstage/community-plugins` repository. It's recommended you deprecate the old plugin packages on npm.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I forgot to update the [plugin directory](https://backstage.io/plugins/) when I migrated the announcements plugins to `backstage/community-plugins`. This was fixed in https://github.com/backstage/backstage/pull/28502. As a follow-up, I have added a note to update the plugin directory in the migration steps. This may not be applicable to all plugins, but it is a good practice to keep the plugin directory up-to-date.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
