### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/dirty-paws-smile.md
+++ b/workspaces/topology/.changeset/dirty-paws-smile.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Long annotations doesn't overflow the sidebar content for Pods anymore

--- a/workspaces/topology/.changeset/hungry-seals-teach.md
+++ b/workspaces/topology/.changeset/hungry-seals-teach.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-topology-common': minor
-'@backstage-community/plugin-topology': minor
----
-
-Backstage version bump to v1.35.0

--- a/workspaces/topology/.changeset/rich-flowers-provide.md
+++ b/workspaces/topology/.changeset/rich-flowers-provide.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-upgraded @backstage-community/plugin-topology plugin to PatternFly 6

--- a/workspaces/topology/plugins/topology-common/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-topology-common [1.3.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-topology-common@1.2.2...@janus-idp/backstage-plugin-topology-common@1.3.0) (2024-07-26)
 
+## 1.6.0
+
+### Minor Changes
+
+- c6207a6: Backstage version bump to v1.35.0
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology-common/package.json
+++ b/workspaces/topology/plugins/topology-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-topology-common",
   "description": "Common functionalities for the topology plugin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Dependencies
 
+## 1.31.0
+
+### Minor Changes
+
+- c6207a6: Backstage version bump to v1.35.0
+- 8ab6e45: upgraded @backstage-community/plugin-topology plugin to PatternFly 6
+
+### Patch Changes
+
+- 8ab6e45: Long annotations doesn't overflow the sidebar content for Pods anymore
+- Updated dependencies [c6207a6]
+  - @backstage-community/plugin-topology-common@1.6.0
+
 ## 1.30.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@1.31.0

### Minor Changes

-   c6207a6: Backstage version bump to v1.35.0
-   8ab6e45: upgraded @backstage-community/plugin-topology plugin to PatternFly 6

### Patch Changes

-   8ab6e45: Long annotations doesn't overflow the sidebar content for Pods anymore
-   Updated dependencies [c6207a6]
    -   @backstage-community/plugin-topology-common@1.6.0

## @backstage-community/plugin-topology-common@1.6.0

### Minor Changes

-   c6207a6: Backstage version bump to v1.35.0
