### PR TITLE
Announcements: improve relative date display when the Start At date is set for the current day

### DIFF
--- a/workspaces/announcements/.changeset/spicy-impalas-behave.md
+++ b/workspaces/announcements/.changeset/spicy-impalas-behave.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements-react': patch
+'@backstage-community/plugin-announcements': patch
+---
+
+Improved relative date display for scheduled announcements. When the Start At date is set for the current day, it now shows "Scheduled Today" instead of "Occurred X hours ago"

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -162,6 +162,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementsPage.card.edit': 'EDIT';
     readonly 'announcementsPage.card.occurred': 'Occurred ';
     readonly 'announcementsPage.card.scheduled': 'Scheduled ';
+    readonly 'announcementsPage.card.today': 'Today';
     readonly 'deleteDialog.cancel': 'Cancel';
     readonly 'deleteDialog.title': 'Are you sure you want to delete this announcement?';
     readonly 'deleteDialog.delete': 'Delete';
@@ -170,6 +171,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementsCard.announcements': 'Announcements';
     readonly 'announcementsCard.occurred': 'Occurred';
     readonly 'announcementsCard.scheduled': 'Scheduled';
+    readonly 'announcementsCard.today': 'Today';
     readonly 'announcementsCard.seeAll': 'See all';
     readonly 'announcementsCard.noAnnouncements': 'No announcements yet, want to';
     readonly 'announcementsCard.addOne': 'add one';
