### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/brown-wasps-drive.md
+++ b/workspaces/quay/.changeset/brown-wasps-drive.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-common': minor
-'@backstage-community/plugin-quay': minor
----
-
-Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.

--- a/workspaces/quay/.changeset/kind-knives-happen.md
+++ b/workspaces/quay/.changeset/kind-knives-happen.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-quay-common': minor
-'@backstage-community/plugin-quay': minor
----
-
-Add a quay-backend plugin to query the quay.io API

--- a/workspaces/quay/.changeset/little-bottles-burn.md
+++ b/workspaces/quay/.changeset/little-bottles-burn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': major
----
-
-release quay-backend plugin

--- a/workspaces/quay/.changeset/short-parrots-juggle.md
+++ b/workspaces/quay/.changeset/short-parrots-juggle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
----
-
-Update documentation on the Proxy and new Quay backend functionality

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.5.0
+
+### Minor Changes
+
+- e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.
+
 ## 2.4.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @backstage-community/plugin-quay-backend
+
+## 1.0.0
+
+### Major Changes
+
+- 6f747d0: release quay-backend plugin
+
+### Patch Changes
+
+- Updated dependencies [e541edd]
+- Updated dependencies [e541edd]
+  - @backstage-community/plugin-quay-common@1.6.0

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-quay-common
 
+## 1.6.0
+
+### Minor Changes
+
+- e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.
+- e541edd: Add a quay-backend plugin to query the quay.io API
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 1.17.0
+
+### Minor Changes
+
+- e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.
+- e541edd: Add a quay-backend plugin to query the quay.io API
+- 4a04fa7: Update documentation on the Proxy and new Quay backend functionality
+
+### Patch Changes
+
+- Updated dependencies [e541edd]
+- Updated dependencies [e541edd]
+  - @backstage-community/plugin-quay-common@1.6.0
+
 ## 1.16.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay-backend@1.0.0

### Major Changes

-   6f747d0: release quay-backend plugin

### Patch Changes

-   Updated dependencies [e541edd]
-   Updated dependencies [e541edd]
    -   @backstage-community/plugin-quay-common@1.6.0

## @backstage-community/plugin-quay@1.17.0

### Minor Changes

-   e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.
-   e541edd: Add a quay-backend plugin to query the quay.io API
-   4a04fa7: Update documentation on the Proxy and new Quay backend functionality

### Patch Changes

-   Updated dependencies [e541edd]
-   Updated dependencies [e541edd]
    -   @backstage-community/plugin-quay-common@1.6.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.5.0

### Minor Changes

-   e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.

## @backstage-community/plugin-quay-common@1.6.0

### Minor Changes

-   e541edd: Adds a new quay-backend plugin and updates the frontend quay plugin to use this new backend.
-   e541edd: Add a quay-backend plugin to query the quay.io API
