### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/version-bump-1-36-1.md
+++ b/workspaces/rbac/.changeset/version-bump-1-36-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': minor
-'@backstage-community/plugin-rbac-common': minor
-'@backstage-community/plugin-rbac-node': minor
----
-
-Backstage version bump to v1.36.1

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 5.6.0
+
+### Minor Changes
+
+- 0253db6: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- Updated dependencies [0253db6]
+  - @backstage-community/plugin-rbac-common@1.14.0
+  - @backstage-community/plugin-rbac-node@1.10.0
+
 ## 5.5.3
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "5.5.3",
+  "version": "5.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.14.0
+
+### Minor Changes
+
+- 0253db6: Backstage version bump to v1.36.1
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.10.0
+
+### Minor Changes
+
+- 0253db6: Backstage version bump to v1.36.1
+
 ## 1.9.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.39.0
+
+### Minor Changes
+
+- 0253db6: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- Updated dependencies [0253db6]
+  - @backstage-community/plugin-rbac-common@1.14.0
+
 ## 1.38.3
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.38.3",
+  "version": "1.39.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.39.0

### Minor Changes

-   0253db6: Backstage version bump to v1.36.1

### Patch Changes

-   Updated dependencies [0253db6]
    -   @backstage-community/plugin-rbac-common@1.14.0

## @backstage-community/plugin-rbac-backend@5.6.0

### Minor Changes

-   0253db6: Backstage version bump to v1.36.1

### Patch Changes

-   Updated dependencies [0253db6]
    -   @backstage-community/plugin-rbac-common@1.14.0
    -   @backstage-community/plugin-rbac-node@1.10.0

## @backstage-community/plugin-rbac-common@1.14.0

### Minor Changes

-   0253db6: Backstage version bump to v1.36.1

## @backstage-community/plugin-rbac-node@1.10.0

### Minor Changes

-   0253db6: Backstage version bump to v1.36.1
