### PR TITLE
Version Packages (matomo)

### DIFF
--- a/workspaces/matomo/.changeset/strange-terms-begin.md
+++ b/workspaces/matomo/.changeset/strange-terms-begin.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-matomo-backend': minor
-'@backstage-community/plugin-matomo': minor
----
-
-bump backstage to 1.34.2 and remove @spotify/prettier-config

--- a/workspaces/matomo/plugins/matomo-backend/CHANGELOG.md
+++ b/workspaces/matomo/plugins/matomo-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.13.0
+
+### Minor Changes
+
+- 8888b6f: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/matomo/plugins/matomo-backend/package.json
+++ b/workspaces/matomo/plugins/matomo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-matomo-backend",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/matomo/plugins/matomo/CHANGELOG.md
+++ b/workspaces/matomo/plugins/matomo/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.12.0
+
+### Minor Changes
+
+- 8888b6f: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
 ## 1.11.0
 
 ### Minor Changes

--- a/workspaces/matomo/plugins/matomo/package.json
+++ b/workspaces/matomo/plugins/matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-matomo",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-matomo@1.12.0

### Minor Changes

-   8888b6f: bump backstage to 1.34.2 and remove @spotify/prettier-config

## @backstage-community/plugin-matomo-backend@1.13.0

### Minor Changes

-   8888b6f: bump backstage to 1.34.2 and remove @spotify/prettier-config
