### PR TITLE
chore: add/update multiple catalog-info

### DIFF
--- a/workspaces/3scale/catalog-info.yaml
+++ b/workspaces/3scale/catalog-info.yaml
@@ -5,6 +5,8 @@ metadata:
   name: backstage-community-3scale
   title: 3scale plugin
   description: The 3scale Backstage provider plugin synchronizes the 3scale content into the Backstage catalog.
+  annotations:
+    github.com/project-slug: backstage/community-plugins
 spec:
   type: backstage-plugin
   lifecycle: production

--- a/workspaces/3scale/plugins/3scale-backend/catalog-info.yaml
+++ b/workspaces/3scale/plugins/3scale-backend/catalog-info.yaml
@@ -2,10 +2,11 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-3scale
-  title: 3scale plugin
+  name: backstage-community-3scale-backend
+  title: '@backstage-community/plugin-3scale-backend'
   description: The 3scale Backstage provider plugin synchronizes the 3scale content into the Backstage catalog.
 spec:
-  type: backstage-plugin
+  type: backstage-backend-plugin
   lifecycle: production
   owner: rhdh-team
+  subcomponentOf: backstage-community-3scale

--- a/workspaces/3scale/plugins/3scale-backend/catalog-info.yaml
+++ b/workspaces/3scale/plugins/3scale-backend/catalog-info.yaml
@@ -5,6 +5,8 @@ metadata:
   name: backstage-community-3scale-backend
   title: '@backstage-community/plugin-3scale-backend'
   description: The 3scale Backstage provider plugin synchronizes the 3scale content into the Backstage catalog.
+  annotations:
+    github.com/project-slug: backstage/community-plugins
 spec:
   type: backstage-backend-plugin
   lifecycle: production

--- a/workspaces/acr/catalog-info.yaml
+++ b/workspaces/acr/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: A Backstage plugin that displays information about your container images available in the Azure Container Registry
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - azure
     - container-registry

--- a/workspaces/acr/catalog-info.yaml
+++ b/workspaces/acr/catalog-info.yaml
@@ -1,10 +1,23 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-plugin-acr-workspace
-  title: 'Azure Container Registry plugin for Backstage'
+  name: backstage-community-acr
+  title: Azure Container Registry plugin
   description: A Backstage plugin that displays information about your container images available in the Azure Container Registry
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+    github.com/team-slug: backstage/community-plugins-maintainers
+    sonarqube.org/project-key: backstage-community_plugins
+  tags:
+    - azure
+    - container-registry
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  lifecycle: experimental
   type: backstage-plugin
-  owner: maintainers
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/acr/plugins/acr/catalog-info.yaml
+++ b/workspaces/acr/plugins/acr/catalog-info.yaml
@@ -1,4 +1,3 @@
----
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
@@ -8,8 +7,6 @@ metadata:
   description: A Backstage plugin that displays information about your container images available in the Azure Container Registry
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
       title: GitHub Source

--- a/workspaces/acr/plugins/acr/catalog-info.yaml
+++ b/workspaces/acr/plugins/acr/catalog-info.yaml
@@ -1,28 +1,3 @@
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: backstage-community-acr
-  title: Azure Container Registry plugin
-  description: A Backstage plugin that displays information about your container images available in the Azure Container Registry
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr/catalog-info.yaml
-    github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/acr-plugin-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: owner-unknown
-  system: rhdh
-  subcomponentOf: backstage-community-plugins
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
@@ -32,11 +7,8 @@ metadata:
   title: '@backstage-community/plugin-acr'
   description: A Backstage plugin that displays information about your container images available in the Azure Container Registry
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/acr-plugin-maintainers
+    github.com/team-slug: backstage/community-plugins-maintainers
     sonarqube.org/project-key: backstage-community_plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/acr/plugins/acr
@@ -46,6 +18,5 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: owner-unknown
-  system: rhdh
+  owner: rhdh-team
   subcomponentOf: backstage-community-acr

--- a/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: 'Analytics Module: Matomo'
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
     - analytics
   links:
@@ -30,8 +28,6 @@ metadata:
   description: 'Analytics Module: Matomo'
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage_community-plugins
   tags:
     - analytics
   links:

--- a/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
@@ -2,9 +2,9 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-analytics-segment
-  title: 'Analytics Module: Segment'
-  description: 'Analytics Module: Segment'
+  name: backstage-community-analytics-matomo
+  title: 'Analytics Module: Matomo'
+  description: 'Analytics Module: Matomo'
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage-community/maintainers-plugins
@@ -12,7 +12,7 @@ metadata:
   tags:
     - analytics
   links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics-provider-segment/plugins/analytics-provider-segment
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics/plugins/analytics-module-matomo
       title: GitHub Source
       icon: source
       type: source
