### PR TITLE
fix(rbac): update roleRef in metadata and policies

### DIFF
--- a/workspaces/rbac/.changeset/itchy-dots-compare.md
+++ b/workspaces/rbac/.changeset/itchy-dots-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Fixed a bug where updating a role name via the `PUT </api/permission/roles/:kind/:namespace/:name>` endpoint did not propagate changes to metadata and permissions, leaving them mapped to the old role name.

--- a/workspaces/rbac/.changeset/itchy-dots-compare.md
+++ b/workspaces/rbac/.changeset/itchy-dots-compare.md
@@ -1,5 +1,6 @@
 ---
 '@backstage-community/plugin-rbac-backend': patch
+'@backstage-community/plugin-rbac': patch
 ---
 
-Fixed a bug where updating a role name via the `PUT </api/permission/roles/:kind/:namespace/:name>` endpoint did not propagate changes to metadata and permissions, leaving them mapped to the old role name.
+Fixed a bug where updating a role name via the `PUT </api/permission/roles/:kind/:namespace/:name>` endpoint did not propagate changes to metadata, permissions and conditions, leaving them mapped to the old role name.

--- a/workspaces/rbac/plugins/rbac-backend/__fixtures__/test-utils.ts
+++ b/workspaces/rbac/plugins/rbac-backend/__fixtures__/test-utils.ts
@@ -136,6 +136,7 @@ export async function newEnforcerDelegate(
   return new EnforcerDelegate(
     enf,
     mockAuditorService,
+    conditionalStorageMock,
     roleMetadataStorageMock,
     mockClientKnex,
   );

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
@@ -99,6 +99,7 @@ export const useAdminsFromConfig = async (
     await enf.addGroupingPolicies(
       addedRoleMembers,
       getAdminRoleMetadata(),
+      undefined,
       trx,
     );
 

--- a/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
@@ -85,7 +85,7 @@ export class DataBaseRoleMetadataStorage implements RoleMetadataStorage {
 
   async findRoleMetadata(
     roleEntityRef: string,
-    trx: Knex.Transaction,
+    trx?: Knex.Transaction,
   ): Promise<RoleMetadataDao | undefined> {
     const db = trx || this.knex;
     return await db

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
@@ -42,6 +42,7 @@ import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { MODEL } from '../service/permission-model';
 import { CSVFileWatcher } from './csv-file-watcher';
 import { mockAuditorService } from '../../__fixtures__/mock-utils';
+import { conditionalStorageMock } from '../../__fixtures__/mock-utils';
 
 const legacyPermission = [
   'role:default/legacy',
@@ -182,6 +183,7 @@ describe('CSVFileWatcher', () => {
     enforcerDelegate = new EnforcerDelegate(
       enf,
       mockAuditorService,
+      conditionalStorageMock,
       roleMetadataStorageMock,
       knex,
     );

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.hierarchy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.hierarchy.test.ts
@@ -1120,6 +1120,7 @@ async function newEnforcerDelegate(
   return new EnforcerDelegate(
     enf,
     mockAuditorService,
+    conditionalStorageMock,
     roleMetadataStorageMock,
     mockClientKnex,
   );

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1865,6 +1865,7 @@ describe('Policy checks for conditional policies', () => {
     const enfDelegate = new EnforcerDelegate(
       enf,
       mockAuditorService,
+      conditionalStorageMock,
       roleMetadataStorageMock,
       mockClientKnex,
     );
@@ -2294,6 +2295,7 @@ async function newEnforcerDelegate(
   return new EnforcerDelegate(
     enf,
     mockAuditorService,
+    conditionalStorageMock,
     roleMetadataStorageMock,
     mockClientKnex,
   );

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -46,6 +46,7 @@ import {
   expectAuditorLog,
 } from '../../__fixtures__/auditor-test-utils';
 import { ActionType, PermissionEvents } from '../auditor/auditor';
+import { conditionalStorageMock } from '../../__fixtures__/mock-utils';
 
 const mockLoggerService = mockServices.logger.mock();
 
@@ -188,6 +189,7 @@ describe('Connection', () => {
     enforcerDelegate = new EnforcerDelegate(
       enf,
       mockAuditorService,
+      conditionalStorageMock,
       roleMetadataStorageMock,
       knex,
     );
@@ -537,6 +539,7 @@ describe('connectRBACProviders', () => {
     const enforcerDelegate = new EnforcerDelegate(
       enf,
       mockAuditorService,
+      conditionalStorageMock,
       roleMetadataStorageMock,
       knex,
     );

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -27,7 +27,10 @@ import {
 import { BackstageRoleManager } from '../role-manager/role-manager';
 import { EnforcerDelegate } from './enforcer-delegate';
 import { MODEL } from './permission-model';
-import { mockAuditorService } from '../../__fixtures__/mock-utils';
+import {
+  conditionalStorageMock,
+  mockAuditorService,
+} from '../../__fixtures__/mock-utils';
 
 // TODO: Move to 'catalogServiceMock' from '@backstage/plugin-catalog-node/testUtils'
 // once '@backstage/plugin-catalog-node' is upgraded
@@ -189,6 +192,7 @@ describe('EnforcerDelegate', () => {
     return new EnforcerDelegate(
       enf,
       mockAuditorService,
+      conditionalStorageMock,
       roleMetadataStorageMock,
       knex,
     );

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -876,16 +876,24 @@ describe('EnforcerDelegate', () => {
       const oldRoleName = 'role:default/dev-team';
       roleMetadataStorageMock.findRoleMetadata = jest
         .fn()
-        .mockImplementation(async (): Promise<RoleMetadataDao> => {
-          return {
-            source: 'rest',
-            roleEntityRef: oldRoleName,
-            author: modifiedBy,
-            modifiedBy,
-            description: 'Role for dev engineers',
-            createdAt: '2024-03-01 00:23:41+00',
-          };
-        });
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+            _trx: Knex.Knex.Transaction,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === oldRoleName) {
+              return {
+                source: 'rest',
+                roleEntityRef: oldRoleName,
+                author: modifiedBy,
+                modifiedBy,
+                description: 'Role for dev engineers',
+                createdAt: '2024-03-01 00:23:41+00',
+              };
+            }
+            return undefined;
+          },
+        );
 
       const enfDelegate = await createEnfDelegate(
         [],

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -925,22 +925,21 @@ describe('EnforcerDelegate', () => {
         );
 
       const secondGroupingPolicyWithOldRole = ['user:default/tim', oldRoleName];
-      const firstRolePolicy = [oldRoleName, 'catalog-entity', 'read', 'allow'];
-      const secondRolePolicy = [
+      const policyWithOldRole = [
         oldRoleName,
         'catalog-entity',
-        'write',
+        'delete',
         'allow',
       ];
       const expectedPolicies = [
-        policy,
-        [newRoleName, 'catalog-entity', 'read', 'allow'],
-        [newRoleName, 'catalog-entity', 'write', 'allow'],
+        secondPolicy,
+        [newRoleName, 'policy-entity', 'read', 'allow'],
+        [newRoleName, 'catalog-entity', 'delete', 'allow'],
       ];
 
       const enfDelegate = await createEnfDelegate(
-        [policy, firstRolePolicy, secondRolePolicy],
-        [groupingPolicy, secondGroupingPolicyWithOldRole],
+        [policy, secondPolicy, policyWithOldRole],
+        [groupingPolicy, secondGroupingPolicy, secondGroupingPolicyWithOldRole],
       );
 
       const groupingPolicyWithRenamedRole = ['user:default/tom', newRoleName];
@@ -961,9 +960,10 @@ describe('EnforcerDelegate', () => {
       );
 
       const storedPolicies = await enfDelegate.getGroupingPolicy();
-      expect(storedPolicies.length).toEqual(2);
-      expect(storedPolicies[0]).toEqual(groupingPolicyWithRenamedRole);
-      expect(storedPolicies[1]).toEqual(secondGroupingPolicyWithRenamedRole);
+      expect(storedPolicies.length).toEqual(3);
+      expect(storedPolicies[0]).toEqual(secondGroupingPolicy); // different role remained unchanged
+      expect(storedPolicies[1]).toEqual(groupingPolicyWithRenamedRole);
+      expect(storedPolicies[2]).toEqual(secondGroupingPolicyWithRenamedRole);
 
       expect(enfRemoveGroupingPoliciesSpy).toHaveBeenCalledWith([
         groupingPolicy,

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -27,6 +27,7 @@ import { mergeRoleMetadata, policiesToString, policyToString } from '../helper';
 import { MODEL } from './permission-model';
 import { PoliciesData } from '../auditor/auditor';
 import { AuditorService } from '@backstage/backend-plugin-api';
+import { ConditionalStorage } from '../database/conditional-storage';
 
 export type RoleEvents = 'roleAdded';
 export interface RoleEventEmitter<T extends RoleEvents> {
@@ -46,6 +47,7 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   constructor(
     private readonly enforcer: Enforcer,
     private readonly auditor: AuditorService,
+    private readonly conditionalStorage: ConditionalStorage,
     private readonly roleMetadataStorage: RoleMetadataStorage,
     private readonly knex: Knex,
   ) {}

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -324,6 +324,7 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
     policies: string[][],
     roleMetadata: RoleMetadataDao,
     externalTrx?: Knex.Transaction,
+    oldRoleEntityRef?: string,
   ): Promise<void> {
     if (this.loadPolicyPromise) {
       await this.loadPolicyPromise;
@@ -341,13 +342,13 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
       try {
         const currentRoleMetadata =
           await this.roleMetadataStorage.findRoleMetadata(
-            roleMetadata.roleEntityRef,
+            oldRoleEntityRef ?? roleMetadata.roleEntityRef,
             trx,
           );
         if (currentRoleMetadata) {
           await this.roleMetadataStorage.updateRoleMetadata(
             mergeRoleMetadata(currentRoleMetadata, roleMetadata),
-            roleMetadata.roleEntityRef,
+            oldRoleEntityRef ?? roleMetadata.roleEntityRef,
             trx,
           );
         } else {
@@ -398,7 +399,26 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
       }
 
       await this.removeGroupingPolicies(oldRole, currentMetadata, true, trx);
-      await this.addGroupingPolicies(newRole, newRoleMetadata, trx);
+      await this.addGroupingPolicies(
+        newRole,
+        newRoleMetadata,
+        trx,
+        currentMetadata.roleEntityRef,
+      );
+
+      // Role name changed -> update roleEntityRef in policies
+      if (newRoleMetadata.roleEntityRef !== currentMetadata.roleEntityRef) {
+        const oldPolicies = await this.enforcer.getFilteredPolicy(
+          0,
+          currentMetadata.roleEntityRef,
+        );
+        const updatedPolicies = oldPolicies.map(oldPolicy => [
+          newRoleMetadata.roleEntityRef,
+          ...oldPolicy.slice(1),
+        ]);
+        await this.updatePolicies(oldPolicies, updatedPolicies, trx);
+      }
+
       await trx.commit();
     } catch (err) {
       await trx.rollback(err);
@@ -409,15 +429,20 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   async updatePolicies(
     oldPolicies: string[][],
     newPolicies: string[][],
+    externalTrx?: Knex.Transaction,
   ): Promise<void> {
-    const trx = await this.knex.transaction();
+    const trx = externalTrx ?? (await this.knex.transaction());
 
     try {
       await this.removePolicies(oldPolicies, trx);
       await this.addPolicies(newPolicies, trx);
-      await trx.commit();
+      if (!externalTrx) {
+        await trx.commit();
+      }
     } catch (err) {
-      await trx.rollback(err);
+      if (!externalTrx) {
+        await trx.rollback(err);
+      }
       throw err;
     }
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -323,8 +323,8 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   async addGroupingPolicies(
     policies: string[][],
     roleMetadata: RoleMetadataDao,
-    externalTrx?: Knex.Transaction,
     oldRoleEntityRef?: string,
+    externalTrx?: Knex.Transaction,
   ): Promise<void> {
     if (this.loadPolicyPromise) {
       await this.loadPolicyPromise;
@@ -402,8 +402,8 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
       await this.addGroupingPolicies(
         newRole,
         newRoleMetadata,
-        trx,
         currentMetadata.roleEntityRef,
+        trx,
       );
 
       // Role name changed -> update roleEntityRef in policies

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -419,6 +419,25 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
           ...oldPolicy.slice(1),
         ]);
         await this.updatePolicies(oldPolicies, updatedPolicies, trx);
+
+        const oldConditions = await this.conditionalStorage.filterConditions(
+          currentMetadata.roleEntityRef,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          trx,
+        );
+        for (const condition of oldConditions) {
+          await this.conditionalStorage.updateCondition(
+            condition.id,
+            {
+              ...condition,
+              roleEntityRef: newRoleMetadata.roleEntityRef,
+            },
+            trx,
+          );
+        }
       }
 
       await trx.commit();

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
@@ -129,6 +129,7 @@ export class PolicyBuilder {
     const enforcerDelegate = new EnforcerDelegate(
       enf,
       env.auditor,
+      conditionStorage,
       roleMetadataStorage,
       databaseClient,
     );

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
@@ -85,7 +85,6 @@ export const RoleForm = ({
   const rbacApi = useApi(rbacApiRef);
 
   const updateRole = async (
-    name: string,
     values: RoleFormValues,
     formikHelpers: FormikHelpers<RoleFormValues>,
   ) => {
@@ -122,7 +121,7 @@ export const RoleForm = ({
           isSamePermissionPolicy,
         );
 
-        await removePermissions(name, deletePermissions, rbacApi);
+        await removePermissions(newName, deletePermissions, rbacApi);
         await createPermissions(newPermissions, rbacApi);
 
         await removeConditions(deleteConditions, rbacApi);
@@ -180,7 +179,7 @@ export const RoleForm = ({
       formikHelpers: FormikHelpers<RoleFormValues>,
     ) => {
       if (roleName) {
-        updateRole(roleName, values, formikHelpers);
+        updateRole(values, formikHelpers);
       } else {
         newRole(values, formikHelpers);
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When role name is updated using RBAC API: `PUT </api/permission/roles/:kind/:namespace/:name>`
it is correctly updated for group policies, but it is not updated for any existing permissions which stay mapped to the old role name. Metadata are also not updated correctly.

### How to test
Please change `user:default/dzemanov` to your user in the following queries.

1. Create role `viewer`:

`curl -X POST "http://localhost:7007/api/permission/roles" -d '{ "memberReferences":  [ "user:default/dzemanov" ], "name": "role:default/viewer" }' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -v`

2. Add permissions to viewer

`curl -X POST "http://localhost:7007/api/permission/policies" -d '[{"entityReference": "role:default/viewer", "permission": "catalog-entity", "policy": "read", "effect":"allow"}]' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

`curl -X POST "http://localhost:7007/api/permission/policies" -d '[{"entityReference": "role:default/viewer", "permission": "catalog.entity.create", "policy": "create", "effect":"allow"}]' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

3. Add conditions to viewer
`curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/viewer","pluginId":"catalog","resourceType":"catalog-entity", "permissionMapping": ["delete"], "conditions":{"rule":"IS_ENTITY_KIND","resourceType":"catalog-entity","params":{"kinds":["Template"]}}}' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

3. Rename role

`curl -X PUT "http://localhost:7007/api/permission/roles/role/default/viewer" -d '{ "oldRole": { "memberReferences":  [ "user:default/dzemanov" ], "name": "role:default/viewer" }, "newRole": { "memberReferences": [ "user:default/dzemanov" ], "name": "role:default/viewer2" } }' -H "Content-Type: application/json" -H "Authorization: Bearer $token"`

5. Confirm, that `roleEntityRef` is correctly updated not only for group policies, but also for permissions, metadata and conditions.

#### Fixes
[RHIDP-5153](https://issues.redhat.com/browse/RHIDP-5153)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
