### PR TITLE
ci(release_workspace_version): fix workflow issues

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -30,30 +30,23 @@ jobs:
               && "${{ github.event.pull_request.user.login }}" == "backstage-service" ]] \
               && [[ "${{ github.event.pull_request.head.ref }}" == maintenance-changesets-release/* ]] \
               && [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
-                echo "is_version_pr=true" >> $GITHUB_ENV
+                echo "is_version_pr=true" >> $GITHUB_OUTPUT
               else
-                echo "is_version_pr=false" >> $GITHUB_ENV
-                exit 1
+                echo "is_version_pr=false" >> $GITHUB_OUTPUT
               fi
-            # ADDED: Extracts workspace name from branch, ensuring it is a workspace/** branch
+
+        # ADDED: Extracts workspace name from branch, ensuring it is a workspace/** branch
         - name: Extract Workspace name from branch
           id: extract_workspace
           run: |
-              WORKSPACE_NAME=$(echo "${{ github.ref }}" | cut -d'/' -f2)
-              echo "workspace_name=$WORKSPACE_NAME" >> $GITHUB_ENV
-
-        - name: Verify workspace match
-          run: |
-              PR_WORKSPACE=$(echo "${{ github.event.pull_request.head.ref }}" | cut -d'/' -f2)
-              if [[ "$PR_WORKSPACE" != "${{ env.workspace_name }}" ]]; then
-                echo "Workspace mismatch: PR workspace ($PR_WORKSPACE) does not match target branch workspace (${{ env.workspace_name }})"
-                exit 1
-              fi
+              WORKSPACE_NAME=$(echo "${{ github.event.pull_request.base.ref }}" | cut -d'/' -f2)
+              echo "workspace_name=$WORKSPACE_NAME" >> $GITHUB_OUTPUT
 
   changesets-pr:
     name: Update Version Packages PR for ${{ needs.check-merged-pr.outputs.workspace_name }} on branch ${{ github.ref }}
     runs-on: ubuntu-latest
     needs: check-merged-pr
+    if: needs.check-merged-pr.outputs.is_version_pr == 'false'
     defaults:
       run:
         working-directory: ./workspaces/${{ needs.check-merged-pr.outputs.workspace_name }}
@@ -112,7 +105,7 @@ jobs:
         env:
           WORKSPACE_NAME: ${{ needs.check-merged-pr.outputs.workspace_name }}
           COMMIT_SHA_BEFORE: '${{ github.event.before }}'
-        
+
       - name: Update Version Packages (${{ needs.check-merged-pr.outputs.workspace_name }}) PR
         id: changesets-pr
         if: steps.release_check.outputs.needs_release != 'true'
@@ -130,7 +123,7 @@ jobs:
     name: Prior Version Release workspace ${{ needs.check-merged-pr.outputs.workspace_name }} on branch ${{ github.ref }}
     runs-on: ubuntu-latest
     needs: changesets-pr
-    if: needs.changesets-pr.outputs.needs_release == 'true'
+    if: needs.check-merged-pr.outputs.is_version_pr == 'true'
     defaults:
       run:
         working-directory: ./workspaces/${{ needs.check-merged-pr.outputs.workspace_name }}


### PR DESCRIPTION
- No longer exit job when not a Version Packages PR
- Set `is_version_pr` and `workspace_name` correctly using `GITHUB_OUTPUT`
- Extract workspace name from `github.event.pull_request.base.ref` (workspace branch)
- Remove redundant workspace validation check

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