@@ -25,9 +25,9 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-plugin-analytics-provider-segment
-  title: '@backstage-community/plugin-analytics-provider-segment'
-  description: 'Analytics Module: Segment'
+  name: backstage-community-plugin-analytics-provider-matomo
+  title: '@backstage-community/plugin-analytics-provider-matomo'
+  description: 'Analytics Module: Matomo'
   annotations:
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage-community/maintainers-plugins
@@ -35,7 +35,7 @@ metadata:
   tags:
     - analytics
   links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics-provider-segment/plugins/analytics-provider-segment
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/analytics/plugins/analytics-module-matomo
       title: GitHub Source
       icon: source
       type: source
@@ -43,4 +43,4 @@ spec:
   type: backstage-frontend-plugin-module
   lifecycle: production
   owner: rhdh-team
-  subcomponentOf: backstage-community-analytics-segment
+  subcomponentOf: backstage-community-analytics-matomo

--- a/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: 'Analytics Module: Matomo'
   description: 'Analytics Module: Matomo'
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - analytics
   links:

--- a/workspaces/analytics/plugins/analytics-provider-segment/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-provider-segment/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: 'Analytics Module: Segment'
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
     - analytics
   links:
@@ -30,8 +28,6 @@ metadata:
   description: 'Analytics Module: Segment'
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage_community-plugins
   tags:
     - analytics
   links:

--- a/workspaces/analytics/plugins/analytics-provider-segment/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-provider-segment/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: 'Analytics Module: Segment'
   description: 'Analytics Module: Segment'
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - analytics
   links:

--- a/workspaces/jfrog-artifactory/catalog-info.yaml
+++ b/workspaces/jfrog-artifactory/catalog-info.yaml
@@ -7,7 +7,6 @@ metadata:
   description: Jfrog Artifactory plugin for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage/community-plugins-maintainers
   links:
     - url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory
       title: GitHub Source

--- a/workspaces/jfrog-artifactory/catalog-info.yaml
+++ b/workspaces/jfrog-artifactory/catalog-info.yaml
@@ -1,13 +1,19 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: jfrog-artifactory
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-jfrog-artifactory
+  title: Jfrog Artifactory plugin
+  description: Jfrog Artifactory plugin for Backstage
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+    github.com/team-slug: backstage/community-plugins-maintainers
+  links:
+    - url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
@@ -2,13 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-jfrog-artifactory
-  title: Jfrog Artifactory plugin
+  name: backstage-community-jfrog-artifactory-frontend
+  title: '@backstage-community/plugin-jfrog-artifactory'
   description: Jfrog Artifactory plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/jfrog-artifactory
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage/community-plugins-maintainers
   links:
@@ -17,33 +14,7 @@ metadata:
       icon: source
       type: source
 spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: owner-unknown
-  system: rhdh
-  subcomponentOf: backstage-community-jfrog-artifactory
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: backstage-community-jfrog-artifactory-frontend
-  title: '@backstage-community/plugin-jfrog-artifactory'
-  description: Jfrog Artifactory plugin for Backstage
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/jfrog-artifactory
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
-    github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: ckstage/community-plugins-maintainers
-  links:
-    - url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: owner-unknown
-  system: rhdh
+  owner: rhdh-team
   subcomponentOf: backstage-community-jfrog-artifactory

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
@@ -7,7 +7,6 @@ metadata:
   description: Jfrog Artifactory plugin for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage/community-plugins-maintainers
   links:
     - url: https://github.com/backstage/community-plugins/edit/main/workspaces/jfrog-artifactory
       title: GitHub Source

--- a/workspaces/keycloak/catalog-info.yaml
+++ b/workspaces/keycloak/catalog-info.yaml
@@ -1,13 +1,18 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: keycloak
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-keycloak
+  title: Keycloak plugin
+  description: Keycloak backend plugin for Backstage
+  annotations:
+    github.com/project-slug: backstage-community/backstage-plugins
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/keycloak/catalog-info.yaml
+++ b/workspaces/keycloak/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: Keycloak plugin
   description: Keycloak backend plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
       title: GitHub Source

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
@@ -2,42 +2,11 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-keycloak
-  title: Keycloak plugin
-  description: Keycloak backend plugin for Backstage
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
-    github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: backstage-core-team
-  system: backstage
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
   name: backstage-community-catalog-backend-module-keycloak
   title: '@backstage-community/backstage-plugin-catalog-backend-module-keycloak'
   description: Keycloak backend plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
       title: GitHub Source
@@ -46,6 +15,5 @@ metadata:
 spec:
   type: backstage-backend-plugin
   lifecycle: production
-  owner: backstage-core-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-keycloak

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-catalog-backend-module-keycloak'
   description: Keycloak backend plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak
       title: GitHub Source

