### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/calm-geckos-drop.md
+++ b/workspaces/topology/.changeset/calm-geckos-drop.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-topology-common': minor
-'@backstage-community/plugin-topology': minor
----
-
-bump backstage to 1.34.2 and remove @spotify/prettier-config

--- a/workspaces/topology/plugins/topology-common/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-topology-common [1.3.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-topology-common@1.2.2...@janus-idp/backstage-plugin-topology-common@1.3.0) (2024-07-26)
 
+## 1.5.0
+
+### Minor Changes
+
+- df7804a: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
 ## 1.4.4
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology-common/package.json
+++ b/workspaces/topology/plugins/topology-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.30.0
+
+### Minor Changes
+
+- df7804a: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
+### Patch Changes
+
+- Updated dependencies [df7804a]
+  - @backstage-community/plugin-topology-common@1.5.0
+
 ## 1.29.10
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.29.10",
+  "version": "1.30.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.30.0

### Minor Changes

-   df7804a: bump backstage to 1.34.2 and remove @spotify/prettier-config

### Patch Changes

-   Updated dependencies [df7804a]
    -   @backstage-community/plugin-topology-common@1.5.0

## @backstage-community/plugin-topology-common@1.5.0

### Minor Changes

-   df7804a: bump backstage to 1.34.2 and remove @spotify/prettier-config
