### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/dull-yaks-hang.md
+++ b/workspaces/announcements/.changeset/dull-yaks-hang.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Added announcement ID to the useAsync dependency array in the AnnouncementPage component.
-
-This fixes an issue where the AnnouncementPage component did not re-fetch the announcement details when the ID in the routing path changed. As a result the user who was on the AnnouncementPage couldn't see the details of the next announcement they accessed, e.g. from the search dialogue.

--- a/workspaces/announcements/.changeset/lovely-falcons-smoke.md
+++ b/workspaces/announcements/.changeset/lovely-falcons-smoke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed bug in AnnouncementPage component where subheader spacing was missing

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-announcements
 
+## 0.1.5
+
+### Patch Changes
+
+- 1909e4d: Added announcement ID to the useAsync dependency array in the AnnouncementPage component.
+
+  This fixes an issue where the AnnouncementPage component did not re-fetch the announcement details when the ID in the routing path changed. As a result the user who was on the AnnouncementPage couldn't see the details of the next announcement they accessed, e.g. from the search dialogue.
+
+- ef67a29: Fixed bug in AnnouncementPage component where subheader spacing was missing
+
 ## 0.1.4
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.1.5

### Patch Changes

-   1909e4d: Added announcement ID to the useAsync dependency array in the AnnouncementPage component.

    This fixes an issue where the AnnouncementPage component did not re-fetch the announcement details when the ID in the routing path changed. As a result the user who was on the AnnouncementPage couldn't see the details of the next announcement they accessed, e.g. from the search dialogue.

-   ef67a29: Fixed bug in AnnouncementPage component where subheader spacing was missing
