### PR TITLE
fix(rbac): allow alias resolver to work for all rules

### DIFF
--- a/workspaces/rbac/.changeset/giant-experts-smell.md
+++ b/workspaces/rbac/.changeset/giant-experts-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Fixed an issue where aliases would not be applied across all conditional policy rules.

--- a/workspaces/rbac/plugins/rbac-backend/src/conditional-aliases/alias-resolver.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/conditional-aliases/alias-resolver.test.ts
@@ -433,6 +433,95 @@ describe('replaceAliases', () => {
       });
     });
 
+    it('should replace aliases with criteria anyOf and few values in a different order', () => {
+      const conditionParam: PermissionCriteria<
+        PermissionCondition<string, PermissionRuleParams>
+      > = {
+        anyOf: [
+          {
+            rule: 'IS_ENTITY_KIND',
+            resourceType: 'catalog-entity',
+            params: { kinds: ['Group', 'User'] },
+          },
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['$ownerRefs'],
+            },
+          },
+        ],
+      };
+
+      replaceAliases(conditionParam, {
+        userEntityRef: 'user:default/tim',
+        ownershipEntityRefs: ['user:default/tim', 'group:default/team-a'],
+      });
+
+      expect(conditionParam).toEqual({
+        anyOf: [
+          {
+            rule: 'IS_ENTITY_KIND',
+            resourceType: 'catalog-entity',
+            params: { kinds: ['Group', 'User'] },
+          },
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/tim', 'group:default/team-a'],
+            },
+          },
+        ],
+      });
+    });
+
+    it('should replace aliases with criteria anyOf and few values for other rules', () => {
+      const conditionParam: PermissionCriteria<
+        PermissionCondition<string, PermissionRuleParams>
+      > = {
+        anyOf: [
+          {
+            rule: 'HAS_ANNOTATION',
+            resourceType: 'catalog-entity',
+            params: { value: '$currentUser', annotation: 'template/creator' },
+          },
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['$ownerRefs'],
+            },
+          },
+        ],
+      };
+
+      replaceAliases(conditionParam, {
+        userEntityRef: 'user:default/tim',
+        ownershipEntityRefs: ['user:default/tim', 'group:default/team-a'],
+      });
+
+      expect(conditionParam).toEqual({
+        anyOf: [
+          {
+            rule: 'HAS_ANNOTATION',
+            resourceType: 'catalog-entity',
+            params: {
+              value: 'user:default/tim',
+              annotation: 'template/creator',
+            },
+          },
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/tim', 'group:default/team-a'],
+            },
+          },
+        ],
+      });
+    });
+
     it('should replace aliases with criteria allOf', () => {
       const conditionParam: PermissionCriteria<
         PermissionCondition<string, PermissionRuleParams>

--- a/workspaces/rbac/plugins/rbac-backend/src/conditional-aliases/alias-resolver.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/conditional-aliases/alias-resolver.ts
@@ -97,8 +97,8 @@ export function replaceAliases(
   if ('anyOf' in conditions) {
     for (const condition of conditions.anyOf) {
       replaceAliases(condition, userInfo);
-      return;
     }
+    return;
   }
 
   const params = (
@@ -106,8 +106,12 @@ export function replaceAliases(
   ).params;
   if (params) {
     for (const key of Object.keys(params)) {
+      const currentParams = (
+        conditions as PermissionCondition<string, PermissionRuleParams>
+      ).params;
+
       let modifiedParams = replaceAliasWithValue(
-        params,
+        currentParams,
         key,
         isCurrentUserAlias,
         userInfo.userEntityRef,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an issue where aliases were not being applied properly across all conditional rules. There were two scenarios that I ended up fixing as they were both situations where this happened. 

1. Whenever an alias with a conditional rule appeared anywhere other than the first condition. An example can be found below.

```
result: CONDITIONAL
roleEntityRef: 'role:default/first-issue'
pluginId: catalog
resourceType: catalog-entity
permissionMapping:
  - read
conditions:
  anyOf:
    - rule: IS_ENTITY_KIND
      resourceType: catalog-entity
      params:
        kinds:
          - template
    - rule: IS_ENTITY_OWNER
      resourceType: catalog-entity
      params:
        claims:
          - $currentUser
```

2. Whenever an alias was used with a rule other than `IS_ENTITY_OWNER`. An example can be found below.

```
result: CONDITIONAL
roleEntityRef: 'role:default/another_test'
pluginId: catalog
resourceType: catalog-entity
permissionMapping:
  - read
conditions:
  rule: HAS_ANNOTATION
  resourceType: catalog-entity
  params:
    value: $currentUser
    annotation: template/creator
```

- Fixes: #2409 
- Fixes: #2950

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
