### PR TITLE
Update GOVERNANCE.md's links

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,8 +1,8 @@
-The Backstage Community Plugins project area is governed according to the model specified in the [GOVERNANCE.md](https://github.com/backstage/backstage/blob/master/GOVERNANCE.md) file located in the `backstage/backstage` repository. We encourage all contributors and maintainers to review these guidelines to understand their roles and responsibilities.
+The Backstage Community Plugins project area is governed according to the model specified in the [GOVERNANCE.md](https://github.com/backstage/community/blob/main/GOVERNANCE.md) file located in the `backstage/community` repository. We encourage all contributors and maintainers to review these guidelines to understand their roles and responsibilities.
 
 # Governance Roles
 
 The governance of this repository is managed by specific roles:
 
 * [Community Plugins Area Owners](https://github.com/backstage/backstage/blob/master/OWNERS.md#community-plugins)
-* [Plugin Maintainers](https://github.com/backstage/backstage/blob/master/GOVERNANCE.md#plugin-maintainer)
+* [Plugin Maintainers](https://github.com/backstage/community/blob/main/GOVERNANCE.md#plugin-maintainer)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The GOVERNANCE links point to `backstage/backstage` instead of to `backstage/community` repo

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