--- a/workspaces/nexus-repository-manager/catalog-info.yaml
+++ b/workspaces/nexus-repository-manager/catalog-info.yaml
@@ -1,13 +1,18 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: nexus-repository-manager
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-nexus-repository-manager
+  title: Nexus Repository Manager
+  description: Nexus Repository Manager plugin for Backstage
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
@@ -2,41 +2,11 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-nexus-repository-manager
-  title: Nexus Repository Manager
-  description: Nexus Repository Manager plugin for Backstage
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
-    github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/community-plugins-maintainers
-    sonarqube.org/project-key: backstage/community-plugins
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: rhdh-team
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: backstage-community-nexus-repository-manager
+  name: backstage-community-nexus-repository-manager-frontend
   title: '@backstage-community/plugin-nexus-repository-manager'
   description: Nexus Repository Manager plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager
-    backstage.io/view-url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/community-plugins-maintainers
-    sonarqube.org/project-key: backstage/community-plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/nexus-repository-manager/plugins/nexus-repository-manager
       title: GitHub Source

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/catalog-info.yaml
@@ -20,8 +20,7 @@ metadata:
 spec:
   type: backstage-plugin
   lifecycle: production
-  owner: owner-unknown
-  system: rhdh
+  owner: rhdh-team
   subcomponentOf: backstage-community-plugins
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
@@ -47,5 +46,4 @@ spec:
   type: backstage-frontend-plugin
   lifecycle: production
   owner: rhdh-team
-  system: rhdh
   subcomponentOf: backstage-community-nexus-repository-manager

--- a/workspaces/ocm/catalog-info.yaml
+++ b/workspaces/ocm/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: OCM plugin
   description: Open Cluster Management plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/catalog-info.yaml
+++ b/workspaces/ocm/catalog-info.yaml
@@ -1,13 +1,23 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: ocm
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-ocm
+  title: OCM plugin
+  description: Open Cluster Management plugin for Backstage
+  annotations:
+    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/team-slug: backstage/maintainers-plugins
+    sonarqube.org/project-key: backstage-community_plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/ocm/catalog-info.yaml
+++ b/workspaces/ocm/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Open Cluster Management plugin for Backstage
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
@@ -23,8 +23,7 @@ metadata:
 spec:
   type: backstage-backend-plugin
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-ocm
   providesApis:
     - backstage-community-ocm-backend-api
@@ -41,7 +40,7 @@ metadata:
     backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
     backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    #github.com/team-slug: backstage-community/maintainers
+    github.com/team-slug: backstage/community-plugins-maintainers
     sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
@@ -54,8 +53,7 @@ metadata:
 spec:
   type: openapi
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-ocm
   definition:
     $text: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/src/schema/openapi.yaml

--- a/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
@@ -6,12 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-backend'
   description: Open Cluster Management backend plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm-backend
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift
@@ -36,12 +31,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-backend'
   description: Open Cluster Management backend plugin OpenAPI specs for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm-backend
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-backend'
   description: Open Cluster Management backend plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - kubernetes
     - openshift
@@ -31,7 +31,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-backend'
   description: Open Cluster Management backend plugin OpenAPI specs for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-common'
   description: Open Cluster Management common package for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
@@ -23,6 +23,5 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-ocm

--- a/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
@@ -6,12 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm-common'
   description: Open Cluster Management common package for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm-backend
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm/catalog-info.yaml
@@ -2,35 +2,6 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-ocm
-  title: OCM plugin
-  description: Open Cluster Management plugin for Backstage
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm/catalog-info.yaml
-    github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - kubernetes
-    - openshift
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: backstage-team
-  system: backstage
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
   name: backstage-community-ocm-frontend
   title: '@backstage-community/backstage-plugin-ocm'
   description: Open Cluster Management plugin for Backstage
@@ -52,6 +23,5 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-ocm

--- a/workspaces/ocm/plugins/ocm/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm'
   description: Open Cluster Management plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/ocm/plugins/ocm/catalog-info.yaml
+++ b/workspaces/ocm/plugins/ocm/catalog-info.yaml
@@ -6,12 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-ocm'
   description: Open Cluster Management plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/ocm/plugins/ocm/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/ocm/plugins/ocm/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/quay/catalog-info.yaml
+++ b/workspaces/quay/catalog-info.yaml
@@ -4,18 +4,13 @@ kind: Component
 metadata:
   name: backstage-community-quay
   title: Quay plugin
-  description: Quay plugin for Backstage
+  description: Quay plugin to show container images
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/quay/plugins/quay/catalog-info.yaml
-    github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage-community/rhtap
-    sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - quay
+    github.com/project-slug: backstage/community-plugins
+    github.com/team-slug: backstage-community/maintainers-plugins
+    sonarqube.org/project-key: backstage-community_backstage-plugins
   links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
+    - url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay
       title: GitHub Source
       icon: source
       type: source
@@ -23,5 +18,3 @@ spec:
   type: backstage-plugin
   lifecycle: production
   owner: rhtap-team
