### PR TITLE
Repository: fix for workspaces dropdown in issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/snippets/workspaces-dropdown.yaml
+++ b/.github/ISSUE_TEMPLATE/snippets/workspaces-dropdown.yaml
@@ -3,6 +3,7 @@ id: workspace
 attributes:
   label: Workspace
   options:
+    - "Select a workspace..."
     - 3scale
     - acr
     - adr

--- a/scripts/create-workspaces-dropdown.js
+++ b/scripts/create-workspaces-dropdown.js
@@ -38,6 +38,7 @@ id: workspace
 attributes:
   label: Workspace
   options:
+    - "Select a workspace..."
 ${workspaces.map(w => `    - ${w}`).join('\n')}
   default: 0
 validations:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I looked a bit into how we could prevent `3scale` from being the default workspace selected in the issue templates. The ideal solution would be to have no default and for a warning to be provided if a user fails to select a valid workspace from the options. Github issues don't seem to currently support that and looks like others have run into this issue too (see discussion: https://github.com/orgs/community/discussions/150368).

The next best thing in my opinion would be to have the default set as `"Select a workspace..."`. While it would still be possible for users to submit an issue with "Select a workspace..." selected, this would prevent 3scale from being pre-selected as the default (which should help with automating issue triaging). It would also serve as a placeholder, increasing the likelihood that issue reporters will notice and choose the correct workspace, rather than overlooking the selection when 3scale is set as the default.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
