### PR TITLE
ci(release_workspace_version): fix null value, fetch correct git history

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -90,7 +90,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Fetch previous commit for release check
-        run: git fetch origin '${{ github.event.before }}'
+        run: git fetch origin '${{ github.event.pull_request.base.sha }}'
 
       - name: Fetch the commit that triggered the workflow (used by backstage/changesets-action)
         run: git fetch origin ${{ github.sha }}
@@ -104,7 +104,8 @@ jobs:
         working-directory: ./
         env:
           WORKSPACE_NAME: ${{ needs.check-merged-pr.outputs.workspace_name }}
-          COMMIT_SHA_BEFORE: '${{ github.event.before }}'
+          COMMIT_SHA_BEFORE: '${{ github.event.pull_request.base.sha }}'
+          TARGET_BRANCH: ${{ github.ref }}
 
       - name: Update Version Packages (${{ needs.check-merged-pr.outputs.workspace_name }}) PR
         id: changesets-pr


### PR DESCRIPTION
`github.event.before` does not exist in the context of a pull_request event, update to use `github.event.pull_request.base.sha` instead. Also pass TARGET_BRANCH to check-if-release script.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
