### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/version-bump-1-37-0.md
+++ b/workspaces/linguist/.changeset/version-bump-1-37-0.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': minor
-'@backstage-community/plugin-linguist': minor
-'@backstage-community/plugin-linguist-backend': minor
-'@backstage-community/plugin-linguist-common': minor
----
-
-Backstage version bump to v1.37.0

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.7.0
+
+### Minor Changes
+
+- 10ae338: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [10ae338]
+  - @backstage-community/plugin-linguist-common@0.6.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.13.0
+
+### Minor Changes
+
+- 10ae338: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [10ae338]
+  - @backstage-community/plugin-linguist-common@0.6.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.6.0
+
+### Minor Changes
+
+- 10ae338: Backstage version bump to v1.37.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist
 
+## 0.6.0
+
+### Minor Changes
+
+- 10ae338: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [10ae338]
+  - @backstage-community/plugin-linguist-common@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.7.0

### Minor Changes

-   10ae338: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [10ae338]
    -   @backstage-community/plugin-linguist-common@0.6.0

## @backstage-community/plugin-linguist@0.6.0

### Minor Changes

-   10ae338: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [10ae338]
    -   @backstage-community/plugin-linguist-common@0.6.0

## @backstage-community/plugin-linguist-backend@0.13.0

### Minor Changes

-   10ae338: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [10ae338]
    -   @backstage-community/plugin-linguist-common@0.6.0

## @backstage-community/plugin-linguist-common@0.6.0

### Minor Changes

-   10ae338: Backstage version bump to v1.37.0
