### PR TITLE
fix(rbac): fix to show multiple CRUD actions on single resource-type correctly in edit form

### DIFF
--- a/workspaces/rbac/.changeset/rare-turkeys-pump.md
+++ b/workspaces/rbac/.changeset/rare-turkeys-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Fix to show conditional permission policy with multiple CRUD actions on single resource-type created via CLI/CSV correctly in edit form.

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
@@ -220,10 +220,14 @@ export const RoleForm = ({
   };
 
   const canNextPermissionPoliciesStep = () => {
+    const selectedPluginsLength = formik.values.selectedPlugins.filter(
+      sp => !!sp.value,
+    ).length;
     return (
-      !!formik.values.selectedPlugins.length &&
-      formik.values.permissionPoliciesRows.filter(pp => !!pp?.plugin).length ===
-        formik.values.permissionPoliciesRows.length &&
+      selectedPluginsLength > 0 &&
+      formik.values.permissionPoliciesRows.filter(pp =>
+        formik.values.selectedPlugins.find(sp => sp.value === pp.plugin),
+      ).length >= selectedPluginsLength &&
       !formik.errors.selectedPlugins &&
       (!formik.errors.permissionPoliciesRows ||
         (Array.isArray(formik.errors.permissionPoliciesRows) &&

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/SelectedPermissionPoliciesColumn.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/SelectedPermissionPoliciesColumn.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { getRulesNumber } from '../../utils/create-role-utils';
+import { getPolicyString } from '../../utils/rbac-utils';
 import { ConditionsData } from '../ConditionalAccess/types';
 import { RowPolicy } from './types';
 
@@ -29,13 +30,7 @@ export const selectedPermissionPoliciesColumn = () => [
   {
     title: 'Policies',
     field: 'policies',
-    render: (policies: RowPolicy[]) => {
-      const policyStr = policies.reduce((acc: string, p) => {
-        if (p.effect === 'allow') return acc.concat(`${p.policy}, `);
-        return acc;
-      }, '');
-      return policyStr.slice(0, policyStr.length - 2);
-    },
+    render: (policies: RowPolicy[]) => getPolicyString(policies),
   },
   {
     title: 'Conditional',

--- a/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.test.ts
@@ -365,7 +365,7 @@ describe('getConditionalPermissionsData', () => {
           permissions: ['catalog.entity.read'],
           policies: {
             ['catalog.entity.read']: {
-              policies: ['read'],
+              policies: ['Read'],
               isResourced: true,
               resourceType: 'catalog-entity',
             },
@@ -386,7 +386,7 @@ describe('getConditionalPermissionsData', () => {
         permission: 'catalog.entity.read',
         isResourced: true,
         resourceType: 'catalog-entity',
-        policies: [{ policy: 'read', effect: 'allow' }],
+        policies: [{ policy: 'Read', effect: 'allow' }],
         policyString: 'Read',
         conditions: {
           condition: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes: https://issues.redhat.com/browse/RHIDP-6063, https://issues.redhat.com/browse/RHIDP-6062

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

<img width="1728" alt="Screenshot 2025-02-27 at 8 37 51 PM" src="https://github.com/user-attachments/assets/b3b925fd-7bc5-445a-ac7a-9f1abc2babb4" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Steps for testing
 - Create role
 - Create condition via CLI
```
curl -X POST "http://localhost:7007/api/permission/roles/conditions" -d '{"result":"CONDITIONAL","roleEntityRef": "role:default/developer","pluginId":"catalog","resourceType":"catalog-entity", "permissionMapping": ["read","update","delete"], "conditions":{"rule":"IS_ENTITY_OWNER","resourceType":"catalog-entity","params":{"claims":["user:default/divyanshiGupta"]}}}' -H "Content-Type: application/json" -H "Authorization: Bearer token" -v
```