### PR TITLE
feat(matomo): add configurable user tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,10 @@ yarn.lock                                           @backstage/community-plugins
 /workspaces/3scale                                  @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr
 /workspaces/acr                                     @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @invincibleJai
 /workspaces/adr                                     @backstage/community-plugins-maintainers  @kuangp
-/workspaces/analytics                               @backstage/community-plugins-maintainers  @jmezach
+/workspaces/analytics                               @backstage/community-plugins-maintainers
+/workspaces/analytics/plugins/analytics-module-matomo                              @backstage/community-plugins-maintainers  @deshmukhmayur @yashoswalyo @riginoommen
+/workspaces/analytics/plugins/analytics-module-newrelic-browser                    @backstage/community-plugins-maintainers  @jmezach
+/workspaces/analytics/plugins/analytics-provider-segment                           @backstage/community-plugins-maintainers  @AndrienkoAleksandr @PatAKnight @dzemanov 
 /workspaces/announcements                           @backstage/community-plugins-maintainers  @kurtaking
 /workspaces/azure-devops                            @backstage/community-plugins-maintainers  @awanlin
 /workspaces/azure-storage-explorer                  @backstage/community-plugins-maintainers  @deepan10

--- a/workspaces/analytics/.changeset/nasty-mangos-tap.md
+++ b/workspaces/analytics/.changeset/nasty-mangos-tap.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-matomo': minor
+---
+
+Configurable user tracking for Matomo

--- a/workspaces/analytics/plugins/analytics-module-matomo/README.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/README.md
@@ -49,6 +49,7 @@ app:
     matomo:
       host: ${ANALYTICS_MATOMO_INSTANCE_URL}
       siteId: ${ANALYTICS_MATOMO_SITE_ID}
+      identity: optional # (optional) to enable user tracking. Is disabled by default
 ```
 
 4. Update CSP in your `app-config.yaml`:(optional)

--- a/workspaces/analytics/plugins/analytics-module-matomo/app-config.yaml
+++ b/workspaces/analytics/plugins/analytics-module-matomo/app-config.yaml
@@ -1,0 +1,10 @@
+app:
+  title: 'Matomo Test'
+  analytics:
+    matomo:
+      host: example.com
+      siteId: 2
+      identity: 'disabled'
+
+backend:
+  baseUrl: http://localhost:7007

--- a/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
+++ b/workspaces/analytics/plugins/analytics-module-matomo/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-analytics-module-matomo
+  title: '@backstage-community/plugin-analytics-module-matomo'
+spec:
+  lifecycle: experimental
+  type: backstage-frontend-plugin-module
+  owner: maintainers

--- a/workspaces/analytics/plugins/analytics-module-matomo/config.d.ts
+++ b/workspaces/analytics/plugins/analytics-module-matomo/config.d.ts
@@ -28,6 +28,13 @@ export interface Config {
          * @visibility frontend
          */
         siteId: string;
+
+        /**
+         * Controls how the identityApi is used when sending data to Matomo:
+         *
+         * @visibility frontend
+         */
+        identity?: 'disabled' | 'optional' | 'required';
       };
     };
   };

--- a/workspaces/analytics/plugins/analytics-module-matomo/dev/Playground.tsx
+++ b/workspaces/analytics/plugins/analytics-module-matomo/dev/Playground.tsx
@@ -15,11 +15,23 @@
  */
 import React from 'react';
 import { LinkButton } from '@backstage/core-components';
+import { useAnalytics } from '@backstage/core-plugin-api';
 
 export const Playground = () => {
+  const analyticsApi = useAnalytics();
+
+  const handleEvent = () => {
+    analyticsApi.captureEvent('click', 'Test Button clicked');
+  };
+
   return (
     <div style={{ display: 'flex', margin: '4rem' }}>
-      <LinkButton variant="contained" color="primary" to="#clicked">
+      <LinkButton
+        variant="contained"
+        color="primary"
+        to="#clicked"
+        onClick={handleEvent}
+      >
         Click Here
       </LinkButton>
     </div>

--- a/workspaces/analytics/plugins/analytics-module-matomo/dev/index.tsx
+++ b/workspaces/analytics/plugins/analytics-module-matomo/dev/index.tsx
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 import React from 'react';
-
 import { createDevApp } from '@backstage/dev-utils';
-
-import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
-
 import { MatomoAnalyticsApi } from '../src';
 import { Playground } from './Playground';
 
 createDevApp()
   .registerApi(MatomoAnalyticsApi)
-  .addThemes(getAllThemes())
   .addPage({
     title: 'Matomo Analytics Playground',
     path: '/analytics-module-matomo',

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -16,7 +16,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "start": "backstage-cli package start",
+    "start": "backstage-cli package start --config app-config.yaml",
     "build": "backstage-cli package build",
     "prettier:check": "prettier --ignore-unknown --check .",
     "prettier:fix": "prettier --ignore-unknown --write .",

--- a/workspaces/analytics/plugins/analytics-module-matomo/report.api.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/report.api.md
@@ -9,6 +9,7 @@ import { ApiFactory } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Config } from '@backstage/config/index';
 import { ConfigApi } from '@backstage/core-plugin-api';
+import { IdentityApi } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
 export const analyticsModuleMatomoPlugin: BackstagePlugin<{}, {}, {}>;
@@ -18,7 +19,12 @@ export class MatomoAnalytics implements AnalyticsApi {
   // (undocumented)
   captureEvent(event: AnalyticsEvent): void;
   // (undocumented)
-  static fromConfig(config: ConfigApi): MatomoAnalytics;
+  static fromConfig(
+    config: ConfigApi,
+    options?: {
+      identityApi?: IdentityApi;
+    },
+  ): MatomoAnalytics;
 }
 
 // @public
@@ -27,6 +33,7 @@ export const MatomoAnalyticsApi: ApiFactory<
   MatomoAnalytics,
   {
     configApi: Config;
+    identityApi: IdentityApi;
   }
 >;
 

--- a/workspaces/analytics/plugins/analytics-module-matomo/src/api/index.ts
+++ b/workspaces/analytics/plugins/analytics-module-matomo/src/api/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { MatomoAnalytics, MatomoAnalyticsApi } from './Matomo';
+export { MatomoAnalytics } from './Matomo';

--- a/workspaces/analytics/plugins/analytics-module-matomo/src/index.ts
+++ b/workspaces/analytics/plugins/analytics-module-matomo/src/index.ts
@@ -13,5 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  analyticsApiRef,
+  configApiRef,
+  createApiFactory,
+  identityApiRef,
+} from '@backstage/core-plugin-api';
+import { MatomoAnalytics } from './api';
+
 export { analyticsModuleMatomoPlugin } from './plugin';
 export * from './api';
+/**
+ * API factory method for matomo
+ *
+ * @public
+ */
+export const MatomoAnalyticsApi = createApiFactory({
+  api: analyticsApiRef,
+  deps: { configApi: configApiRef, identityApi: identityApiRef },
+  factory: ({ configApi, identityApi }) =>
+    MatomoAnalytics.fromConfig(configApi, {
+      identityApi,
+    }),
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a configurable option to enable user tracking.

Borrowed the `identity` option from the ga module for consistency.

The user tracking is only enabled when the `app.analytics.matomo.identity` is `required | optional`, and is disabled by default.

Also refactored the code and moved the api factory from the `MatomoAnalytics` file to `index.ts`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
