### PR TITLE
fix(tekton): remove resets from PF CSS import

### DIFF
--- a/workspaces/tekton/.changeset/bright-buttons-call.md
+++ b/workspaces/tekton/.changeset/bright-buttons-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Remove CSS resets from PatternFly CSS import

--- a/workspaces/tekton/plugins/tekton/src/components/Tekton/TektonCIComponent.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/Tekton/TektonCIComponent.tsx
@@ -23,7 +23,7 @@ import { ModelsPlural } from '../../models';
 import PermissionAlert from '../common/PermissionAlert';
 import PipelineRunList from '../PipelineRunList/PipelineRunList';
 
-import '@patternfly/react-core/dist/styles/base.css';
+import '@patternfly/react-core/dist/styles/base-no-reset.css';
 import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 
 const savedStylesheets = new Set<HTMLLinkElement>();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

remove resets from PF CSS import per discussion with @christoph-jerolimov and @benwilcock. Thanks @christoph-jerolimov for spotting the bug :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
