### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/cyan-frogs-notice.md
+++ b/workspaces/jenkins/.changeset/cyan-frogs-notice.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': patch
----
-
-Fixed a bug when Jenkins permissions were not exposed by Jenkins at `/api/jenkins/.well-known/backstage/permissions/metadata`.

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.12.1
+
+### Patch Changes
+
+- 4dc7013: Fixed a bug when Jenkins permissions were not exposed by Jenkins at `/api/jenkins/.well-known/backstage/permissions/metadata`.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins-backend@0.12.1

### Patch Changes

-   4dc7013: Fixed a bug when Jenkins permissions were not exposed by Jenkins at `/api/jenkins/.well-known/backstage/permissions/metadata`.
