### PR TITLE
Adding briefRepresentation flag to pass to group API call

### DIFF
--- a/workspaces/keycloak/.changeset/long-pens-sing.md
+++ b/workspaces/keycloak/.changeset/long-pens-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-keycloak': patch
+---
+
+Adding briefRepresentation flag to config to fetch additional group attributes

--- a/workspaces/keycloak/.changeset/long-pens-sing.md
+++ b/workspaces/keycloak/.changeset/long-pens-sing.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
+'@backstage-community/plugin-catalog-backend-module-keycloak': minor
 ---
 
 Adding briefRepresentation flag to config to fetch additional group and user attributes

--- a/workspaces/keycloak/.changeset/long-pens-sing.md
+++ b/workspaces/keycloak/.changeset/long-pens-sing.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-catalog-backend-module-keycloak': patch
 ---
 
-Adding briefRepresentation flag to config to fetch additional group attributes
+Adding briefRepresentation flag to config to fetch additional group and user attributes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/config.d.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/config.d.ts
@@ -56,7 +56,8 @@ export interface Config {
            */
           maxConcurrency?: number;
           /**
-           * Whether the API call will return a brief representation for groups or not. Defaults to true
+           * Whether the API call will return a brief representation for groups and users or not. Defaults to true
+           * @defaultValue true
            */
           briefRepresentation?: boolean;
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/config.d.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/config.d.ts
@@ -55,7 +55,10 @@ export interface Config {
            * Maximum request concurrency to prevent DoS attacks on the Keycloak server.
            */
           maxConcurrency?: number;
-
+          /**
+           * Whether the API call will return a brief representation for groups or not. Defaults to true
+           */
+          briefRepresentation?: boolean;
           schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         } & (
           | {

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/report.api.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/report.api.md
@@ -98,6 +98,7 @@ export type KeycloakProviderConfig = {
   userQuerySize?: number;
   groupQuerySize?: number;
   maxConcurrency?: number;
+  briefRepresentation?: boolean;
 };
 
 // @public

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.test.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.test.ts
@@ -47,6 +47,7 @@ describe('readProviderConfigs', () => {
         schedule: undefined,
         userQuerySize: undefined,
         groupQuerySize: undefined,
+        briefRepresentation: undefined,
       },
     ]);
   });
