### PR TITLE
Version Packages (mta)

### DIFF
--- a/workspaces/mta/.changeset/many-bulldogs-scream.md
+++ b/workspaces/mta/.changeset/many-bulldogs-scream.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-Removed usages and references of `@backstage/backend-common`

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider
 
+## 0.2.0
+
+### Minor Changes
+
+- a26bb15: Removed usages and references of `@backstage/backend-common`
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider",
   "description": "The mta-entity-provider backend module for the catalog plugin.",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-backend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-mta-backend
 
+## 0.3.0
+
+### Minor Changes
+
+- a26bb15: Removed usages and references of `@backstage/backend-common`
+
 ## 0.2.2
 
 ### Patch Changes

--- a/workspaces/mta/plugins/mta-backend/package.json
+++ b/workspaces/mta/plugins/mta-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-backend",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-mta-frontend
 
+## 0.2.0
+
+### Minor Changes
+
+- a26bb15: Removed usages and references of `@backstage/backend-common`
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/mta/plugins/mta-frontend/package.json
+++ b/workspaces/mta/plugins/mta-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-frontend",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-scaffolder-backend-module-mta
 
+## 0.3.0
+
+### Minor Changes
+
+- a26bb15: Removed usages and references of `@backstage/backend-common`
+
 ## 0.2.1
 
 ### Patch Changes

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-scaffolder-backend-module-mta",
   "description": "The mta module for @backstage/plugin-scaffolder-backend",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider@0.2.0

### Minor Changes

-   a26bb15: Removed usages and references of `@backstage/backend-common`

## @backstage-community/backstage-plugin-mta-backend@0.3.0

### Minor Changes

-   a26bb15: Removed usages and references of `@backstage/backend-common`

## @backstage-community/backstage-plugin-mta-frontend@0.2.0

### Minor Changes

-   a26bb15: Removed usages and references of `@backstage/backend-common`

## @backstage-community/backstage-plugin-scaffolder-backend-module-mta@0.3.0

### Minor Changes

-   a26bb15: Removed usages and references of `@backstage/backend-common`
