### PR TITLE
fix(kubernetes-actions): Kubernetes actions template secrets update

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/examples/templates/01-kubernetes-template.yaml
@@ -30,6 +30,7 @@ spec:
         token:
           title: Token
           type: string
+          ui:field: Secret
           description: Bearer token to authenticate with
         skipTLSVerify:
           title: Skip TLS verification
@@ -38,6 +39,7 @@ spec:
         caData:
           title: CA data
           type: string
+          ui:field: Secret
           description: Certificate Authority base64 encoded certificate
         labels:
           title: Labels
@@ -57,7 +59,7 @@ spec:
         namespace: ${{ parameters.namespace }}
         clusterRef: ${{ parameters.clusterRef }}
         url: ${{ parameters.url }}
-        token: ${{ parameters.token }}
+        token: ${{ secrets.token }}
         skipTLSVerify: ${{ parameters.skipTLSVerify }}
-        caData: ${{ parameters.caData }}
+        caData: ${{ secrets.caData }}
         labels: ${{ parameters.labels }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- changes `token` and `caData` to secrets in `@backstage-community/plugin-scaffolder-backend-module-kubernetes`

**Fixes**: [RHIDP-6139](https://issues.redhat.com/browse/RHIDP-6139)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
