### PR TITLE
[jenkins] Improvements to backend config

### DIFF
--- a/workspaces/jenkins/.changeset/jenkins-meaningless-pop-song.md
+++ b/workspaces/jenkins/.changeset/jenkins-meaningless-pop-song.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+Fixed a bug that prevented the backend from starting if no config was provided.

--- a/workspaces/jenkins/.changeset/jenkins-one-thread.md
+++ b/workspaces/jenkins/.changeset/jenkins-one-thread.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+Updated config schema to indicate that _either_ a `jenkins.instances` array should be provided _or_ `jenkins.baseUrl`, `jenkins.username`, and `jenkins.apiKey`, but never both.

--- a/workspaces/jenkins/plugins/jenkins-backend/config.d.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/config.d.ts
@@ -15,45 +15,47 @@
  */
 
 export interface Config {
-  jenkins?: {
-    /**
-     * Default instance baseUrl, can be specified on a named instance called "default"
-     */
-    baseUrl?: string;
-    /**
-     * Default instance username, can be specified on a named instance called "default"
-     */
-    username?: string;
-    /**
-     * Default instance projectCountLimit, can be specified on a named instance called "default"
-     */
-    projectCountLimit?: number;
-    /**
-     * Default Instance apiKey, can be specified on a named instance called "default"
-     * @visibility secret
-     */
-    apiKey?: string;
-
-    instances?: {
-      /**
-       * Name of the instance, this will be used in an annotation on catalog entities to refer to jobs on this instance.
-       *
-       * Use a name of "default" to specify the jenkins instance details if the annotation doesn't explicitly name an
-       * instance.
-       */
-      name: string;
-      baseUrl: string;
-      username: string;
-      projectCountLimit?: number;
-      /** @visibility secret */
-      apiKey: string;
-      extraRequestHeaders?: {
-        /** @visibility secret */
-        Authorization?: string;
-        /** @visibility secret */
-        authorization?: string;
-        [key: string]: string | undefined;
+  jenkins?:
+    | {
+        /**
+         * Default instance baseUrl, can be specified on a named instance called "default"
+         */
+        baseUrl: string;
+        /**
+         * Default instance username, can be specified on a named instance called "default"
+         */
+        username: string;
+        /**
+         * Default instance projectCountLimit, can be specified on a named instance called "default"
+         */
+        projectCountLimit?: number;
+        /**
+         * Default Instance apiKey, can be specified on a named instance called "default"
+         * @visibility secret
+         */
+        apiKey: string;
+      }
+    | {
+        instances: {
+          /**
+           * Name of the instance, this will be used in an annotation on catalog entities to refer to jobs on this instance.
+           *
+           * Use a name of "default" to specify the jenkins instance details if the annotation doesn't explicitly name an
+           * instance.
+           */
+          name: string;
+          baseUrl: string;
+          username: string;
+          projectCountLimit?: number;
+          /** @visibility secret */
+          apiKey: string;
+          extraRequestHeaders?: {
+            /** @visibility secret */
+            Authorization?: string;
+            /** @visibility secret */
+            authorization?: string;
+            [key: string]: string | undefined;
+          };
+        }[];
       };
-    }[];
-  };
 }

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
@@ -25,6 +25,11 @@ import {
 import { mockServices } from '@backstage/backend-test-utils';
 
 describe('JenkinsConfig', () => {
+  it('Reads empty config', async () => {
+    const config = JenkinsConfig.fromConfig(new ConfigReader({}));
+    expect(config.instances).toEqual([]);
+  });
+
   it('Reads simple config and annotation', async () => {
     const config = JenkinsConfig.fromConfig(
       new ConfigReader({

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -89,11 +89,9 @@ export class JenkinsConfig {
   static fromConfig(config: Config): JenkinsConfig {
     const DEFAULT_JENKINS_NAME = 'default';
 
-    const jenkinsConfig = config.getConfig('jenkins');
-
     // load all named instance config
     const namedInstanceConfig: JenkinsInstanceConfig[] =
-      jenkinsConfig.getOptionalConfigArray('instances')?.map(c => ({
+      config.getOptionalConfigArray('jenkins.instances')?.map(c => ({
         name: c.getString('name'),
         baseUrl: c.getString('baseUrl'),
         username: c.getString('username'),
@@ -112,15 +110,15 @@ export class JenkinsConfig {
     );
 
     // Get these as optional strings and check to give a better error message
-    const baseUrl = jenkinsConfig.getOptionalString('baseUrl');
-    const username = jenkinsConfig.getOptionalString('username');
-    const apiKey = jenkinsConfig.getOptionalString('apiKey');
-    const crumbIssuer = jenkinsConfig.getOptionalBoolean('crumbIssuer');
-    const extraRequestHeaders = jenkinsConfig.getOptional<
+    const baseUrl = config.getOptionalString('jenkins.baseUrl');
+    const username = config.getOptionalString('jenkins.username');
+    const apiKey = config.getOptionalString('jenkins.apiKey');
+    const crumbIssuer = config.getOptionalBoolean('jenkins.crumbIssuer');
+    const extraRequestHeaders = config.getOptional<
       JenkinsInstanceConfig['extraRequestHeaders']
-    >('extraRequestHeaders');
-    const allowedBaseUrlOverrideRegex = jenkinsConfig.getOptionalString(
-      'allowedBaseUrlOverrideRegex',
+    >('jenkins.extraRequestHeaders');
+    const allowedBaseUrlOverrideRegex = config.getOptionalString(
+      'jenkins.allowedBaseUrlOverrideRegex',
     );
 
     if (hasNamedDefault && (baseUrl || username || apiKey)) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Removes the call to `config.getConfig('jenkins')`, which unnecessarily throws if the `jenkins` key is not set.
- Adds conditional logic to the config schema to make it clearer at build-time how the keys under `jenkins` should be provided (rather than having to wait until run-time to find out), e.g.
   
   ```
   yarn backstage-cli config:check @backstage-community/plugin-jenkins-backend --strict
   ```
   
   Will now show an error in situations like:
   - Only some of `apiKey`, `username`, and `baseUrl` are provided
   - Any of the above are provided, but an `instances` array is also provided

Closes https://github.com/backstage/community-plugins/issues/2858

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
