### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-0e9972a.md
+++ b/workspaces/ocm/.changeset/renovate-0e9972a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
----
-
-Updated dependency `@testing-library/user-event` to `14.6.1`.

--- a/workspaces/ocm/.changeset/version-bump-1-36-1.md
+++ b/workspaces/ocm/.changeset/version-bump-1-36-1.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.36.1

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 5.5.0
+
+### Minor Changes
+
+- fb29ca1: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- Updated dependencies [fb29ca1]
+  - @backstage-community/plugin-ocm-common@3.8.0
+
 ## 5.4.1
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.8.0
+
+### Minor Changes
+
+- fb29ca1: Backstage version bump to v1.36.1
+
 ## 3.7.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 5.4.0
+
+### Minor Changes
+
+- fb29ca1: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- 32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
+- Updated dependencies [fb29ca1]
+  - @backstage-community/plugin-ocm-common@3.8.0
+
 ## 5.3.2
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.3.2",
+  "version": "5.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.4.0

### Minor Changes

-   fb29ca1: Backstage version bump to v1.36.1

### Patch Changes

-   32135b8: Updated dependency `@testing-library/user-event` to `14.6.1`.
-   Updated dependencies [fb29ca1]
    -   @backstage-community/plugin-ocm-common@3.8.0

## @backstage-community/plugin-ocm-backend@5.5.0

### Minor Changes

-   fb29ca1: Backstage version bump to v1.36.1

### Patch Changes

-   Updated dependencies [fb29ca1]
    -   @backstage-community/plugin-ocm-common@3.8.0

## @backstage-community/plugin-ocm-common@3.8.0

### Minor Changes

-   fb29ca1: Backstage version bump to v1.36.1
