### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/kind-sides-act.md
+++ b/workspaces/redhat-argocd/.changeset/kind-sides-act.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Add backwards compatibility fixes to support RoadieHQ ArgoCD Backend

--- a/workspaces/redhat-argocd/.changeset/renovate-0e9972a.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-0e9972a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@testing-library/user-event` to `14.6.1`.

--- a/workspaces/redhat-argocd/.changeset/renovate-65fea94.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-65fea94.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@playwright/test` to `1.51.0`.

--- a/workspaces/redhat-argocd/.changeset/spotty-onions-sneeze.md
+++ b/workspaces/redhat-argocd/.changeset/spotty-onions-sneeze.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Remove CSS resets from PatternFly CSS import

--- a/workspaces/redhat-argocd/.changeset/wild-cups-kick.md
+++ b/workspaces/redhat-argocd/.changeset/wild-cups-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': minor
----
-
-Add scalprum configuration for generating OCI artifacts

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- 110b103: Add scalprum configuration for generating OCI artifacts
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.17.0
+
+### Minor Changes
+
+- df9d65d: Add backwards compatibility fixes to support RoadieHQ ArgoCD Backend
+
+### Patch Changes
+
+- 32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
+- c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
+- 989bd8c: Remove CSS resets from PatternFly CSS import
+
 ## 1.16.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.17.0

### Minor Changes

-   df9d65d: Add backwards compatibility fixes to support RoadieHQ ArgoCD Backend

### Patch Changes

-   32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
-   c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
-   989bd8c: Remove CSS resets from PatternFly CSS import

## @backstage-community/plugin-redhat-argocd-backend@0.4.0

### Minor Changes

-   110b103: Add scalprum configuration for generating OCI artifacts
