### PR TITLE
fix: add scope to the for each command

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -4,32 +4,32 @@ on:
   workflow_dispatch:
     inputs:
       workspace:
-        description: "Name of the Workspace"
+        description: 'Name of the Workspace'
         required: true
         type: string
       force_release:
-        description: "Force release even if no changesets are present"
+        description: 'Force release even if no changesets are present'
         required: false
         type: boolean
       branch:
-        description: "Branch to run the workflow on"
+        description: 'Branch to run the workflow on'
         required: false
-        default: "main"
+        default: 'main'
         type: string
   workflow_call:
     inputs:
       force_release:
-        description: "Force release even if no changesets are present"
+        description: 'Force release even if no changesets are present'
         required: false
         type: boolean
       workspace:
-        description: "Name of the Workspace"
+        description: 'Name of the Workspace'
         required: true
         type: string
       branch:
-        description: "Branch to run the workflow on"
+        description: 'Branch to run the workflow on'
         required: false
-        default: "main"
+        default: 'main'
         type: string
 
 concurrency:
@@ -154,10 +154,10 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish
+          yarn workspaces foreach -W -v --no-private npm publish --access public --tolerate-republish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
+
       - name: Create tag
         working-directory: ${{ github.workspace }}/scripts/ci
         run: node create-tag.js


### PR DESCRIPTION
## Hey, I just made a Pull Request!


yarn 4 does not allow for each to run without setting a scope.

setting scope -W (worktree) as it was the default value before..
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
