### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/pink-pens-drive.md
+++ b/workspaces/adr/.changeset/pink-pens-drive.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Fixed a bug that caused no ADRs to be returned from `/list` if at least one failed to parse.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.5.3
+
+### Patch Changes
+
+- eb6cbef: Fixed a bug that caused no ADRs to be returned from `/list` if at least one failed to parse.
+
 ## 0.5.2
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.5.3

### Patch Changes

-   eb6cbef: Fixed a bug that caused no ADRs to be returned from `/list` if at least one failed to parse.
