### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/twenty-swans-play.md
+++ b/workspaces/kafka/.changeset/twenty-swans-play.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-kafka-backend': patch
-'@backstage-community/plugin-kafka': patch
----
-
-Add link to a [kafkajs](https://kafka.js.org/docs/confiuration#ssl) docs with ssl options
-Update Reference to the kafka-backend plugin in a Readme

--- a/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kafka-backend
 
+## 0.5.1
+
+### Patch Changes
+
+- 381a2b0: Add link to a [kafkajs](https://kafka.js.org/docs/confiuration#ssl) docs with ssl options
+  Update Reference to the kafka-backend plugin in a Readme
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/kafka/plugins/kafka-backend/package.json
+++ b/workspaces/kafka/plugins/kafka-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Backstage backend plugin that integrates towards Kafka",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/kafka/plugins/kafka/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kafka
 
+## 0.5.1
+
+### Patch Changes
+
+- 381a2b0: Add link to a [kafkajs](https://kafka.js.org/docs/confiuration#ssl) docs with ssl options
+  Update Reference to the kafka-backend plugin in a Readme
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/kafka/plugins/kafka/package.json
+++ b/workspaces/kafka/plugins/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Backstage plugin that integrates towards Kafka",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka@0.5.1

### Patch Changes

-   381a2b0: Add link to a [kafkajs](https://kafka.js.org/docs/confiuration#ssl) docs with ssl options
    Update Reference to the kafka-backend plugin in a Readme

## @backstage-community/plugin-kafka-backend@0.5.1

### Patch Changes

-   381a2b0: Add link to a [kafkajs](https://kafka.js.org/docs/confiuration#ssl) docs with ssl options
    Update Reference to the kafka-backend plugin in a Readme