-  system: backstage
-  subcomponentOf: backstage-community-plugins

--- a/workspaces/quay/catalog-info.yaml
+++ b/workspaces/quay/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Quay plugin to show container images
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_backstage-plugins
   links:
     - url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay
       title: GitHub Source

--- a/workspaces/quay/plugins/quay-actions/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay-actions/catalog-info.yaml
@@ -2,18 +2,14 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-quay
+  name: backstage-community-quay-actions
   title: Quay scaffolder actions
   description: Quay actions for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage-community/maintainers-plugins
     sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
-    - quay
     - scaffolder
     - actions
   links:
@@ -25,8 +21,6 @@ spec:
   type: backstage-plugin
   lifecycle: production
   owner: rhdh-team
-  system: rhdh
-  subcomponentOf: backstage-community-backstage-plugins
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
@@ -36,14 +30,10 @@ metadata:
   title: '@backstage-community/plugin-scaffolder-backend-module-quay'
   description: Quay actions for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-actions/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage-community/maintainers-plugins
     sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
-    - quay
     - scaffolder
     - actions
   links:
@@ -55,5 +45,4 @@ spec:
   type: backstage-frontend-plugin-module
   lifecycle: production
   owner: rhdh-team
-  system: rhdh
   subcomponentOf: backstage-community-quay-actions

--- a/workspaces/quay/plugins/quay-actions/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay-actions/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Quay actions for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
     - scaffolder
     - actions
@@ -31,8 +29,6 @@ metadata:
   description: Quay actions for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_backstage-plugins
   tags:
     - scaffolder
     - actions

--- a/workspaces/quay/plugins/quay-common/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay-common/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Quay Common plugin
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage-community/rhtap
-    sonarqube.org/project-key: backstage-community_plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay-common
       title: GitHub Source

--- a/workspaces/quay/plugins/quay-common/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay-common/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-quay-common'
   description: Quay Common plugin
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay-common
       title: GitHub Source

--- a/workspaces/quay/plugins/quay-common/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay-common/catalog-info.yaml
@@ -6,14 +6,9 @@ metadata:
   title: '@backstage-community/backstage-plugin-quay-common'
   description: Quay Common plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay-common
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay-common/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/quay/plugins/quay-common/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage-community/rhtap
     sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - quay
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay-common
       title: GitHub Source
@@ -23,5 +18,4 @@ spec:
   type: backstage-common-library
   lifecycle: production
   owner: rhtap-team
-  system: backstage
   subcomponentOf: backstage-community-quay

--- a/workspaces/quay/plugins/quay/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Quay plugin for Backstage
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage-community/rhtap
-    sonarqube.org/project-key: backstage-community_plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
       title: GitHub Source

--- a/workspaces/quay/plugins/quay/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-quay'
   description: Quay plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
       title: GitHub Source

--- a/workspaces/quay/plugins/quay/catalog-info.yaml
+++ b/workspaces/quay/plugins/quay/catalog-info.yaml
@@ -6,14 +6,9 @@ metadata:
   title: '@backstage-community/backstage-plugin-quay'
   description: Quay plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/quay/plugins/quay/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/quay/plugins/quay/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage-community/rhtap
     sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - quay
   links:
     - url: https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay
       title: GitHub Source
@@ -23,5 +18,4 @@ spec:
   type: backstage-frontend-plugin
   lifecycle: production
   owner: rhtap-team
-  system: backstage
   subcomponentOf: backstage-community-quay

--- a/workspaces/rbac/catalog-info.yaml
+++ b/workspaces/rbac/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: RBAC for Backstage and RHDH
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/catalog-info.yaml
+++ b/workspaces/rbac/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: RBAC plugin
   description: RBAC for Backstage and RHDH
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/catalog-info.yaml
+++ b/workspaces/rbac/catalog-info.yaml
@@ -1,13 +1,23 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: rbac
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-rbac
+  title: RBAC plugin
+  description: RBAC for Backstage and RHDH
+  annotations:
+    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/team-slug: backstage/maintainers-plugins
+    sonarqube.org/project-key: backstage-community_plugins
+  tags:
+    - security
+    - rbac
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/rbac
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-backend'
   description: RBAC backend plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-backend
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage/maintainers-plugins
     sonarqube.org/project-key: backstage-community_plugins
@@ -23,6 +20,5 @@ metadata:
 spec:
   type: backstage-backend-plugin
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-rbac

--- a/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: RBAC backend plugin for Backstage
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-backend'
   description: RBAC backend plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-common'
   description: RBAC plugin shared code
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: RBAC plugin shared code
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-common'
   description: RBAC plugin shared code
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-common
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage/maintainers-plugins
     sonarqube.org/project-key: backstage-community_plugins
@@ -23,6 +20,5 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: backstage-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-rbac

