### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/plain-memes-smash.md
+++ b/workspaces/redhat-argocd/.changeset/plain-memes-smash.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
-'@backstage-community/plugin-redhat-argocd-common': patch
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/redhat-argocd/.changeset/real-pandas-shop.md
+++ b/workspaces/redhat-argocd/.changeset/real-pandas-shop.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd-common': minor
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Bump backstage version to 1.36.1

--- a/workspaces/redhat-argocd/.changeset/renovate-0a015cb.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-0a015cb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@playwright/test` to `1.51.1`.

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.5.0
+
+### Minor Changes
+
+- 1eafdb8: Bump backstage version to 1.36.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- Updated dependencies [f84ad73]
+- Updated dependencies [1eafdb8]
+  - @backstage-community/plugin-redhat-argocd-common@1.4.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.4.0
+
+### Minor Changes
+
+- 1eafdb8: Bump backstage version to 1.36.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.18.0
+
+### Minor Changes
+
+- 1eafdb8: Bump backstage version to 1.36.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- c31699d: Updated dependency `@playwright/test` to `1.51.1`.
+- Updated dependencies [f84ad73]
+- Updated dependencies [1eafdb8]
+  - @backstage-community/plugin-redhat-argocd-common@1.4.0
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.18.0

### Minor Changes

-   1eafdb8: Bump backstage version to 1.36.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   c31699d: Updated dependency `@playwright/test` to `1.51.1`.
-   Updated dependencies [f84ad73]
-   Updated dependencies [1eafdb8]
    -   @backstage-community/plugin-redhat-argocd-common@1.4.0

## @backstage-community/plugin-redhat-argocd-backend@0.5.0

### Minor Changes

-   1eafdb8: Bump backstage version to 1.36.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   Updated dependencies [f84ad73]
-   Updated dependencies [1eafdb8]
    -   @backstage-community/plugin-redhat-argocd-common@1.4.0

## @backstage-community/plugin-redhat-argocd-common@1.4.0

### Minor Changes

-   1eafdb8: Bump backstage version to 1.36.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
