### PR TITLE
Added Rate Limiting in Confluence Plugin

### DIFF
--- a/workspaces/confluence/.changeset/smooth-panthers-scream.md
+++ b/workspaces/confluence/.changeset/smooth-panthers-scream.md
@@ -1,0 +1,5 @@
+---
+'# @backstage-community/plugin-search-backend-module-confluence-collator': minor
+---
+
+Added configurable rate limiting to the Confluence plugin to mitigate excessive requests and improve performance under high load. Administrators can now set limits on API calls to better control usage. Please refer to the documentation for configuration details.

--- a/workspaces/confluence/.changeset/smooth-panthers-scream.md
+++ b/workspaces/confluence/.changeset/smooth-panthers-scream.md
@@ -1,5 +1,5 @@
 ---
-'# @backstage-community/plugin-search-backend-module-confluence-collator': minor
+'@backstage-community/plugin-search-backend-module-confluence-collator': minor
 ---
 
 Added configurable rate limiting to the Confluence plugin to mitigate excessive requests and improve performance under high load. Administrators can now set limits on API calls to better control usage. Please refer to the documentation for configuration details.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -65,6 +65,7 @@ confluence:
     token: '${CONFLUENCE_TOKEN}'
   spaces: [] # It is highly recommended to safely list the spaces that you want to index, otherwise all spaces will be indexed.
   query: '' # If your spaces contain documents you don't want to index, you can use a CQL query to more precisely select them. This is combined with the spaces parameter above.
