### PR TITLE
fix(rbac): show selected permissions based on resource-type and action mapping in edit form if resource-type used in simple permission policy creation

### DIFF
--- a/workspaces/rbac/.changeset/long-doors-appear.md
+++ b/workspaces/rbac/.changeset/long-doors-appear.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+In edit role form show selected permissions for a plugin based on resource-type and policy mapping if resource-type used in creation of simple permission policy via CLI/CSV file.

--- a/workspaces/rbac/plugins/rbac/src/hooks/useRoles.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useRoles.ts
@@ -30,7 +30,11 @@ import {
 
 import { rbacApiRef } from '../api/RBACBackendClient';
 import { RolesData } from '../types';
-import { getPermissions, getPermissionsArray } from '../utils/rbac-utils';
+import {
+  getPermissions,
+  getPermissionsArray,
+  getPluginInfo,
+} from '../utils/rbac-utils';
 
 type RoleWithConditionalPoliciesCount = Role & {
   conditionalPoliciesCount: number;
@@ -181,10 +185,10 @@ export const useRoles = (
                   policies as RoleBasedPolicy[],
                 ).map(
                   po =>
-                    (permissionPolicies as PluginPermissionMetaData[]).find(
-                      pp =>
-                        pp.policies?.find(pol => po.permission === pol.name),
-                    )?.pluginId,
+                    getPluginInfo(
+                      permissionPolicies as PluginPermissionMetaData[],
+                      po,
+                    ).pluginId,
                 );
                 accPls = [...accPls, ...pls].filter(val => !!val) as string[];
               }

--- a/workspaces/rbac/plugins/rbac/src/types.ts
+++ b/workspaces/rbac/plugins/rbac/src/types.ts
@@ -57,6 +57,7 @@ export type PermissionsDataSet = {
   policyString?: Set<string>;
   isResourced?: boolean;
   resourceType?: string;
+  usingResourceType?: boolean;
 };
 
 export type SelectedPlugin = { label: string; value: string };
@@ -70,6 +71,7 @@ export type PermissionsData = {
   isResourced?: boolean;
   conditions?: ConditionsData;
   resourceType?: string;
+  usingResourceType?: boolean;
 };
 
 export type MemberEntity = UserEntity | GroupEntity;

--- a/workspaces/rbac/plugins/rbac/src/utils/create-role-utils.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/create-role-utils.ts
@@ -182,7 +182,13 @@ export const getPermissionPoliciesData = (
 
   return permissionPoliciesRows.reduce(
     (acc: RoleBasedPolicy[], permissionPolicyRow) => {
-      const { permission, policies, conditions } = permissionPolicyRow;
+      const {
+        permission,
+        policies,
+        conditions,
+        resourceType,
+        usingResourceType,
+      } = permissionPolicyRow;
       const permissionPoliciesData = policies.reduce(
         (pAcc: RoleBasedPolicy[], policy) => {
           if (policy.effect === 'allow' && !conditions) {
@@ -190,7 +196,10 @@ export const getPermissionPoliciesData = (
               ...pAcc,
               {
                 entityReference: `${kind}:${namespace}/${name}`,
-                permission: `${permission}`,
+                permission:
+                  resourceType && usingResourceType
+                    ? `${resourceType}`
+                    : `${permission}`,
                 policy: policy.policy.toLocaleLowerCase('en-US'),
                 effect: 'allow',
               },

--- a/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.test.ts
@@ -183,26 +183,36 @@ describe('rbac utils', () => {
 
   it('should return plugin-id of the policy', () => {
     expect(
-      getPluginInfo(mockPermissionPolicies, 'catalog.entity.read').pluginId,
+      getPluginInfo(mockPermissionPolicies, {
+        permission: 'catalog.entity.read',
+        policy: 'read',
+      }).pluginId,
     ).toBe('catalog');
     expect(
-      getPluginInfo(mockPermissionPolicies, 'scaffolder.template.read')
-        .pluginId,
+      getPluginInfo(mockPermissionPolicies, {
+        permission: 'scaffolder.template.read',
+        policy: 'read',
+      }).pluginId,
     ).toBe('scaffolder');
   });
 
   it('should return if the permission is resourced', () => {
     expect(
-      getPluginInfo(mockPermissionPolicies, 'catalog.entity.read').isResourced,
+      getPluginInfo(mockPermissionPolicies, {
+        permission: 'catalog.entity.read',
+        policy: 'read',
+      }).isResourced,
     ).toBe(true);
     expect(
-      getPluginInfo(mockPermissionPolicies, 'scaffolder.template.read')
-        .isResourced,
+      getPluginInfo(mockPermissionPolicies, {
+        permission: 'scaffolder.template.read',
+        policy: 'read',
+      }).isResourced,
     ).toBe(true);
   });
 
   it('should return the permissions data', () => {
-    let data = getPermissionsData(mockPolicies, mockPermissionPolicies);
+    const data = getPermissionsData(mockPolicies, mockPermissionPolicies);
     expect(data[0]).toEqual({
       permission: 'policy.entity.read',
       plugin: 'permission',
@@ -215,19 +225,7 @@ describe('rbac utils', () => {
       policyString: ['Read'],
       isResourced: true,
       resourceType: 'policy-entity',
-    });
-    data = getPermissionsData(mockPolicies, []);
-    expect(data[0]).toEqual({
-      permission: 'policy.entity.read',
-      plugin: '-',
-      policies: [
-        {
-          effect: 'allow',
-          policy: 'Read',
-        },
-      ],
-      policyString: ['Read'],
-      isResourced: false,
+      usingResourceType: false,
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes: https://issues.redhat.com/browse/RHIDP-6066, https://issues.redhat.com/browse/RHIDP-6067


https://github.com/user-attachments/assets/bdd996a1-8f70-4176-9559-826bf467efac



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

**Steps for testing:**

- Create role `developer`
- Add following permissions to the above role via CLI which is using resource-type instead of permission name:
```
curl -X POST "http://localhost:7007/api/permission/policies" -d '[
  {
    "entityReference": "role:default/developer",
    "permission": "catalog-entity",
    "policy": "read",
    "effect": "allow"
  },
  {
    "entityReference": "role:default/developer",
    "permission": "catalog-entity",
    "policy": "delete",
    "effect": "allow"
  },
  {
    "entityReference": "role:default/developer",
    "permission": "catalog-entity",
    "policy": "update",
    "effect": "allow"
  }
]' -H "Content-Type: application/json" -H "Authorization: Bearer <token>" -v
```