### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/four-beans-hang.md
+++ b/workspaces/quay/.changeset/four-beans-hang.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-remove prettier from devDevpendencies

--- a/workspaces/quay/.changeset/giant-files-give.md
+++ b/workspaces/quay/.changeset/giant-files-give.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay': minor
----
-
-Add scalprum configuration for generating OCI artifacts

--- a/workspaces/quay/.changeset/olive-files-matter.md
+++ b/workspaces/quay/.changeset/olive-files-matter.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': patch
----
-
-Added missing `@backstage/plugin-permission-node` dependency

--- a/workspaces/quay/.changeset/renovate-65fea94.md
+++ b/workspaces/quay/.changeset/renovate-65fea94.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@playwright/test` to `1.51.0`.

--- a/workspaces/quay/.changeset/version-bump-1-36-1.md
+++ b/workspaces/quay/.changeset/version-bump-1-36-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.36.1

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 2.6.0
+
+### Minor Changes
+
+- 1f3ea2f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDevpendencies
+
 ## 2.5.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.1.0
+
+### Minor Changes
+
+- 110b103: Add scalprum configuration for generating OCI artifacts
+- 1f3ea2f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- acf8999: Added missing `@backstage/plugin-permission-node` dependency
+- Updated dependencies [973a5ef]
+- Updated dependencies [1f3ea2f]
+  - @backstage-community/plugin-quay-common@1.7.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-quay-common
 
+## 1.7.0
+
+### Minor Changes
+
+- 1f3ea2f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDevpendencies
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,20 @@
 ### Dependencies
 
+## 1.19.0
+
+### Minor Changes
+
+- 110b103: Add scalprum configuration for generating OCI artifacts
+- 1f3ea2f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDevpendencies
+- c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
+- Updated dependencies [973a5ef]
+- Updated dependencies [1f3ea2f]
+  - @backstage-community/plugin-quay-common@1.7.0
+
 ## 1.18.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.19.0

### Minor Changes

-   110b103: Add scalprum configuration for generating OCI artifacts
-   1f3ea2f: Backstage version bump to v1.36.1

### Patch Changes

-   973a5ef: remove prettier from devDevpendencies
-   c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
-   Updated dependencies [973a5ef]
-   Updated dependencies [1f3ea2f]
    -   @backstage-community/plugin-quay-common@1.7.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.6.0

### Minor Changes

-   1f3ea2f: Backstage version bump to v1.36.1

### Patch Changes

-   973a5ef: remove prettier from devDevpendencies

## @backstage-community/plugin-quay-backend@1.1.0

### Minor Changes

-   110b103: Add scalprum configuration for generating OCI artifacts
-   1f3ea2f: Backstage version bump to v1.36.1

### Patch Changes

-   acf8999: Added missing `@backstage/plugin-permission-node` dependency
-   Updated dependencies [973a5ef]
-   Updated dependencies [1f3ea2f]
    -   @backstage-community/plugin-quay-common@1.7.0

## @backstage-community/plugin-quay-common@1.7.0

### Minor Changes

-   1f3ea2f: Backstage version bump to v1.36.1

### Patch Changes

-   973a5ef: remove prettier from devDevpendencies
