### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/version-bump-1-37-0.md
+++ b/workspaces/azure-devops/.changeset/version-bump-1-37-0.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': minor
-'@backstage-community/plugin-azure-devops-backend': minor
-'@backstage-community/plugin-azure-devops-common': minor
-'@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor': minor
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': minor
----
-
-Backstage version bump to v1.37.0

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.14.0
+
+### Minor Changes
+
+- 75f72bb: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [75f72bb]
+  - @backstage-community/plugin-azure-devops-common@0.9.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.9.0
+
+### Minor Changes
+
+- 75f72bb: Backstage version bump to v1.37.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.13.0
+
+### Minor Changes
+
+- 75f72bb: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [75f72bb]
+  - @backstage-community/plugin-azure-devops-common@0.9.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.6.0
+
+### Minor Changes
+
+- 75f72bb: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [75f72bb]
+  - @backstage-community/plugin-azure-devops-common@0.9.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.7.0
+
+### Minor Changes
+
+- 75f72bb: Backstage version bump to v1.37.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.13.0

### Minor Changes

-   75f72bb: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [75f72bb]
    -   @backstage-community/plugin-azure-devops-common@0.9.0

## @backstage-community/plugin-azure-devops-backend@0.14.0

### Minor Changes

-   75f72bb: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [75f72bb]
    -   @backstage-community/plugin-azure-devops-common@0.9.0

## @backstage-community/plugin-azure-devops-common@0.9.0

### Minor Changes

-   75f72bb: Backstage version bump to v1.37.0

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.6.0

### Minor Changes

-   75f72bb: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [75f72bb]
    -   @backstage-community/plugin-azure-devops-common@0.9.0

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.7.0

### Minor Changes

-   75f72bb: Backstage version bump to v1.37.0
