### PR TITLE
Version Packages (feedback)

### DIFF
--- a/workspaces/feedback/.changeset/gentle-glasses-exercise.md
+++ b/workspaces/feedback/.changeset/gentle-glasses-exercise.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-feedback-backend': major
----
-
-**BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/feedback/plugins/feedback-backend/README.md) for instructions on how to use the new backend system.
-
-Removed usages and references of `@backstage/backend-common`

--- a/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @janus-idp/backstage-plugin-feedback-backend [1.7.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-feedback-backend@1.6.0...@janus-idp/backstage-plugin-feedback-backend@1.7.0) (2024-07-26)
 
+## 2.0.0
+
+### Major Changes
+
+- 1140bf4: **BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/feedback/plugins/feedback-backend/README.md) for instructions on how to use the new backend system.
+
+  Removed usages and references of `@backstage/backend-common`
+
 ## 1.7.11
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-backend",
-  "version": "1.7.11",
+  "version": "2.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-feedback-backend@2.0.0

### Major Changes

-   1140bf4: **BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/feedback/plugins/feedback-backend/README.md) for instructions on how to use the new backend system.

    Removed usages and references of `@backstage/backend-common`
