### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/version-bump-1-35-0.md
+++ b/workspaces/quay/.changeset/version-bump-1-35-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.35.0

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.4.0
+
+### Minor Changes
+
+- 7226329: Backstage version bump to v1.35.0
+
 ## 2.3.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.5.0
+
+### Minor Changes
+
+- 7226329: Backstage version bump to v1.35.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.16.0
+
+### Minor Changes
+
+- 7226329: Backstage version bump to v1.35.0
+
+### Patch Changes
+
+- Updated dependencies [7226329]
+  - @backstage-community/plugin-quay-common@1.5.0
+
 ## 1.15.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.16.0

### Minor Changes

-   7226329: Backstage version bump to v1.35.0

### Patch Changes

-   Updated dependencies [7226329]
    -   @backstage-community/plugin-quay-common@1.5.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.4.0

### Minor Changes

-   7226329: Backstage version bump to v1.35.0

## @backstage-community/plugin-quay-common@1.5.0

### Minor Changes

-   7226329: Backstage version bump to v1.35.0
