### PR TITLE
ci(release_workspace_version): remove incorrect publish filter

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -171,7 +171,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private --include "${{ needs.check-merged-pr.outputs.workspace_name }}" npm publish --access public --tolerate-republish --tag "maintenance"
+          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       


### PR DESCRIPTION
The `--include` publish flag was incorrectly set to the workspace directory name. However, we're already within the workspace directory, so this flag is unnecessary and preventing publishing.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
