### PR TITLE
Version Packages (jaeger)

### DIFF
--- a/workspaces/jaeger/.changeset/ten-cooks-study.md
+++ b/workspaces/jaeger/.changeset/ten-cooks-study.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jaeger-common': minor
-'@backstage-community/plugin-jaeger': minor
----
-
-bump backstage to 1.34.2 and remove @spotify/prettier-config

--- a/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jaeger-common
 
+## 0.2.0
+
+### Minor Changes
+
+- 69897a1: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/jaeger/plugins/jaeger-common/package.json
+++ b/workspaces/jaeger/plugins/jaeger-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-jaeger-common",
   "description": "Common functionalities for the jaeger plugin",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-jaeger
 
+## 0.2.0
+
+### Minor Changes
+
+- 69897a1: bump backstage to 1.34.2 and remove @spotify/prettier-config
+
+### Patch Changes
+
+- Updated dependencies [69897a1]
+  - @backstage-community/plugin-jaeger-common@0.2.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/jaeger/plugins/jaeger/package.json
+++ b/workspaces/jaeger/plugins/jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jaeger",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jaeger@0.2.0

### Minor Changes

-   69897a1: bump backstage to 1.34.2 and remove @spotify/prettier-config

### Patch Changes

-   Updated dependencies [69897a1]
    -   @backstage-community/plugin-jaeger-common@0.2.0

## @backstage-community/plugin-jaeger-common@0.2.0

### Minor Changes

-   69897a1: bump backstage to 1.34.2 and remove @spotify/prettier-config
