### PR TITLE
Version Packages (blackduck)

### DIFF
--- a/workspaces/blackduck/.changeset/eight-ladybugs-clap.md
+++ b/workspaces/blackduck/.changeset/eight-ladybugs-clap.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-blackduck-backend': minor
-'@backstage-community/plugin-blackduck': minor
----
-
-Removed usages and references of @backstage/backend-common
-Removed support for legacy backend system

--- a/workspaces/blackduck/plugins/blackduck-backend/CHANGELOG.md
+++ b/workspaces/blackduck/plugins/blackduck-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-blackduck-backend
 
+## 0.2.0
+
+### Minor Changes
+
+- 7cd9866: Removed usages and references of @backstage/backend-common
+  Removed support for legacy backend system
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/blackduck/plugins/blackduck-backend/package.json
+++ b/workspaces/blackduck/plugins/blackduck-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-blackduck-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/blackduck/plugins/blackduck/CHANGELOG.md
+++ b/workspaces/blackduck/plugins/blackduck/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-blackduck
 
+## 0.2.0
+
+### Minor Changes
+
+- 7cd9866: Removed usages and references of @backstage/backend-common
+  Removed support for legacy backend system
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/blackduck/plugins/blackduck/package.json
+++ b/workspaces/blackduck/plugins/blackduck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-blackduck",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-blackduck@0.2.0

### Minor Changes

-   7cd9866: Removed usages and references of @backstage/backend-common
    Removed support for legacy backend system

## @backstage-community/plugin-blackduck-backend@0.2.0

### Minor Changes

-   7cd9866: Removed usages and references of @backstage/backend-common
    Removed support for legacy backend system
