### PR TITLE
fix(jenkins-backend): add permissions to JenkinsBuilder

### DIFF
--- a/workspaces/jenkins/.changeset/cyan-frogs-notice.md
+++ b/workspaces/jenkins/.changeset/cyan-frogs-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+Fixed a bug when Jenkins permissions were not exposed by Jenkins at `/api/jenkins/.well-known/backstage/permissions/metadata`.

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
@@ -32,6 +32,8 @@ import {
 } from '@backstage/backend-plugin-api';
 
 import { Config } from '@backstage/config';
+import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
+import { jenkinsPermissions } from '@backstage-community/plugin-jenkins-common';
 
 /** @public */
 export type JenkinsBuilderReturn = Promise<{
@@ -108,6 +110,11 @@ export class JenkinsBuilder {
 
     const router = Router();
     router.use(express.json());
+    router.use(
+      createPermissionIntegrationRouter({
+        permissions: jenkinsPermissions,
+      }),
+    );
 
     router.get(
       '/v1/entity/:namespace/:kind/:name/projects',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes not exposing Jenkins permission metadata at `/api/jenkins/.well-known/backstage/permissions/metadata`.

#### Fixes
- Fixes: [RHIDP-6071](https://issues.redhat.com/browse/RHIDP-6071)
- Fixes: https://github.com/backstage/community-plugins/issues/2801
- Fixes: https://github.com/backstage/community-plugins/issues/2797

![Screenshot From 2025-03-03 13-09-51](https://github.com/user-attachments/assets/3af545dc-a5d9-4dcb-afa3-7d58ed37b077)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
