### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-0e9972a.md
+++ b/workspaces/rbac/.changeset/renovate-0e9972a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@testing-library/user-event` to `14.6.1`.

--- a/workspaces/rbac/.changeset/renovate-65fea94.md
+++ b/workspaces/rbac/.changeset/renovate-65fea94.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@playwright/test` to `1.51.0`.

--- a/workspaces/rbac/.changeset/rude-singers-wonder.md
+++ b/workspaces/rbac/.changeset/rude-singers-wonder.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac-node': patch
-'@backstage-community/plugin-rbac': patch
----
-
-remove prettier from devDevpendencies

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.5.3
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDevpendencies
+- Updated dependencies [973a5ef]
+  - @backstage-community/plugin-rbac-node@1.9.1
+
 ## 5.5.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.9.1
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDevpendencies
+
 ## 1.9.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.38.3
+
+### Patch Changes
+
+- 32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
+- c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
+- 973a5ef: remove prettier from devDevpendencies
+
 ## 1.38.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.38.3

### Patch Changes

-   32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
-   c222ea4: Updated dependency `@playwright/test` to `1.51.0`.
-   973a5ef: remove prettier from devDevpendencies

## @backstage-community/plugin-rbac-backend@5.5.3

### Patch Changes

-   973a5ef: remove prettier from devDevpendencies
-   Updated dependencies [973a5ef]
    -   @backstage-community/plugin-rbac-node@1.9.1

## @backstage-community/plugin-rbac-node@1.9.1

### Patch Changes

-   973a5ef: remove prettier from devDevpendencies