+  requestsPerSecond: 5 #If your Confluence Server is getting a lot of API requests hit, you can use this parameter to mention the api requests per second like mentioned in this example
 ```
 
 Documentation about CQL can be found [here](https://developer.atlassian.com/server/confluence/advanced-searching-using-cql)

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -65,7 +65,7 @@ confluence:
     token: '${CONFLUENCE_TOKEN}'
   spaces: [] # It is highly recommended to safely list the spaces that you want to index, otherwise all spaces will be indexed.
   query: '' # If your spaces contain documents you don't want to index, you can use a CQL query to more precisely select them. This is combined with the spaces parameter above.
-  maxRequestsPerSecond: 5 #If your Confluence Server is getting a lot of API requests hit, you can use this parameter to mention the api requests per second like mentioned in this example
+  maxRequestsPerSecond: 5 # If your Confluence Server is getting a lot of API requests hit, you can use this parameter to specify the maximum number of API requests per second.
 ```
 
 Documentation about CQL can be found [here](https://developer.atlassian.com/server/confluence/advanced-searching-using-cql)

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -65,7 +65,7 @@ confluence:
     token: '${CONFLUENCE_TOKEN}'
   spaces: [] # It is highly recommended to safely list the spaces that you want to index, otherwise all spaces will be indexed.
   query: '' # If your spaces contain documents you don't want to index, you can use a CQL query to more precisely select them. This is combined with the spaces parameter above.
-  requestsPerSecond: 5 #If your Confluence Server is getting a lot of API requests hit, you can use this parameter to mention the api requests per second like mentioned in this example
+  maxRequestsPerSecond: 5 #If your Confluence Server is getting a lot of API requests hit, you can use this parameter to mention the api requests per second like mentioned in this example
 ```
 
 Documentation about CQL can be found [here](https://developer.atlassian.com/server/confluence/advanced-searching-using-cql)

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -93,6 +93,6 @@ export interface Config {
      * The number of requests per second to make to the Confluence API.
      * @visibility backend
      */
-    requestsPerSecond?: number;
+    maxRequestsPerSecond?: number;
   };
 }

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -89,5 +89,10 @@ export interface Config {
      * Defaults to `15`.
      */
     parallelismLimit?: number;
+    /**
+     * The number of requests per second to make to the Confluence API.
+     * @visibility backend
+     */
+    requestsPerSecond?: number;
   };
 }

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -87,10 +87,11 @@ export interface Config {
      * many things are being processed concurrently.
      *
      * Defaults to `15`.
+     * @deprecated Use `maxRequestsPerSecond` instead.
      */
     parallelismLimit?: number;
     /**
-     * The number of requests per second to make to the Confluence API.
+     * The maximum number of requests per second to make to the Confluence API.
      * @visibility backend
      */
     maxRequestsPerSecond?: number;

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -34,7 +34,8 @@
     "@backstage/plugin-search-backend-node": "^1.3.9",
     "@backstage/plugin-search-common": "^1.2.17",
     "node-fetch": "^2.6.7",
-    "p-limit": "^3.1.0"
+    "p-limit": "^3.1.0",
+    "p-throttle": "^4.1.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "^1.3.1",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/report.api.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/report.api.md
@@ -38,6 +38,7 @@ export type ConfluenceCollatorFactoryOptions = {
   spaces?: string[];
   query?: string;
   parallelismLimit?: number;
+  maxRequestsPerSecond?: number;
   logger: LoggerService;
 };
 

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
@@ -66,7 +66,7 @@ export type ConfluenceCollatorFactoryOptions = {
   spaces?: string[];
   query?: string;
   parallelismLimit?: number;
-  requestsPerSecond?: number;
+  maxRequestsPerSecond?: number;
   logger: LoggerService;
 };
 
@@ -157,9 +157,9 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
     this.parallelismLimit = options.parallelismLimit;
     this.logger = options.logger.child({ documentType: this.type });
 
-    if (options.requestsPerSecond) {
+    if (options.maxRequestsPerSecond) {
       const throttle = pThrottle({
-        limit: options.requestsPerSecond,
+        limit: options.maxRequestsPerSecond,
         interval: 1000,
       });
       this.fetch = throttle(async (url: RequestInfo, init?: RequestInit) => {
@@ -214,8 +214,8 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
       spaces,
       query,
       parallelismLimit,
-      requestsPerSecond: config.getOptionalNumber(
-        'confluence.requestsPerSecond',
+      maxRequestsPerSecond: config.getOptionalNumber(
+        'confluence.maxRequestsPerSecond',
       ),
     });
   }

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
@@ -19,9 +19,10 @@ import {
 } from '@backstage/plugin-search-common';
 import { Config } from '@backstage/config';
 import { Readable } from 'stream';
-import fetch from 'node-fetch';
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
 import pLimit from 'p-limit';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import pThrottle from 'p-throttle';
 
 /**
  * Document metadata
@@ -65,6 +66,7 @@ export type ConfluenceCollatorFactoryOptions = {
   spaces?: string[];
   query?: string;
   parallelismLimit?: number;
+  requestsPerSecond?: number;
   logger: LoggerService;
 };
 
@@ -138,6 +140,10 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
   private readonly parallelismLimit: number | undefined;
   private readonly logger: LoggerService;
   public readonly type: string = 'confluence';
+  private readonly fetch: (
+    url: RequestInfo,
+    init?: RequestInit,
+  ) => Promise<Response>;
 
   private constructor(options: ConfluenceCollatorFactoryOptions) {
     this.baseUrl = options.baseUrl;
@@ -150,6 +156,19 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
     this.query = options.query;
     this.parallelismLimit = options.parallelismLimit;
     this.logger = options.logger.child({ documentType: this.type });
+
+    if (options.requestsPerSecond) {
+      const throttle = pThrottle({
+        limit: options.requestsPerSecond,
+        interval: 1000,
+      });
+      this.fetch = throttle(async (url: RequestInfo, init?: RequestInit) => {
+        const response = await fetch(url, init);
+        return response;
+      });
+    } else {
+      this.fetch = fetch;
+    }
   }
 
   static fromConfig(config: Config, options: ConfluenceCollatorFactoryOptions) {
@@ -195,9 +214,11 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
       spaces,
       query,
       parallelismLimit,
+      requestsPerSecond: config.getOptionalNumber(
+        'confluence.requestsPerSecond',
+      ),
     });
   }
-
   async getCollator() {
     return Readable.from(this.execute());
   }
@@ -353,7 +374,7 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
   }
 
   private async get<T = any>(requestUrl: string): Promise<T> {
-    const res = await fetch(requestUrl, {
+    const res = await this.fetch(requestUrl, {
       method: 'get',
       headers: {
         Authorization: this.getAuthorizationHeader(),
@@ -369,7 +390,6 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
 
       throw new Error(`Request failed with ${res.status} ${res.statusText}`);
     }
-
     return await res.json();
   }
 }

--- a/workspaces/confluence/yarn.lock
+++ b/workspaces/confluence/yarn.lock
@@ -2864,6 +2864,7 @@ __metadata:
     msw: "npm:^1.0.0"
     node-fetch: "npm:^2.6.7"
     p-limit: "npm:^3.1.0"
+    p-throttle: "npm:^4.1.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<I have added the Rate Kimiting feature in Confluence plugin so that users can enter the requests per second in the config to make the api calls to confluence server more efficient>

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
