### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/renovate-997ea7d.md
+++ b/workspaces/linkerd/.changeset/renovate-997ea7d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Updated dependency `parse-duration` to `^2.0.0`.

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.15
+
+### Patch Changes
+
+- Updated dependencies [5d2de92]
+  - @backstage-community/plugin-linkerd-backend@0.5.1
+
 ## 0.0.14
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.5.1
+
+### Patch Changes
+
+- 5d2de92: Updated dependency `parse-duration` to `^2.0.0`.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd-backend@0.5.1

### Patch Changes

-   5d2de92: Updated dependency `parse-duration` to `^2.0.0`.

## backend@0.0.15

### Patch Changes

-   Updated dependencies [5d2de92]
    -   @backstage-community/plugin-linkerd-backend@0.5.1
