### PR TITLE
feat(copilot): Adds engagement and seat analysis metrics

### DIFF
--- a/workspaces/copilot/.changeset/wise-shrimps-count.md
+++ b/workspaces/copilot/.changeset/wise-shrimps-count.md
@@ -1,0 +1,42 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+'@backstage-community/plugin-copilot-common': minor
+'@backstage-community/plugin-copilot': minor
+---
+
+Adds engagement metrics to be viewed. No personal details are currently stored.
+(Like information on who hasnt been using its license).
+
+This is done by fetching the seat billing information from Github.
+[API ref](https://docs.github.com/en/rest/copilot/copilot-user-management?apiVersion=2022-11-28#list-all-copilot-seat-assignments-for-an-organization)
+
+It then selects out the following metrics based of the billing information
+
+- Total assigned seats
+- Seats never used
+  (user has undefined last_activity_at property)
+- Seats not used in the last 7/14/28 days
+  (diff between "today" and last_activity_at)
+
+This is presented in a slightly different way since they are absolute numbers.
+The following metrics are presented based on the last day of the selected period range
+
+- Total assigned seats
+- Seats never used
+- Inactive seats last 7/14/28 days
+
+The following metrics are calculated as average for the selected period range
+excluding weekends (since usage usually goes down during theese days).
+
+- Avg Total Active users
+- Avg Total Engaged users
+- Avg IDE Completion users
+- Avg IDE Chat users
+- Avg Github.com Chat users
+- Avg Github.com PR users
+
+All of the new metrics also have an own bar chart displaying this over the selected period range.
+(Except seats not used in 7/14/28 days, who got a line-chart with multiple lines)
+
+The backend has also been updated to use Octokit to fetch data instead of own implementation.
+This also fixes the problem with pagination for some endpoints.

--- a/workspaces/copilot/plugins/copilot-backend/migrations/202503111030_add_seat_analysys.js
+++ b/workspaces/copilot/plugins/copilot-backend/migrations/202503111030_add_seat_analysys.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.createTable('seats', table => {
+    table.comment('Table for storing metrics for CoPilot seat metrics');
+    table.date('day').notNullable().comment('Date of the metrics data');
+    table
+      .string('type')
+      .notNullable()
+      .defaultTo('organization')
+      .comment('The type of metric');
+    table.string('team_name', 255).nullable().comment('Name of the team');
+    table.integer('total_seats').notNullable().comment('Total seats');
+    table
+      .integer('seats_never_used')
+      .notNullable()
+      .comment('Total seats never used');
+    table
+      .integer('seats_inactive_7_days')
+      .notNullable()
+      .comment('Total seats inactive for 7 days');
+    table
+      .integer('seats_inactive_14_days')
+      .notNullable()
+      .comment('Total seats inactive for 14 days');
+    table
+      .integer('seats_inactive_28_days')
+      .notNullable()
+      .comment('Total seats inactive for 28 days');
+    table.unique(['day', 'type', 'team_name'], { indexName: 'uk_seat_day' });
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.dropTable('seats');
+};

--- a/workspaces/copilot/plugins/copilot-backend/migrations/202503111030_add_seat_analysys.js
+++ b/workspaces/copilot/plugins/copilot-backend/migrations/202503111030_add_seat_analysys.js
@@ -25,7 +25,7 @@ exports.up = async function up(knex) {
       .notNullable()
       .defaultTo('organization')
       .comment('The type of metric');
-    table.string('team_name', 255).nullable().comment('Name of the team');
+    table.string('team_name', 255).notNullable().comment('Name of the team');
     table.integer('total_seats').notNullable().comment('Total seats');
     table
       .integer('seats_never_used')

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -46,6 +46,7 @@
     "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.16.2",
+    "@octokit/rest": "^21.1.1",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -46,7 +46,7 @@
     "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/integration": "^1.16.2",
-    "@octokit/rest": "^21.1.1",
+    "@octokit/rest": "20.1.0",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.ts
@@ -18,9 +18,10 @@ import { ResponseError } from '@backstage/errors';
 import { Config } from '@backstage/config';
 import {
   CopilotMetrics,
+  CopilotSeats,
   TeamInfo,
 } from '@backstage-community/plugin-copilot-common';
-import fetch from 'node-fetch';
+import { Octokit } from '@octokit/rest';
 import {
   CopilotConfig,
   CopilotCredentials,
@@ -43,6 +44,9 @@ interface GithubApi {
 }
 
 export class GithubClient implements GithubApi {
+  private enterpriseOctokit?: Octokit;
+  private organizationOctokit?: Octokit;
+
   constructor(
     private readonly copilotConfig: CopilotConfig,
     private readonly config: Config,
@@ -57,58 +61,171 @@ export class GithubClient implements GithubApi {
     return await getGithubCredentials(this.config, this.copilotConfig);
   }
 
+  private async getOctokit(
+    type: 'enterprise' | 'organization',
+  ): Promise<Octokit> {
+    const credentials = await this.getCredentials();
+    const headers = credentials[type]?.headers || {};
+
+    return new Octokit({
+      baseUrl: this.copilotConfig.apiBaseUrl,
+      auth: headers.Authorization?.replace('Bearer ', '') || '',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  }
+
+  private async getEnterpriseOctokit(): Promise<Octokit> {
+    if (!this.enterpriseOctokit) {
+      this.enterpriseOctokit = await this.getOctokit('enterprise');
+    }
+    return this.enterpriseOctokit;
+  }
+
+  private async getOrganizationOctokit(): Promise<Octokit> {
+    if (!this.organizationOctokit) {
+      this.organizationOctokit = await this.getOctokit('organization');
+    }
+    return this.organizationOctokit;
+  }
+
   async fetchEnterpriseCopilotMetrics(): Promise<CopilotMetrics[]> {
+    const octokit = await this.getEnterpriseOctokit();
     const path = `/enterprises/${this.copilotConfig.enterprise}/copilot/metrics`;
-    return this.get(path);
+
+    try {
+      const response = await octokit.request(`GET ${path}`);
+      return response.data as CopilotMetrics[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
   async fetchEnterpriseTeamCopilotMetrics(
     teamId: string,
   ): Promise<CopilotMetrics[]> {
+    const octokit = await this.getEnterpriseOctokit();
     const path = `/enterprises/${this.copilotConfig.enterprise}/team/${teamId}/copilot/metrics`;
-    return this.get(path);
+
+    try {
+      const response = await octokit.request(`GET ${path}`);
+      return response.data as CopilotMetrics[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
   async fetchEnterpriseTeams(): Promise<TeamInfo[]> {
+    const octokit = await this.getEnterpriseOctokit();
     const path = `/enterprises/${this.copilotConfig.enterprise}/teams`;
-    return this.get(path);
+
+    try {
+      const teams = await octokit.paginate(`GET ${path}`, {
+        per_page: 100, // Maximum allowed per page
+      });
+      return teams as TeamInfo[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
+  }
+
+  async fetchEnterpriseSeats(): Promise<any> {
+    const octokit = await this.getEnterpriseOctokit();
+    const path = `/enterprises/${this.copilotConfig.enterprise}/copilot/billing/seats`;
+
+    try {
+      const seats = await octokit.paginate(`GET ${path}`, {
+        per_page: 100, // Maximum allowed per page
+      });
+
+      return this.mergePaginationResult(seats as CopilotSeats[]);
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
   async fetchOrganizationCopilotMetrics(): Promise<CopilotMetrics[]> {
+    const octokit = await this.getOrganizationOctokit();
     const path = `/orgs/${this.copilotConfig.organization}/copilot/metrics`;
-    return this.get(path);
+
+    try {
+      const response = await octokit.request(`GET ${path}`);
+      return response.data as CopilotMetrics[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
   async fetchOrganizationTeamCopilotMetrics(
     teamId: string,
   ): Promise<CopilotMetrics[]> {
+    const octokit = await this.getOrganizationOctokit();
     const path = `/orgs/${this.copilotConfig.organization}/team/${teamId}/copilot/metrics`;
-    return this.get(path);
+
+    try {
+      const response = await octokit.request(`GET ${path}`);
+      return response.data as CopilotMetrics[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
   async fetchOrganizationTeams(): Promise<TeamInfo[]> {
+    const octokit = await this.getOrganizationOctokit();
     const path = `/orgs/${this.copilotConfig.organization}/teams`;
-    return this.get(path);
+
+    try {
+      const teams = await octokit.paginate(`GET ${path}`, {
+        per_page: 100, // Maximum allowed per page
+      });
+      return teams as TeamInfo[];
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
   }
 
-  private async get<T>(path: string): Promise<T> {
-    const credentials = await this.getCredentials();
-    const headers = path.startsWith('/enterprises')
-      ? credentials.enterprise?.headers
-      : credentials.organization?.headers;
+  async fetchOrganizationSeats(): Promise<CopilotSeats> {
+    const octokit = await this.getOrganizationOctokit();
 
-    const response = await fetch(`${this.copilotConfig.apiBaseUrl}${path}`, {
-      headers: {
-        ...headers,
-        Accept: 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-    });
+    try {
+      const seats = await octokit.paginate(octokit.copilot.listCopilotSeats, {
+        org: this.copilotConfig.organization!,
+        per_page: 100, // Maximum allowed per page
+      });
 
-    if (!response.ok) {
-      throw await ResponseError.fromResponse(response);
+      return this.mergePaginationResult(seats as CopilotSeats[]);
+    } catch (error) {
+      throw ResponseError.fromResponse(error.response || error);
+    }
+  }
+
+  /**
+   * This function is used to merge paginated results from the GitHub API
+   * that does not work as one would expect. If the api returns a object which
+   * contains paginated results, we get an array of the objects instead of merged data.
+   * So this function merges this data into one object where the property "seats" are
+   * merged into a single array.
+   * @param data
+   * @returns paginated result as one would expect
+   */
+  mergePaginationResult(data: CopilotSeats[]): CopilotSeats {
+    if (data.length === 0) {
+      return {
+        total_seats: 0,
+        seats: [],
+      };
     }
 
-    return response.json() as Promise<T>;
+    // total_seats is the same for all pages, so we can just take it from the first page
+    // and merge the seats from all pages into one array
+    const totalSeats = data[0].total_seats;
+    const seats = data.map(seat => seat.seats).flat();
+
+    return {
+      total_seats: totalSeats,
+      seats: seats,
+    };
   }
 }

--- a/workspaces/copilot/plugins/copilot-backend/src/service/router.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/service/router.ts
@@ -198,6 +198,37 @@ async function createRouter(
   );
 
   router.get(
+    '/engagements',
+    validateQuery(metricsQuerySchema),
+    async (req, res) => {
+      const { startDate, endDate, type, team } = req.query as MetricsQuery;
+
+      const engagements = await db.getEngagementMetrics(
+        startDate,
+        endDate,
+        type,
+        team,
+      );
+      if (!engagements) {
+        throw new NotFoundError();
+      }
+
+      return res.json(engagements);
+    },
+  );
+
+  router.get('/seats', validateQuery(metricsQuerySchema), async (req, res) => {
+    const { startDate, endDate, type, team } = req.query as MetricsQuery;
+
+    const seats = await db.getSeatMetrics(startDate, endDate, type, team);
+    if (!seats) {
+      throw new NotFoundError();
+    }
+
+    return res.json(seats);
+  });
+
+  router.get(
     '/metrics/period-range',
     validateQuery(periodRangeQuerySchema),
     async (req, res) => {

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
@@ -19,6 +19,7 @@ import {
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
 import {
+  convertToSeatAnalysis,
   filterBaseMetrics,
   filterIdeChatEditorModelMetrics,
   filterIdeChatMetrics,
@@ -138,6 +139,10 @@ export async function discoverEnterpriseMetrics({
       await batchInsertInChunks(ideChatEditorModels, 30, async chunk => {
         await db.batchInsertIdeChatEditorModels(chunk);
       });
+
+      const seats = await api.fetchOrganizationSeats();
+      const seatsToInsert = convertToSeatAnalysis(seats, type);
+      await db.insertSeatAnalysys(seatsToInsert);
 
       logger.info(
         '[discoverEnterpriseMetrics] Inserted new metrics into the database',

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
@@ -19,6 +19,7 @@ import {
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
 import {
+  convertToTeamSeatAnalysis,
   filterBaseMetrics,
   filterIdeChatEditorModelMetrics,
   filterIdeChatMetrics,
@@ -158,6 +159,15 @@ export async function discoverEnterpriseTeamMetrics({
           await batchInsertInChunks(ideChatEditorModels, 30, async chunk => {
             await db.batchInsertIdeChatEditorModels(chunk);
           });
+
+          // Fetch seat analysis
+          const seats = await api.fetchEnterpriseSeats();
+          const seatsToInsert = convertToTeamSeatAnalysis(
+            seats,
+            type,
+            team.slug,
+          );
+          await db.insertSeatAnalysys(seatsToInsert);
 
           logger.info(
             `[discoverEnterpriseTeamMetrics] Inserted new metrics into the database for team: ${team.slug}`,

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
@@ -29,6 +29,7 @@ import {
   filterIdeChatMetrics,
   filterIdeEditorMetrics,
   filterIdeChatEditorModelMetrics,
+  convertToSeatAnalysis,
 } from '../utils/metricHelpers';
 import { TaskOptions } from './TaskManagement';
 
@@ -138,6 +139,10 @@ export async function discoverOrganizationMetrics({
       await batchInsertInChunks(ideChatEditorModels, 30, async chunk => {
         await db.batchInsertIdeChatEditorModels(chunk);
       });
+
+      const seats = await api.fetchOrganizationSeats();
+      const seatsToInsert = convertToSeatAnalysis(seats, type);
+      await db.insertSeatAnalysys(seatsToInsert);
 
       logger.info(
         '[discoverOrganizationMetrics] Inserted new metrics into the database',

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
@@ -20,6 +20,7 @@ import {
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
 import {
+  convertToTeamSeatAnalysis,
   filterBaseMetrics,
   filterIdeChatEditorModelMetrics,
   filterIdeChatMetrics,
@@ -159,6 +160,15 @@ export async function discoverOrganizationTeamMetrics({
           await batchInsertInChunks(ideChatEditorModels, 30, async chunk => {
             await db.batchInsertIdeChatEditorModels(chunk);
           });
+
+          // Fetch seat analysis
+          const seats = await api.fetchOrganizationSeats();
+          const seatsToInsert = convertToTeamSeatAnalysis(
+            seats,
+            type,
+            team.slug,
+          );
+          await db.insertSeatAnalysys(seatsToInsert);
 
           logger.info(
             `[discoverOrganizationTeamMetrics] Inserted new metrics into the database for team: ${team.slug}`,

--- a/workspaces/copilot/plugins/copilot-common/report.api.md
+++ b/workspaces/copilot/plugins/copilot-common/report.api.md
@@ -15,15 +15,15 @@ export interface Breakdown {
 }
 
 // @public
-export interface CopilotAssgningTeam {
-  id: number;
-  slug: string;
-}
-
-// @public
 export interface CopilotAssignee {
   id: number;
   login: string;
+}
+
+// @public
+export interface CopilotAssigningTeam {
+  id: number;
+  slug: string;
 }
 
 // @public
@@ -115,7 +115,7 @@ export interface CopilotRepositoryModels {
 // @public
 export interface CopilotSeat {
   assignee: CopilotAssignee;
-  assigning_team: CopilotAssgningTeam;
+  assigning_team: CopilotAssigningTeam;
   created_at: string;
   last_activity_at: string;
   last_activity_editor: string;
@@ -197,13 +197,6 @@ export interface SeatAnalysis {
   team_name: string;
   total_seats: number;
   type: MetricsType;
-}
-
-// @public
-export interface SeatInfo {
-  id: number;
-  name: string;
-  slug: string;
 }
 
 // @public

--- a/workspaces/copilot/plugins/copilot-common/report.api.md
+++ b/workspaces/copilot/plugins/copilot-common/report.api.md
@@ -15,6 +15,18 @@ export interface Breakdown {
 }
 
 // @public
+export interface CopilotAssgningTeam {
+  id: number;
+  slug: string;
+}
+
+// @public
+export interface CopilotAssignee {
+  id: number;
+  login: string;
+}
+
+// @public
 export interface CopilotChatEditors {
   models: CopilotChatModels[];
   name: string;
@@ -101,6 +113,23 @@ export interface CopilotRepositoryModels {
 }
 
 // @public
+export interface CopilotSeat {
+  assignee: CopilotAssignee;
+  assigning_team: CopilotAssgningTeam;
+  created_at: string;
+  last_activity_at: string;
+  last_activity_editor: string;
+  plan_type: string;
+  updated_at: string;
+}
+
+// @public
+export interface CopilotSeats {
+  seats: CopilotSeat[];
+  total_seats: number;
+}
+
+// @public
 export interface DotcomChat {
   models: DotcomChatModels[];
   total_engaged_users: number;
@@ -118,6 +147,19 @@ export interface DotcomChatModels {
 export interface DotcomPullRequests {
   repositories: CopilotRepository[];
   total_engaged_users: number;
+}
+
+// @public
+export interface EngagementMetrics {
+  day: string;
+  dotcom_chats_engaged_users: number;
+  dotcom_prs_engaged_users: number;
+  ide_chats_engaged_users: number;
+  ide_completions_engaged_users: number;
+  team_name?: string;
+  total_active_users: number;
+  total_engaged_users: number;
+  type: MetricsType;
 }
 
 // @public @deprecated
@@ -143,6 +185,25 @@ export type MetricsType = 'enterprise' | 'organization';
 export interface PeriodRange {
   maxDate: string;
   minDate: string;
+}
+
+// @public
+export interface SeatAnalysis {
+  day: string;
+  seats_inactive_14_days: number;
+  seats_inactive_28_days: number;
+  seats_inactive_7_days: number;
+  seats_never_used: number;
+  team_name: string;
+  total_seats: number;
+  type: MetricsType;
+}
+
+// @public
+export interface SeatInfo {
+  id: number;
+  name: string;
+  slug: string;
 }
 
 // @public

--- a/workspaces/copilot/plugins/copilot-common/src/index.ts
+++ b/workspaces/copilot/plugins/copilot-common/src/index.ts
@@ -185,28 +185,6 @@ export interface TeamInfo {
 }
 
 /**
- * Represents information about seats.
- *
- * @public
- */
-export interface SeatInfo {
-  /**
-   * The unique identifier of the team.
-   */
-  id: number;
-
-  /**
-   * The slug of the team, used for URL-friendly identifiers.
-   */
-  slug: string;
-
-  /**
-   * The name of the team.
-   */
-  name: string;
-}
-
-/**
  * Represents the metrics data for copilot ide language metrics
  *
  * @public
@@ -598,7 +576,7 @@ export interface CopilotAssignee {
  *
  * @public
  */
-export interface CopilotAssgningTeam {
+export interface CopilotAssigningTeam {
   /**
    * The unique identifier of the team.
    */
@@ -641,7 +619,7 @@ export interface CopilotSeat {
   /**
    * The team that assigned this seat.
    */
-  assigning_team: CopilotAssgningTeam;
+  assigning_team: CopilotAssigningTeam;
 }
 /**
  * Represents the base seat data for copilot

--- a/workspaces/copilot/plugins/copilot-common/src/index.ts
+++ b/workspaces/copilot/plugins/copilot-common/src/index.ts
@@ -524,7 +524,15 @@ export interface CopilotMetrics {
   copilot_dotcom_pull_requests: DotcomPullRequests;
 }
 
+/**
+ * Represents the engagement metrics for copilot.
+ *
+ * @public
+ */
 export interface EngagementMetrics {
+  /**
+   * The date for the metrics reported.
+   */
   day: string;
   /**
    * The type of the metrics data.
@@ -538,42 +546,154 @@ export interface EngagementMetrics {
    */
   team_name?: string;
 
+  /**
+   * The total number of users who have used Copilot.
+   */
   total_active_users: number;
+
+  /**
+   * The total number of users who have meaningfully interacted with Copilot features.
+   */
   total_engaged_users: number;
+
+  /**
+   * The number of users who have engaged with IDE code completions.
+   */
   ide_completions_engaged_users: number;
+
+  /**
+   * The number of users who have engaged with IDE chat features.
+   */
   ide_chats_engaged_users: number;
+
+  /**
+   * The number of users who have engaged with GitHub.com chat features.
+   */
   dotcom_chats_engaged_users: number;
+
+  /**
+   * The number of users who have engaged with pull request features.
+   */
   dotcom_prs_engaged_users: number;
 }
 
+/**
+ * Represents the assignee for a copilot seat
+ *
+ * @public
+ */
 export interface CopilotAssignee {
+  /**
+   * The unique identifier of the assignee.
+   */
   id: number;
+  /**
+   * The login username of the assignee.
+   */
   login: string;
 }
+
+/**
+ * Represents the assigning team for a copilot seat
+ *
+ * @public
+ */
 export interface CopilotAssgningTeam {
+  /**
+   * The unique identifier of the team.
+   */
   id: number;
+  /**
+   * The slug of the team, used for URL-friendly identifiers.
+   */
   slug: string;
 }
+/**
+ * Represents the a seat for copilot
+ *
+ * @public
+ */
 export interface CopilotSeat {
+  /**
+   * The date when the seat was created.
+   */
   created_at: string;
+  /**
+   * The date when the seat was last updated.
+   */
   updated_at: string;
+  /**
+   * The date when the seat was last active.
+   */
   last_activity_at: string;
+  /**
+   * The editor used in the last activity.
+   */
   last_activity_editor: string;
+  /**
+   * The type of plan for this seat.
+   */
   plan_type: string;
+  /**
+   * The user assigned to this seat.
+   */
   assignee: CopilotAssignee;
+  /**
+   * The team that assigned this seat.
+   */
   assigning_team: CopilotAssgningTeam;
 }
+/**
+ * Represents the base seat data for copilot
+ *
+ * @public
+ */
 export interface CopilotSeats {
+  /**
+   * The total number of seats available.
+   */
   total_seats: number;
+  /**
+   * The list of individual seats.
+   */
   seats: CopilotSeat[];
 }
+/**
+ * Represents the seat analysis data for copilot
+ *
+ * @public
+ */
 export interface SeatAnalysis {
+  /**
+   * The date for the analysis.
+   */
   day: string;
+  /**
+   * The type of the seat data (enterprise or organization).
+   */
   type: MetricsType;
+  /**
+   * The name of the team for this analysis.
+   */
   team_name: string;
+  /**
+   * The total number of seats available.
+   */
   total_seats: number;
+  /**
+   * The number of seats that have never been used.
+   */
   seats_never_used: number;
+  /**
+   * The number of seats inactive for 7 days.
+   */
   seats_inactive_7_days: number;
+  /**
+   * The number of seats inactive for 14 days.
+   */
   seats_inactive_14_days: number;
+  /**
+   * The number of seats inactive for 28 days.
+   */
   seats_inactive_28_days: number;
 }

--- a/workspaces/copilot/plugins/copilot-common/src/index.ts
+++ b/workspaces/copilot/plugins/copilot-common/src/index.ts
@@ -185,6 +185,28 @@ export interface TeamInfo {
 }
 
 /**
+ * Represents information about seats.
+ *
+ * @public
+ */
+export interface SeatInfo {
+  /**
+   * The unique identifier of the team.
+   */
+  id: number;
+
+  /**
+   * The slug of the team, used for URL-friendly identifiers.
+   */
+  slug: string;
+
+  /**
+   * The name of the team.
+   */
+  name: string;
+}
+
+/**
  * Represents the metrics data for copilot ide language metrics
  *
  * @public
@@ -500,4 +522,58 @@ export interface CopilotMetrics {
    * The total number of pull requests for dotcom users.
    */
   copilot_dotcom_pull_requests: DotcomPullRequests;
+}
+
+export interface EngagementMetrics {
+  day: string;
+  /**
+   * The type of the metrics data.
+   * Can be 'enterprise', 'organization'.
+   */
+  type: MetricsType;
+
+  /**
+   * The name of the team, applicable when the metric is for a specific team.
+   * When null, it indicates metrics for all teams, aggregated at the 'enterprise' or 'organization' level.
+   */
+  team_name?: string;
+
+  total_active_users: number;
+  total_engaged_users: number;
+  ide_completions_engaged_users: number;
+  ide_chats_engaged_users: number;
+  dotcom_chats_engaged_users: number;
+  dotcom_prs_engaged_users: number;
+}
+
+export interface CopilotAssignee {
+  id: number;
+  login: string;
+}
+export interface CopilotAssgningTeam {
+  id: number;
+  slug: string;
+}
+export interface CopilotSeat {
+  created_at: string;
+  updated_at: string;
+  last_activity_at: string;
+  last_activity_editor: string;
+  plan_type: string;
+  assignee: CopilotAssignee;
+  assigning_team: CopilotAssgningTeam;
+}
+export interface CopilotSeats {
+  total_seats: number;
+  seats: CopilotSeat[];
+}
+export interface SeatAnalysis {
+  day: string;
+  type: MetricsType;
+  team_name: string;
+  total_seats: number;
+  seats_never_used: number;
+  seats_inactive_7_days: number;
+  seats_inactive_14_days: number;
+  seats_inactive_28_days: number;
 }

--- a/workspaces/copilot/plugins/copilot/src/api/CopilotApi.ts
+++ b/workspaces/copilot/plugins/copilot/src/api/CopilotApi.ts
@@ -16,9 +16,11 @@
 
 import { createApiRef } from '@backstage/core-plugin-api';
 import {
+  EngagementMetrics,
   Metric,
   MetricsType,
   PeriodRange,
+  SeatAnalysis,
 } from '@backstage-community/plugin-copilot-common';
 
 export const copilotApiRef = createApiRef<CopilotApi>({
@@ -32,6 +34,18 @@ export interface CopilotApi {
     type: MetricsType,
     team?: string,
   ): Promise<Metric[]>;
+  getEngagementMetrics(
+    startDate: Date,
+    endDate: Date,
+    type: MetricsType,
+    team?: string,
+  ): Promise<EngagementMetrics[]>;
+  getSeatMetrics(
+    startDate: Date,
+    endDate: Date,
+    type: MetricsType,
+    team?: string,
+  ): Promise<SeatAnalysis[]>;
   fetchTeams(
     startDate: Date,
     endDate: Date,

--- a/workspaces/copilot/plugins/copilot/src/api/CopilotClient.ts
+++ b/workspaces/copilot/plugins/copilot/src/api/CopilotClient.ts
@@ -18,9 +18,11 @@ import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import { CopilotApi } from './CopilotApi';
 import {
+  EngagementMetrics,
   Metric,
   MetricsType,
   PeriodRange,
+  SeatAnalysis,
 } from '@backstage-community/plugin-copilot-common';
 import { DateTime } from 'luxon';
 
@@ -58,6 +60,61 @@ export class CopilotClient implements CopilotApi {
     const urlSegment = `metrics?${queryString}`;
 
     return await this.get<Metric[]>(urlSegment);
+  }
+
+  public async getEngagementMetrics(
+    startDate: Date,
+    endDate: Date,
+    type: MetricsType,
+    team?: string,
+  ): Promise<EngagementMetrics[]> {
+    const queryString = new URLSearchParams();
+
+    queryString.append(
+      'startDate',
+      DateTime.fromJSDate(startDate).toFormat('yyyy-MM-dd'),
+    );
+    queryString.append(
+      'endDate',
+      DateTime.fromJSDate(endDate).toFormat('yyyy-MM-dd'),
+    );
+
+    queryString.append('type', type);
+
+    if (team) {
+      queryString.append('team', team);
+    }
+
+    const urlSegment = `engagements?${queryString}`;
+
+    return await this.get<EngagementMetrics[]>(urlSegment);
+  }
+  public async getSeatMetrics(
+    startDate: Date,
+    endDate: Date,
+    type: MetricsType,
+    team?: string,
+  ): Promise<SeatAnalysis[]> {
+    const queryString = new URLSearchParams();
+
+    queryString.append(
+      'startDate',
+      DateTime.fromJSDate(startDate).toFormat('yyyy-MM-dd'),
+    );
+    queryString.append(
+      'endDate',
+      DateTime.fromJSDate(endDate).toFormat('yyyy-MM-dd'),
+    );
+
+    queryString.append('type', type);
+
+    if (team) {
+      queryString.append('team', team);
+    }
+
+    const urlSegment = `seats?${queryString}`;
+
+    return await this.get<SeatAnalysis[]>(urlSegment);
   }
 
   public async periodRange(type: MetricsType): Promise<PeriodRange> {

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/Card.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/Card.tsx
@@ -32,6 +32,8 @@ type CardItemProps = {
   startDate: Date;
   endDate: Date;
   icon: ElementType<ReactNode>;
+  valueIsOnlyForLastDay?: boolean;
+  rangeSuffix?: string;
 };
 
 const format = 'dd/MM/yyyy';
@@ -53,9 +55,15 @@ export const Card = ({
   startDate,
   endDate,
   icon,
+  valueIsOnlyForLastDay = false,
+  rangeSuffix = '',
 }: CardItemProps) => {
   const message = useMemo(() => {
     if (primaryValue === 'N/A') return `No data available`;
+    if (valueIsOnlyForLastDay) {
+      const lastSelectedDay = DateTime.fromJSDate(endDate).toFormat(format);
+      return `@ ${lastSelectedDay}`;
+    }
 
     const endDateTime = DateTime.fromJSDate(endDate);
     const now = DateTime.now();
@@ -73,7 +81,7 @@ export const Card = ({
     return `From ${DateTime.fromJSDate(startDate).toFormat(
       format,
     )} to ${endDateTime.toFormat(format)}`;
-  }, [primaryValue, startDate, endDate]);
+  }, [primaryValue, startDate, endDate, valueIsOnlyForLastDay]);
 
   return (
     <InfoCard divider={false}>
@@ -110,7 +118,7 @@ export const Card = ({
       <Divider />
       <Box>
         <FooterText color="textSecondary" variant="caption">
-          {message}
+          {message} {rangeSuffix}
         </FooterText>
       </Box>
     </InfoCard>

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/EngagementCards.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/EngagementCards.tsx
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { PropsWithChildren } from 'react';
+import FunctionsIcon from '@mui/icons-material/Functions';
+import TimelineIcon from '@mui/icons-material/Timeline';
+import Box from '@mui/material/Box';
+import { Card } from './Card';
+import { EngagementCardsProps } from '../../types';
+import { styled } from '@mui/material/styles';
+
+const CardBox = styled(Box)({
+  flex: '1 1 calc(20% - 10px)',
+  minWidth: 200,
+  maxWidth: 'calc(50% - 10px)',
+  boxSizing: 'border-box',
+});
+
+export const EngagementCards = ({
+  team,
+  metrics,
+  metricsByTeam,
+  seats,
+  seatsByTeam,
+  startDate,
+  endDate,
+}: PropsWithChildren<EngagementCardsProps>) => {
+  let primaryValue = 0;
+  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
+    primaryValue = team ? seatsByTeam[0].total_seats : seats[0].total_seats;
+  }
+
+  let secondaryValue: number | undefined = 0;
+  if (seats.length > 0) {
+    secondaryValue = team ? seats[0].total_seats : undefined;
+  }
+
+  let primaryUnusedSeatValue = 0;
+  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
+    primaryUnusedSeatValue = team
+      ? seatsByTeam[0].seats_never_used
+      : seats[0].seats_never_used;
+  }
+
+  let secondaryUnusedSeatValue: number | undefined = 0;
+  if (seats.length > 0) {
+    secondaryUnusedSeatValue = team ? seats[0].seats_never_used : undefined;
+  }
+
+  // Seats inactive for 7 days
+  let primaryInactive7DaysValue = 0;
+  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
+    primaryInactive7DaysValue = team
+      ? seatsByTeam[0].seats_inactive_7_days
+      : seats[0].seats_inactive_7_days;
+  }
+
+  let secondaryInactive7DaysValue: number | undefined = 0;
+  if (seats.length > 0) {
+    secondaryInactive7DaysValue = team
+      ? seats[0].seats_inactive_7_days
+      : undefined;
+  }
+
+  // Seats inactive for 14 days
+  let primaryInactive14DaysValue = 0;
+  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
+    primaryInactive14DaysValue = team
+      ? seatsByTeam[0].seats_inactive_14_days
+      : seats[0].seats_inactive_14_days;
+  }
+
+  let secondaryInactive14DaysValue: number | undefined = 0;
+  if (seats.length > 0) {
+    secondaryInactive14DaysValue = team
+      ? seats[0].seats_inactive_14_days
+      : undefined;
+  }
+
+  // Seats inactive for 28 days
+  let primaryInactive28DaysValue = 0;
+  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
+    primaryInactive28DaysValue = team
+      ? seatsByTeam[0].seats_inactive_28_days
+      : seats[0].seats_inactive_28_days;
+  }
+
+  let secondaryInactive28DaysValue: number | undefined = 0;
+  if (seats.length > 0) {
+    secondaryInactive28DaysValue = team
+      ? seats[0].seats_inactive_28_days
+      : undefined;
+  }
+
+  // Calculate average metrics from the data, excluding weekend data, and round to nearest integer
+  const calculateAverage = (dataSource: any[], property: string): number => {
+    if (!dataSource || dataSource.length === 0) return 0;
+
+    // Filter out weekends (Saturday=6, Sunday=0)
+    const weekdayData = dataSource.filter(item => {
+      if (!item.day) return true; // Keep items without date
+      const date = new Date(item.day);
+      const dayOfWeek = date.getDay();
+      return dayOfWeek !== 0 && dayOfWeek !== 6; // Exclude Sunday (0) and Saturday (6)
+    });
+
+    if (weekdayData.length === 0) return 0;
+
+    const validValues = weekdayData
+      .map(item => Number(item[property]))
+      .filter(val => !isNaN(val));
+
+    if (validValues.length === 0) return 0;
+    return Math.round(
+      validValues.reduce((sum, val) => sum + val, 0) / validValues.length,
+    );
+  };
+
+  // Calculate metrics according to the correct pattern:
+  // - primaryValue: from metricsByTeam if team=true, otherwise from metrics
+  // - secondaryValue: from metrics if team=true, otherwise undefined
+
+  // dotcom_chats_engaged_users
+  const avgDotcomChatsUsers = team
+    ? calculateAverage(metricsByTeam, 'dotcom_chats_engaged_users')
+    : calculateAverage(metrics, 'dotcom_chats_engaged_users');
+  const secondaryDotcomChatsUsers = team
+    ? calculateAverage(metrics, 'dotcom_chats_engaged_users')
+    : undefined;
+
+  // dotcom_prs_engaged_users
+  const avgDotcomPrsUsers = team
+    ? calculateAverage(metricsByTeam, 'dotcom_prs_engaged_users')
+    : calculateAverage(metrics, 'dotcom_prs_engaged_users');
+  const secondaryDotcomPrsUsers = team
+    ? calculateAverage(metrics, 'dotcom_prs_engaged_users')
+    : undefined;
+
+  // ide_chat_engaged_users
+  const avgIdeChatUsers = team
+    ? calculateAverage(metricsByTeam, 'ide_chats_engaged_users')
+    : calculateAverage(metrics, 'ide_chats_engaged_users');
+  const secondaryIdeChatUsers = team
+    ? calculateAverage(metrics, 'ide_chats_engaged_users')
+    : undefined;
+
+  // ide_completions_engaged_users
+  const avgIdeCompletionsUsers = team
+    ? calculateAverage(metricsByTeam, 'ide_completions_engaged_users')
+    : calculateAverage(metrics, 'ide_completions_engaged_users');
+  const secondaryIdeCompletionsUsers = team
+    ? calculateAverage(metrics, 'ide_completions_engaged_users')
+    : undefined;
+
+  // total_active_users
+  const avgTotalActiveUsers = team
+    ? calculateAverage(metricsByTeam, 'total_active_users')
+    : calculateAverage(metrics, 'total_active_users');
+  const secondaryTotalActiveUsers = team
+    ? calculateAverage(metrics, 'total_active_users')
+    : undefined;
+
+  // total_engaged_users
+  const avgTotalEngagedUsers = team
+    ? calculateAverage(metricsByTeam, 'total_engaged_users')
+    : calculateAverage(metrics, 'total_engaged_users');
+  const secondaryTotalEngagedUsers = team
+    ? calculateAverage(metrics, 'total_engaged_users')
+    : undefined;
+
+  return (
+    <Box display="flex" flexWrap="wrap" gap={3} justifyContent="space-between">
+      <CardBox>
+        <Card
+          valueIsOnlyForLastDay
+          team={team}
+          title="Total Assigned seats"
+          primaryValue={primaryValue}
+          secondaryValue={secondaryValue}
+          startDate={startDate}
+          endDate={endDate}
+          icon={() => (
+            <FunctionsIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          valueIsOnlyForLastDay
+          team={team}
+          title="Never used seats"
+          primaryValue={primaryUnusedSeatValue}
+          secondaryValue={secondaryUnusedSeatValue}
+          startDate={startDate}
+          endDate={endDate}
+          icon={() => (
+            <FunctionsIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          team={team}
+          title="Avg. Total Active Users"
+          primaryValue={avgTotalActiveUsers}
+          secondaryValue={secondaryTotalActiveUsers}
+          startDate={startDate}
+          endDate={endDate}
+          rangeSuffix="(Excluding weekends)"
+          icon={() => (
+            <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          team={team}
+          title="Avg. Total Engaged Users"
+          primaryValue={avgTotalEngagedUsers}
+          secondaryValue={secondaryTotalEngagedUsers}
+          startDate={startDate}
+          endDate={endDate}
+          rangeSuffix="(Excluding weekends)"
+          icon={() => (
+            <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          valueIsOnlyForLastDay
+          team={team}
+          title="Inactive seats last 7 days"
+          primaryValue={primaryInactive7DaysValue}
+          secondaryValue={secondaryInactive7DaysValue}
+          startDate={startDate}
+          endDate={endDate}
+          icon={() => (
+            <FunctionsIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          valueIsOnlyForLastDay
+          team={team}
+          title="Inactive seats last 14 days"
+          primaryValue={primaryInactive14DaysValue}
+          secondaryValue={secondaryInactive14DaysValue}
+          startDate={startDate}
+          endDate={endDate}
+          icon={() => (
+            <FunctionsIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <CardBox>
+        <Card
+          valueIsOnlyForLastDay
+          team={team}
+          title="Inactive seats last 28 days"
+          primaryValue={primaryInactive28DaysValue}
+          secondaryValue={secondaryInactive28DaysValue}
+          startDate={startDate}
+          endDate={endDate}
+          icon={() => (
+            <FunctionsIcon style={{ color: '#4CAF50' }} fontSize="large" />
+          )}
+        />
+      </CardBox>
+      <Box
+        display="flex"
+        flexWrap="nowrap"
+        gap={3}
+        justifyContent="space-between"
+        width="100%"
+      >
+        <CardBox>
+          <Card
+            team={team}
+            title="Avg. IDE Completions Users"
+            primaryValue={avgIdeCompletionsUsers}
+            secondaryValue={secondaryIdeCompletionsUsers}
+            startDate={startDate}
+            endDate={endDate}
+            rangeSuffix="(Excluding weekends)"
+            icon={() => (
+              <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+            )}
+          />
+        </CardBox>
+        <CardBox>
+          <Card
+            team={team}
+            title="Avg. IDE Chat Users"
+            primaryValue={avgIdeChatUsers}
+            secondaryValue={secondaryIdeChatUsers}
+            startDate={startDate}
+            endDate={endDate}
+            rangeSuffix="(Excluding weekends)"
+            icon={() => (
+              <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+            )}
+          />
+        </CardBox>
+        <CardBox>
+          <Card
+            team={team}
+            title="Avg. Dotcom Chat Users"
+            primaryValue={avgDotcomChatsUsers}
+            secondaryValue={secondaryDotcomChatsUsers}
+            startDate={startDate}
+            endDate={endDate}
+            rangeSuffix="(Excluding weekends)"
+            icon={() => (
+              <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+            )}
+          />
+        </CardBox>
+        <CardBox>
+          <Card
+            team={team}
+            title="Avg. Dotcom PR Users"
+            primaryValue={avgDotcomPrsUsers}
+            secondaryValue={secondaryDotcomPrsUsers}
+            startDate={startDate}
+            endDate={endDate}
+            rangeSuffix="(Excluding weekends)"
+            icon={() => (
+              <TimelineIcon style={{ color: '#4CAF50' }} fontSize="large" />
+            )}
+          />
+        </CardBox>
+      </Box>
+    </Box>
+  );
+};

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/EngagementCards.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/EngagementCards.tsx
@@ -20,6 +20,7 @@ import Box from '@mui/material/Box';
 import { Card } from './Card';
 import { EngagementCardsProps } from '../../types';
 import { styled } from '@mui/material/styles';
+import { DateTime } from 'luxon';
 
 const CardBox = styled(Box)({
   flex: '1 1 calc(20% - 10px)',
@@ -37,70 +38,101 @@ export const EngagementCards = ({
   startDate,
   endDate,
 }: PropsWithChildren<EngagementCardsProps>) => {
-  let primaryValue = 0;
-  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
-    primaryValue = team ? seatsByTeam[0].total_seats : seats[0].total_seats;
+  // Helper function to find the data point for the end date
+  const findLatestDataPoint = (dataArray: any[]) => {
+    if (!dataArray || dataArray.length === 0) return null;
+
+    // Format endDate to YYYY-MM-DD for comparison
+    const endDateTime = DateTime.fromJSDate(endDate);
+    const formattedEndDate = endDateTime.toFormat('yyyy-MM-dd');
+
+    // Find the data point with day matching endDate
+    const matchingPoint = dataArray.find(item => {
+      if (!item.day) return false;
+      // Format item.day to YYYY-MM-DD for comparison
+      const itemDate = new Date(item.day).toISOString().split('T')[0];
+      return itemDate === formattedEndDate;
+    });
+
+    // Return matching point or null if not found
+    return matchingPoint || null;
+  };
+
+  // Get the most recent data points
+  const latestTeamSeat = findLatestDataPoint(seatsByTeam);
+  const latestSeat = findLatestDataPoint(seats);
+
+  let primaryValue = 'N/A';
+  if ((team && latestTeamSeat) || latestSeat) {
+    primaryValue =
+      team && latestTeamSeat
+        ? latestTeamSeat.total_seats
+        : latestSeat?.total_seats || 'N/A';
   }
 
-  let secondaryValue: number | undefined = 0;
-  if (seats.length > 0) {
-    secondaryValue = team ? seats[0].total_seats : undefined;
+  let secondaryValue: number | undefined = undefined;
+  if (latestSeat) {
+    secondaryValue = team ? latestSeat.total_seats : undefined;
   }
 
-  let primaryUnusedSeatValue = 0;
-  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
-    primaryUnusedSeatValue = team
-      ? seatsByTeam[0].seats_never_used
-      : seats[0].seats_never_used;
+  let primaryUnusedSeatValue = 'N/A';
+  if ((team && latestTeamSeat) || latestSeat) {
+    primaryUnusedSeatValue =
+      team && latestTeamSeat
+        ? latestTeamSeat.seats_never_used
+        : latestSeat?.seats_never_used || 'N/A';
   }
 
-  let secondaryUnusedSeatValue: number | undefined = 0;
-  if (seats.length > 0) {
-    secondaryUnusedSeatValue = team ? seats[0].seats_never_used : undefined;
+  let secondaryUnusedSeatValue: number | undefined = undefined;
+  if (latestSeat) {
+    secondaryUnusedSeatValue = team ? latestSeat.seats_never_used : undefined;
   }
 
   // Seats inactive for 7 days
-  let primaryInactive7DaysValue = 0;
-  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
-    primaryInactive7DaysValue = team
-      ? seatsByTeam[0].seats_inactive_7_days
-      : seats[0].seats_inactive_7_days;
+  let primaryInactive7DaysValue = 'N/A';
+  if ((team && latestTeamSeat) || latestSeat) {
+    primaryInactive7DaysValue =
+      team && latestTeamSeat
+        ? latestTeamSeat.seats_inactive_7_days
+        : latestSeat?.seats_inactive_7_days || 'N/A';
   }
 
-  let secondaryInactive7DaysValue: number | undefined = 0;
-  if (seats.length > 0) {
+  let secondaryInactive7DaysValue: number | undefined = undefined;
+  if (latestSeat) {
     secondaryInactive7DaysValue = team
-      ? seats[0].seats_inactive_7_days
+      ? latestSeat.seats_inactive_7_days
       : undefined;
   }
 
   // Seats inactive for 14 days
-  let primaryInactive14DaysValue = 0;
-  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
-    primaryInactive14DaysValue = team
-      ? seatsByTeam[0].seats_inactive_14_days
-      : seats[0].seats_inactive_14_days;
+  let primaryInactive14DaysValue = 'N/A';
+  if ((team && latestTeamSeat) || latestSeat) {
+    primaryInactive14DaysValue =
+      team && latestTeamSeat
+        ? latestTeamSeat.seats_inactive_14_days
+        : latestSeat?.seats_inactive_14_days || 'N/A';
   }
 
-  let secondaryInactive14DaysValue: number | undefined = 0;
-  if (seats.length > 0) {
+  let secondaryInactive14DaysValue: number | undefined = undefined;
+  if (latestSeat) {
     secondaryInactive14DaysValue = team
-      ? seats[0].seats_inactive_14_days
+      ? latestSeat.seats_inactive_14_days
       : undefined;
   }
 
   // Seats inactive for 28 days
-  let primaryInactive28DaysValue = 0;
-  if ((team && seatsByTeam.length > 0) || seats.length > 0) {
-    primaryInactive28DaysValue = team
-      ? seatsByTeam[0].seats_inactive_28_days
-      : seats[0].seats_inactive_28_days;
+  let primaryInactive28DaysValue = 'N/A';
+  if ((team && latestTeamSeat) || latestSeat) {
+    primaryInactive28DaysValue =
+      team && latestTeamSeat
+        ? latestTeamSeat.seats_inactive_28_days
+        : latestSeat?.seats_inactive_28_days || 'N/A';
   }
 
-  let secondaryInactive28DaysValue: number | undefined = 0;
-  if (seats.length > 0) {
+  let secondaryInactive28DaysValue: number | undefined = undefined;
+  if (latestSeat) {
     secondaryInactive28DaysValue = team
-      ? seats[0].seats_inactive_28_days
+      ? latestSeat.seats_inactive_28_days
       : undefined;
   }
 

--- a/workspaces/copilot/plugins/copilot/src/components/Cards/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/Cards/index.ts
@@ -15,3 +15,4 @@
  */
 export { DashboardCards } from './DashboardCards';
 export { LanguageCards } from './LanguageCards';
+export { EngagementCards } from './EngagementCards';

--- a/workspaces/copilot/plugins/copilot/src/components/Charts/EngagementCharts.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Charts/EngagementCharts.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { PropsWithChildren } from 'react';
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { BarChart, LineChart } from '@mui/x-charts';
+import { Chart } from './Chart';
+import { EngagementChartsProps } from '../../types';
+import { DateTime } from 'luxon';
+import {
+  createAssignedSeatSeries,
+  createEngagementSeries,
+  createUnusedSeatSeries,
+} from './seriesUtils';
+import { EngagementMetrics } from '@backstage-community/plugin-copilot-common';
+
+const MainBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+}));
+
+export const EngagementCharts = ({
+  team,
+  metrics,
+  metricsByTeam,
+  seats,
+  seatsByTeam,
+}: PropsWithChildren<EngagementChartsProps>) => {
+  // Helper function to create chart content
+  const createChartContent = (
+    title: string,
+    metricKey: keyof EngagementMetrics,
+  ) => {
+    const baseSeriesData = createEngagementSeries(
+      metrics,
+      metricsByTeam,
+      title,
+      metricKey,
+      team,
+    );
+
+    return (
+      <Chart title={title}>
+        <BarChart
+          xAxis={[
+            {
+              data: metrics.map(x => new Date(x.day)),
+              scaleType: 'band',
+              valueFormatter: date =>
+                DateTime.fromJSDate(date).toFormat('dd-MM-yy'),
+            },
+          ]}
+          bottomAxis={{
+            tickLabelStyle: {
+              angle: 30,
+              textAnchor: 'start',
+            },
+          }}
+          series={baseSeriesData}
+          height={300}
+        />
+      </Chart>
+    );
+  };
+
+  const seatTotalSeries = createAssignedSeatSeries(
+    seats,
+    seatsByTeam,
+    'Total Assigned Seats',
+    team,
+  );
+  const seatsUnusedSeries = createUnusedSeatSeries(seats, seatsByTeam, team);
+
+  return (
+    <MainBox>
+      <Chart title="Total Assigned Seats">
+        <BarChart
+          xAxis={[
+            {
+              data: seats.map(x => new Date(x.day)),
+              scaleType: 'band',
+              valueFormatter: date =>
+                DateTime.fromJSDate(date).toFormat('dd-MM-yy'),
+            },
+          ]}
+          bottomAxis={{
+            tickLabelStyle: {
+              angle: 30,
+              textAnchor: 'start',
+            },
+          }}
+          series={seatTotalSeries}
+          height={300}
+        />
+      </Chart>
+      <Chart title="Unused Seats">
+        <LineChart
+          xAxis={[
+            {
+              data: seats.map(x => new Date(x.day)),
+              scaleType: 'band',
+              valueFormatter: date =>
+                DateTime.fromJSDate(date).toFormat('dd-MM-yy'),
+            },
+          ]}
+          bottomAxis={{
+            tickLabelStyle: {
+              angle: 30,
+              textAnchor: 'start',
+            },
+          }}
+          series={seatsUnusedSeries}
+          height={300}
+        />
+      </Chart>
+      {createChartContent('Total Active Users', 'total_active_users')}
+      {createChartContent('Total Engaged Users', 'total_engaged_users')}
+      {createChartContent(
+        'Total Engaged IDE code completion Users',
+        'ide_completions_engaged_users',
+      )}
+      {createChartContent(
+        'Total Engaged IDE chat Users',
+        'ide_chats_engaged_users',
+      )}
+      {createChartContent(
+        'Total Github.com chat Users',
+        'dotcom_chats_engaged_users',
+      )}
+      {createChartContent(
+        'Total Github.com Pull-Request Users',
+        'dotcom_prs_engaged_users',
+      )}
+    </MainBox>
+  );
+};

--- a/workspaces/copilot/plugins/copilot/src/components/Charts/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/Charts/index.ts
@@ -15,3 +15,4 @@
  */
 export { DashboardCharts } from './DashboardCharts';
 export { LanguageCharts } from './LanguageCharts';
+export { EngagementCharts } from './EngagementCharts';

--- a/workspaces/copilot/plugins/copilot/src/components/Charts/seriesUtils.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/Charts/seriesUtils.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Metric } from '@backstage-community/plugin-copilot-common';
+import {
+  EngagementMetrics,
+  Metric,
+  SeatAnalysis,
+} from '@backstage-community/plugin-copilot-common';
 
 const addSeriesIfTeam = (
   series: any[],
@@ -175,6 +179,142 @@ export const createTotalActiveUsersSeries = (
       metric =>
         metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
           ?.total_active_users ?? null,
+    ),
+  });
+
+  return series;
+};
+
+export const createEngagementSeries = (
+  metrics: EngagementMetrics[],
+  metricsByTeam: EngagementMetrics[],
+  label: string,
+  property: keyof EngagementMetrics,
+  team?: string,
+) => {
+  const series = [
+    {
+      label: `${label} (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x =>
+        x[property] !== undefined ? Number(x[property]) : null,
+      ),
+    },
+  ];
+
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team',
+    label: `${label} (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)?.[
+          property
+        ] ?? null,
+    ),
+  });
+
+  return series;
+};
+
+export const createAssignedSeatSeries = (
+  metrics: SeatAnalysis[],
+  metricsByTeam: SeatAnalysis[],
+  label: string,
+  team?: string,
+) => {
+  const series = [
+    {
+      label: `${label} (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x => x.total_seats),
+    },
+  ];
+
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team',
+    label: `${label} (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
+          ?.total_seats ?? null,
+    ),
+  });
+
+  return series;
+};
+
+export const createUnusedSeatSeries = (
+  metrics: SeatAnalysis[],
+  metricsByTeam: SeatAnalysis[],
+  team?: string,
+) => {
+  const series = [
+    {
+      id: 'series_never_used',
+      label: `Never used (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x => x.seats_never_used),
+    },
+    {
+      id: 'series_not_used_7',
+      label: `Not used last 7 days (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x => x.seats_inactive_7_days),
+    },
+    {
+      id: 'series_not_used_14',
+      label: `Not used last 14 days (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x => x.seats_inactive_14_days),
+    },
+    {
+      id: 'series_not_used_28',
+      label: `Not used last 28 days (Overall)`,
+      valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+      data: metrics.map(x => x.seats_inactive_28_days),
+    },
+  ];
+
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team_never_used',
+    label: `Never used (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
+          ?.seats_never_used ?? null,
+    ),
+  });
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team_not_used_7',
+    label: `Not used last 7 days (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
+          ?.seats_inactive_7_days ?? null,
+    ),
+  });
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team_not_used_14',
+    label: `Not used last 14 days (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
+          ?.seats_inactive_14_days ?? null,
+    ),
+  });
+  addSeriesIfTeam(series, !!team, {
+    id: 'series_by_team_not_used_28',
+    label: `Not used last 28 days (${team})`,
+    valueFormatter: (v: number | null) => v?.toString() ?? 'N/A',
+    data: metrics.map(
+      metric =>
+        metricsByTeam.find(teamMetric => teamMetric.day === metric.day)
+          ?.seats_inactive_28_days ?? null,
     ),
   });
 

--- a/workspaces/copilot/plugins/copilot/src/components/Metrics/Usage.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Metrics/Usage.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React, { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+import { Calendar } from 'simple-date-range-calendar';
+import {
+  useEngagementMetrics,
+  useEngagementMetricsByTeam,
+  useTeams,
+} from '../../hooks';
+import {
+  CardsProps,
+  ChartsProps,
+  EngagementCardsProps,
+  EngagementChartsProps,
+  FilterProps,
+} from '../../types';
+import { InfoCard, Progress } from '@backstage/core-components';
+import { useSharedDateRange, useSharedTeam } from '../../contexts';
+import { useSeatMetrics } from '../../hooks/useSeatMetrics';
+import { useSeatMetricsByTeam } from '../../hooks/useSeatMetricsByTeam';
+
+type MetricsProps = {
+  Cards: React.ElementType<CardsProps>;
+  Charts: React.ElementType<ChartsProps>;
+  Filters: React.ElementType<FilterProps>;
+};
+
+type EngagementMetricsProps = {
+  Cards: React.ElementType<EngagementCardsProps>;
+  Charts: React.ElementType<EngagementChartsProps>;
+  Filters: React.ElementType<FilterProps>;
+};
+
+const MainBox = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(2),
+}));
+
+export const RenderFilters = ({
+  Filters,
+}: Omit<Omit<MetricsProps, 'Cards'>, 'Charts'>) => {
+  const [state] = useSharedDateRange();
+  const [team, setTeam] = useSharedTeam();
+  const data = useTeams(state.startDate, state.endDate);
+  const options = useMemo(
+    () => data.items?.map(x => ({ label: x, value: x })) ?? [],
+    [data.items],
+  );
+
+  if (!Filters) return null;
+
+  if (data.loading) {
+    return <Progress />;
+  }
+
+  return <Filters options={options} team={team} setTeam={setTeam} />;
+};
+
+export const RenderCharts = ({
+  Charts,
+}: Omit<Omit<EngagementMetricsProps, 'Cards'>, 'Filters'>) => {
+  const [state] = useSharedDateRange();
+  const [team] = useSharedTeam();
+  const data = useEngagementMetrics(state.startDate, state.endDate);
+  const dataPerTeam = useEngagementMetricsByTeam(
+    state.startDate,
+    state.endDate,
+  );
+  const seatData = useSeatMetrics(state.startDate, state.endDate);
+  const seatDataPerTeam = useSeatMetricsByTeam(state.startDate, state.endDate);
+
+  if (
+    data.loading ||
+    dataPerTeam.loading ||
+    seatData.loading ||
+    seatDataPerTeam.loading
+  ) {
+    return <Progress />;
+  }
+
+  return (
+    <Charts
+      team={team}
+      metrics={data.items ?? []}
+      metricsByTeam={dataPerTeam.items ?? []}
+      seats={seatData.items ?? []}
+      seatsByTeam={seatDataPerTeam.items ?? []}
+    />
+  );
+};
+export const RenderCards = ({
+  Cards,
+}: Omit<Omit<EngagementMetricsProps, 'Charts'>, 'Filters'>) => {
+  const [state] = useSharedDateRange();
+  const [team] = useSharedTeam();
+
+  const data = useEngagementMetrics(state.startDate, state.endDate);
+  const dataPerTeam = useEngagementMetricsByTeam(
+    state.startDate,
+    state.endDate,
+  );
+
+  const seatData = useSeatMetrics(state.startDate, state.endDate);
+  const seatDataPerTeam = useSeatMetricsByTeam(state.startDate, state.endDate);
+
+  if (
+    !data.loading &&
+    !dataPerTeam.loading &&
+    !seatData.loading &&
+    !seatDataPerTeam.loading
+  ) {
+    return (
+      <Cards
+        team={team}
+        metrics={data.items ?? []}
+        metricsByTeam={dataPerTeam.items ?? []}
+        seats={seatData.items ?? []}
+        seatsByTeam={seatDataPerTeam.items ?? []}
+        startDate={state.startDate}
+        endDate={state.endDate}
+      />
+    );
+  }
+
+  return <Progress />;
+};
+
+export const Usage = ({ Cards, Charts, Filters }: EngagementMetricsProps) => {
+  const [state, setState] = useSharedDateRange();
+
+  const onDateRangeIsSelected = (start: Date, end: Date) => {
+    setState({ startDate: start, endDate: end });
+  };
+
+  return (
+    <MainBox>
+      <Box display="flex" gap={2}>
+        <Box flex={1} maxWidth={296}>
+          <InfoCard divider={false} noPadding>
+            <Calendar
+              styles={{ borderRadius: 4, width: 296 }}
+              startDate={state.startDate}
+              endDate={state.endDate}
+              onDateRangeIsSelected={onDateRangeIsSelected}
+            />
+          </InfoCard>
+        </Box>
+        <Box flex={1}>
+          <Stack pb={1.5}>
+            <RenderFilters Filters={Filters} />
+          </Stack>
+          <RenderCards Cards={Cards} />
+        </Box>
+      </Box>
+      <RenderCharts Charts={Charts} />
+    </MainBox>
+  );
+};

--- a/workspaces/copilot/plugins/copilot/src/components/Metrics/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/Metrics/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { Metrics } from './Metrics';
+export { Usage } from './Usage';

--- a/workspaces/copilot/plugins/copilot/src/components/Pages/EnterprisePage.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Pages/EnterprisePage.tsx
@@ -17,9 +17,9 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TabbedCard, CardTab } from '@backstage/core-components';
-import { Metrics } from '../Metrics';
-import { LanguageCards, DashboardCards } from '../Cards';
-import { LanguageCharts, DashboardCharts } from '../Charts';
+import { Metrics, Usage } from '../Metrics';
+import { LanguageCards, DashboardCards, EngagementCards } from '../Cards';
+import { LanguageCharts, DashboardCharts, EngagementCharts } from '../Charts';
 import { SelectTeamFilter } from '../Filters';
 import { CopilotPage } from './CopilotPage';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
@@ -54,6 +54,13 @@ export const EnterprisePage = (): React.JSX.Element => {
             Filters={SelectTeamFilter}
             Cards={LanguageCards}
             Charts={LanguageCharts}
+          />
+        </CardTab>
+        <CardTab label="Engagement">
+          <Usage
+            Filters={SelectTeamFilter}
+            Cards={EngagementCards}
+            Charts={EngagementCharts}
           />
         </CardTab>
       </TabbedCard>

--- a/workspaces/copilot/plugins/copilot/src/components/Pages/OrganizationPage.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Pages/OrganizationPage.tsx
@@ -17,9 +17,9 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TabbedCard, CardTab } from '@backstage/core-components';
-import { Metrics } from '../Metrics';
-import { LanguageCards, DashboardCards } from '../Cards';
-import { LanguageCharts, DashboardCharts } from '../Charts';
+import { Metrics, Usage } from '../Metrics';
+import { LanguageCards, DashboardCards, EngagementCards } from '../Cards';
+import { LanguageCharts, DashboardCharts, EngagementCharts } from '../Charts';
 import { CopilotPage } from './CopilotPage';
 import { SelectTeamFilter } from '../Filters';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
@@ -54,6 +54,13 @@ export const OrganizationPage = (): React.JSX.Element => {
             Filters={SelectTeamFilter}
             Cards={LanguageCards}
             Charts={LanguageCharts}
+          />
+        </CardTab>
+        <CardTab label="Engagement">
+          <Usage
+            Filters={SelectTeamFilter}
+            Cards={EngagementCards}
+            Charts={EngagementCharts}
           />
         </CardTab>
       </TabbedCard>

--- a/workspaces/copilot/plugins/copilot/src/hooks/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/index.ts
@@ -18,3 +18,5 @@ export { useMetrics } from './useMetrics';
 export { useMetricsByTeam } from './useMetricsByTeam';
 export { usePeriodRange } from './usePeriodRange';
 export { useSetMetricsTypeFromRoute } from './useSetMetricsTypeFromRoute';
+export { useEngagementMetrics } from './useEngagementMetrics';
+export { useEngagementMetricsByTeam } from './useEngagementMetricsByTeam';

--- a/workspaces/copilot/plugins/copilot/src/hooks/useEngagementMetrics.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/useEngagementMetrics.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import { EngagementMetrics } from '@backstage-community/plugin-copilot-common';
+import { copilotApiRef } from '../api';
+import { useSetMetricsTypeFromRoute } from './useSetMetricsTypeFromRoute';
+
+export function useEngagementMetrics(
+  startDate: Date,
+  endDate: Date,
+): {
+  items?: EngagementMetrics[];
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(copilotApiRef);
+
+  const type = useSetMetricsTypeFromRoute();
+
+  const { value, loading, error } = useAsync(() => {
+    if (type) {
+      return api.getEngagementMetrics(startDate, endDate, type);
+    }
+    return Promise.resolve([]);
+  }, [api, type, startDate, endDate]);
+
+  return {
+    items: value,
+    loading,
+    error,
+  };
+}

--- a/workspaces/copilot/plugins/copilot/src/hooks/useEngagementMetricsByTeam.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/useEngagementMetricsByTeam.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import { EngagementMetrics } from '@backstage-community/plugin-copilot-common';
+import { copilotApiRef } from '../api';
+import { useSharedTeam } from '../contexts';
+import { useSetMetricsTypeFromRoute } from './useSetMetricsTypeFromRoute';
+
+export function useEngagementMetricsByTeam(
+  startDate: Date,
+  endDate: Date,
+): {
+  items?: EngagementMetrics[];
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(copilotApiRef);
+  const [team] = useSharedTeam();
+  const type = useSetMetricsTypeFromRoute();
+
+  const { value, loading, error } = useAsync(() => {
+    if (type && team) {
+      return api.getEngagementMetrics(startDate, endDate, type, team);
+    }
+    return Promise.resolve([]);
+  }, [api, type, team, startDate, endDate]);
+
+  return {
+    items: value,
+    loading,
+    error,
+  };
+}

--- a/workspaces/copilot/plugins/copilot/src/hooks/useSeatMetrics.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/useSeatMetrics.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import { SeatAnalysis } from '@backstage-community/plugin-copilot-common';
+import { copilotApiRef } from '../api';
+import { useSetMetricsTypeFromRoute } from './useSetMetricsTypeFromRoute';
+
+export function useSeatMetrics(
+  startDate: Date,
+  endDate: Date,
+): {
+  items?: SeatAnalysis[];
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(copilotApiRef);
+
+  const type = useSetMetricsTypeFromRoute();
+
+  const { value, loading, error } = useAsync(() => {
+    if (type) {
+      return api.getSeatMetrics(startDate, endDate, type);
+    }
+    return Promise.resolve([]);
+  }, [api, type, startDate, endDate]);
+
+  return {
+    items: value,
+    loading,
+    error,
+  };
+}

--- a/workspaces/copilot/plugins/copilot/src/hooks/useSeatMetricsByTeam.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/useSeatMetricsByTeam.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import useAsync from 'react-use/lib/useAsync';
+import { useApi } from '@backstage/core-plugin-api';
+import { SeatAnalysis } from '@backstage-community/plugin-copilot-common';
+import { copilotApiRef } from '../api';
+import { useSetMetricsTypeFromRoute } from './useSetMetricsTypeFromRoute';
+import { useSharedTeam } from '../contexts';
+
+export function useSeatMetricsByTeam(
+  startDate: Date,
+  endDate: Date,
+): {
+  items?: SeatAnalysis[];
+  loading: boolean;
+  error?: Error;
+} {
+  const api = useApi(copilotApiRef);
+  const [team] = useSharedTeam();
+  const type = useSetMetricsTypeFromRoute();
+
+  const { value, loading, error } = useAsync(() => {
+    if (type) {
+      return api.getSeatMetrics(startDate, endDate, type, team);
+    }
+    return Promise.resolve([]);
+  }, [api, type, team, startDate, endDate]);
+
+  return {
+    items: value,
+    loading,
+    error,
+  };
+}

--- a/workspaces/copilot/plugins/copilot/src/types/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/types/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Metric } from '@backstage-community/plugin-copilot-common';
+import {
+  EngagementMetrics,
+  Metric,
+  SeatAnalysis,
+} from '@backstage-community/plugin-copilot-common';
 import React from 'react';
 
 export type LanguageStats = {
@@ -32,10 +36,28 @@ export type CardsProps = {
   endDate: Date;
 };
 
+export type EngagementCardsProps = {
+  team?: string;
+  metrics: EngagementMetrics[];
+  metricsByTeam: EngagementMetrics[];
+  seats: SeatAnalysis[];
+  seatsByTeam: SeatAnalysis[];
+  startDate: Date;
+  endDate: Date;
+};
+
 export type ChartsProps = {
   team?: string;
   metrics: Metric[];
   metricsByTeam: Metric[];
+};
+
+export type EngagementChartsProps = {
+  team?: string;
+  metrics: EngagementMetrics[];
+  metricsByTeam: EngagementMetrics[];
+  seats: SeatAnalysis[];
+  seatsByTeam: SeatAnalysis[];
 };
 
 export type FilterProps = {

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -8755,6 +8755,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/auth-token@npm:^5.0.0":
+  version: 5.1.2
+  resolution: "@octokit/auth-token@npm:5.1.2"
+  checksum: 10/53636ea9dbf77d491ce387d36f75b2c9f76a8f71de0d892e08999e6ef3382a151bd52faf5ad9711b9ade6c19cfe71d4c69cfd4a16594858299201cef93412b0f
+  languageName: node
+  linkType: hard
+
 "@octokit/auth-unauthenticated@npm:^3.0.0":
   version: 3.0.5
   resolution: "@octokit/auth-unauthenticated@npm:3.0.5"
@@ -8802,6 +8809,31 @@ __metadata:
     before-after-hook: "npm:^2.2.0"
     universal-user-agent: "npm:^6.0.0"
   checksum: 10/2e40baf0b5c6949922436a653c213be43befd9690c43dd89872f669f3ac23117ae8ae5e5d6c18094813756c71c3f4fbedd575a891f0b89e12f58b2c38b7f3c13
+  languageName: node
+  linkType: hard
+
+"@octokit/core@npm:^6.1.4":
+  version: 6.1.4
+  resolution: "@octokit/core@npm:6.1.4"
+  dependencies:
+    "@octokit/auth-token": "npm:^5.0.0"
+    "@octokit/graphql": "npm:^8.1.2"
+    "@octokit/request": "npm:^9.2.1"
+    "@octokit/request-error": "npm:^6.1.7"
+    "@octokit/types": "npm:^13.6.2"
+    before-after-hook: "npm:^3.0.2"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10/e6ca903ce037a854c86da93ecf4d12315963745cc3580804cfd55ef6490b4df12de5c46a5864929d88584ba6016d415375115953d15e6c7458a5e037f9282427
+  languageName: node
+  linkType: hard
+
+"@octokit/endpoint@npm:^10.1.3":
+  version: 10.1.3
+  resolution: "@octokit/endpoint@npm:10.1.3"
+  dependencies:
+    "@octokit/types": "npm:^13.6.2"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10/22a03e106ed66005d48a26eebd9bcb95d418b150ac25eb456dcd00623b658175644d3c7e38474549004851f5bc7aecf2da623cd3227d9620f89e2a080174bfc0
   languageName: node
   linkType: hard
 
@@ -8855,6 +8887,17 @@ __metadata:
     "@octokit/types": "npm:^13.0.0"
     universal-user-agent: "npm:^6.0.0"
   checksum: 10/da6857a69dc93cd20a11d3a905db4214d269d246a6aaee1d8734f922024b08ffdef0b3cba2ac79917633043b4f50464242b0bd92a265c960083dfff5b833dbbe
+  languageName: node
+  linkType: hard
+
+"@octokit/graphql@npm:^8.1.2":
+  version: 8.2.1
+  resolution: "@octokit/graphql@npm:8.2.1"
+  dependencies:
+    "@octokit/request": "npm:^9.2.2"
+    "@octokit/types": "npm:^13.8.0"
+    universal-user-agent: "npm:^7.0.0"
+  checksum: 10/d247ef0c73ef8ffdb222e9724514ee4f64ff7195bd71da795db99e39d1e28d3b4c45b9c4a9fc151e263e01ecb259019f74f67a92d022b57fe5b876b720a4bb91
   languageName: node
   linkType: hard
 
@@ -8959,6 +9002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/openapi-types@npm:^23.0.1":
+  version: 23.0.1
+  resolution: "@octokit/openapi-types@npm:23.0.1"
+  checksum: 10/2647ae16bc410cbec930a3d7c25a166366917d7074eef505a6f89d6aa6f5c9972f30e78a4817cbcf7cef5172765db45859805cbfa89591c6175ebceaaa95d199
+  languageName: node
+  linkType: hard
+
 "@octokit/plugin-paginate-graphql@npm:^4.0.0":
   version: 4.0.1
   resolution: "@octokit/plugin-paginate-graphql@npm:4.0.1"
@@ -8976,6 +9026,17 @@ __metadata:
   peerDependencies:
     "@octokit/core": 5
   checksum: 10/82f5bcc3a536a44bed0a205c8301176c0d210b7a1c6d035a79b31a102e2e02f46234a38629cc984a21be544194ac69151814e9a909416aa7389cdffd1297bcd9
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-paginate-rest@npm:^11.4.2":
+  version: 11.4.3
+  resolution: "@octokit/plugin-paginate-rest@npm:11.4.3"
+  dependencies:
+    "@octokit/types": "npm:^13.7.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/fd0fc01d52ecfefdb961ee65a2fc4672980a2cdd859f73ae027935615818738107087a83e4c5b9f69c88666d60bad71d5803df4587816ca2e892ea2683e27fb5
   languageName: node
   linkType: hard
 
@@ -9011,6 +9072,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/plugin-request-log@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@octokit/plugin-request-log@npm:5.3.1"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/a27e163282c8d0ba8feee4d3cbbd1b62e1aa89a892877f7a9876fc17ddde3e1e1af922e6664221a0cabae99b8a7a2a5215b9ec2ee5222edb50e06298e99022b0
+  languageName: node
+  linkType: hard
+
 "@octokit/plugin-rest-endpoint-methods@npm:13.2.2":
   version: 13.2.2
   resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.2.2"
@@ -9019,6 +9089,17 @@ __metadata:
   peerDependencies:
     "@octokit/core": ^5
   checksum: 10/9eccc1a22aa0b65f3f9378f26a74c386683db420c33202998918df1eef492e93212e1849e1d85530f425602663cfc2bfbf385a30991b8a04470334c74ba2386b
+  languageName: node
+  linkType: hard
+
+"@octokit/plugin-rest-endpoint-methods@npm:^13.3.0":
+  version: 13.3.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.1"
+  dependencies:
+    "@octokit/types": "npm:^13.8.0"
+  peerDependencies:
+    "@octokit/core": ">=6"
+  checksum: 10/e883a9c6bba76300a7476dd1e45232c681df56a0f855e63d5de226126c890fc0b7879647c2abd49d663a013e5fdc26c4300942c5ada3d48fbfa0144b099caf16
   languageName: node
   linkType: hard
 
@@ -9080,6 +9161,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/request-error@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "@octokit/request-error@npm:6.1.7"
+  dependencies:
+    "@octokit/types": "npm:^13.6.2"
+  checksum: 10/02273f6388f1fa8e9962f5eeddffac784454200fa291d9e2333eeaa53f70fbf3fb8d9bca191f38457c455dda758b95c8db50167085cfd6f97dd7a67a5aff452d
+  languageName: node
+  linkType: hard
+
 "@octokit/request@npm:^6.0.0, @octokit/request@npm:^6.2.3":
   version: 6.2.8
   resolution: "@octokit/request@npm:6.2.8"
@@ -9106,6 +9196,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octokit/request@npm:^9.2.1, @octokit/request@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "@octokit/request@npm:9.2.2"
+  dependencies:
+    "@octokit/endpoint": "npm:^10.1.3"
+    "@octokit/request-error": "npm:^6.1.7"
+    "@octokit/types": "npm:^13.6.2"
+    fast-content-type-parse: "npm:^2.0.0"
+    universal-user-agent: "npm:^7.0.2"
+  checksum: 10/32d393de86c1a4cc58b605e74fefc0284837c01eca7c4cb1e56e5cf71b3f1b27c76acaae7d333fb43f5478a967c05e9861bc405ce85eaacd158942911adb7943
+  languageName: node
+  linkType: hard
+
 "@octokit/rest@npm:^19.0.3":
   version: 19.0.13
   resolution: "@octokit/rest@npm:19.0.13"
@@ -9115,6 +9218,18 @@ __metadata:
     "@octokit/plugin-request-log": "npm:^1.0.4"
     "@octokit/plugin-rest-endpoint-methods": "npm:^7.1.2"
   checksum: 10/7fbee09a2f832be6802a026713aa93cbf82dcfc8103d68c585b23214caf0accfced6efe2c49169158d39875d5c5ad3994b83b02e26537b75687ac16d0572c212
+  languageName: node
+  linkType: hard
+
+"@octokit/rest@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "@octokit/rest@npm:21.1.1"
+  dependencies:
+    "@octokit/core": "npm:^6.1.4"
+    "@octokit/plugin-paginate-rest": "npm:^11.4.2"
+    "@octokit/plugin-request-log": "npm:^5.3.1"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^13.3.0"
+  checksum: 10/34a0088c19a202e64bb32bfc939411b96267cf4b38773c4483957600f9d5669381bcfe86f3078d1e03cade9d289dc95e196422eac3c1d0939aaba25a78cce9a7
   languageName: node
   linkType: hard
 
@@ -9149,6 +9264,15 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^22.2.0"
   checksum: 10/d2aeebc1d8684c4e950f054a52b484e898b72d9f5f8433bcf010161716eea20d1132820d922212f19557a8f147354f2674d1a27b22941308b7c298bdd2674ffa
+  languageName: node
+  linkType: hard
+
+"@octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+  version: 13.8.0
+  resolution: "@octokit/types@npm:13.8.0"
+  dependencies:
+    "@octokit/openapi-types": "npm:^23.0.1"
+  checksum: 10/7f260cd3f98887626e791cc0e71ae718b689f359ff6546ed0343364bb213c70807f71135956659470ecdf2b4a5a0c32b6437bd5a3af412883ef3a62f41e811f8
   languageName: node
   linkType: hard
 
@@ -15167,6 +15291,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"before-after-hook@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "before-after-hook@npm:3.0.2"
+  checksum: 10/57dfee78930276a740559552460a83f31c605e0164f02f170f71352aa1f4f5fb2c1632ac3bcba06ba711c32bd88b7e3c82431428e0c4984fbd2336faa78cf08c
+  languageName: node
+  linkType: hard
+
 "better-path-resolve@npm:1.0.0":
   version: 1.0.0
   resolution: "better-path-resolve@npm:1.0.0"
@@ -19543,6 +19674,13 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: 10/bfd6d55f3c0c04d826fe0213264b383c03f32825af6b1ff777f3f2dc49467e599361993568d75b7b19a8ea1bb08c8e7cd8c3d87d179ced91bb0dcf81ca6938e0
+  languageName: node
+  linkType: hard
+
+"fast-content-type-parse@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "fast-content-type-parse@npm:2.0.1"
+  checksum: 10/ec361f5b79254259dadc8192005ceaa54789e63779f144ec3033bd54710f7cb666d47528aa0b12ea29da13f812a0c5f78ce7bc7d779f400bc612f2c65a5972d5
   languageName: node
   linkType: hard
 
@@ -33102,6 +33240,13 @@ __metadata:
   version: 6.0.1
   resolution: "universal-user-agent@npm:6.0.1"
   checksum: 10/fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
+  languageName: node
+  linkType: hard
+
+"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "universal-user-agent@npm:7.0.2"
+  checksum: 10/3f02cb6de0bb9fbaf379566bd0320d8e46af6e4358a2e88fce7e70687ed7b48b37f479d728bb22f4204a518e363f3038ac4841c033af1ee2253f6428a6c67e53
   languageName: node
   linkType: hard
 

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -8995,13 +8995,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^22.2.0":
-  version: 22.2.0
-  resolution: "@octokit/openapi-types@npm:22.2.0"
-  checksum: 10/0471b0c789fada5aa2390e6f82ba477738228ef7d2d986dda9aab0cb625d1562bd178ba0ba4d2655ce841079cd5efff9e58ece2077c27e569ea22109ea301830
-  languageName: node
-  linkType: hard
-
 "@octokit/openapi-types@npm:^23.0.1":
   version: 23.0.1
   resolution: "@octokit/openapi-types@npm:23.0.1"
@@ -9258,16 +9251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.5.0":
-  version: 13.5.0
-  resolution: "@octokit/types@npm:13.5.0"
-  dependencies:
-    "@octokit/openapi-types": "npm:^22.2.0"
-  checksum: 10/d2aeebc1d8684c4e950f054a52b484e898b72d9f5f8433bcf010161716eea20d1132820d922212f19557a8f147354f2674d1a27b22941308b7c298bdd2674ffa
-  languageName: node
-  linkType: hard
-
-"@octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.5.0, @octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
   version: 13.8.0
   resolution: "@octokit/types@npm:13.8.0"
   dependencies:

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -2761,6 +2761,7 @@ __metadata:
     "@backstage/plugin-auth-backend": "npm:^0.24.4"
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.6"
     "@backstage/test-utils": "npm:^1.7.6"
+    "@octokit/rest": "npm:20.1.0"
     "@types/express": "npm:*"
     "@types/node-fetch": "npm:^2.6.11"
     "@types/supertest": "npm:^2.0.8"

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -8755,13 +8755,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/auth-token@npm:^5.0.0":
-  version: 5.1.2
-  resolution: "@octokit/auth-token@npm:5.1.2"
-  checksum: 10/53636ea9dbf77d491ce387d36f75b2c9f76a8f71de0d892e08999e6ef3382a151bd52faf5ad9711b9ade6c19cfe71d4c69cfd4a16594858299201cef93412b0f
-  languageName: node
-  linkType: hard
-
 "@octokit/auth-unauthenticated@npm:^3.0.0":
   version: 3.0.5
   resolution: "@octokit/auth-unauthenticated@npm:3.0.5"
@@ -8797,7 +8790,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0":
+"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.0.2":
   version: 5.2.0
   resolution: "@octokit/core@npm:5.2.0"
   dependencies:
@@ -8809,31 +8802,6 @@ __metadata:
     before-after-hook: "npm:^2.2.0"
     universal-user-agent: "npm:^6.0.0"
   checksum: 10/2e40baf0b5c6949922436a653c213be43befd9690c43dd89872f669f3ac23117ae8ae5e5d6c18094813756c71c3f4fbedd575a891f0b89e12f58b2c38b7f3c13
-  languageName: node
-  linkType: hard
-
-"@octokit/core@npm:^6.1.4":
-  version: 6.1.4
-  resolution: "@octokit/core@npm:6.1.4"
-  dependencies:
-    "@octokit/auth-token": "npm:^5.0.0"
-    "@octokit/graphql": "npm:^8.1.2"
-    "@octokit/request": "npm:^9.2.1"
-    "@octokit/request-error": "npm:^6.1.7"
-    "@octokit/types": "npm:^13.6.2"
-    before-after-hook: "npm:^3.0.2"
-    universal-user-agent: "npm:^7.0.0"
-  checksum: 10/e6ca903ce037a854c86da93ecf4d12315963745cc3580804cfd55ef6490b4df12de5c46a5864929d88584ba6016d415375115953d15e6c7458a5e037f9282427
-  languageName: node
-  linkType: hard
-
-"@octokit/endpoint@npm:^10.1.3":
-  version: 10.1.3
-  resolution: "@octokit/endpoint@npm:10.1.3"
-  dependencies:
-    "@octokit/types": "npm:^13.6.2"
-    universal-user-agent: "npm:^7.0.2"
-  checksum: 10/22a03e106ed66005d48a26eebd9bcb95d418b150ac25eb456dcd00623b658175644d3c7e38474549004851f5bc7aecf2da623cd3227d9620f89e2a080174bfc0
   languageName: node
   linkType: hard
 
@@ -8887,17 +8855,6 @@ __metadata:
     "@octokit/types": "npm:^13.0.0"
     universal-user-agent: "npm:^6.0.0"
   checksum: 10/da6857a69dc93cd20a11d3a905db4214d269d246a6aaee1d8734f922024b08ffdef0b3cba2ac79917633043b4f50464242b0bd92a265c960083dfff5b833dbbe
-  languageName: node
-  linkType: hard
-
-"@octokit/graphql@npm:^8.1.2":
-  version: 8.2.1
-  resolution: "@octokit/graphql@npm:8.2.1"
-  dependencies:
-    "@octokit/request": "npm:^9.2.2"
-    "@octokit/types": "npm:^13.8.0"
-    universal-user-agent: "npm:^7.0.0"
-  checksum: 10/d247ef0c73ef8ffdb222e9724514ee4f64ff7195bd71da795db99e39d1e28d3b4c45b9c4a9fc151e263e01ecb259019f74f67a92d022b57fe5b876b720a4bb91
   languageName: node
   linkType: hard
 
@@ -8995,10 +8952,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/openapi-types@npm:^23.0.1":
-  version: 23.0.1
-  resolution: "@octokit/openapi-types@npm:23.0.1"
-  checksum: 10/2647ae16bc410cbec930a3d7c25a166366917d7074eef505a6f89d6aa6f5c9972f30e78a4817cbcf7cef5172765db45859805cbfa89591c6175ebceaaa95d199
+"@octokit/openapi-types@npm:^22.2.0":
+  version: 22.2.0
+  resolution: "@octokit/openapi-types@npm:22.2.0"
+  checksum: 10/0471b0c789fada5aa2390e6f82ba477738228ef7d2d986dda9aab0cb625d1562bd178ba0ba4d2655ce841079cd5efff9e58ece2077c27e569ea22109ea301830
   languageName: node
   linkType: hard
 
@@ -9022,17 +8979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^11.4.2":
-  version: 11.4.3
-  resolution: "@octokit/plugin-paginate-rest@npm:11.4.3"
-  dependencies:
-    "@octokit/types": "npm:^13.7.0"
-  peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 10/fd0fc01d52ecfefdb961ee65a2fc4672980a2cdd859f73ae027935615818738107087a83e4c5b9f69c88666d60bad71d5803df4587816ca2e892ea2683e27fb5
-  languageName: node
-  linkType: hard
-
 "@octokit/plugin-paginate-rest@npm:^6.1.2":
   version: 6.1.2
   resolution: "@octokit/plugin-paginate-rest@npm:6.1.2"
@@ -9045,14 +8991,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-paginate-rest@npm:^9.0.0":
-  version: 9.2.1
-  resolution: "@octokit/plugin-paginate-rest@npm:9.2.1"
+"@octokit/plugin-paginate-rest@npm:^9.0.0, @octokit/plugin-paginate-rest@npm:^9.1.5":
+  version: 9.2.2
+  resolution: "@octokit/plugin-paginate-rest@npm:9.2.2"
   dependencies:
     "@octokit/types": "npm:^12.6.0"
   peerDependencies:
     "@octokit/core": 5
-  checksum: 10/1528ab17eedb6705e30ad8576493f06b40f29a87c920a4affeb9715fe5f386e064b79eadd401c0cd1e7ec22287a461da4f5353a4ee57bc614fd890b0aa139d77
+  checksum: 10/9afdd61d24a276ed7c2a8e436f735066d1b71601177deb97afa204a1f224257ca9c02681bc94dcda921d37c288a342124f7dfdd88393817306fe0b1ad1f0690f
   languageName: node
   linkType: hard
 
@@ -9065,12 +9011,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-request-log@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "@octokit/plugin-request-log@npm:5.3.1"
+"@octokit/plugin-request-log@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@octokit/plugin-request-log@npm:4.0.1"
   peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 10/a27e163282c8d0ba8feee4d3cbbd1b62e1aa89a892877f7a9876fc17ddde3e1e1af922e6664221a0cabae99b8a7a2a5215b9ec2ee5222edb50e06298e99022b0
+    "@octokit/core": 5
+  checksum: 10/fd8c0a201490cba00084689a0d1d54fc7b5ab5b6bdb7e447056b947b1754f78526e9685400eab10d3522bfa7b5bc49c555f41ec412c788610b96500b168f3789
   languageName: node
   linkType: hard
 
@@ -9085,14 +9031,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-rest-endpoint-methods@npm:^13.3.0":
-  version: 13.3.1
-  resolution: "@octokit/plugin-rest-endpoint-methods@npm:13.3.1"
+"@octokit/plugin-rest-endpoint-methods@npm:^10.2.0":
+  version: 10.4.1
+  resolution: "@octokit/plugin-rest-endpoint-methods@npm:10.4.1"
   dependencies:
-    "@octokit/types": "npm:^13.8.0"
+    "@octokit/types": "npm:^12.6.0"
   peerDependencies:
-    "@octokit/core": ">=6"
-  checksum: 10/e883a9c6bba76300a7476dd1e45232c681df56a0f855e63d5de226126c890fc0b7879647c2abd49d663a013e5fdc26c4300942c5ada3d48fbfa0144b099caf16
+    "@octokit/core": 5
+  checksum: 10/1090fc5a1bebb7b48c512e178f8ad69a3ef8332e583274972f3a3035e9be9200093e22a5dbfe0f71aa1a7a8817e54bb915af3c2a3f88db1311a2873cef176552
   languageName: node
   linkType: hard
 
@@ -9154,15 +9100,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request-error@npm:^6.1.7":
-  version: 6.1.7
-  resolution: "@octokit/request-error@npm:6.1.7"
-  dependencies:
-    "@octokit/types": "npm:^13.6.2"
-  checksum: 10/02273f6388f1fa8e9962f5eeddffac784454200fa291d9e2333eeaa53f70fbf3fb8d9bca191f38457c455dda758b95c8db50167085cfd6f97dd7a67a5aff452d
-  languageName: node
-  linkType: hard
-
 "@octokit/request@npm:^6.0.0, @octokit/request@npm:^6.2.3":
   version: 6.2.8
   resolution: "@octokit/request@npm:6.2.8"
@@ -9189,16 +9126,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/request@npm:^9.2.1, @octokit/request@npm:^9.2.2":
-  version: 9.2.2
-  resolution: "@octokit/request@npm:9.2.2"
+"@octokit/rest@npm:20.1.0":
+  version: 20.1.0
+  resolution: "@octokit/rest@npm:20.1.0"
   dependencies:
-    "@octokit/endpoint": "npm:^10.1.3"
-    "@octokit/request-error": "npm:^6.1.7"
-    "@octokit/types": "npm:^13.6.2"
-    fast-content-type-parse: "npm:^2.0.0"
-    universal-user-agent: "npm:^7.0.2"
-  checksum: 10/32d393de86c1a4cc58b605e74fefc0284837c01eca7c4cb1e56e5cf71b3f1b27c76acaae7d333fb43f5478a967c05e9861bc405ce85eaacd158942911adb7943
+    "@octokit/core": "npm:^5.0.2"
+    "@octokit/plugin-paginate-rest": "npm:^9.1.5"
+    "@octokit/plugin-request-log": "npm:^4.0.0"
+    "@octokit/plugin-rest-endpoint-methods": "npm:^10.2.0"
+  checksum: 10/a34ef12f066128dcac2680ba3a3fad8b2eb1ce0f278b613bf4497310701a752148c0a9703a6fb35326dcfb9a1958c541a6722d5c6eaf2e1612c8b935dfed8eb3
   languageName: node
   linkType: hard
 
@@ -9211,18 +9147,6 @@ __metadata:
     "@octokit/plugin-request-log": "npm:^1.0.4"
     "@octokit/plugin-rest-endpoint-methods": "npm:^7.1.2"
   checksum: 10/7fbee09a2f832be6802a026713aa93cbf82dcfc8103d68c585b23214caf0accfced6efe2c49169158d39875d5c5ad3994b83b02e26537b75687ac16d0572c212
-  languageName: node
-  linkType: hard
-
-"@octokit/rest@npm:^21.1.1":
-  version: 21.1.1
-  resolution: "@octokit/rest@npm:21.1.1"
-  dependencies:
-    "@octokit/core": "npm:^6.1.4"
-    "@octokit/plugin-paginate-rest": "npm:^11.4.2"
-    "@octokit/plugin-request-log": "npm:^5.3.1"
-    "@octokit/plugin-rest-endpoint-methods": "npm:^13.3.0"
-  checksum: 10/34a0088c19a202e64bb32bfc939411b96267cf4b38773c4483957600f9d5669381bcfe86f3078d1e03cade9d289dc95e196422eac3c1d0939aaba25a78cce9a7
   languageName: node
   linkType: hard
 
@@ -9251,12 +9175,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.5.0, @octokit/types@npm:^13.6.2, @octokit/types@npm:^13.7.0, @octokit/types@npm:^13.8.0":
-  version: 13.8.0
-  resolution: "@octokit/types@npm:13.8.0"
+"@octokit/types@npm:^13.0.0, @octokit/types@npm:^13.1.0, @octokit/types@npm:^13.5.0":
+  version: 13.5.0
+  resolution: "@octokit/types@npm:13.5.0"
   dependencies:
-    "@octokit/openapi-types": "npm:^23.0.1"
-  checksum: 10/7f260cd3f98887626e791cc0e71ae718b689f359ff6546ed0343364bb213c70807f71135956659470ecdf2b4a5a0c32b6437bd5a3af412883ef3a62f41e811f8
+    "@octokit/openapi-types": "npm:^22.2.0"
+  checksum: 10/d2aeebc1d8684c4e950f054a52b484e898b72d9f5f8433bcf010161716eea20d1132820d922212f19557a8f147354f2674d1a27b22941308b7c298bdd2674ffa
   languageName: node
   linkType: hard
 
@@ -15275,13 +15199,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"before-after-hook@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "before-after-hook@npm:3.0.2"
-  checksum: 10/57dfee78930276a740559552460a83f31c605e0164f02f170f71352aa1f4f5fb2c1632ac3bcba06ba711c32bd88b7e3c82431428e0c4984fbd2336faa78cf08c
-  languageName: node
-  linkType: hard
-
 "better-path-resolve@npm:1.0.0":
   version: 1.0.0
   resolution: "better-path-resolve@npm:1.0.0"
@@ -19658,13 +19575,6 @@ __metadata:
   version: 1.4.1
   resolution: "extsprintf@npm:1.4.1"
   checksum: 10/bfd6d55f3c0c04d826fe0213264b383c03f32825af6b1ff777f3f2dc49467e599361993568d75b7b19a8ea1bb08c8e7cd8c3d87d179ced91bb0dcf81ca6938e0
-  languageName: node
-  linkType: hard
-
-"fast-content-type-parse@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "fast-content-type-parse@npm:2.0.1"
-  checksum: 10/ec361f5b79254259dadc8192005ceaa54789e63779f144ec3033bd54710f7cb666d47528aa0b12ea29da13f812a0c5f78ce7bc7d779f400bc612f2c65a5972d5
   languageName: node
   linkType: hard
 
@@ -33224,13 +33134,6 @@ __metadata:
   version: 6.0.1
   resolution: "universal-user-agent@npm:6.0.1"
   checksum: 10/fdc8e1ae48a05decfc7ded09b62071f571c7fe0bd793d700704c80cea316101d4eac15cc27ed2bb64f4ce166d2684777c3198b9ab16034f547abea0d3aa1c93c
-  languageName: node
-  linkType: hard
-
-"universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "universal-user-agent@npm:7.0.2"
-  checksum: 10/3f02cb6de0bb9fbaf379566bd0320d8e46af6e4358a2e88fce7e70687ed7b48b37f479d728bb22f4204a518e363f3038ac4841c033af1ee2253f6428a6c67e53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds metrics for engagement and seat analysis.

It adds a few new metrics:
* Total assigned seats
* Seats never used
* Seats not used in the last 7/14/28 days

The new metrics are presented with the value from the last day of the selected period range, since an average of the above does not make sense.

It also show some new metrics from the previous change to the new metrics API:
* Total engaged users
* Total active users
* Total engaged IDE completion users
* Total engaged IDE chat users
* Total engaged Github.com chat users
* Total engaged Github.com PR users

Average metrics of the above are calculated excluding weekends, since that can make the average a bit missleading.

Backend also changed to use octokit to fetch data from Github.

Also found that when using PostgreSQL as database, the unique index using null are not working as expected. So the new metrics use empty string instead. This will have to be addressed for the other metrics also. Will do that in a separate PR. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
![Screenshot 2025-03-14 095528](https://github.com/user-attachments/assets/d6894ad8-3523-4279-a2cd-e0b1a37623f8)
![Screenshot 2025-03-14 091854](https://github.com/user-attachments/assets/d9859ad2-466d-422e-ac14-c1ba32e8bdaa)
