### PR TITLE
plugin(jenkins): mark createRouter as deprecated

### DIFF
--- a/workspaces/jenkins/.changeset/chilled-hotels-doubt.md
+++ b/workspaces/jenkins/.changeset/chilled-hotels-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+createRouter export is now deprecated

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/router.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/router.ts
@@ -45,7 +45,10 @@ export interface RouterOptions {
   config: Config;
 }
 
-/** @internal */
+/**
+ * @deprecated Please migrate to the new backend system as this will be removed in the future.
+ * @internal
+ * */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As per guidance from #1176, mark the createRouter export as deprecated. This export will be removed later on.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
