### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/jenkins-meaningless-pop-song.md
+++ b/workspaces/jenkins/.changeset/jenkins-meaningless-pop-song.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': patch
----
-
-Fixed a bug that prevented the backend from starting if no config was provided.

--- a/workspaces/jenkins/.changeset/jenkins-one-thread.md
+++ b/workspaces/jenkins/.changeset/jenkins-one-thread.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': patch
----
-
-Updated config schema to indicate that _either_ a `jenkins.instances` array should be provided _or_ `jenkins.baseUrl`, `jenkins.username`, and `jenkins.apiKey`, but never both.

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.12.2
+
+### Patch Changes
+
+- 319b23a: Fixed a bug that prevented the backend from starting if no config was provided.
+- 319b23a: Updated config schema to indicate that _either_ a `jenkins.instances` array should be provided _or_ `jenkins.baseUrl`, `jenkins.username`, and `jenkins.apiKey`, but never both.
+
 ## 0.12.1
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins-backend@0.12.2

### Patch Changes

-   319b23a: Fixed a bug that prevented the backend from starting if no config was provided.
-   319b23a: Updated config schema to indicate that _either_ a `jenkins.instances` array should be provided _or_ `jenkins.baseUrl`, `jenkins.username`, and `jenkins.apiKey`, but never both.
