### PR TITLE
fix(rbac): avoid filter's args duplication

### DIFF
--- a/workspaces/rbac/.changeset/sharp-mice-explain.md
+++ b/workspaces/rbac/.changeset/sharp-mice-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Avoid filter's args duplication.

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -74,8 +74,13 @@ const config = mockServices.rootConfig({
     },
   },
 });
-const policy = ['user:default/tom', 'policy-entity', 'read', 'allow'];
-const secondPolicy = ['user:default/tim', 'catalog-entity', 'write', 'allow'];
+const policy = ['role:default/dev-team', 'policy-entity', 'read', 'allow'];
+const secondPolicy = [
+  'role:default/qa-team',
+  'catalog-entity',
+  'create',
+  'allow',
+];
 
 const groupingPolicy = ['user:default/tom', 'role:default/dev-team'];
 const secondGroupingPolicy = ['user:default/tim', 'role:default/qa-team'];
@@ -268,17 +273,69 @@ describe('EnforcerDelegate', () => {
       expect(policies.length).toEqual(0);
     });
 
-    it('should return filteredPolicy', async () => {
+    it('should return filtered policy by role name', async () => {
       const enfDelegate = await createEnfDelegate([policy, secondPolicy]);
 
       // filter by policy assignment person
       const policies = await enfDelegate.getFilteredPolicy(
         0,
-        'user:default/tim',
+        'role:default/qa-team',
       );
 
       expect(policies.length).toEqual(1);
       expect(policies[0]).toEqual(secondPolicy);
+    });
+
+    it('should return filtered policy by policy name', async () => {
+      const enfDelegate = await createEnfDelegate([policy, secondPolicy]);
+
+      const policyName = policy[1];
+      const policies = await enfDelegate.getFilteredPolicy(0, '', policyName);
+
+      expect(policies.length).toEqual(1);
+      expect(policies[0]).toEqual(policy);
+    });
+
+    it('should return filtered policy by policy name with index offset', async () => {
+      const enfDelegate = await createEnfDelegate([policy, secondPolicy]);
+
+      const policyName = policy[1];
+      const policies = await enfDelegate.getFilteredPolicy(1, policyName);
+
+      expect(policies.length).toEqual(1);
+      expect(policies[0]).toEqual(policy);
+    });
+
+    it('should return filtered policy by policy action', async () => {
+      const enfDelegate = await createEnfDelegate([policy, secondPolicy]);
+
+      const policyAction = policy[2];
+      const policies = await enfDelegate.getFilteredPolicy(
+        0,
+        '',
+        '',
+        policyAction,
+      );
+
+      expect(policies.length).toEqual(1);
+      expect(policies[0]).toEqual(policy);
+    });
+
+    it('should return filtered policy by policy effect', async () => {
+      const enfDelegate = await createEnfDelegate([policy, secondPolicy]);
+
+      const policyEffect = policy[3];
+      const policies = await enfDelegate.getFilteredPolicy(
+        0,
+        '',
+        '',
+        '',
+        policyEffect,
+      );
+
+      expect(policies.length).toEqual(2);
+      expect(policies[0]).toEqual(policy);
+      expect(policies[1]).toEqual(secondPolicy);
     });
   });
 
@@ -294,7 +351,7 @@ describe('EnforcerDelegate', () => {
       expect(policies.length).toEqual(0);
     });
 
-    it('should return filteredPolicy', async () => {
+    it('should return filtered grouping policy by role member', async () => {
       const enfDelegate = await createEnfDelegate(
         [],
         [groupingPolicy, secondGroupingPolicy],
@@ -304,6 +361,39 @@ describe('EnforcerDelegate', () => {
       const policies = await enfDelegate.getFilteredGroupingPolicy(
         0,
         'user:default/tim',
+      );
+
+      expect(policies.length).toEqual(1);
+      expect(policies[0]).toEqual(secondGroupingPolicy);
+    });
+
+    it('should return filtered grouping policy by role name', async () => {
+      const enfDelegate = await createEnfDelegate(
+        [],
+        [groupingPolicy, secondGroupingPolicy],
+      );
+
+      // filter by policy assignment person
+      const policies = await enfDelegate.getFilteredGroupingPolicy(
+        0,
+        '',
+        'role:default/qa-team',
+      );
+
+      expect(policies.length).toEqual(1);
+      expect(policies[0]).toEqual(secondGroupingPolicy);
+    });
+
+    it('should return filtered grouping policy by role name with index offset', async () => {
+      const enfDelegate = await createEnfDelegate(
+        [],
+        [groupingPolicy, secondGroupingPolicy],
+      );
+
+      // filter by policy assignment person
+      const policies = await enfDelegate.getFilteredGroupingPolicy(
+        1,
+        'role:default/qa-team',
       );
 
       expect(policies.length).toEqual(1);

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -164,7 +164,9 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
 
     const filterObj: Record<string, string> = { ptype: 'p' };
     for (let i = 0; i < filter.length; i++) {
-      filterObj[`v${i + fieldIndex}`] = filter[i];
+      if (filter[i]) {
+        filterObj[`v${i + fieldIndex}`] = filter[i];
+      }
     }
 
     await (this.enforcer.getAdapter() as FilteredAdapter).loadFilteredPolicy(
@@ -183,7 +185,9 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
 
     const filterObj: Record<string, string> = { ptype: 'g' };
     for (let i = 0; i < filter.length; i++) {
-      filterObj[`v${i + fieldIndex}`] = filter[i];
+      if (filter[i]) {
+        filterObj[`v${i + fieldIndex}`] = filter[i];
+      }
     }
 
     await (this.enforcer.getAdapter() as FilteredAdapter).loadFilteredPolicy(

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -162,16 +162,14 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   ): Promise<string[][]> {
     const tempModel = newModelFromString(MODEL);
 
-    const filterArgs: Record<string, string>[] = [];
     const filterObj: Record<string, string> = { ptype: 'p' };
     for (let i = 0; i < filter.length; i++) {
       filterObj[`v${i + fieldIndex}`] = filter[i];
-      filterArgs.push(filterObj);
     }
 
     await (this.enforcer.getAdapter() as FilteredAdapter).loadFilteredPolicy(
       tempModel,
-      filterArgs,
+      [filterObj],
     );
 
     return await tempModel.getPolicy('p', 'p');
@@ -183,16 +181,14 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
   ): Promise<string[][]> {
     const tempModel = newModelFromString(MODEL);
 
-    const filterArgs: Record<string, string>[] = [];
     const filterObj: Record<string, string> = { ptype: 'g' };
     for (let i = 0; i < filter.length; i++) {
       filterObj[`v${i + fieldIndex}`] = filter[i];
-      filterArgs.push(filterObj);
     }
 
     await (this.enforcer.getAdapter() as FilteredAdapter).loadFilteredPolicy(
       tempModel,
-      filterArgs,
+      [filterObj],
     );
 
     return await tempModel.getPolicy('g', 'g');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The current code generates duplicate filter arguments, which could affect performance. So, let's avoid filter's args duplication.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
