### PR TITLE
tech-insights: load check links from app config in json-fc module

### DIFF
--- a/workspaces/tech-insights/.changeset/ten-bees-do.md
+++ b/workspaces/tech-insights/.changeset/ten-bees-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+Fixes an issue where optional links were not included when loading checks from app config

--- a/workspaces/tech-insights/README.md
+++ b/workspaces/tech-insights/README.md
@@ -1,8 +1,18 @@
-# [Backstage](https://backstage.io)
+# tech-insights
 
-This is your newly scaffolded Backstage App, Good Luck!
+The tech insights plugin provides a way to define facts (data points) and checks (rules) that can be used to evaluate the state of an entity in the catalog.
 
-To start the app, run:
+## Plugins
+
+- [tech-insights](./plugins/tech-insights/README.md) - The frontend plugin for tech insights
+- [tech-insights-backend](./plugins/tech-insights-backend/README.md) - The backend plugin for tech insights.
+- [tech-insights-backend-module-jsonfc](./plugins/tech-insights-backend-module-jsonfc/README.md) - A module that provides a `JsonRulesEngineFactChecker` fact checker for calculating boolean facts from JSON rules.
+- [tech-insights-common](./plugins/tech-insights-common/README.md) - A common library containing shared utilities to be used across tech-insights plugins
+- [tech-insights-node](./plugins/tech-insights-node/README.md) - A node library providing shared backend functionality for tech-insights plugins
+
+## Local Development
+
+To start the Backstage App, run:
 
 ```sh
 yarn install

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
@@ -369,7 +369,7 @@ export class JsonRulesEngineFactCheckerFactory {
     config: Config,
     options: Omit<JsonRulesEngineFactCheckerFactoryOptions, 'checks'>,
   ): JsonRulesEngineFactCheckerFactory {
-    const checks = readChecksFromConfig(config);
+    const checks = readChecksFromConfig(config, { logger: options.logger });
 
     return new JsonRulesEngineFactCheckerFactory({
       ...options,

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/config.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/config.test.ts
@@ -17,12 +17,15 @@
 import { ConfigReader } from '@backstage/config';
 import { JSON_RULE_ENGINE_CHECK_TYPE } from '../constants';
 import { readChecksFromConfig } from './config';
+import { mockServices } from '@backstage/backend-test-utils';
 
 describe('config', () => {
   describe('readChecksFromConfig', () => {
     it('no config return empty checks array', () => {
       const config = new ConfigReader({});
-      const checks = readChecksFromConfig(config);
+      const checks = readChecksFromConfig(config, {
+        logger: mockServices.logger.mock(),
+      });
 
       expect(checks).toHaveLength(0);
     });
@@ -33,7 +36,9 @@ describe('config', () => {
           factChecker: {},
         },
       });
-      const checks = readChecksFromConfig(config);
+      const checks = readChecksFromConfig(config, {
+        logger: mockServices.logger.mock(),
+      });
 
       expect(checks).toHaveLength(0);
     });
@@ -64,6 +69,12 @@ describe('config', () => {
                     ],
                   },
                 },
+                links: [
+                  {
+                    title: 'Foo Link',
+                    url: 'https://example.com/foo',
+                  },
+                ],
               },
               barCheck: {
                 type: JSON_RULE_ENGINE_CHECK_TYPE,
@@ -86,6 +97,11 @@ describe('config', () => {
                     ],
                   },
                 },
+                links: [
+                  {
+                    wrong: 'wrong',
+                  },
+                ],
               },
               bazCheck: {
                 type: JSON_RULE_ENGINE_CHECK_TYPE,
@@ -107,7 +123,9 @@ describe('config', () => {
         },
       });
 
-      const checks = readChecksFromConfig(config);
+      const checks = readChecksFromConfig(config, {
+        logger: mockServices.logger.mock(),
+      });
 
       expect(checks).toHaveLength(3);
       expect(checks.map(check => check.id)).toEqual([
@@ -132,6 +150,12 @@ describe('config', () => {
           },
         ],
       });
+      expect(fooCheck.links).toEqual([
+        {
+          title: 'Foo Link',
+          url: 'https://example.com/foo',
+        },
+      ]);
 
       const barCheck = checks.find(check => check.id === 'barCheck')!;
       expect(barCheck.name).toEqual('Bar Check');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I tried defining `links: CheckLink[]` on checks in our `app-config.yaml`, and received undefined when trying to display them. 

After reviewing the code, I noticed the links are not being loaded from the config. I've updated the logic that handles that, along with tests to validate.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