--- a/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-node'
   description: Node.js library for the rbac plugin
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Node.js library for the rbac plugin
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac-node'
   description: Node.js library for the rbac plugin
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac-node
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage/maintainers-plugins
     sonarqube.org/project-key: backstage-community_plugins
@@ -23,6 +20,5 @@ metadata:
 spec:
   type: backstage-node-library
   lifecycle: production
-  owner: backstage-core-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-rbac

--- a/workspaces/rbac/plugins/rbac/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: '@backstage-community/backstage-plugin-rbac'
   description: RBAC frontend plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: RBAC frontend plugin for Backstage
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - security
     - rbac

--- a/workspaces/rbac/plugins/rbac/catalog-info.yaml
+++ b/workspaces/rbac/plugins/rbac/catalog-info.yaml
@@ -2,42 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-rbac
-  title: RBAC plugin
-  description: RBAC for Backstage and RHDH
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/rbac/plugins/rbac/catalog-info.yaml
-    github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - security
-    - rbac
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: backstage-team
-  system: backstage
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
   name: backstage-community-rbac-frontend
   title: '@backstage-community/backstage-plugin-rbac'
   description: RBAC frontend plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/rbac/plugins/rbac
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/rbac/plugins/rbac/catalog-info.yaml
     github.com/project-slug: backstage-community/backstage-plugins
     github.com/team-slug: backstage/maintainers-plugins
     sonarqube.org/project-key: backstage-community_plugins
@@ -52,6 +20,5 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: backstage-ui-team
-  system: backstage
+  owner: rhdh-team
   subcomponentOf: backstage-community-rbac

--- a/workspaces/redhat-argocd/plugins/argocd-common/catalog-info.yaml
+++ b/workspaces/redhat-argocd/plugins/argocd-common/catalog-info.yaml
@@ -2,17 +2,13 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-redhat-argocd
-  title: Red Hat ArgoCD plugin
+  name: backstage-community-redhat-argocd-common
+  title: '@backstage-community/plugin-redhat-argocd-common'
   description: Argo CD plugin for Backstage
   annotations:
     github.com/team-slug: redhat-developer/rhdh-plugins-contributers
-  tags:
-    - backstage
-    - redhat
-    - argocd
 spec:
-  type: backstage-plugin
+  type: backstage-common-library
   lifecycle: production
   owner: rhtap-team
-  subcomponentOf: rhdh-plugins
+  subcomponentOf: backstage-community-redhat-argocd

--- a/workspaces/redhat-argocd/plugins/argocd/catalog-info.yaml
+++ b/workspaces/redhat-argocd/plugins/argocd/catalog-info.yaml
@@ -2,17 +2,13 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-redhat-argocd
-  title: Red Hat ArgoCD plugin
+  name: backstage-community-redhat-argocd-frontend
+  title: '@backstage-community/plugin-redhat-argocd'
   description: Argo CD plugin for Backstage
   annotations:
     github.com/team-slug: redhat-developer/rhdh-plugins-contributers
-  tags:
-    - backstage
-    - redhat
-    - argocd
 spec:
-  type: backstage-plugin
+  type: backstage-frontend-plugin
   lifecycle: production
   owner: rhtap-team
-  subcomponentOf: rhdh-plugins
+  subcomponentOf: backstage-community-redhat-argocd

--- a/workspaces/redhat-resource-optimization/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Red Hat Resource Optimization plugin for Backstage
   annotations:
     github.com/project-slug: backstage-community/backstage-plugins
-    github.com/team-slug: backstage/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
 spec:
   type: backstage-plugin
   lifecycle: production

--- a/workspaces/redhat-resource-optimization/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/catalog-info.yaml
@@ -1,13 +1,15 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: redhat-resource-optimization
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-redhat-resource-optimization
+  title: Red Hat Resource Optimization plugin
+  description: Red Hat Resource Optimization plugin for Backstage
+  annotations:
+    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/team-slug: backstage/maintainers-plugins
+    sonarqube.org/project-key: backstage-community_plugins
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/redhat-resource-optimization/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
   title: Red Hat Resource Optimization plugin
   description: Red Hat Resource Optimization plugin for Backstage
   annotations:
-    github.com/project-slug: backstage-community/backstage-plugins
+    github.com/project-slug: backstage/community-plugins
 spec:
   type: backstage-plugin
   lifecycle: production

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-backend/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-backend/catalog-info.yaml
@@ -1,0 +1,11 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-community-redhat-resource-optimization-backend
+  title: '@backstage-community/plugin-redhat-resource-optimization-backend'
+spec:
+  type: backstage-backend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-community-redhat-resource-optimization

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/catalog-info.yaml
@@ -1,0 +1,11 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-community-redhat-resource-optimization-common
+  title: '@backstage-community/plugin-redhat-resource-optimization-common'
+spec:
+  type: backstage-common-library
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-community-redhat-resource-optimization

