### PR TITLE
fix(feedback): fixed newline characters in summary

### DIFF
--- a/workspaces/feedback/.changeset/fuzzy-terms-wait.md
+++ b/workspaces/feedback/.changeset/fuzzy-terms-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-feedback': patch
+---
+
+fixed newline characters causing error in summary field

--- a/workspaces/feedback/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
+++ b/workspaces/feedback/plugins/feedback/src/components/FeedbackDetailsModal/FeedbackDetailsModal.tsx
@@ -252,7 +252,7 @@ export const FeedbackDetailsModal = () => {
                 </Typography>
               </Grid>
               <Grid item xs={12}>
-                <Typography variant="body1">
+                <Typography variant="body1" style={{ whiteSpace: 'pre-line' }}>
                   {modalData.description
                     ? getDescription(modalData.description)
                     : 'No description provided'}

--- a/workspaces/feedback/plugins/feedback/src/components/OpcFeedbackComponent/OpcFeedbackComponent.tsx
+++ b/workspaces/feedback/plugins/feedback/src/components/OpcFeedbackComponent/OpcFeedbackComponent.tsx
@@ -62,9 +62,10 @@ export const OpcFeedbackComponent = () => {
       analytics.captureEvent('click', `submit - ${event.detail.data.summary}`);
       const userEntity = (await identityApi.getBackstageIdentity())
         .userEntityRef;
+      const lines = event.detail.data.summary.split('\n') as string[];
       const resp = await feedbackApi.createFeedback({
-        summary: event.detail.data.summary,
-        description: '',
+        summary: lines[0],
+        description: lines.slice(1).join('\n'),
         projectId: projectId,
         url: window.location.href,
         userAgent: window.navigator.userAgent,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Create feedbacks with newline characters in summary.
- fixed rendering newline for description

### Screenshots:

![image](https://github.com/user-attachments/assets/0b1c4335-c935-41c5-9fc7-0dc455668abc)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
