### PR TITLE
fix(announcements): remove divider from AnnouncementSearchResultListItem

### DIFF
--- a/workspaces/announcements/.changeset/perfect-mice-hear.md
+++ b/workspaces/announcements/.changeset/perfect-mice-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Removed divider from AnnouncementSearchResultListItem

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
@@ -27,7 +27,6 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Divider,
   Typography,
 } from '@material-ui/core';
 import RecordVoiceOverIcon from '@material-ui/icons/RecordVoiceOver';
@@ -108,22 +107,16 @@ export const AnnouncementSearchResultListItem = ({
   );
 
   return (
-    <>
-      <ListItem alignItems="center">
-        <ListItemIcon
-          title={t('announcementSearchResultListItem.announcement')}
-        >
-          <RecordVoiceOverIcon />
-        </ListItemIcon>
-        <ListItemText
-          primary={title}
-          secondary={excerpt}
-          className={classes.itemText}
-          primaryTypographyProps={{ variant: 'h6' }}
-        />
-      </ListItem>
-
-      <Divider component="li" />
-    </>
+    <ListItem alignItems="center">
+      <ListItemIcon title={t('announcementSearchResultListItem.announcement')}>
+        <RecordVoiceOverIcon />
+      </ListItemIcon>
+      <ListItemText
+        primary={title}
+        secondary={excerpt}
+        className={classes.itemText}
+        primaryTypographyProps={{ variant: 'h6' }}
+      />
+    </ListItem>
   );
 };


### PR DESCRIPTION
This PR removes the divider from AnnouncementSearchResultListItem since it acts as a duplicate divider. Especially if you have applied any sort of formatting, like we have, this can look really bad:

Before:
<img width="789" alt="Scherm­afbeelding 2025-01-30 om 14 54 28" src="https://github.com/user-attachments/assets/1dd00aca-7d46-45b7-81cc-322bc211d5bc" />

After:
<img width="780" alt="Scherm­afbeelding 2025-01-30 om 14 54 39" src="https://github.com/user-attachments/assets/73a9f09f-1b5f-472f-b4cd-1b14770f97ec" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
