### PR TITLE
[manage] Fixed theming and the organization view

### DIFF
--- a/workspaces/manage/.changeset/hot-forks-provide.md
+++ b/workspaces/manage/.changeset/hot-forks-provide.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-manage-react': patch
+---
+
+Export usePosition hook, to deduce the available screen size for an element

--- a/workspaces/manage/.changeset/late-lions-confess.md
+++ b/workspaces/manage/.changeset/late-lions-confess.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-manage': patch
+---
+
+Fixed theming issue in header label, and improved the organization view with better UI for zooming and toggles for different view options

--- a/workspaces/manage/examples/org.yaml
+++ b/workspaces/manage/examples/org.yaml
@@ -15,3 +15,21 @@ metadata:
 spec:
   type: team
   children: []
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: employees
+spec:
+  type: team
+  children: []
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: acme-corp
+spec:
+  type: team
+  children:
+    - guests
+    - employees

--- a/workspaces/manage/plugins/manage-react/report.api.md
+++ b/workspaces/manage/plugins/manage-react/report.api.md
@@ -386,6 +386,35 @@ export function useOwnedKinds(onlyOwned?: boolean): string[];
 // @public
 export function useOwners(): Owners;
 
+// @public
+export function usePosition(
+  element: Element | undefined,
+): UsePositionResult | undefined;
+
+// @public (undocumented)
+export interface UsePositionClientSize {
+  // (undocumented)
+  height: number;
+  // (undocumented)
+  width: number;
+}
+
+// @public (undocumented)
+export interface UsePositionElementPosition {
+  // (undocumented)
+  left: number;
+  // (undocumented)
+  top: number;
+}
+
+// @public (undocumented)
+export interface UsePositionResult {
+  // (undocumented)
+  client: UsePositionClientSize;
+  // (undocumented)
+  element: UsePositionElementPosition;
+}
+
 // @public (undocumented)
 export interface UserSettingsContextResult<T extends JsonValue> {
   // (undocumented)

--- a/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/TabContentFullHeight.tsx
+++ b/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/TabContentFullHeight.tsx
@@ -86,7 +86,7 @@ export function ManageTabContentFullHeight({
   }, []);
 
   return (
-    <div id="fpp" ref={setRef} style={style}>
+    <div ref={setRef} style={style}>
       {children}
     </div>
   );

--- a/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/index.ts
+++ b/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/index.ts
@@ -15,3 +15,9 @@
  */
 export type { TabContentFullHeightProps } from './TabContentFullHeight';
 export { ManageTabContentFullHeight } from './TabContentFullHeight';
+export type {
+  UsePositionClientSize,
+  UsePositionElementPosition,
+  UsePositionResult,
+} from './usePosition';
+export { usePosition } from './usePosition';

--- a/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/usePosition.ts
+++ b/workspaces/manage/plugins/manage-react/src/components/TabContentFullHeight/usePosition.ts
@@ -17,21 +17,28 @@ import { useMemo, useState } from 'react';
 
 import { useResizeObserver } from './useResizeObserver';
 
+/** @public */
 export interface UsePositionClientSize {
   width: number;
   height: number;
 }
 
+/** @public */
 export interface UsePositionElementPosition {
   left: number;
   top: number;
 }
 
+/** @public */
 export interface UsePositionResult {
   client: UsePositionClientSize;
   element: UsePositionElementPosition;
 }
 
+/**
+ * Calculate the position of an element, and the size of the client window.
+ * @public
+ */
 export function usePosition(element: Element | undefined) {
   const [clientSize, setClientSize] = useState<
     UsePositionClientSize | undefined

--- a/workspaces/manage/plugins/manage-react/src/index.ts
+++ b/workspaces/manage/plugins/manage-react/src/index.ts
@@ -65,7 +65,11 @@ export type {
 export type {
   ManageTabContentFullHeight,
   TabContentFullHeightProps,
+  UsePositionClientSize,
+  UsePositionElementPosition,
+  UsePositionResult,
 } from './components/TabContentFullHeight';
+export { usePosition } from './components/TabContentFullHeight';
 
 export type {
   CreateUserSettingsContextOptions,

--- a/workspaces/manage/plugins/manage/report.api.md
+++ b/workspaces/manage/plugins/manage/report.api.md
@@ -14,6 +14,7 @@ import { default as React_2 } from 'react';
 import { ReactNode } from 'react';
 import { RoutedTabs } from '@backstage/core-components';
 import { RouteRef } from '@backstage/core-plugin-api';
+import { SwitchProps } from '@mui/material/Switch';
 import { TableOptions } from '@backstage/core-components';
 
 // @public
@@ -72,6 +73,13 @@ export interface ManageKindOptions {
 export const ManagePage: ManagePageImpl;
 
 // @public
+export function ManagePageFilters({
+  switchColor,
+}: {
+  switchColor?: SwitchColor;
+}): React_2.JSX.Element;
+
+// @public
 export function ManagePageImpl<SupportedKinds extends string>(
   props: PropsWithChildren<ManagePageProps<SupportedKinds> & HeaderProps>,
 ): React_2.JSX.Element;
@@ -121,10 +129,20 @@ export interface ManageTabsProps {
 export const OrganizationGraph: OrganizationGraphImpl;
 
 // @public
-export function OrganizationGraphImpl(): React_2.JSX.Element;
+export function OrganizationGraphImpl({
+  enableWholeOrganization,
+}: OrganizationGraphProps): React_2.JSX.Element;
+
+// @public
+export interface OrganizationGraphProps {
+  enableWholeOrganization?: boolean;
+}
 
 // @public (undocumented)
 export type SubRouteTab = ComponentProps<typeof RoutedTabs>['routes'][number];
+
+// @public
+export type SwitchColor = SwitchProps['color'];
 
 // @public (undocumented)
 export type TableColumn = ManageColumnSimple | ManageColumnModule;
@@ -137,6 +155,15 @@ export type TableRow = {
 
 // @public
 export function TabOrderCard(): React_2.JSX.Element;
+
+// @public
+export function useManagePageCombined(
+  defaultValue?: boolean,
+): [
+  value: boolean | undefined,
+  setValue: (value: boolean) => void,
+  isSettled: boolean,
+];
 
 // (No @packageDocumentation comment for this package)
 ```

--- a/workspaces/manage/plugins/manage/src/components/ManagePageFilters/ManagePageFilters.tsx
+++ b/workspaces/manage/plugins/manage/src/components/ManagePageFilters/ManagePageFilters.tsx
@@ -18,19 +18,36 @@ import React, { useCallback } from 'react';
 import { makeStyles } from '@mui/styles';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import Switch from '@mui/material/Switch';
+import Switch, { SwitchProps } from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
+
+import { HeaderLabel } from '@backstage/core-components';
 
 import { useManagePageCombined } from './useFilters';
 
-const useStyles = makeStyles(theme => ({
+/**
+ * Color of the page header switch
+ * @public
+ */
+export type SwitchColor = SwitchProps['color'];
+
+const useStyles = makeStyles(() => ({
   label: {
-    color: theme.page.fontColor,
     userSelect: 'none',
   },
 }));
 
-export function ManagePageFilters() {
+/**
+ * Filter component for the page header, showing a switch to toggle between
+ * combined and separate entity tabs.
+ *
+ * @public
+ */
+export function ManagePageFilters({
+  switchColor = 'primary',
+}: {
+  switchColor?: SwitchColor;
+}) {
   const { label } = useStyles();
   const [combined, setCombined] = useManagePageCombined();
 
@@ -42,18 +59,23 @@ export function ManagePageFilters() {
   );
 
   return (
-    <FormGroup row>
-      <FormControlLabel
-        control={
-          <Switch
-            checked={combined ?? false}
-            onChange={handleChange}
-            name="manage-page-combined"
-            color="primary"
+    <HeaderLabel
+      label="Entity tabs"
+      value={
+        <FormGroup row>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={combined ?? false}
+                onChange={handleChange}
+                name="manage-page-combined"
+                color={switchColor}
+              />
+            }
+            label={<Typography className={label}>Combine</Typography>}
           />
-        }
-        label={<Typography className={label}>Combine entities</Typography>}
-      />
-    </FormGroup>
+        </FormGroup>
+      }
+    />
   );
 }

--- a/workspaces/manage/plugins/manage/src/components/ManagePageFilters/index.ts
+++ b/workspaces/manage/plugins/manage/src/components/ManagePageFilters/index.ts
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type { SwitchColor } from './ManagePageFilters';
 export { ManagePageFilters } from './ManagePageFilters';
 export { useManagePageCombined } from './useFilters';

--- a/workspaces/manage/plugins/manage/src/components/ManagePageFilters/useFilters.ts
+++ b/workspaces/manage/plugins/manage/src/components/ManagePageFilters/useFilters.ts
@@ -15,6 +15,11 @@
  */
 import { useUserSettings } from '@backstage-community/plugin-manage-react';
 
+/**
+ * Hook to return whether the entity tabs are combined or not.
+ *
+ * @public
+ */
 export function useManagePageCombined(defaultValue?: boolean) {
   return useUserSettings<boolean>('$manage-page-filter', 'combined', {
     defaultValue,

--- a/workspaces/manage/plugins/manage/src/components/OrganizationGraph/index.ts
+++ b/workspaces/manage/plugins/manage/src/components/OrganizationGraph/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type { OrganizationGraphProps } from './OrganizationGraph';
 export { OrganizationGraphImpl } from './OrganizationGraph';

--- a/workspaces/manage/plugins/manage/src/index.ts
+++ b/workspaces/manage/plugins/manage/src/index.ts
@@ -31,6 +31,12 @@ export type {
   ManagePageImpl,
 } from './components/ManagePage';
 
+export type { SwitchColor } from './components/ManagePageFilters';
+export {
+  ManagePageFilters,
+  useManagePageCombined,
+} from './components/ManagePageFilters';
+
 export type {
   SubRouteTab,
   ManageTabsProps,
@@ -38,7 +44,10 @@ export type {
   ManageTabsImpl,
 } from './components/ManageTabs';
 
-export type { OrganizationGraphImpl } from './components/OrganizationGraph';
+export type {
+  OrganizationGraphProps,
+  OrganizationGraphImpl,
+} from './components/OrganizationGraph';
 
 export { MANAGE_KIND_COMMON } from './components/ManageTabs';
 


### PR DESCRIPTION
### Combined entities (page header) toggle

The top-right header label showing a "Combined" switch cannot easily be themed, as it didn't use the `<HeaderLabel>` component which applies an overridable theme. This means that the text color can be unreadable for themes that have overridden the page header into something close to the regular background color.

This PR uses a `<HeaderLabel>` and also exports the combine switch component so it can be rendered separately (if the implementor wants other header labels as well), and also being able to choose the switch icon color.

### Organization view

The organization view showed not only all your parent groups (which is correct), but also each of their children groups, which basically shows the whole org. This was not the intention, and and although it's sometimes useful (for small and medium size organization) it can become cluttered for large organizations.

This PR defaults to only showing the group structure from the user and _upwards_ by default. It adds two toggles to the view; To show the "whole organization" (i.e. follow group _children_), and to flip top-down to left-right.

The size of the view is also improved, so that the height of this graph adapts to the screen size. This reduces flickering and makes zooming in work better in that a graph that's very wide (and not very tall) can still be zoomed in to the whole screen estate available, and not only in the initial bounding box of the graph component.

<img width="922" alt="organization-view" src="https://github.com/user-attachments/assets/eecd8283-deba-4db7-bf17-661215817a5e" />


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