--- a/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/catalog-info.yaml
+++ b/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/catalog-info.yaml
@@ -1,0 +1,11 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-community-redhat-resource-optimization-frontend
+  title: '@backstage-community/plugin-redhat-resource-optimization'
+spec:
+  type: backstage-frontend-plugin
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-community-redhat-resource-optimization

--- a/workspaces/scaffolder-backend-module-annotator/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-annotator/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-annotator
+  title: Annotator scaffolder actions
+  description: This module allows users to create custom actions for annotating their entity objects. Additionally, it enables users to utilize existing custom actions provided by the module for annotating entities with timestamps and scaffolder entity references.
+  tags:
+    - scaffolder
+    - annotator
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/.lintstagedrc.json
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/.lintstagedrc.json
@@ -1,4 +1,0 @@
-{
-  "*": "prettier --ignore-unknown --write",
-  "*.{js,jsx,ts,tsx,mjs,cjs}": "backstage-cli package lint --fix"
-}

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-annotator
+  title: '@backstage-community/plugin-scaffolder-backend-module-annotator'
+  description: This module allows users to create custom actions for annotating their entity objects. Additionally, it enables users to utilize existing custom actions provided by the module for annotating entities with timestamps and scaffolder entity references.
+  tags:
+    - scaffolder
+    - annotator
+spec:
+  type: backstage-backend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-plugin-scaffolder-annotator

--- a/workspaces/scaffolder-backend-module-kubernetes/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-kubernetes/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-kubernetes
+  title: Kubernetes scaffolder actions
+  description: This module provides Backstage template actions for Kubernetes.
+  tags:
+    - scaffolder
+    - kubernetes
+spec:
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-kubernetes
+  title: '@backstage-community/plugin-scaffolder-backend-module-kubernetes'
+  description: This module provides Backstage template actions for Kubernetes.
+  tags:
+    - scaffolder
+    - kubernetes
+spec:
+  type: backstage-backend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-plugin-scaffolder-kubernetes

--- a/workspaces/scaffolder-backend-module-regex/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-regex/catalog-info.yaml
@@ -1,13 +1,23 @@
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: scaffolder-backend-module-regex
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-community-regex-actions
+  title: Regex scaffolder actions
+  description: The regex custom scaffolder (software template) actions
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+    github.com/team-slug: backstage-community/maintainers-plugins
+    sonarqube.org/project-key: backstage-community_plugins
+  tags:
+    - scaffolder
+    - actions
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: maintainers

--- a/workspaces/scaffolder-backend-module-regex/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-regex/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: The regex custom scaffolder (software template) actions
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - scaffolder
     - actions

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/.lintstagedrc.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/.lintstagedrc.json
@@ -1,4 +1,0 @@
-{
-  "*": "prettier --ignore-unknown --write",
-  "*.{js,jsx,ts,tsx,mjs,cjs}": "backstage-cli package lint --fix"
-}

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
@@ -2,42 +2,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: backstage-community-regex-actions
-  title: Regex scaffolder actions
-  description: The regex custom actions
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
-    github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - scaffolder
-    - actions
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: community-plugins-core-team
-  system: community-plugins
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
   name: backstage-community-regex-actions-module
   title: '@backstage-community/plugin-scaffolder-backend-module-regex'
   description: The regex custom actions
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage-community/maintainers-plugins
     sonarqube.org/project-key: backstage-community_plugins
@@ -50,8 +18,7 @@ metadata:
       icon: source
       type: source
 spec:
-  type: backstage-plugin
+  type: backstage-backend-plugin-module
   lifecycle: production
-  owner: community-plugins-core-team
-  system: community-plugins
-  subcomponentOf: backstage-community-plugins
+  owner: maintainers
+  subcomponentOf: backstage-community-regex-actions

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: The regex custom actions
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/maintainers-plugins
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - scaffolder
     - actions

--- a/workspaces/scaffolder-backend-module-servicenow/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-servicenow/catalog-info.yaml
@@ -1,13 +1,12 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: scaffolder-backend-module-servicenow
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-plugin-scaffolder-servicenow
+  title: ServiceNow scaffolder actions
+  description: This plugin provides Backstage template actions for ServiceNow.
+  tags:
+    - scaffolder
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-servicenow
+  title: '@backstage-community/plugin-scaffolder-backend-module-servicenow'
+  description: This plugin provides Backstage template actions for ServiceNow.
+  tags:
+    - scaffolder
+spec:
+  type: backstage-backend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-plugin-scaffolder-servicenow

--- a/workspaces/scaffolder-backend-module-sonarqube/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-sonarqube/catalog-info.yaml
@@ -1,13 +1,12 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: scaffolder-backend-module-sonarqube
-  description: An example of a Backstage application.
-  # Example for optional annotations
-  # annotations:
-  #   github.com/project-slug: backstage/backstage
-  #   backstage.io/techdocs-ref: dir:.
+  name: backstage-plugin-scaffolder-sonarqube
+  title: SonarQube scaffolder actions
+  description: This module provides Backstage template actions for SonarQube.
+  tags:
+    - scaffolder
 spec:
