### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/short-kids-applaud.md
+++ b/workspaces/rbac/.changeset/short-kids-applaud.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Reduces the number of times that we build the group hierarchy graphs during evaluation. Originally, during time of evaluation, we would build a graph to of all of the groups that a user was directly or indirectly a member of. Now, we only build the graph once and pass along all of the roles that the user is directly or indirectly attached to.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 5.5.0
+
+### Minor Changes
+
+- 36e2c6c: Reduces the number of times that we build the group hierarchy graphs during evaluation. Originally, during time of evaluation, we would build a graph to of all of the groups that a user was directly or indirectly a member of. Now, we only build the graph once and pass along all of the roles that the user is directly or indirectly attached to.
+
 ## 5.4.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@5.5.0

### Minor Changes

-   36e2c6c: Reduces the number of times that we build the group hierarchy graphs during evaluation. Originally, during time of evaluation, we would build a graph to of all of the groups that a user was directly or indirectly a member of. Now, we only build the graph once and pass along all of the roles that the user is directly or indirectly attached to.
