### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/bright-buttons-call.md
+++ b/workspaces/tekton/.changeset/bright-buttons-call.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Remove CSS resets from PatternFly CSS import

--- a/workspaces/tekton/.changeset/renovate-0e9972a.md
+++ b/workspaces/tekton/.changeset/renovate-0e9972a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@testing-library/user-event` to `14.6.1`.

--- a/workspaces/tekton/.changeset/renovate-2e31c25.md
+++ b/workspaces/tekton/.changeset/renovate-2e31c25.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@types/lodash` to `4.17.16`.

--- a/workspaces/tekton/.changeset/renovate-65fea94.md
+++ b/workspaces/tekton/.changeset/renovate-65fea94.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@playwright/test` to `1.51.0`.

--- a/workspaces/tekton/.changeset/short-camels-stay.md
+++ b/workspaces/tekton/.changeset/short-camels-stay.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-removed prettier from devDependencies

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 3.21.1
+
+### Patch Changes
+
+- 76de75c: Remove CSS resets from PatternFly CSS import
+- 32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
+- 3199ac1: Updated dependency `@types/lodash` to `4.17.16`.
+- c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
+- 973a5ef: removed prettier from devDependencies
+
 ## 3.21.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.21.0",
+  "version": "3.21.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.21.1

### Patch Changes

-   76de75c: Remove CSS resets from PatternFly CSS import
-   32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
-   3199ac1: Updated dependency `@types/lodash` to `4.17.16`.
-   c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
-   973a5ef: removed prettier from devDependencies
