### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/version-bump-1-37-0.md
+++ b/workspaces/cicd-statistics/.changeset/version-bump-1-37-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics': minor
-'@backstage-community/plugin-cicd-statistics-module-buildkite': minor
-'@backstage-community/plugin-cicd-statistics-module-gitlab': minor
----
-
-Backstage version bump to v1.37.0

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.4.0
+
+### Minor Changes
+
+- 6dce3f5: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [6dce3f5]
+  - @backstage-community/plugin-cicd-statistics@0.5.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.5.0
+
+### Minor Changes
+
+- 6dce3f5: Backstage version bump to v1.37.0
+
+### Patch Changes
+
+- Updated dependencies [6dce3f5]
+  - @backstage-community/plugin-cicd-statistics@0.5.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.5.0
+
+### Minor Changes
+
+- 6dce3f5: Backstage version bump to v1.37.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.5.0

### Minor Changes

-   6dce3f5: Backstage version bump to v1.37.0

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.4.0

### Minor Changes

-   6dce3f5: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [6dce3f5]
    -   @backstage-community/plugin-cicd-statistics@0.5.0

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.5.0

### Minor Changes

-   6dce3f5: Backstage version bump to v1.37.0

### Patch Changes

-   Updated dependencies [6dce3f5]
    -   @backstage-community/plugin-cicd-statistics@0.5.0
