### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/version-bump-1-36-0.md
+++ b/workspaces/github-actions/.changeset/version-bump-1-36-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': minor
----
-
-Backstage version bump to v1.36.0

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.8.0
+
+### Minor Changes
+
+- 435f142: Backstage version bump to v1.36.0
+
 ## 0.7.2
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.8.0

### Minor Changes

-   435f142: Backstage version bump to v1.36.0