@@ -66,6 +67,7 @@ describe('readProviderConfigs', () => {
                 clientSecret: 'myclientsecret',
                 userQuerySize: 100,
                 groupQuerySize: 200,
+                briefRepresentation: true,
                 schedule: {
                   frequency: { hours: 1 },
                   timeout: { minutes: 50 },
@@ -92,6 +94,7 @@ describe('readProviderConfigs', () => {
         clientSecret: 'myclientsecret',
         userQuerySize: 100,
         groupQuerySize: 200,
+        briefRepresentation: true,
         schedule: {
           scope: undefined,
           frequency: { hours: 1 },

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
@@ -96,6 +96,12 @@ export type KeycloakProviderConfig = {
    * Maximum request concurrency to prevent DoS attacks on the Keycloak server.
    */
   maxConcurrency?: number;
+
+  /**
+   * Whether if the API call will return a brief representation for groups.
+   * A complete representation will include attributes
+   */
+  briefRepresentation?: boolean;
 };
 
 const readProviderConfig = (
@@ -116,6 +122,9 @@ const readProviderConfig = (
     providerConfigInstance.getOptionalNumber('groupQuerySize');
   const maxConcurrency =
     providerConfigInstance.getOptionalNumber('maxConcurrency');
+  const briefRepresentation = providerConfigInstance.getOptionalBoolean(
+    'briefRepresentation',
+  );
 
   if (clientId && !clientSecret) {
     throw new InputError(
@@ -156,6 +165,7 @@ const readProviderConfig = (
     userQuerySize,
     groupQuerySize,
     maxConcurrency,
+    briefRepresentation,
   };
 };
 

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
@@ -98,8 +98,9 @@ export type KeycloakProviderConfig = {
   maxConcurrency?: number;
 
   /**
-   * Whether the API call will return a brief representation for groups or not. Defaults to true.
-   * A complete representation will include attributes
+   * Whether the API call will return a brief representation for groups and users or not. Defaults to true.
+   * A complete representation will include additional attributes
+   * @defaultValue true
    */
   briefRepresentation?: boolean;
 };

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/config.ts
@@ -98,7 +98,7 @@ export type KeycloakProviderConfig = {
   maxConcurrency?: number;
 
   /**
-   * Whether if the API call will return a brief representation for groups.
+   * Whether the API call will return a brief representation for groups or not. Defaults to true.
    * A complete representation will include attributes
    */
   briefRepresentation?: boolean;

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/constants.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/constants.ts
@@ -18,3 +18,4 @@ export const KEYCLOAK_HOST_ANNOTATION = 'keycloak.org/host';
 export const KEYCLOAK_ID_ANNOTATION = 'keycloak.org/id';
 export const KEYCLOAK_REALM_ANNOTATION = 'keycloak.org/realm';
 export const KEYCLOAK_ENTITY_QUERY_SIZE = 100;
+export const KEYCLOAK_BRIEF_REPRESENTATION_DEFAULT = true;

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
@@ -29,6 +29,7 @@ import {
   KEYCLOAK_ENTITY_QUERY_SIZE,
   KEYCLOAK_ID_ANNOTATION,
   KEYCLOAK_REALM_ANNOTATION,
+  KEYCLOAK_BRIEF_REPRESENTATION_DEFAULT,
 } from './constants';
 import { noopGroupTransformer, noopUserTransformer } from './transformers';
 import {
@@ -120,7 +121,8 @@ export async function getEntities<T extends Users | Groups>(
     typeof rawEntityCount === 'number' ? rawEntityCount : rawEntityCount.count;
 
   const pageCount = Math.ceil(entityCount / entityQuerySize);
-  const brief = config.briefRepresentation ?? true;
+  const brief =
+    config.briefRepresentation ?? KEYCLOAK_BRIEF_REPRESENTATION_DEFAULT;
 
   // The next line acts like range in python
   const entityPromises = Array.from({ length: pageCount }, (_, i) =>
@@ -195,6 +197,9 @@ export async function processGroupsRecursively(
   topLevelGroups: GroupRepresentationWithParent[],
 ) {
   const allGroups: GroupRepresentationWithParent[] = [];
+  const brief =
+    config.briefRepresentation ?? KEYCLOAK_BRIEF_REPRESENTATION_DEFAULT;
+
   for (const group of topLevelGroups) {
     allGroups.push(group);
 
@@ -204,7 +209,7 @@ export async function processGroupsRecursively(
         parentId: group.id!,
         first: 0,
         max: group.subGroupCount,
-        briefRepresentation: true,
+        briefRepresentation: brief,
       });
       const subGroupResults = await processGroupsRecursively(
         kcAdminClient,
@@ -301,6 +306,9 @@ export const readKeycloakRealm = async (
   }
 
   logger.debug(`Fetching group members for keycloak groups and list subgroups`);
+  const brief =
+    config.briefRepresentation ?? KEYCLOAK_BRIEF_REPRESENTATION_DEFAULT;
+
   const kGroups = await Promise.all(
     rawKGroups.map(g =>
       limit(async () => {
@@ -321,7 +329,7 @@ export const readKeycloakRealm = async (
               parentId: g.id!,
               first: 0,
               max: g.subGroupCount,
-              briefRepresentation: false,
+              briefRepresentation: brief,
               realm: config.realm,
             });
           }

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
@@ -120,6 +120,7 @@ export async function getEntities<T extends Users | Groups>(
     typeof rawEntityCount === 'number' ? rawEntityCount : rawEntityCount.count;
 
   const pageCount = Math.ceil(entityCount / entityQuerySize);
+  const brief = config.briefRepresentation ?? true;
 
   // The next line acts like range in python
   const entityPromises = Array.from({ length: pageCount }, (_, i) =>
@@ -130,6 +131,7 @@ export async function getEntities<T extends Users | Groups>(
             realm: config.realm,
             max: entityQuerySize,
             first: i * entityQuerySize,
+            briefRepresentation: brief,
           })
           .then(ents => {
             logger.debug(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a briefRepresentation flag to the config of catalog-backend-module-keycloak plugin so that we can pass it along the API call in order to retrieve additional information when fetching groups. This will be true by default, maintaining current functionality when not present.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