-  type: website
-  owner: john@example.com
-  lifecycle: experimental
+  type: backstage-plugin
+  lifecycle: production
+  owner: rhdh-team

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/catalog-info.yaml
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-scaffolder-backend-module-sonarqube
+  title: '@backstage-community/plugin-scaffolder-backend-module-sonarqube'
+  description: This module provides Backstage template actions for SonarQube.
+  tags:
+    - scaffolder
+spec:
+  type: backstage-backend-plugin-module
+  lifecycle: production
+  owner: rhdh-team
+  subcomponentOf: backstage-plugin-scaffolder-sonarqube

--- a/workspaces/topology/catalog-info.yaml
+++ b/workspaces/topology/catalog-info.yaml
@@ -1,9 +1,22 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: topology
-  description: TODO
+  name: backstage-community-plugin-topology
+  title: Topology plugin
+  description: The Topology plugin enables you to visualize the workloads such as Deployment, Job, Daemonset, Statefulset, CronJob, Pods and Virtual Machines powering any service on the Kubernetes cluster.
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+    github.com/team-slug: backstage-community/community-plugins-maintainers
+    sonarqube.org/project-key: backstage-community_plugins
+  tags:
+    - kubernetes
+    - openshift
+  links:
+    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/topology/plugins/topology
+      title: GitHub Source
+      icon: source
+      type: source
 spec:
   type: backstage-plugin
-  owner: maintainers
   lifecycle: production
+  owner: rhdh-team

--- a/workspaces/topology/catalog-info.yaml
+++ b/workspaces/topology/catalog-info.yaml
@@ -6,8 +6,6 @@ metadata:
   description: The Topology plugin enables you to visualize the workloads such as Deployment, Job, Daemonset, Statefulset, CronJob, Pods and Virtual Machines powering any service on the Kubernetes cluster.
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/topology/plugins/topology-common/catalog-info.yaml
+++ b/workspaces/topology/plugins/topology-common/catalog-info.yaml
@@ -7,8 +7,6 @@ metadata:
   description: Topology plugin for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/topology/plugins/topology-common/catalog-info.yaml
+++ b/workspaces/topology/plugins/topology-common/catalog-info.yaml
@@ -6,9 +6,6 @@ metadata:
   title: '@backstage-community/plugin-topology-common'
   description: Topology plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/topology/plugins/topology-common
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/topology/plugins/topology-common/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/topology/plugins/topology-common/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     github.com/team-slug: backstage-community/community-plugins-maintainers
     sonarqube.org/project-key: backstage-community_plugins
@@ -23,6 +20,5 @@ metadata:
 spec:
   type: backstage-common-library
   lifecycle: production
-  owner: maintainers
-  system: rhdh
-  subcomponentOf: backstage-community-plugins
+  owner: rhdh-team
+  subcomponentOf: backstage-community-plugin-topology

--- a/workspaces/topology/plugins/topology/catalog-info.yaml
+++ b/workspaces/topology/plugins/topology/catalog-info.yaml
@@ -6,8 +6,6 @@ metadata:
   description: Topology plugin for Backstage
   annotations:
     github.com/project-slug: backstage/community-plugins
-    githubworkspaces/topology/.com/team-slug: backstage-community/topology-plugin-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
   tags:
     - kubernetes
     - openshift

--- a/workspaces/topology/plugins/topology/catalog-info.yaml
+++ b/workspaces/topology/plugins/topology/catalog-info.yaml
@@ -1,33 +1,3 @@
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: backstage-community-plugin-topology
-  title: Topology plugin
-  description: Topology plugin for Backstage
-  annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/topology/plugins/topology-common
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/topology/plugins/topology/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/topology/plugins/topology/catalog-info.yaml
-    github.com/project-slug: backstage/community-plugins
-    github.com/team-slug: backstage-community/community-plugins-maintainers
-    sonarqube.org/project-key: backstage-community_plugins
-  tags:
-    - kubernetes
-    - openshift
-  links:
-    - url: https://github.com/backstage/community-plugins/tree/main/workspaces/topology/plugins/topology
-      title: GitHub Source
-      icon: source
-      type: source
-spec:
-  type: backstage-plugin
-  lifecycle: production
-  owner: maintainers
-  system: rhdh
-  subcomponentOf: backstage-community-plugins
----
-# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
@@ -35,9 +5,6 @@ metadata:
   title: '@backstage-community/plugin-topology'
   description: Topology plugin for Backstage
   annotations:
