### PR TITLE
Version Packages (opencost)

### DIFF
--- a/workspaces/opencost/.changeset/young-garlics-draw-two.md
+++ b/workspaces/opencost/.changeset/young-garlics-draw-two.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-opencost': patch
----
-
-Added a section to the README to explain how to use the Backstage proxy to expose a private OpenCost service.

--- a/workspaces/opencost/.changeset/young-garlics-draw.md
+++ b/workspaces/opencost/.changeset/young-garlics-draw.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-opencost': patch
----
-
-Fixed an issue causing the build of a Backstage app to fail due to an issue when importing `KeyboardDatePicker` from `material-ui`.

--- a/workspaces/opencost/plugins/opencost/CHANGELOG.md
+++ b/workspaces/opencost/plugins/opencost/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-opencost
 
+## 0.5.1
+
+### Patch Changes
+
+- 3f3a60a: Added a section to the README to explain how to use the Backstage proxy to expose a private OpenCost service.
+- 3f3a60a: Fixed an issue causing the build of a Backstage app to fail due to an issue when importing `KeyboardDatePicker` from `material-ui`.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/opencost/plugins/opencost/package.json
+++ b/workspaces/opencost/plugins/opencost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-opencost",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "opencost",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-opencost@0.5.1

### Patch Changes

-   3f3a60a: Added a section to the README to explain how to use the Backstage proxy to expose a private OpenCost service.
-   3f3a60a: Fixed an issue causing the build of a Backstage app to fail due to an issue when importing `KeyboardDatePicker` from `material-ui`.
