### PR TITLE
Version Packages (github-discussions)

### DIFF
--- a/workspaces/github-discussions/.changeset/kind-mirrors-jam.md
+++ b/workspaces/github-discussions/.changeset/kind-mirrors-jam.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-github-discussions': minor
-'@backstage-community/plugin-github-discussions-common': minor
-'@backstage-community/plugin-github-discussions': minor
----
-
-Updated dependencies to Backstage v1.36.1

--- a/workspaces/github-discussions/.changeset/lovely-bugs-fold.md
+++ b/workspaces/github-discussions/.changeset/lovely-bugs-fold.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-github-discussions': patch
-'@backstage-community/plugin-github-discussions-common': patch
-'@backstage-community/plugin-github-discussions': patch
----
-
-Added missing api-reports.

--- a/workspaces/github-discussions/packages/app/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/app/CHANGELOG.md
@@ -1,0 +1,9 @@
+# app
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [9d7e356]
+- Updated dependencies [9d7e356]
+  - @backstage-community/plugin-github-discussions@0.2.0

--- a/workspaces/github-discussions/packages/app/package.json
+++ b/workspaces/github-discussions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-discussions/packages/backend/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/backend/CHANGELOG.md
@@ -1,0 +1,9 @@
+# backend
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [9d7e356]
+- Updated dependencies [9d7e356]
+  - @backstage-community/plugin-search-backend-module-github-discussions@0.2.0

--- a/workspaces/github-discussions/packages/backend/package.json
+++ b/workspaces/github-discussions/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @backstage-community/plugin-github-discussions-common
+
+## 0.2.0
+
+### Minor Changes
+
+- 9d7e356: Updated dependencies to Backstage v1.36.1
+
+### Patch Changes
+
+- 9d7e356: Added missing api-reports.

--- a/workspaces/github-discussions/plugins/github-discussions-common/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-github-discussions-common",
   "description": "Common functionalities for the github-discussions plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @backstage-community/plugin-github-discussions
+
+## 0.2.0
+
+### Minor Changes
+
+- 9d7e356: Updated dependencies to Backstage v1.36.1
+
+### Patch Changes
+
+- 9d7e356: Added missing api-reports.
+- Updated dependencies [9d7e356]
+- Updated dependencies [9d7e356]
+  - @backstage-community/plugin-github-discussions-common@0.2.0

--- a/workspaces/github-discussions/plugins/github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-discussions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @backstage-community/plugin-search-backend-module-github-discussions
+
+## 0.2.0
+
+### Minor Changes
+
+- 9d7e356: Updated dependencies to Backstage v1.36.1
+
+### Patch Changes
+
+- 9d7e356: Added missing api-reports.
+- Updated dependencies [9d7e356]
+- Updated dependencies [9d7e356]
+  - @backstage-community/plugin-github-discussions-common@0.2.0

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-github-discussions",
   "description": "The github-discussions backend module for the search plugin.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-discussions@0.2.0

### Minor Changes

-   9d7e356: Updated dependencies to Backstage v1.36.1

### Patch Changes

-   9d7e356: Added missing api-reports.
-   Updated dependencies [9d7e356]
-   Updated dependencies [9d7e356]
    -   @backstage-community/plugin-github-discussions-common@0.2.0

## @backstage-community/plugin-github-discussions-common@0.2.0

### Minor Changes

-   9d7e356: Updated dependencies to Backstage v1.36.1

### Patch Changes

-   9d7e356: Added missing api-reports.

## @backstage-community/plugin-search-backend-module-github-discussions@0.2.0

### Minor Changes

-   9d7e356: Updated dependencies to Backstage v1.36.1

### Patch Changes

-   9d7e356: Added missing api-reports.
-   Updated dependencies [9d7e356]
-   Updated dependencies [9d7e356]
    -   @backstage-community/plugin-github-discussions-common@0.2.0

## app@0.0.1

### Patch Changes

-   Updated dependencies [9d7e356]
-   Updated dependencies [9d7e356]
    -   @backstage-community/plugin-github-discussions@0.2.0

## backend@0.0.1

### Patch Changes

-   Updated dependencies [9d7e356]
-   Updated dependencies [9d7e356]
    -   @backstage-community/plugin-search-backend-module-github-discussions@0.2.0
