### PR TITLE
feat(azure-devops): export getAnnotationValuesFromEntity

### DIFF
--- a/workspaces/azure-devops/.changeset/late-items-beg.md
+++ b/workspaces/azure-devops/.changeset/late-items-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops': minor
+---
+
+Export function `getAnnotationValuesFromEntity`

--- a/workspaces/azure-devops/plugins/azure-devops/report.api.md
+++ b/workspaces/azure-devops/plugins/azure-devops/report.api.md
@@ -323,6 +323,16 @@ export enum FilterType {
 }
 
 // @public (undocumented)
+export function getAnnotationValuesFromEntity(entity: Entity): {
+  project: string;
+  repo?: string;
+  definition?: string;
+  host?: string;
+  org?: string;
+  readmePath?: string;
+};
+
+// @public (undocumented)
 export const isAzureDevOpsAvailable: (entity: Entity) => boolean;
 
 // @public (undocumented)

--- a/workspaces/azure-devops/plugins/azure-devops/src/index.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/index.ts
@@ -29,6 +29,8 @@ export { AzurePullRequestsIcon } from './components/AzurePullRequestsIcon';
 
 export * from './api';
 
+export { getAnnotationValuesFromEntity } from './utils';
+
 export { FilterType } from './components/PullRequestsPage';
 export type {
   PullRequestColumnConfig,

--- a/workspaces/azure-devops/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/utils/getAnnotationValuesFromEntity.ts
@@ -23,6 +23,7 @@ import {
   AZURE_DEVOPS_HOST_ORG_ANNOTATION,
 } from '@backstage-community/plugin-azure-devops-common';
 
+/** @public **/
 export function getAnnotationValuesFromEntity(entity: Entity): {
   project: string;
   repo?: string;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change exports the function getAnnotationValuesFromEntity, allowing plugins to access it via AzureDevopsApi calls. Plugins can utilize this function to derive entity annotations for use as function parameters.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
