### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/renovate-66d5724.md
+++ b/workspaces/keycloak/.changeset/renovate-66d5724.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Updated dependency `@keycloak/keycloak-admin-client` to `26.1.2`.

--- a/workspaces/keycloak/.changeset/thin-mice-drop.md
+++ b/workspaces/keycloak/.changeset/thin-mice-drop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': minor
----
-
-Extend support to Keycloak v26 and RHBK v26

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 3.7.0
+
+### Minor Changes
+
+- f32a370: Extend support to Keycloak v26 and RHBK v26
+
+### Patch Changes
+
+- 61697c6: Updated dependency `@keycloak/keycloak-admin-client` to `26.1.2`.
+
 ## 3.6.0
 
 ### Minor Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.7.0

### Minor Changes

-   f32a370: Extend support to Keycloak v26 and RHBK v26

### Patch Changes

-   61697c6: Updated dependency `@keycloak/keycloak-admin-client` to `26.1.2`.
