### PR TITLE
refactor: replace HTML tags with MUI components

### DIFF
--- a/workspaces/announcements/.changeset/lemon-shrimps-pump.md
+++ b/workspaces/announcements/.changeset/lemon-shrimps-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Replaced HTML elements with MUI components in `AnnouncementsCard` and `AnnouncementsPage` for uniform styling.

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -42,6 +42,7 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
+  Box,
 } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import NewReleasesIcon from '@material-ui/icons/NewReleases';
@@ -131,7 +132,7 @@ export const AnnouncementsCard = ({
                 </Link>
               }
               secondary={
-                <div>
+                <Box>
                   <Typography variant="body2" color="textSecondary">
                     {DateTime.fromISO(announcement.created_at).toRelative()}
                     {announcement.category && (
@@ -150,19 +151,15 @@ export const AnnouncementsCard = ({
                   <Typography variant="body2" color="textSecondary">
                     {announcement.excerpt}
                   </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    <small>
-                      <small>
-                        {formatAnnouncementStartTime(
-                          announcement.start_at,
-                          t('announcementsCard.occurred'),
-                          t('announcementsCard.scheduled'),
-                          t('announcementsCard.today'),
-                        )}
-                      </small>
-                    </small>
+                  <Typography variant="caption" color="textSecondary">
+                    {formatAnnouncementStartTime(
+                      announcement.start_at,
+                      t('announcementsCard.occurred'),
+                      t('announcementsCard.scheduled'),
+                      t('announcementsCard.today'),
+                    )}
                   </Typography>
-                </div>
+                </Box>
               }
             />{' '}
           </ListItem>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -58,6 +58,7 @@ import {
   useAnnouncementsTranslation,
 } from '@backstage-community/plugin-announcements-react';
 import {
+  Box,
   Card,
   CardContent,
   CardHeader,
@@ -150,16 +151,16 @@ const AnnouncementCard = ({
         )}
         , {DateTime.fromISO(announcement.created_at).toRelative()}
       </Typography>
-      <Typography variant="body2" color="textSecondary">
-        <small>
+      <Box>
+        <Typography variant="caption" color="textSecondary">
           {formatAnnouncementStartTime(
             announcement.start_at,
             t('announcementsCard.occurred'),
             t('announcementsCard.scheduled'),
             t('announcementsCard.today'),
           )}
-        </small>
-      </Typography>
+        </Typography>
+      </Box>
     </>
   );
   const { loading: loadingDeletePermission, allowed: canDelete } =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Apply @kurtaking suggestion https://github.com/backstage/community-plugins/pull/3139#discussion_r1981648568 by removing `html` in favor of Mui components

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
