### PR TITLE
Quay actions template update

### DIFF
--- a/workspaces/quay/app-config.yaml
+++ b/workspaces/quay/app-config.yaml
@@ -60,6 +60,12 @@ catalog:
       rules:
         - allow: [User, Group]
 
+    # Quay template
+    - type: file
+      target: ../../plugins/quay-actions/examples/templates/01-quay-template.yaml
+      rules:
+        - allow: [Template]
+
 quay:
-  uiUrl: 'https://quay.io'
+  apiUrl: 'https://quay.io'
   apiKey: ''

--- a/workspaces/quay/packages/backend/package.json
+++ b/workspaces/quay/packages/backend/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@backstage-community/plugin-quay-backend": "workspace:^",
     "@backstage-community/plugin-quay-common": "workspace:^",
+    "@backstage-community/plugin-scaffolder-backend-module-quay": "workspace:^",
     "@backstage/backend-defaults": "^0.7.0",
     "@backstage/backend-plugin-api": "^1.1.1",
     "@backstage/config": "^1.3.2",

--- a/workspaces/quay/packages/backend/src/index.ts
+++ b/workspaces/quay/packages/backend/src/index.ts
@@ -47,5 +47,9 @@ backend.add(
 
 // Quay backend
 backend.add(import('@backstage-community/plugin-quay-backend'));
+// Quay scaffolder module
+backend.add(
+  import('@backstage-community/plugin-scaffolder-backend-module-quay'),
+);
 
 backend.start();

--- a/workspaces/quay/plugins/quay-actions/examples/templates/01-quay-template.yaml
+++ b/workspaces/quay/plugins/quay-actions/examples/templates/01-quay-template.yaml
@@ -19,7 +19,7 @@ spec:
           title: Token
           type: string
           description: Bearer token used for authorization
-          ui:widget: password
+          ui:field: Secret
         visibility:
           title: Visiblity
           type: string
@@ -51,7 +51,7 @@ spec:
       action: quay:create-repository
       input:
         baseUrl: ${{ parameters.baseUrl }}
-        token: ${{ parameters.token }}
+        token: ${{ secrets.token }}
         name: ${{ parameters.name }}
         visibility: ${{ parameters.visibility }}
         description: ${{ parameters.description }}

--- a/workspaces/quay/plugins/quay-actions/examples/templates/01-quay-template.yaml
+++ b/workspaces/quay/plugins/quay-actions/examples/templates/01-quay-template.yaml
@@ -21,7 +21,7 @@ spec:
           description: Bearer token used for authorization
           ui:field: Secret
         visibility:
-          title: Visiblity
+          title: Visibility
           type: string
           description: Visibility setting for the created repository, either public or private
           ui:widget: select

--- a/workspaces/quay/plugins/quay-actions/src/actions/createQuayRepository.test.ts
+++ b/workspaces/quay/plugins/quay-actions/src/actions/createQuayRepository.test.ts
@@ -28,7 +28,7 @@ describe('quay:create-repository', () => {
     jest.resetAllMocks();
   });
 
-  const mockContext = createMockActionContext();
+  const mockContext = createMockActionContext({ secrets: { token: 'TOKEN' } });
 
   it('should create a quay repository', async () => {
     const body: ResponseBody = {

--- a/workspaces/quay/plugins/quay-actions/src/actions/createQuayRepository.ts
+++ b/workspaces/quay/plugins/quay-actions/src/actions/createQuayRepository.ts
@@ -86,7 +86,7 @@ export function createQuayRepositoryAction() {
     schema: {
       input: {
         type: 'object',
-        required: ['name', 'visibility', 'description', 'token'],
+        required: ['name', 'visibility', 'description'],
         properties: {
           name: {
             title: 'Repository name',
@@ -141,8 +141,8 @@ export function createQuayRepositoryAction() {
       },
     },
     async handler(ctx) {
-      const { token, name, visibility, namespace, description, repoKind } =
-        ctx.input;
+      const { name, visibility, namespace, description, repoKind } = ctx.input;
+      const token = ctx.secrets?.token;
       const baseUrl = getUrl(ctx.input.baseUrl);
       isValueValid(visibility, 'visibility', ['public', 'private']);
       isValueValid(repoKind, 'repository kind', [

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -2721,7 +2721,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage-community/plugin-scaffolder-backend-module-quay@workspace:plugins/quay-actions":
+"@backstage-community/plugin-scaffolder-backend-module-quay@workspace:^, @backstage-community/plugin-scaffolder-backend-module-quay@workspace:plugins/quay-actions":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-scaffolder-backend-module-quay@workspace:plugins/quay-actions"
   dependencies:
@@ -15277,6 +15277,7 @@ __metadata:
   dependencies:
     "@backstage-community/plugin-quay-backend": "workspace:^"
     "@backstage-community/plugin-quay-common": "workspace:^"
+    "@backstage-community/plugin-scaffolder-backend-module-quay": "workspace:^"
     "@backstage/backend-defaults": "npm:^0.7.0"
     "@backstage/backend-plugin-api": "npm:^1.1.1"
     "@backstage/cli": "npm:^0.29.5"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- `@backstage-community/plugin-scaffolder-backend-module-quay` uses the insecure deprecated `ui:widget: password` instead of `ui:field: Secret`. As a result, token can be fully seen on the screen.

- Updates quay workspace to use `@backstage-community/plugin-scaffolder-backend-module-quay`
- Updates `app-config.yaml` to use `apiKey` instead of `uiKey` as it is required for quay backend to work. 

Before:
![quay-actions-token](https://github.com/user-attachments/assets/edaa02be-ffe1-4a3f-a089-07a93ce54809)

After:
![quay-actions-fix](https://github.com/user-attachments/assets/969bd4a0-2115-4070-80e0-e5b817ac2635)

#### Fixes
[RHIDP-6081](https://issues.redhat.com/browse/RHIDP-6081)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
