### PR TITLE
Version Packages (todo)

### DIFF
--- a/workspaces/todo/.changeset/good-masks-switch.md
+++ b/workspaces/todo/.changeset/good-masks-switch.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-todo-backend': minor
----
-
-Removed usages and references of `@backstage/backend-common`
-Removed deprecated exports for createRouter and RouterOptions

--- a/workspaces/todo/plugins/todo-backend/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-todo-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- a1d6b70: Removed usages and references of `@backstage/backend-common`
+  Removed deprecated exports for createRouter and RouterOptions
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/todo/plugins/todo-backend/package.json
+++ b/workspaces/todo/plugins/todo-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo-backend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A Backstage backend plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-todo-backend@0.7.0

### Minor Changes

-   a1d6b70: Removed usages and references of `@backstage/backend-common`
    Removed deprecated exports for createRouter and RouterOptions
