### PR TITLE
plugin(jenkins-backend): Add extension point

### DIFF
--- a/workspaces/jenkins/.changeset/tasty-wasps-behave.md
+++ b/workspaces/jenkins/.changeset/tasty-wasps-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+Add ExtensionPoint to allow usage of a custom JenkinsInfoProvider

--- a/workspaces/jenkins/plugins/jenkins-backend/src/extensions.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/extensions.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtensionPoint } from '@backstage/backend-plugin-api';
+import { JenkinsInfoProvider } from './service';
+
+/**
+ * @public
+ */
+export interface JenkinsInfoProviderExtensionPoint {
+  setInfoProvider(infoProvider: JenkinsInfoProvider): void;
+}
+
+/**
+ * Extension point that allows a different JenkinsInfoProvider to be used.
+ *
+ * @public
+ */
+export const jenkinsInfoProviderExtensionPoint =
+  createExtensionPoint<JenkinsInfoProviderExtensionPoint>({
+    id: 'jenkins.info-provider',
+  });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add an extension point to the `jenkins-backend` plugin so a custom JenkinsInforProvider can be used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
