### PR TITLE
fix(ci): make config validation step run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: yarn fix --check
 
       - name: validate config
-        if: ${{ hashFiles('app-config.yaml') != '' }}
+        if: ${{ hashFiles(format('workspaces/{0}/app-config.yaml', matrix.workspace)) != '' }}
         run: yarn backstage-cli config:check --lax
 
       - name: type checking and declarations


### PR DESCRIPTION
Fixing the condition for the `validate config` step, which points to the root of the repo, instead of the changed workspaces.

Same as redhat-developer/rhdh-plugins#278 for reference.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
