### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/polite-steaks-buy.md
+++ b/workspaces/announcements/.changeset/polite-steaks-buy.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-- Fixed Active field column in announcements admin table, which was preventing proper sorting by `active` state.
-- Enhanced readability of the Active status in the admin announcements table using `Status` components.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements
 
+## 0.5.3
+
+### Patch Changes
+
+- 3b99ef7: - Fixed Active field column in announcements admin table, which was preventing proper sorting by `active` state.
+  - Enhanced readability of the Active status in the admin announcements table using `Status` components.
+
 ## 0.5.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.5.3

### Patch Changes

-   3b99ef7: - Fixed Active field column in announcements admin table, which was preventing proper sorting by `active` state.
    -   Enhanced readability of the Active status in the admin announcements table using `Status` components.
