### PR TITLE
Fix (MTA): Add configuration for github auth

### DIFF
--- a/workspaces/mta/.changeset/two-fishes-cough.md
+++ b/workspaces/mta/.changeset/two-fishes-cough.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
+'@backstage-community/backstage-plugin-mta-backend': minor
+---
+
+Add configuration for github auth

--- a/workspaces/mta/backstage-operator-cr.yaml
+++ b/workspaces/mta/backstage-operator-cr.yaml
@@ -5,14 +5,17 @@ metadata:
 spec:
   application:
     appConfig:
-      # configMaps:
-      #   - name: app-config-rhdh
+      configMaps:
+        - name: app-config-rhdh
       mountPath: /opt/app-root/src
-    # dynamicPluginsConfigMapName: dynamic-plugins-rhdh
+    dynamicPluginsConfigMapName: dynamic-plugins-rhdh
     extraFiles:
       mountPath: /opt/app-root/src
     replicas: 1
     route:
       enabled: true
+    extraEnvs:
+      secrets:
+        - name: github-secret
   database:
     enableLocalDb: true

--- a/workspaces/mta/dynamic-plugins.yaml
+++ b/workspaces/mta/dynamic-plugins.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dynamic-plugins-rhdh
+  namespace: local-backstage
+  labels:
+    rhdh.redhat.com/ext-config-sync: 'true'
+  annotations:
+    rhdh.redhat.com/backstage-name: 'developer-hub'
+data:
+  dynamic-plugins.yaml: |
+    includes:
+      - dynamic-plugins.default.yaml
+    plugins:
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+      - disabled: false
+        package: "@backstage-community/backstage-plugin-mta-backend@0.3.0"
+        integrity: sha512-gEmEEa1Fuh+jRqGiLg5JgrBGj+rdRxohnGuIcXb6iTuv2kG0gqkLHu/U1smm+rdBZ78h8lnbrCsEMPKwvjWs+A==
+      - disabled: false
+        package: "@ianbolton/backstage-plugin-mta-frontend@0.1.8"
+        integrity: sha512-OIzO+6HMAv78sN4a6LjB928AX0StJXY3PlhkXJRt/Er+AO+2m2MGvTkS0QzZGvoBoquwQjV+s+CFWDnhrGCAAQ==
+      - disabled: false
+        package: "@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider@0.2.0"
+        integrity: sha512-M2s8SN3/tgav+1q1RWVgxAA0V/bRFeT4GesMMWh7/WpFcrqAe65fUJ1YrTPeDavtjW27YE/RZCjwdM9xtPoc5w==
+      - disabled: false
+        package: "@backstage-community/backstage-plugin-scaffolder-backend-module-mta@0.3.0"
+        integrity: sha512-dGdjnBGmmMtvQ46LF1QUzlu+C1fnLyI0iljTJfwToOiZOxfb1vl/1gsPfT74kLSit1fYLPm8N+weS0i5+NqS8A==

