### PR TITLE
fix: remove "private: true" from package json to fix release

### DIFF
--- a/workspaces/tech-insights/plugins/tech-insights-react/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-react/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`yarn new` generates the new plugin with `private: true` set in the package.json file. This will break releases in the community repository. 

Merging https://github.com/backstage/community-plugins/pull/2579 with this caused a failure in CI. This will fix that, and we should see the first version successfully released. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