@@ -280,6 +282,7 @@ export const useAnnouncementsTranslation: () => {
     readonly 'announcementsPage.card.edit': 'EDIT';
     readonly 'announcementsPage.card.occurred': 'Occurred ';
     readonly 'announcementsPage.card.scheduled': 'Scheduled ';
+    readonly 'announcementsPage.card.today': 'Today';
     readonly 'deleteDialog.cancel': 'Cancel';
     readonly 'deleteDialog.title': 'Are you sure you want to delete this announcement?';
     readonly 'deleteDialog.delete': 'Delete';
@@ -288,6 +291,7 @@ export const useAnnouncementsTranslation: () => {
     readonly 'announcementsCard.announcements': 'Announcements';
     readonly 'announcementsCard.occurred': 'Occurred';
     readonly 'announcementsCard.scheduled': 'Scheduled';
+    readonly 'announcementsCard.today': 'Today';
     readonly 'announcementsCard.seeAll': 'See all';
     readonly 'announcementsCard.noAnnouncements': 'No announcements yet, want to';
     readonly 'announcementsCard.addOne': 'add one';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -42,6 +42,7 @@ export const announcementsTranslationRef = createTranslationRef({
         delete: 'DELETE',
         occurred: 'Occurred ',
         scheduled: 'Scheduled ',
+        today: 'Today',
       },
       grid: {
         announcementDeleted: 'Announcement deleted.',
@@ -65,6 +66,7 @@ export const announcementsTranslationRef = createTranslationRef({
       addOne: 'add one',
       occurred: 'Occurred',
       scheduled: 'Scheduled',
+      today: 'Today',
     },
     announcementSearchResultListItem: {
       published: 'Published',

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
@@ -94,4 +94,26 @@ describe('AnnouncementsCard', () => {
       expect(screen.getByText(new RegExp(a.excerpt, 'i'))).toBeInTheDocument();
     });
   });
+
+  it('should display "today" when the announcement start date matches current date', async () => {
+    const today = DateTime.now().toISODate();
+    const announcementsList: AnnouncementsList = {
+      count: 1,
+      results: [
+        {
+          id: '1',
+          title: 'Today Announcement',
+          excerpt: 'This is happening today',
+          body: 'Body 1',
+          publisher: 'Body1',
+          created_at: today,
+          active: true,
+          start_at: today,
+        },
+      ],
+    };
+
+    await renderAnnouncementsCard(announcementsList);
+    expect(screen.getByText(/Scheduled Today/i)).toBeInTheDocument();
+  });
 });

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -29,6 +29,7 @@ import {
   announcementViewRouteRef,
   rootRouteRef,
 } from '../../routes';
+import { formatAnnouncementStartTime } from '../utils/announcementDateUtils';
 import {
   announcementsApiRef,
   useAnnouncements,
@@ -151,10 +152,14 @@ export const AnnouncementsCard = ({
                   </Typography>
                   <Typography variant="body2" color="textSecondary">
                     <small>
-                      {DateTime.fromISO(announcement.start_at) < DateTime.now()
-                        ? `${t('announcementsCard.occurred')} `
-                        : `${t('announcementsCard.scheduled')} `}
-                      {DateTime.fromISO(announcement.start_at).toRelative()}
+                      <small>
+                        {formatAnnouncementStartTime(
+                          announcement.start_at,
+                          t('announcementsCard.occurred'),
+                          t('announcementsCard.scheduled'),
+                          t('announcementsCard.today'),
+                        )}
+                      </small>
                     </small>
                   </Typography>
                 </div>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -25,6 +25,8 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
 import { fireEvent, screen } from '@testing-library/react';
 import { announcementsApiRef } from '@backstage-community/plugin-announcements-react';
+import { DateTime } from 'luxon';
+import { AnnouncementsList } from '@backstage-community/plugin-announcements-common';
 
 const mockAnnouncements = [
   {
@@ -151,6 +153,51 @@ describe('AnnouncementsPage', () => {
 
       fireEvent.mouseOver(screen.getByText('announcement-...'));
       expect(await screen.findByText('announcement-title')).toBeInTheDocument();
+    });
+
+    it('should display "today" when the announcement start date matches current date', async () => {
+      const today = DateTime.now().toISODate();
+      const todayAnnouncement: AnnouncementsList = {
+        count: 1,
+        results: [
+          {
+            id: '1',
+            title: 'Today Announcement',
+            excerpt: 'This is happening today',
+            body: 'This is the full body of the announcement.',
+            publisher: 'default:user/user',
+            created_at: today,
+            active: true,
+            start_at: today,
+          },
+        ],
+      };
+      const mockAnnouncementsTodayApi = {
+        announcements: jest.fn().mockResolvedValue(todayAnnouncement),
+      };
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [permissionApiRef, mockApis.permission()],
+            [announcementsApiRef, mockAnnouncementsTodayApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <AnnouncementsPage
+            themeId="home"
+            title="Announcements"
+            buttonOptions={{ name: 'customNoun' }}
+            cardOptions={{ titleLength: 13 }}
+          />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/announcements': rootRouteRef,
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(screen.getByText(/Scheduled Today/i)).toBeInTheDocument();
     });
   });
 });

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -70,6 +70,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { Alert, Pagination } from '@material-ui/lab';
+import { formatAnnouncementStartTime } from '../utils/announcementDateUtils';
 
 const useStyles = makeStyles(theme => {
   return {
@@ -151,10 +152,12 @@ const AnnouncementCard = ({
       </Typography>
       <Typography variant="body2" color="textSecondary">
         <small>
-          {DateTime.fromISO(announcement.start_at) < DateTime.now()
-            ? `${t('announcementsPage.card.occurred')} `
-            : `${t('announcementsPage.card.scheduled')} `}
-          {DateTime.fromISO(announcement.start_at).toRelative()}
+          {formatAnnouncementStartTime(
+            announcement.start_at,
+            t('announcementsCard.occurred'),
+            t('announcementsCard.scheduled'),
+            t('announcementsCard.today'),
+          )}
         </small>
       </Typography>
     </>

--- a/workspaces/announcements/plugins/announcements/src/components/utils/announcementDateUtils.ts
+++ b/workspaces/announcements/plugins/announcements/src/components/utils/announcementDateUtils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DateTime } from 'luxon';
+
+/**
+ * Formats the announcement start time.
+ *
+ * @param startAt - The ISO 8601 formatted start time of the announcement.
+ * @param occurred - The localized string indicating the announcement occurred.
+ * @param scheduled - The localized string indicating the announcement is scheduled.
+ * @param today - The localized string for when the announcement is happening today.
+ * @returns - A formatted start at string.
+ */
+export const formatAnnouncementStartTime = (
+  startAt: string,
+  occurred: string,
+  scheduled: string,
+  today: string,
+): string => {
+  const startDate = DateTime.fromISO(startAt);
+  const now = DateTime.now();
+
+  if (startDate.hasSame(now, 'day')) {
+    return `${scheduled} ${today}`;
+  }
+
+  return startDate < now
+    ? `${occurred} ${startDate.toRelative()}`
+    : `${scheduled} ${startDate.toRelative()}`;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

One of the fixes I planned: https://github.com/backstage/community-plugins/issues/2416#issuecomment-2671449230

When creating a new announcement, the default Start At date is set to midnight of the current day. This PR ensures that if the announcement is scheduled for today, the date will display as "Scheduled Today" instead of "X hours ago" (from midnight time).

<img width="325" alt="image" src="https://github.com/user-attachments/assets/013c0b3b-b1ce-4486-ab8f-6b307e708010" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