--- a/workspaces/mta/github-secret.yaml
+++ b/workspaces/mta/github-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-secret
+  namespace: local-backstage
+type: Opaque
+stringData:
+  AUTH_GITHUB_APP_ID: 'appid'
+  AUTH_GITHUB_CLIENT_ID: 'clientid'
+  AUTH_GITHUB_CLIENT_SECRET: 'secret'
+  GITHUB_PRIVATE_KEY: xxxxxxxx
+  GITHUB_ORGANIZATION: 'org'

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/src/provider/MTAEntityProvider.ts
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/src/provider/MTAEntityProvider.ts
@@ -49,7 +49,6 @@ export class MTAProvider implements EntityProvider {
 
   /** [3] */
   async connect(connection: EntityProviderConnection): Promise<void> {
-    this.logger.info('connecting');
     this.connection = connection;
     this.scheduler.scheduleTask({
       frequency: { seconds: 5 },
@@ -92,10 +91,9 @@ export class MTAProvider implements EntityProvider {
     const clientID = this.config.getString('mta.providerAuth.clientID');
     const secret = this.config.getString('mta.providerAuth.secret');
     const baseURLAuth = `${baseUrl}/auth/realms/${realm}`;
-    this.logger.info(`Discovering issuer from ${baseURLAuth}`);
 
     custom.setHttpOptionsDefaults({
-      timeout: 5000, // Extend timeout to 5000ms
+      timeout: 5000,
     });
 
     let mtaAuthIssuer;
@@ -103,8 +101,7 @@ export class MTAProvider implements EntityProvider {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         mtaAuthIssuer = await Issuer.discover(baseURLAuth);
-        this.logger.info('Issuer discovered successfully');
-        break; // Exit loop on success
+        break;
       } catch (error: any) {
         this.logger.error(
           `Attempt ${attempt}: Discovery failed - ${error?.message}`,
@@ -125,15 +122,10 @@ export class MTAProvider implements EntityProvider {
       response_types: ['code'],
     });
 
-    this.logger.info('Client created successfully');
-
-    this.logger.info('Attempting to obtain grant');
-
     try {
       const grant = await authClient.grant({
         grant_type: 'client_credentials',
       });
-      this.logger.info('Grant obtained successfully');
       return grant;
     } catch (error: any) {
       this.logger.error(`Error obtaining grant: ${error.message}`);
@@ -142,9 +134,6 @@ export class MTAProvider implements EntityProvider {
   }
 
   async fetchApplications(accessToken: string) {
-    const url = `${this.config.getString('mta.url')}/hub/applications`;
-    this.logger.info(`Attempting to fetch applications from ${url}`);
-
     const response = await fetch(
       `${this.config.getString('mta.url')}/hub/applications`,
       {
@@ -157,8 +146,6 @@ export class MTAProvider implements EntityProvider {
       },
     );
 
-    this.logger.info(`Received response with status: ${response.status}`);
-
     if (response.status !== 200) {
       throw new Error(
         `Failed to fetch applications: Status ${response.status}`,
@@ -169,24 +156,17 @@ export class MTAProvider implements EntityProvider {
 
   async processApplications(applications: any) {
     try {
-      // Map applications to entities
       const entities = applications.map((app: any) =>
         this.mapApplicationToEntity(app),
       );
 
-      // Apply mutations to update the catalog
       await this.connection?.applyMutation({
         type: 'full',
         entities: entities,
       });
 
-      // Optionally refresh connections or handle post-mutation logic
-      this.logger.info(
-        'Successfully processed applications, refreshing data...',
-      );
       await this.refreshData(entities);
     } catch (error: any) {
-      // Log detailed error messages
       this.logger.error(`Error processing applications: ${error.message}`, {
         error,
       });
@@ -195,7 +175,6 @@ export class MTAProvider implements EntityProvider {
   }
 
   mapApplicationToEntity(application: any) {
-    // Example mapping logic, which you should customize based on your application structure
     const name = application.name.replace(/ /g, '-');
     const encodedAppName = encodeURIComponent(JSON.stringify(application.name));
     const issuesUrl = `${this.config.getString(
@@ -238,123 +217,7 @@ export class MTAProvider implements EntityProvider {
   }
 
   async refreshData(entities: any) {
-    // Refresh logic, such as refreshing entity keys or other post-update tasks
     const keys = entities.map((entity: any) => entity.key);
     await this.connection?.refresh({ keys });
-    this.logger.info('Data refresh triggered for entities.');
   }
 }
-
-// const getResponse = await fetch(`${baseUrlHub}/applications`, {
-//   credentials: 'include',
-//   headers: {
-//     Accept: 'application/json, text/plain, */*',
-//     Authorization: `Bearer ${tokenSet.access_token}`,
-//   },
-//   method: 'GET',
-// });
-
-// if (getResponse.status !== 200) {
-//   this.logger.info(
-//     `unable to call hub ${getResponse.status} message ${JSON.stringify(
-//       await getResponse.text(),
-//     )}`,
-//   );
-//   return;
-// }
-// const j = await getResponse.json();
-// if (!Array.isArray(j)) {
-//   this.logger.info('expecting array of applications');
-//   return;
-// }
-
-// this.logger.info(`status: ${getResponse.status} json ${JSON.stringify(j)}`);
-//  mapApplicationToEntity
-
-//     await this.connection
-//       .applyMutation({
-//         type: 'full',
-//         entities: j.map(application => {
-//           const name = application.name.replace(/ /g, '-');
-//           const encodedAppName = encodeURIComponent(
-//             JSON.stringify(application.name),
-//           ); // Ensure the application name is URI-encoded
-//           const issuesUrl = `${baseUrlMta}/issues?i%3Afilters=%7B%22application.name%22%3A%5B${encodedAppName}%5D%7D&i%3AitemsPerPage=10&i%3ApageNumber=1&i%3AsortColumn=description&i%3AsortDirection=asc`;
-
-//           return {
-//             key: application.id,
-//             locationKey: this.getProviderName(),
-//             entity: {
-//               apiVersion: 'backstage.io/v1alpha1',
-//               kind: 'Component',
-//               metadata: {
-//                 annotations: {
-//                   'backstage.io/managed-by-location': `url:${baseUrlMta}/application/${application.id}`,
-//                   'backstage.io/managed-by-origin-location': `url:${baseUrlMta}/application/${application.id}`,
-//                   'issues-url': `${issuesUrl}`,
-//                 },
-//                 name: name,
-//                 id: application.id,
-//                 namespace: 'default',
-//                 application: application,
-//               },
-//               spec: {
-//                 type: 'service',
-//                 lifecycle: 'experimental',
-//                 owner: 'unknown',
-//               },
-//             },
-//           };
-//         }),
-//       })
-//       .then(() => {
-//         console.log('REFRESHING');
-//         this.logger.info('refreshing');
-//         this.connection?.refresh({
-//           keys: j.map(application => application.id),
-//         });
-//       })
-//       .catch(e => {
-//         this.logger.info(`error applying mutation ${e}`);
-//       });
-//   }
-// }
-// const baseUrl = this.config.getString('mta.url');
-// const baseUrlHub = `${baseUrl}/hub`;
-// const baseUrlMta = `${baseUrl}`;
-// const realm = this.config.getString('mta.providerAuth.realm');
-// const clientID = this.config.getString('mta.providerAuth.clientID');
-// const secret = this.config.getString('mta.providerAuth.secret');
-// const baseURLAuth = `${baseUrl}/auth/realms/${realm}`;
-// const mtaAuthIssuer = await Issuer.discover(baseURLAuth);
-// const authClient = new mtaAuthIssuer.Client({
-//   client_id: clientID,
-//   client_secret: secret,
-//   response_types: ['code'],
-// });
-// const code_verifier = generators.codeVerifier();
-// const code_challenge = generators.codeChallenge(code_verifier);
-
-// const tokenSet = await authClient.grant({
-//   grant_type: 'client_credentials',
-// });
-// if (!tokenSet.access_token) {
-//   this.logger.info('unable to access hub');
-// }
-
-// console.log({
-//   code_verifier,
-//   code_challenge,
-//   tokenSet,
-//   baseURLAuth,
-//   baseUrlHub,
-// });
-
-// this.logger.info({
-//   code_verifier,
-//   code_challenge,
-//   tokenSet,
-//   baseURLAuth,
-//   baseUrlHub,
-// });
-// }

--- a/workspaces/mta/plugins/mta-backend/src/database/storage.ts
+++ b/workspaces/mta/plugins/mta-backend/src/database/storage.ts
@@ -34,7 +34,6 @@ export class DataBaseEntityApplicationStorage
     logger: LoggerService,
     migrationsDir: string,
   ): Promise<EntityApplicationStorage> {
-    logger.info('Starting to migrate database');
     await knex.migrate.latest({
       directory: migrationsDir,
     });

--- a/workspaces/mta/rebuild-script.sh
+++ b/workspaces/mta/rebuild-script.sh
@@ -119,4 +119,6 @@ EOF
 # Step 6: Execute additional setup scripts and apply Kubernetes resources
 ./02-create-plugin-registry.sh
 oc apply -f app-config-rhdh.yaml
+oc apply -f github-secret.yaml
+# oc apply -f dynamic-plugins.yaml # This is done above if testing local builds. Comment out if using the plugin registry.
 oc apply -f backstage-operator-cr.yaml


### PR DESCRIPTION
- Add github auth configuration for the development workflow. This includes optional npm registry specific dynamic plugins configmap that can be used in lieu of the custom local registry and github secrets for configuring the auth & syncing the gh org users to the backstage instance, and updated references & configuration in the backstage operator cr and example app config cr. 
- Cleans up logs and commented out code