### PR TITLE
Version Packages (lighthouse)

### DIFF
--- a/workspaces/lighthouse/.changeset/five-guests-joke.md
+++ b/workspaces/lighthouse/.changeset/five-guests-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse-backend': minor
----
-
-**BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/lighthouse/plugins/lighthouse-backend/README.md) for instructions on how to use the new backend system.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-lighthouse-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- ce2f38e: **BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/lighthouse/plugins/lighthouse-backend/README.md) for instructions on how to use the new backend system.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/lighthouse/plugins/lighthouse-backend/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-backend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-lighthouse-backend@0.6.0

### Minor Changes

-   ce2f38e: **BREAKING** Removed support for the legacy backend system. Please refer to the [README](https://github.com/backstage/community-plugins/blob/main/workspaces/lighthouse/plugins/lighthouse-backend/README.md) for instructions on how to use the new backend system.
