### PR TITLE
Octopus deployments table UI tweaking 

### DIFF
--- a/workspaces/octopus-deploy/.changeset/metal-carpets-refuse.md
+++ b/workspaces/octopus-deploy/.changeset/metal-carpets-refuse.md
@@ -1,0 +1,10 @@
+---
+'@backstage-community/plugin-octopus-deploy': patch
+---
+
+### UI tweaking release table
+
+- added external links to the Octopus release version detail
+- table title contains external link to the Octopus project (moved from the table footer to save some space)
+- fixed searching for states in the table
+- fixed state icon position next to state

--- a/workspaces/octopus-deploy/.changeset/metal-carpets-refuse.md
+++ b/workspaces/octopus-deploy/.changeset/metal-carpets-refuse.md
@@ -2,7 +2,7 @@
 '@backstage-community/plugin-octopus-deploy': patch
 ---
 
-### UI tweaking release table
+UI tweaking release table
 
 - added external links to the Octopus release version detail
 - table title contains external link to the Octopus project (moved from the table footer to save some space)

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/report.api.md
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/report.api.md
@@ -119,6 +119,7 @@ export type OctopusProjectGroup = {
 export type OctopusRelease = {
   Id: string;
   Version: string;
+  Links: OctopusLinks;
 };
 
 // @public (undocumented)

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/src/api/index.ts
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/src/api/index.ts
@@ -43,6 +43,7 @@ export type OctopusReleaseProgression = {
 export type OctopusRelease = {
   Id: string;
   Version: string;
+  Links: OctopusLinks;
 };
 
 /** @public */

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/src/components/ReleaseTable/ReleaseTable.tsx
@@ -199,7 +199,7 @@ export const ReleaseTable = ({
         <Box display="flex" alignItems="center">
           <OctopusDeployIcon style={{ fontSize: 30 }} />
           <Box mr={1} />
-          Octopus <Box mr={1} /> {projectTitle} <Box mr={1} /> deploys (
+          Octopus Deploy - <Box mr={1} /> {projectTitle} <Box mr={1} /> (
           {releases ? releases.length : 0})
         </Box>
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!
UI Tweaking:
- added external links to the Octopus release version detail
- table title contains external link to the Octopus project (moved from the table footer to save some space)
- fixed searching for states in the table
- fixed state icon position next to state

**BEFORE**:
![image](https://github.com/user-attachments/assets/4a4d79df-235e-41ba-bd12-410ab79c3c2b)


**AFTER:**
![image](https://github.com/user-attachments/assets/e1f31bf4-1a7a-4d67-a310-a583197b221c)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [] Added or updated documentation
- [] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
