### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/forty-lamps-confess.md
+++ b/workspaces/quay/.changeset/forty-lamps-confess.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-backend': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/quay/.changeset/orange-donuts-love.md
+++ b/workspaces/quay/.changeset/orange-donuts-love.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-remove unused dependencies: @types/node

--- a/workspaces/quay/.changeset/renovate-0a015cb.md
+++ b/workspaces/quay/.changeset/renovate-0a015cb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@playwright/test` to `1.51.1`.

--- a/workspaces/quay/.changeset/renovate-a43be6f.md
+++ b/workspaces/quay/.changeset/renovate-a43be6f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.11`.

--- a/workspaces/quay/.changeset/rich-apricots-train.md
+++ b/workspaces/quay/.changeset/rich-apricots-train.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Fixed a bug where link to Quay repository was not displayed when `@backstage-community/plugin-quay-backend` was used with key `quay.apiUrl`

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.6.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 2.6.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.1.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- Updated dependencies [f84ad73]
+  - @backstage-community/plugin-quay-common@1.7.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.7.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 1.7.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.19.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- 3bd5e99: remove unused dependencies: @types/node
+- c31699d: Updated dependency `@playwright/test` to `1.51.1`.
+- f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
+- 61cf479: Fixed a bug where link to Quay repository was not displayed when `@backstage-community/plugin-quay-backend` was used with key `quay.apiUrl`
+- Updated dependencies [f84ad73]
+  - @backstage-community/plugin-quay-common@1.7.1
+
 ## 1.19.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.19.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   3bd5e99: remove unused dependencies: @types/node
-   c31699d: Updated dependency `@playwright/test` to `1.51.1`.
-   f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
-   61cf479: Fixed a bug where link to Quay repository was not displayed when `@backstage-community/plugin-quay-backend` was used with key `quay.apiUrl`
-   Updated dependencies [f84ad73]
    -   @backstage-community/plugin-quay-common@1.7.1

## @backstage-community/plugin-scaffolder-backend-module-quay@2.6.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json

## @backstage-community/plugin-quay-backend@1.1.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   Updated dependencies [f84ad73]
    -   @backstage-community/plugin-quay-common@1.7.1

## @backstage-community/plugin-quay-common@1.7.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
