### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/long-doors-appear.md
+++ b/workspaces/rbac/.changeset/long-doors-appear.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-In edit role form show selected permissions for a plugin based on resource-type and policy mapping if resource-type used in creation of simple permission policy via CLI/CSV file.

--- a/workspaces/rbac/.changeset/renovate-c101bad.md
+++ b/workspaces/rbac/.changeset/renovate-c101bad.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.10`.

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.38.1
+
+### Patch Changes
+
+- 152eb5f: In edit role form show selected permissions for a plugin based on resource-type and policy mapping if resource-type used in creation of simple permission policy via CLI/CSV file.
+- 3e35324: Updated dependency `start-server-and-test` to `2.0.10`.
+
 ## 1.38.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.38.1

### Patch Changes

-   152eb5f: In edit role form show selected permissions for a plugin based on resource-type and policy mapping if resource-type used in creation of simple permission policy via CLI/CSV file.
-   3e35324: Updated dependency `start-server-and-test` to `2.0.10`.
