### PR TITLE
docs: Update explore plugin doc

### DIFF
--- a/workspaces/explore/plugins/explore/README.md
+++ b/workspaces/explore/plugins/explore/README.md
@@ -105,12 +105,22 @@ Create a custom explore page in
 ```tsx
 import {
   CatalogKindExploreContent,
+  ToolExplorerContent,
   ExploreLayout,
+  explorePlugin,
 } from '@backstage-community/plugin-explore';
+import {
+  createRoutableExtension,
+  createRouteRef,
+} from '@backstage/core-plugin-api';
 import React from 'react';
 import { InnerSourceExploreContent } from './InnerSourceExploreContent';
 
-export const ExplorePage = () => {
+export const exploreRouteRef = createRouteRef({
+  id: 'explore',
+});
+
+export const explorePageContent = () => {
   return (
     <ExploreLayout
       title="Explore the ACME corp ecosystem"
@@ -125,9 +135,20 @@ export const ExplorePage = () => {
       <ExploreLayout.Route path="inner-source" title="InnerSource">
         <InnerSourceExploreContent />
       </ExploreLayout.Route>
+      <ExploreLayout.Route path="tools" title="Tools">
+        <ToolExplorerContent />
+      </ExploreLayout.Route>
     </ExploreLayout>
   );
 };
+
+export const ExplorePage = explorePlugin.provide(
+  createRoutableExtension({
+    name: 'ExplorePage',
+    component: async () => explorePageContent,
+    mountPoint: exploreRouteRef,
+  }),
+);
 
 export const explorePage = <ExplorePage />;
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Update the explore plugin doc, to extend the customisation example to include references to how you would include the `ToolExplorerContent` component that requires the explore API.

Currently the doc isn't clear enough when it comes to customising and the requirements it needs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
