### PR TITLE
Remove @backstage/backend-common from pingidentity

### DIFF
--- a/workspaces/pingidentity/.changeset/unlucky-pots-lick.md
+++ b/workspaces/pingidentity/.changeset/unlucky-pots-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
+---
+
+removed unused dependency @backstage/backend-common

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
@@ -29,7 +29,6 @@
     "prepack": "backstage-cli package prepack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.25.0",
     "@backstage/backend-plugin-api": "^1.1.1",
     "@backstage/catalog-model": "^1.7.3",
     "@backstage/config": "^1.3.2",

--- a/workspaces/pingidentity/yarn.lock
+++ b/workspaces/pingidentity/yarn.lock
@@ -2737,7 +2737,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-catalog-backend-module-pingidentity@workspace:plugins/catalog-backend-module-pingidentity"
   dependencies:
-    "@backstage/backend-common": "npm:^0.25.0"
     "@backstage/backend-defaults": "npm:^0.7.0"
     "@backstage/backend-plugin-api": "npm:^1.1.1"
     "@backstage/backend-test-utils": "npm:^1.2.1"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed unused dependency `@backstage/backend-common` from pingidentity


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
