### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/rotten-rings-bathe.md
+++ b/workspaces/github-actions/.changeset/rotten-rings-bathe.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Backstage version bump to v1.35.0

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.7.1
+
+### Patch Changes
+
+- b11a62d: Backstage version bump to v1.35.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.7.1

### Patch Changes

-   b11a62d: Backstage version bump to v1.35.0
