### PR TITLE
Version Packages (shortcuts)

### DIFF
--- a/workspaces/shortcuts/.changeset/lazy-birds-unite.md
+++ b/workspaces/shortcuts/.changeset/lazy-birds-unite.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-shortcuts': patch
----
-
-Fixed code example in the README.md file where a code line was lacking an apostrophe and a semicolon

--- a/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
+++ b/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-shortcuts
 
+## 0.5.1
+
+### Patch Changes
+
+- 34a5da7: Fixed code example in the README.md file where a code line was lacking an apostrophe and a semicolon
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/shortcuts/plugins/shortcuts/package.json
+++ b/workspaces/shortcuts/plugins/shortcuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-shortcuts",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Backstage plugin that provides a shortcuts feature to the sidebar",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-shortcuts@0.5.1

### Patch Changes

-   34a5da7: Fixed code example in the README.md file where a code line was lacking an apostrophe and a semicolon
