### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/long-glasses-cry.md
+++ b/workspaces/redhat-argocd/.changeset/long-glasses-cry.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-common': minor
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-bump backstage to 1.34.2 and remove @spotify/prettier-config

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.1.0
+
+### Minor Changes
+
+- 5b0553e: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
 ## 1.0.7
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.12.0
+
+### Minor Changes
+
+- 5b0553e: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
+### Patch Changes
+
+- Updated dependencies [5b0553e]
+  - @backstage-community/plugin-redhat-argocd-common@1.1.0
+
 ## 1.11.3
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.12.0

### Minor Changes

-   5b0553e: bump backstage to 1.34.2 and remove @spotify/prettier-config

### Patch Changes

-   Updated dependencies [5b0553e]
    -   @backstage-community/plugin-redhat-argocd-common@1.1.0

## @backstage-community/plugin-redhat-argocd-common@1.1.0

### Minor Changes

-   5b0553e: bump backstage to 1.34.2 and remove @spotify/prettier-config
