### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/version-bump-1-35-1.md
+++ b/workspaces/linguist/.changeset/version-bump-1-35-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': minor
-'@backstage-community/plugin-linguist': minor
-'@backstage-community/plugin-linguist-backend': minor
-'@backstage-community/plugin-linguist-common': minor
----
-
-Backstage version bump to v1.35.1

--- a/workspaces/linguist/packages/app/CHANGELOG.md
+++ b/workspaces/linguist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.11
+
+### Patch Changes
+
+- Updated dependencies [cf27ad1]
+  - @backstage-community/plugin-linguist@0.4.0
+
 ## 0.0.10
 
 ### Patch Changes

--- a/workspaces/linguist/packages/app/package.json
+++ b/workspaces/linguist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linguist/packages/backend/CHANGELOG.md
+++ b/workspaces/linguist/packages/backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # backend
 
+## 0.0.18
+
+### Patch Changes
+
+- Updated dependencies [cf27ad1]
+  - @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.5.0
+  - @backstage-community/plugin-linguist-backend@0.11.0
+  - app@0.0.11
+
 ## 0.0.17
 
 ### Patch Changes

--- a/workspaces/linguist/packages/backend/package.json
+++ b/workspaces/linguist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.5.0
+
+### Minor Changes
+
+- cf27ad1: Backstage version bump to v1.35.1
+
+### Patch Changes
+
+- Updated dependencies [cf27ad1]
+  - @backstage-community/plugin-linguist-common@0.4.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.11.0
+
+### Minor Changes
+
+- cf27ad1: Backstage version bump to v1.35.1
+
+### Patch Changes
+
+- Updated dependencies [cf27ad1]
+  - @backstage-community/plugin-linguist-common@0.4.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.4.0
+
+### Minor Changes
+
+- cf27ad1: Backstage version bump to v1.35.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist
 
+## 0.4.0
+
+### Minor Changes
+
+- cf27ad1: Backstage version bump to v1.35.1
+
+### Patch Changes
+
+- Updated dependencies [cf27ad1]
+  - @backstage-community/plugin-linguist-common@0.4.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.5.0

### Minor Changes

-   cf27ad1: Backstage version bump to v1.35.1

### Patch Changes

-   Updated dependencies [cf27ad1]
    -   @backstage-community/plugin-linguist-common@0.4.0

## @backstage-community/plugin-linguist@0.4.0

### Minor Changes

-   cf27ad1: Backstage version bump to v1.35.1

### Patch Changes

-   Updated dependencies [cf27ad1]
    -   @backstage-community/plugin-linguist-common@0.4.0

## @backstage-community/plugin-linguist-backend@0.11.0

### Minor Changes

-   cf27ad1: Backstage version bump to v1.35.1

### Patch Changes

-   Updated dependencies [cf27ad1]
    -   @backstage-community/plugin-linguist-common@0.4.0

## @backstage-community/plugin-linguist-common@0.4.0

### Minor Changes

-   cf27ad1: Backstage version bump to v1.35.1

## app@0.0.11

### Patch Changes

-   Updated dependencies [cf27ad1]
    -   @backstage-community/plugin-linguist@0.4.0

## backend@0.0.18

### Patch Changes

-   Updated dependencies [cf27ad1]
    -   @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.5.0
    -   @backstage-community/plugin-linguist-backend@0.11.0
    -   app@0.0.11
