### PR TITLE
Fix: (MTA) Frontend plugin scalprum name change

### DIFF
--- a/workspaces/mta/.changeset/lemon-zebras-glow.md
+++ b/workspaces/mta/.changeset/lemon-zebras-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/backstage-plugin-mta-frontend': minor
+---
+
+Add scalprum plugin name for frontend-plugin

--- a/workspaces/mta/.gitignore
+++ b/workspaces/mta/.gitignore
@@ -61,3 +61,4 @@ e2e-test-report/
 app-config-rhdh.yaml
 dist-dynamic/
 deploy/
+dist-scalprum/

--- a/workspaces/mta/plugins/mta-frontend/package.json
+++ b/workspaces/mta/plugins/mta-frontend/package.json
@@ -14,6 +14,12 @@
     "url": "https://github.com/backstage/community-plugins",
     "directory": "workspaces/mta/plugins/mta-frontend"
   },
+  "scalprum": {
+    "name": "backstage-community.backstage-plugin-mta-frontend",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts"
+    }
+  },
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "mta-frontend",

--- a/workspaces/mta/plugins/mta-frontend/package.json
+++ b/workspaces/mta/plugins/mta-frontend/package.json
@@ -70,6 +70,7 @@
   "files": [
     "app-config.dynamic.yaml",
     "dist",
+    "dist-scalprum",
     "migrations/**/*"
   ]
 }

--- a/workspaces/mta/rebuild-script.sh
+++ b/workspaces/mta/rebuild-script.sh
@@ -26,7 +26,7 @@ npx -y @janus-idp/cli@^1.11.1 package export-dynamic-plugin --clean
 cd ../..
 
 cd plugins/mta-frontend
-npx -y @janus-idp/cli@^1.11.1 package export-dynamic-plugin --clean
+npx -y @janus-idp/cli@^1.11.1 package export-dynamic-plugin --clean --in-place
 cd ../..
 
 cd plugins/catalog-backend-module-mta-entity-provider


### PR DESCRIPTION
- Resolves plugin name resolution when consuming frontend plugin from npm registry. 
- Adds scalprum files to exported available files within npm registry. 
- Update the rebuild script to reflect recent documentation changes [here](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/index.md).  