### PR TITLE
Fix plugin setup doc to avoid unnecessary import

### DIFF
--- a/workspaces/github-actions/.changeset/eighty-planets-help.md
+++ b/workspaces/github-actions/.changeset/eighty-planets-help.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-github-actions': patch
 ---
 
-Fixed plugin setup documentation to avoid unnecessary import
+Fixed plugin setup documentation to show example of use with availability check in the catalog EntityPage

--- a/workspaces/github-actions/.changeset/eighty-planets-help.md
+++ b/workspaces/github-actions/.changeset/eighty-planets-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-actions': patch
+---
+
+Fixed plugin setup documentation to avoid unnecessary import

--- a/workspaces/github-actions/plugins/github-actions/README.md
+++ b/workspaces/github-actions/plugins/github-actions/README.md
@@ -100,6 +100,7 @@ yarn --cwd packages/app add @backstage-community/plugin-github-actions
 // In packages/app/src/components/catalog/EntityPage.tsx
 import {
   EntityGithubActionsContent,
+  isGithubActionsAvailable,
 } from '@backstage-community/plugin-github-actions';
 
 // You can add the tab to any number of pages, the service page is shown as an
@@ -107,7 +108,7 @@ import {
 const serviceEntityPage = (
   <EntityLayout>
     {/* other tabs... */}
-    <EntityLayout.Route path="/github-actions" title="GitHub Actions">
+    <EntityLayout.Route path="/github-actions" title="GitHub Actions" if={isGithubActionsAvailable}>
       <EntityGithubActionsContent />
     </EntityLayout.Route>
 ```

--- a/workspaces/github-actions/plugins/github-actions/README.md
+++ b/workspaces/github-actions/plugins/github-actions/README.md
@@ -100,7 +100,6 @@ yarn --cwd packages/app add @backstage-community/plugin-github-actions
 // In packages/app/src/components/catalog/EntityPage.tsx
 import {
   EntityGithubActionsContent,
-  isGithubActionsAvailable,
 } from '@backstage-community/plugin-github-actions';
 
 // You can add the tab to any number of pages, the service page is shown as an


### PR DESCRIPTION
## Improve GitHub Actions plugin doc

Fixed doc to show example of use with availability check when [integrating GitHub Actions plugin to EntityPage](https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions#integrating-with-entitypage). While appearing harmless, it might create confusion (and warnings in IDE because of unused import) for newcomers discovering Backstage plugins. *The Devil is in the detail.*

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
