### PR TITLE
copilot: Enable copilot to use github app auth

### DIFF
--- a/workspaces/copilot/.changeset/rich-dogs-wash.md
+++ b/workspaces/copilot/.changeset/rich-dogs-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+---
+
+Added ability to use GitHub App authentication for organization level metrics

--- a/workspaces/copilot/plugins/copilot-backend/README.md
+++ b/workspaces/copilot/plugins/copilot-backend/README.md
@@ -63,9 +63,9 @@ To install the plugin using the old method:
 
 ## Configuration
 
-### Environment Variables
+### App Config
 
-To configure the GitHub Copilot plugin, you need to set the following environment variables:
+To configure the GitHub Copilot plugin, you need to set the following values in the app-config:
 
 - **`copilot.host`**: The host URL for your GitHub Copilot instance (e.g., `github.com` or `github.enterprise.com`).
 - **`copilot.enterprise`**: The name of your GitHub Enterprise instance (e.g., `my-enterprise`).
@@ -75,9 +75,14 @@ These variables are used to configure the plugin and ensure it communicates with
 
 ### GitHub Credentials
 
-**Important:** The GitHub token, necessary for authentication, should be managed within your Backstage integrations configuration. Ensure that your GitHub integration in the Backstage configuration includes the necessary token for the `GithubCredentialsProvider` to function correctly.
+GitHub support different auth methods depending on which API you are using.
 
