### PR TITLE
adr-backend: fix no adr's returned if one fails to parse

### DIFF
--- a/workspaces/adr/.changeset/pink-pens-drive.md
+++ b/workspaces/adr/.changeset/pink-pens-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-adr-backend': patch
+---
+
+Fixed a bug that caused no ADRs to be returned from `/list` if at least one failed to parse.

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -128,6 +128,7 @@ class MockCacheClient implements CacheService {
 
 describe('createRouter', () => {
   let app: express.Express;
+  const routerErrorLoggerMock = jest.fn((message: string) => message);
 
   beforeEach(async () => {
     jest.resetAllMocks();
@@ -136,7 +137,7 @@ describe('createRouter', () => {
       reader: mockUrlReader,
       cacheClient: new MockCacheClient(),
       logger: {
-        error: (message: any) => message,
+        error: routerErrorLoggerMock as unknown,
       } as LoggerService,
     });
     app = express().use(router);
@@ -192,6 +193,8 @@ describe('createRouter', () => {
       expect(error).toBeFalsy();
       expect(status).toBe(expectedStatusCode);
       expect(body).toEqual(expectedBody);
+      expect(routerErrorLoggerMock.mock.calls).toHaveLength(1);
+      expect(routerErrorLoggerMock.mock.calls[0][0]).toContain('.gitkeep');
     });
   });
 

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -194,7 +194,9 @@ describe('createRouter', () => {
       expect(status).toBe(expectedStatusCode);
       expect(body).toEqual(expectedBody);
       expect(routerErrorLoggerMock.mock.calls).toHaveLength(1);
-      expect(routerErrorLoggerMock.mock.calls[0][0]).toContain('.gitkeep');
+      expect(routerErrorLoggerMock.mock.calls[0][0]).toBe(
+        'Failed to parse .gitkeep: ADR has no content',
+      );
     });
   });
 

--- a/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.test.ts
@@ -52,6 +52,10 @@ const testingUrlFakeFileTree: UrlReaderServiceReadTreeResponseFile[] = [
     path: 'testFile002.txt',
     content: makeBufferFromString('testFile001.txt content'),
   },
+  {
+    path: '.gitkeep',
+    content: makeBufferFromString(''),
+  },
 ];
 
 const makeFileContent = async (fileContent: string) => {

--- a/workspaces/adr/plugins/adr-backend/src/service/router.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.ts
@@ -77,7 +77,7 @@ export async function createRouter(
                 ...adrInfo,
               };
             } catch (e: any) {
-              logger.error(`Failed to parse ${file.path}: ${e.reason}`);
+              logger.error(`Failed to parse ${file.path}: ${e.message}`);
               return null;
             }
           })


### PR DESCRIPTION
## Hey, I just made a Pull Request!

At the moment if there is any file that can not be parsed in the directory tree searched through by the `/list` endpoint, then no ADRs are returned at all. We encountered this issue at our company while having `.gitkeep` and other files within the directory tree.

This MR changes this behavior to ignore and log files that failed to parse and return the rest.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
