### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/eighty-planets-help.md
+++ b/workspaces/github-actions/.changeset/eighty-planets-help.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Fixed plugin setup documentation to show example of use with availability check in the catalog EntityPage

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.7.2
+
+### Patch Changes
+
+- 58d4734: Fixed plugin setup documentation to show example of use with availability check in the catalog EntityPage
+
 ## 0.7.1
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.7.2

### Patch Changes

-   58d4734: Fixed plugin setup documentation to show example of use with availability check in the catalog EntityPage