-### GitHub Token Scopes
+- Enterprise API - [only supports "classic" PAT tokens](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage?apiVersion=2022-11-28#get-a-summary-of-copilot-usage-for-enterprise-members)
+- Org Api - [Supports app tokens, "classic", and fine grained PAT tokens](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage?apiVersion=2022-11-28#get-a-summary-of-copilot-usage-for-organization-members)
+
+This plugin supports both schemes and detects the best scheme based on which API(s) you have configured for use.
+
+### GitHub Token/App Scopes
 
 To ensure the GitHub Copilot plugin operates correctly within your organization or enterprise, your GitHub access token must include specific scopes. These scopes grant the plugin the necessary permissions to interact with your GitHub organization and manage Copilot usage.
 
@@ -95,10 +100,18 @@ To ensure the GitHub Copilot plugin operates correctly within your organization 
 
 #### How to Configure Token Scopes
 
-1. **Generate a Personal Access Token (PAT):**
-   - Navigate to [GitHub Personal Access Tokens](https://github.com/settings/tokens).
-   - Click on **Generate new token**.
-   - Select the scopes according to your needs
+**Generate a Personal Access Token (PAT) (Entperise only supports "classic" PAT tokens)**
+
+- Navigate to [GitHub Personal Access Tokens](https://github.com/settings/tokens).
+- Click on **Generate new token**.
+- Select the scopes according to your needs
+
+**Using a GitHub App**
+
+- Create or reuse an existing GitHub App that you own.
+- Navigate to the app permissions
+- Select the permissions to read the org and manage billing for copilot and save
+- Install and update permissions in your oeg.
 
 ### YAML Configuration Example
 
@@ -115,10 +128,24 @@ copilot:
   enterprise: YOUR_ENTERPRISE_NAME_HERE
   organization: YOUR_ORGANIZATION_NAME_HERE
 
+# Using a PAT
 integrations:
   github:
     - host: YOUR_GITHUB_HOST_HERE
       token: YOUR_GENERATED_TOKEN
+
+# Using a GitHub App
+integrations:
+  github:
+    - host: github.com
+      apps:
+        - appId: YOUR_APP_ID
+          allowedInstallationOwners:
+            - YOUR_ORG_NAME
+          clientId: CLIENT_ID
+          clientSecret: CLIENT_SECRET
+          webhookSecret: WEBHOOK_SECRET
+          privateKey: PRIVATE_KEY
 ```
 
 ### API Documentation

--- a/workspaces/copilot/plugins/copilot-backend/README.md
+++ b/workspaces/copilot/plugins/copilot-backend/README.md
@@ -148,6 +148,8 @@ integrations:
           privateKey: PRIVATE_KEY
 ```
 
+[You can find more about the integrations config in the official docs](https://backstage.io/docs/integrations/github/locations/)
+
 ### API Documentation
 
 For more details on using the GitHub Copilot and Teams APIs, refer to the following documentation:

--- a/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.ts
@@ -18,7 +18,12 @@ import { ResponseError } from '@backstage/errors';
 import { Config } from '@backstage/config';
 import { Metric, TeamInfo } from '@backstage-community/plugin-copilot-common';
 import fetch from 'node-fetch';
-import { getGithubInfo, GithubInfo } from '../utils/GithubUtils';
+import {
+  CopilotConfig,
+  CopilotCredentials,
+  getCopilotConfig,
+  getGithubCredentials,
+} from '../utils/GithubUtils';
 
 interface GithubApi {
   fetchEnterpriseCopilotUsage: () => Promise<Metric[]>;
@@ -30,47 +35,59 @@ interface GithubApi {
 }
 
 export class GithubClient implements GithubApi {
-  constructor(private readonly props: GithubInfo) {}
+  constructor(
+    private readonly copilotConfig: CopilotConfig,
+    private readonly config: Config,
+  ) {}
 
   static async fromConfig(config: Config) {
-    const info = await getGithubInfo(config);
-    return new GithubClient(info);
+    const info = getCopilotConfig(config);
+    return new GithubClient(info, config);
+  }
+
+  private async getCredentials(): Promise<CopilotCredentials> {
+    return await getGithubCredentials(this.config, this.copilotConfig);
   }
 
   async fetchEnterpriseCopilotUsage(): Promise<Metric[]> {
-    const path = `/enterprises/${this.props.enterprise}/copilot/usage`;
+    const path = `/enterprises/${this.copilotConfig.enterprise}/copilot/usage`;
     return this.get(path);
   }
 
   async fetchEnterpriseTeamCopilotUsage(teamId: string): Promise<Metric[]> {
-    const path = `/enterprises/${this.props.enterprise}/team/${teamId}/copilot/usage`;
+    const path = `/enterprises/${this.copilotConfig.enterprise}/team/${teamId}/copilot/usage`;
     return this.get(path);
   }
 
   async fetchEnterpriseTeams(): Promise<TeamInfo[]> {
-    const path = `/enterprises/${this.props.enterprise}/teams`;
+    const path = `/enterprises/${this.copilotConfig.enterprise}/teams`;
     return this.get(path);
   }
 
   async fetchOrganizationCopilotUsage(): Promise<Metric[]> {
-    const path = `/orgs/${this.props.organization}/copilot/usage`;
+    const path = `/orgs/${this.copilotConfig.organization}/copilot/usage`;
     return this.get(path);
   }
 
   async fetchOrganizationTeamCopilotUsage(teamId: string): Promise<Metric[]> {
-    const path = `/orgs/${this.props.organization}/team/${teamId}/copilot/usage`;
+    const path = `/orgs/${this.copilotConfig.organization}/team/${teamId}/copilot/usage`;
     return this.get(path);
   }
 
   async fetchOrganizationTeams(): Promise<TeamInfo[]> {
-    const path = `/orgs/${this.props.organization}/teams`;
+    const path = `/orgs/${this.copilotConfig.organization}/teams`;
     return this.get(path);
   }
 
   private async get<T>(path: string): Promise<T> {
-    const response = await fetch(`${this.props.apiBaseUrl}${path}`, {
+    const credentials = await this.getCredentials();
+    const headers = path.startsWith('/enterprises')
+      ? credentials.enterprise?.headers
+      : credentials.organization?.headers;
+
+    const response = await fetch(`${this.copilotConfig.apiBaseUrl}${path}`, {
       headers: {
-        ...this.props.credentials.headers,
+        ...headers,
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
       },

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
@@ -86,7 +86,7 @@ describe('getCopilotConfig', () => {
   });
 });
 
-describe('getGithubInfo', () => {
+describe('getGithubCredentials', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getCopilotConfig, getGithubCredentials } from './GithubUtils';
+import { mockServices } from '@backstage/backend-test-utils';
+import { DefaultGithubCredentialsProvider } from '@backstage/integration';
+
+describe('getCopilotConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if host is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        copilot: {},
+      },
+    });
+
+    expect(() => getCopilotConfig(mockConfig)).toThrow(
+      "Missing required config value at 'copilot.host'",
+    );
+  });
+
+  it('should throw an error if GitHub configuration is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        copilot: {
+          host: 'myhost.com',
+        },
+      },
+    });
+
+    expect(() => getCopilotConfig(mockConfig)).toThrow(
+      'GitHub configuration for host "myhost.com" is missing or incomplete.',
+    );
+  });
+
+  it('should throw an error if enterprise is set but token is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com' }],
+        },
+        copilot: {
+          host: 'github.com',
+          enterprise: 'test',
+        },
+      },
+    });
+
+    expect(() => getCopilotConfig(mockConfig)).toThrow(
+      'Enterprise API for copilot only works with "classic PAT" tokens. No token is configured for "github.com" in the config.',
+    );
+  });
+
+  it('should throw an error if organization is set but token or app is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com' }],
+        },
+        copilot: {
+          host: 'github.com',
+          organization: 'test',
+        },
+      },
+    });
+
+    expect(() => getCopilotConfig(mockConfig)).toThrow(
+      'Organization API for copilot works with both classic and fine grained PAT tokens or GitHub apps. No token or app is configured for "github.com" in the config.',
+    );
+  });
+});
+
+describe('getGithubInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if GitHub configuration is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {},
+    });
+
+    await expect(
+      getGithubCredentials(mockConfig, {
+        host: 'myhost.com',
+        apiBaseUrl: '',
+      }),
+    ).rejects.toThrow(
+      'GitHub configuration for host "myhost.com" is missing or incomplete.',
+    );
+  });
+
+  it('should throw an error if enterprise is set but token is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com' }],
+        },
+      },
+    });
+
+    await expect(
+      getGithubCredentials(mockConfig, {
+        host: 'github.com',
+        enterprise: 'test',
+        apiBaseUrl: '',
+      }),
+    ).rejects.toThrow(
+      'Enterprise API for copilot only works with "classic PAT" tokens. No token is configured for "github.com" in the config.',
+    );
+  });
+
+  it('should throw an error if organization is set but token or app is missing', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com' }],
+        },
+      },
+    });
+
+    await expect(
+      getGithubCredentials(mockConfig, {
+        host: 'github.com',
+        organization: 'test',
+        apiBaseUrl: '',
+      }),
+    ).rejects.toThrow(
+      'Organization API for copilot works with both classic and fine grained PAT tokens or GitHub apps. No token or app is configured for "github.com" in the config.',
+    );
+  });
+
+  it('should return organisation credentials with token config', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com', token: 'test-token' }],
+        },
+      },
+    });
+
+    const result = await getGithubCredentials(mockConfig, {
+      host: 'github.com',
+      organization: 'test',
+      apiBaseUrl: '',
+    });
+
+    expect(result).toEqual({
+      enterprise: undefined,
+      organization: {
+        type: 'token',
+        headers: { Authorization: 'Bearer test-token' },
+        token: 'test-token',
+      },
+    });
+  });
+
+  it('should return enterprise credentials with token config', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com', token: 'test-token' }],
+        },
+      },
+    });
+
+    const result = await getGithubCredentials(mockConfig, {
+      host: 'github.com',
+      enterprise: 'test',
+      apiBaseUrl: '',
+    });
+
+    expect(result).toEqual({
+      enterprise: {
+        type: 'token',
+        headers: { Authorization: 'Bearer test-token' },
+        token: 'test-token',
+      },
+      organization: undefined,
+    });
+  });
+
+  it('should return both organization and enterprise credentials with token config', async () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'github.com', token: 'test-token' }],
+        },
+      },
+    });
+
+    const result = await getGithubCredentials(mockConfig, {
+      host: 'github.com',
+      organization: 'my-org',
+      enterprise: 'my-ent',
+      apiBaseUrl: '',
+    });
+
+    expect(result).toEqual({
+      enterprise: {
+        type: 'token',
+        headers: { Authorization: 'Bearer test-token' },
+        token: 'test-token',
+      },
+      organization: {
+        type: 'token',
+        headers: { Authorization: 'Bearer test-token' },
+        token: 'test-token',
+      },
+    });
+  });
+
+  it('should return organization credentials with app config', async () => {
+    jest
+      .spyOn(DefaultGithubCredentialsProvider.prototype, 'getCredentials')
+      .mockResolvedValue({
+        type: 'app',
+        headers: { Authorization: 'Bearer app-token' },
+        token: 'app-token',
+      });
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [
+            {
+              host: 'github.com',
+              apps: [
+                {
+                  appId: 1234,
+                  clientId: 'test',
+                  clientSecret: 'test',
+                  privateKey: `test`,
+                  webhookSecret: 'shhh',
+                  allowedInstallationOwners: ['test'],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await getGithubCredentials(mockConfig, {
+      host: 'github.com',
+      organization: 'test',
+      apiBaseUrl: '',
+    });
+
+    expect(result).toEqual({
+      enterprise: undefined,
+      organization: {
+        type: 'app',
+        headers: { Authorization: 'Bearer app-token' },
+        token: 'app-token',
+      },
+    });
+  });
+
+  it('should return organization credentials with app config and enterprise credentials with token config', async () => {
+    jest
+      .spyOn(DefaultGithubCredentialsProvider.prototype, 'getCredentials')
+      .mockResolvedValue({
+        type: 'app',
+        headers: { Authorization: 'Bearer app-token' },
+        token: 'app-token',
+      });
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [
+            {
+              host: 'github.com',
+              token: 'enterprise-token',
+              apps: [
+                {
+                  appId: 1234,
+                  clientId: 'test',
+                  clientSecret: 'test',
+                  privateKey: `test`,
+                  webhookSecret: 'shhh',
+                  allowedInstallationOwners: ['test'],
+                },
+              ],
+            },
+          ],
+        },
+        copilot: {
+          host: 'github.com',
+          organization: 'test',
+          enterprise: 'my-enterprise',
+        },
+      },
+    });
+
+    const result = await getGithubCredentials(mockConfig, {
+      host: 'github.com',
+      organization: 'test',
+      enterprise: 'my-enterprise',
+      apiBaseUrl: '',
+    });
+
+    expect(result).toEqual({
+      enterprise: {
+        type: 'token',
+        headers: { Authorization: 'Bearer enterprise-token' },
+        token: 'enterprise-token',
+      },
+      organization: {
+        type: 'app',
+        headers: { Authorization: 'Bearer app-token' },
+        token: 'app-token',
+      },
+    });
+  });
+});

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
@@ -26,10 +26,6 @@ export type CopilotCredentials = {
   organization?: GithubCredentials;
 };
 
-export type GithubInfo = {
-  credentials: CopilotCredentials;
-};
-
 export type CopilotConfig = {
   host: string;
   enterprise?: string;


### PR DESCRIPTION
When using the copilot organisation API its possible to use GitHub application authentication over only PAT token authentication.

This PR enables you to mix and match between the different types of auth.

This required a small refactor, as the credentials for the app could be short lived they need to be requested each time from the GithubCredentials provider directly. This under the hood will deal with recycling credentials that are about to expire.

To do this I have split the credentials config from the rest. The basic config will be checked on startup and will ensure that all the right config is in place to make it run. The credentials will then be retrieved on demand when making requests to the GH API.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


closes https://github.com/backstage/community-plugins/issues/2141
