### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/rare-pumpkins-punch.md
+++ b/workspaces/entity-feedback/.changeset/rare-pumpkins-punch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': patch
----
-
-Fixed bug where 404 errors were thrown in case entityRef in URI was decoded by middleware before reaching backend

--- a/workspaces/entity-feedback/packages/backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.13
+
+### Patch Changes
+
+- Updated dependencies [19d1f27]
+  - @backstage-community/plugin-entity-feedback-backend@0.7.1
+
 ## 0.0.12
 
 ### Patch Changes

--- a/workspaces/entity-feedback/packages/backend/package.json
+++ b/workspaces/entity-feedback/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.7.1
+
+### Patch Changes
+
+- 19d1f27: Fixed bug where 404 errors were thrown in case entityRef in URI was decoded by middleware before reaching backend
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "entity-feedback",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback-backend@0.7.1

### Patch Changes

-   19d1f27: Fixed bug where 404 errors were thrown in case entityRef in URI was decoded by middleware before reaching backend

## backend@0.0.13

### Patch Changes

-   Updated dependencies [19d1f27]
    -   @backstage-community/plugin-entity-feedback-backend@0.7.1
