### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/beige-ties-drive.md
+++ b/workspaces/sonarqube/.changeset/beige-ties-drive.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': patch
----
-
-Added missing `instanceKey` to the documentation examples

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [a8acb68]
+  - @backstage-community/plugin-sonarqube-backend@0.4.1
+
 ## 0.0.5
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.4.1
+
+### Patch Changes
+
+- a8acb68: Added missing `instanceKey` to the documentation examples
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.4.1

### Patch Changes

-   a8acb68: Added missing `instanceKey` to the documentation examples

## backend@0.0.6

### Patch Changes

-   Updated dependencies [a8acb68]
    -   @backstage-community/plugin-sonarqube-backend@0.4.1
