### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/funny-stars-fold.md
+++ b/workspaces/tekton/.changeset/funny-stars-fold.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-remove unused dependency: @types/node

--- a/workspaces/tekton/.changeset/mighty-guests-bake.md
+++ b/workspaces/tekton/.changeset/mighty-guests-bake.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-tekton-common': minor
-'@backstage-community/plugin-tekton': minor
----
-
-Bump backstage version to 1.36.1

--- a/workspaces/tekton/.changeset/renovate-0a015cb.md
+++ b/workspaces/tekton/.changeset/renovate-0a015cb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@playwright/test` to `1.51.1`.

--- a/workspaces/tekton/.changeset/renovate-a43be6f.md
+++ b/workspaces/tekton/.changeset/renovate-a43be6f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.11`.

--- a/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @janus-idp/backstage-plugin-tekton-common
 
+## 1.8.0
+
+### Minor Changes
+
+- de82c49: Bump backstage version to 1.36.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton-common/package.json
+++ b/workspaces/tekton/plugins/tekton-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-tekton-common",
   "description": "Common functionalities for the tekton plugin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 3.22.0
+
+### Minor Changes
+
+- de82c49: Bump backstage version to 1.36.1
+
+### Patch Changes
+
+- 43ed904: remove unused dependency: @types/node
+- c31699d: Updated dependency `@playwright/test` to `1.51.1`.
+- f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
+- Updated dependencies [de82c49]
+  - @backstage-community/plugin-tekton-common@1.8.0
+
 ## 3.21.1
 
 ### Patch Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.21.1",
+  "version": "3.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.22.0

### Minor Changes

-   de82c49: Bump backstage version to 1.36.1

### Patch Changes

-   43ed904: remove unused dependency: @types/node
-   c31699d: Updated dependency `@playwright/test` to `1.51.1`.
-   f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
-   Updated dependencies [de82c49]
    -   @backstage-community/plugin-tekton-common@1.8.0

## @backstage-community/plugin-tekton-common@1.8.0

### Minor Changes

-   de82c49: Bump backstage version to 1.36.1