-    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/topology/plugins/topology
-    backstage.io/view-url: https://github.com/backstage/community-plugins/blob/main/workspaces/topology/plugins/topology/catalog-info.yaml
-    backstage.io/edit-url: https://github.com/backstage/community-plugins/edit/main/workspaces/topology/plugins/topology/catalog-info.yaml
     github.com/project-slug: backstage/community-plugins
     githubworkspaces/topology/.com/team-slug: backstage-community/topology-plugin-maintainers
     sonarqube.org/project-key: backstage-community_plugins
@@ -52,6 +19,5 @@ metadata:
 spec:
   type: backstage-frontend-plugin
   lifecycle: production
-  owner: maintainers
-  system: rhdh
+  owner: rhdh-team
   subcomponentOf: backstage-community-plugin-topology


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates a bunch of `catalog-info.yaml`s for plugins afaik Red Hat provided last year.

I've wanted see that plugins in the software catalog and tried to solve the biggest issue...

1. For the "backstage-plugin" there is a catalog-into.yaml in the workspace.
   * Except for the analytics plugins which uses a grouped workspace.
2. For the frontend/backend plugin there is one in each plugins folder.
3. I removed some invalid or unused annotations like
4. I removed the system rhdh completely.

### I've tried this with this Location resource like this

Just the 'plugins' (workspace):

```yaml
apiVersion: backstage.io/v1alpha1
kind: Location
metadata:
  name: backstage-community-plugins-local
spec:
  type: file
  targets:
    - ../../backstage/community-plugins/workspaces/3scale/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/acr/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/jfrog-artifactory/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/ocm/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/quay/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/rbac/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-argocd/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-resource-optimization/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-annotator/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-kubernetes/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-regex/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-servicenow/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-sonarqube/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/tekton/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/topology/catalog-info.yaml
```

Include also the plugin 'packages' (fronend/backend):

```yaml
apiVersion: backstage.io/v1alpha1
kind: Location
metadata:
  name: backstage-community-packages-local
spec:
  type: file
  targets:
    - ../../backstage/community-plugins/workspaces/3scale/plugins/3scale-backend/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/acr/plugins/acr/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/analytics/plugins/analytics-provider-segment/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/ocm/plugins/ocm-backend/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/ocm/plugins/ocm-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/ocm/plugins/ocm/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/quay/plugins/quay-actions/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/quay/plugins/quay-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/quay/plugins/quay/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/rbac/plugins/rbac-backend/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/rbac/plugins/rbac-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/rbac/plugins/rbac-node/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/rbac/plugins/rbac/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-argocd/plugins/argocd-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-argocd/plugins/argocd/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-backend/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/redhat-resource-optimization/plugins/redhat-resource-optimization/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/tekton/plugins/tekton-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/tekton/plugins/tekton/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/topology/plugins/topology-common/catalog-info.yaml
    - ../../backstage/community-plugins/workspaces/topology/plugins/topology/catalog-info.yaml
```

It should later work with url references, of course.

### Here are a bunch of screenshots ;)

![3scale](https://github.com/user-attachments/assets/a10e669c-54cd-439f-86a8-6a2629523cc6)

![acr](https://github.com/user-attachments/assets/55c1b44c-66d1-4405-897c-d608ae59975a)

![annotator-scaffolder-actions](https://github.com/user-attachments/assets/ba76fea0-c47c-4bc4-8dd1-9ff9f175ffbe)

![kubernetes-scaffolder-actions](https://github.com/user-attachments/assets/908e63ea-b231-48dc-b465-59d934da0522)

![matomo](https://github.com/user-attachments/assets/f13c7f46-086f-4209-89da-9b88006afb1f)

![ocm](https://github.com/user-attachments/assets/763a5afb-02b5-4a92-8c0e-59858b177902)

![quay-plugin](https://github.com/user-attachments/assets/22e4dca5-87b9-44ce-afd8-e424819f36e3)

![quay-scaffolder-actions](https://github.com/user-attachments/assets/00dcf245-724d-4582-aa6e-7f7ac04474ad)

![rbac](https://github.com/user-attachments/assets/ac3d952e-874c-4ea2-ab04-a971742f7814)

![redhat-argocd](https://github.com/user-attachments/assets/be0bd50b-a059-43e4-96a9-b5567bf16854)

![redhat-resource-optimization](https://github.com/user-attachments/assets/f2ff4e41-cc1e-464d-a792-97e85df8f755)

![regex](https://github.com/user-attachments/assets/d51ab186-7324-4a90-9bbb-5f5c5481aab7)

![segment](https://github.com/user-attachments/assets/145cf240-3eb8-4b9a-8493-d1b6783f6e55)

![servicenow](https://github.com/user-attachments/assets/bb5c2635-4a50-440f-980c-10bd5ca17e1c)

![sonarqube](https://github.com/user-attachments/assets/dd73159e-c83a-473a-83b7-d42309ba0019)

![topology](https://github.com/user-attachments/assets/7d09392b-c5fe-4508-85aa-021fd31894d7)

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
