### PR TITLE
plugin(scaffolder-relation-processor): update README to test prior version release

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/chilly-brooms-push.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/chilly-brooms-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
+---
+
+This release will be functionally equivalent to 2.1.0.

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/README.md
@@ -12,7 +12,7 @@ This is an extension module to the catalog-backend plugin, providing an addition
 
 ### Installing on the new backend system
 
-To install this module into the [new backend system](https://backstage.io/docs/backend-system/), add the following into the `packages/backend/src/index.ts` file:
+To install this module into the [new backend system](https://backstage.io/docs/backend-system/) add the following into the `packages/backend/src/index.ts` file:
 
 ```ts title="packages/backend/src/index.ts
 const backend = createBackend();


### PR DESCRIPTION

This release is functionally equivalent to the previous release, but the README has been updated to test the prior version release.

Identical to https://github.com/backstage/community-plugins/pull/2986, which didn't work as the GitHub action didn't yet exist on the target branch.

## Hey, I just made a Pull Request!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
