### PR TITLE
fix(copilot) : team_name changed to empty string instead of null

### DIFF
--- a/workspaces/copilot/.changeset/eighty-poets-fail.md
+++ b/workspaces/copilot/.changeset/eighty-poets-fail.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+team_name column changed to empty string instead of null since
+PostgreSQL cant handle unique indexes with null.
+
+This makes it possible for duplicate values to be inserted into
+the database for the same day.

--- a/workspaces/copilot/plugins/copilot-backend/migrations/202503211252_change_tables_to_not_nullable.js
+++ b/workspaces/copilot/plugins/copilot-backend/migrations/202503211252_change_tables_to_not_nullable.js
@@ -1,0 +1,773 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  // get rows with duplicte day, type and team_name WHERE team_name is null
+  const rows = await knex('copilot_metrics')
+    .select(
+      'day',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_active_users',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_active_users',
+    )
+    .havingRaw('count(*) > 1');
+
+  // if we found any rows:
+  // 1. Delete the nulls
+  // 2. Insert a new row with the same day, type and team_name = ''
+  if (rows.length > 0) {
+    for (const row of rows) {
+      // first delete all the null rows
+      await knex('copilot_metrics')
+        .where('day', row.day)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('copilot_metrics')
+        .insert({
+          day: row.day,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+          total_active_users: row.total_active_users,
+        })
+        .onConflict(['day', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('copilot_metrics')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_completions
+  const ideCompletionsRows = await knex('ide_completions')
+    .select('day', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (ideCompletionsRows.length > 0) {
+    for (const row of ideCompletionsRows) {
+      // first delete all the null rows
+      await knex('ide_completions')
+        .where('day', row.day)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_completions')
+        .insert({
+          day: row.day,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_completions')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_completions_language_users
+  const ideLangUsersRows = await knex('ide_completions_language_users')
+    .select('day', 'language', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'language', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (ideLangUsersRows.length > 0) {
+    for (const row of ideLangUsersRows) {
+      // first delete all the null rows
+      await knex('ide_completions_language_users')
+        .where('day', row.day)
+        .where('language', row.language)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_completions_language_users')
+        .insert({
+          day: row.day,
+          language: row.language,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'language', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_completions_language_users')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_completions_language_editors
+  const ideLangEditorsRows = await knex('ide_completions_language_editors')
+    .select('day', 'editor', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'editor', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (ideLangEditorsRows.length > 0) {
+    for (const row of ideLangEditorsRows) {
+      // first delete all the null rows
+      await knex('ide_completions_language_editors')
+        .where('day', row.day)
+        .where('editor', row.editor)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_completions_language_editors')
+        .insert({
+          day: row.day,
+          editor: row.editor,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'editor', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_completions_language_editors')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_completions_language_editors_model
+  const ideLangEditorsModelRows = await knex(
+    'ide_completions_language_editors_model',
+  )
+    .select(
+      'day',
+      'editor',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'editor',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+    )
+    .havingRaw('count(*) > 1');
+
+  if (ideLangEditorsModelRows.length > 0) {
+    for (const row of ideLangEditorsModelRows) {
+      // first delete all the null rows
+      await knex('ide_completions_language_editors_model')
+        .where('day', row.day)
+        .where('editor', row.editor)
+        .where('model', row.model)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_completions_language_editors_model')
+        .insert({
+          day: row.day,
+          editor: row.editor,
+          model: row.model,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'editor', 'model', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_completions_language_editors_model')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_completions_language_editors_model_language
+  const ideLangEditorsModelLangRows = await knex(
+    'ide_completions_language_editors_model_language',
+  )
+    .select(
+      'day',
+      'editor',
+      'model',
+      'language',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_code_acceptances',
+      'total_code_suggestions',
+      'total_code_lines_accepted',
+      'total_code_lines_suggested',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'editor',
+      'model',
+      'language',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_code_acceptances',
+      'total_code_suggestions',
+      'total_code_lines_accepted',
+      'total_code_lines_suggested',
+    )
+    .havingRaw('count(*) > 1');
+
+  if (ideLangEditorsModelLangRows.length > 0) {
+    for (const row of ideLangEditorsModelLangRows) {
+      // first delete all the null rows
+      await knex('ide_completions_language_editors_model_language')
+        .where('day', row.day)
+        .where('editor', row.editor)
+        .where('model', row.model)
+        .where('language', row.language)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_completions_language_editors_model_language')
+        .insert({
+          day: row.day,
+          editor: row.editor,
+          model: row.model,
+          language: row.language,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+          total_code_acceptances: row.total_code_acceptances,
+          total_code_suggestions: row.total_code_suggestions,
+          total_code_lines_accepted: row.total_code_lines_accepted,
+          total_code_lines_suggested: row.total_code_lines_suggested,
+        })
+        .onConflict(['day', 'editor', 'model', 'language', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_completions_language_editors_model_language')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_chats
+  const ideChatsRows = await knex('ide_chats')
+    .select('day', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (ideChatsRows.length > 0) {
+    for (const row of ideChatsRows) {
+      // first delete all the null rows
+      await knex('ide_chats')
+        .where('day', row.day)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_chats')
+        .insert({
+          day: row.day,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_chats').where('team_name', null).update({ team_name: '' });
+
+  // ide_chat_editors
+  const ideChatEditorsRows = await knex('ide_chat_editors')
+    .select('day', 'editor', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'editor', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (ideChatEditorsRows.length > 0) {
+    for (const row of ideChatEditorsRows) {
+      // first delete all the null rows
+      await knex('ide_chat_editors')
+        .where('day', row.day)
+        .where('editor', row.editor)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_chat_editors')
+        .insert({
+          day: row.day,
+          editor: row.editor,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'editor', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_chat_editors')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // ide_chat_editors_model
+  const ideChatEditorsModelRows = await knex('ide_chat_editors_model')
+    .select(
+      'day',
+      'editor',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_chat_copy_events',
+      'total_chat_insertion_events',
+      'total_chats',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'editor',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_chat_copy_events',
+      'total_chat_insertion_events',
+      'total_chats',
+    )
+    .havingRaw('count(*) > 1');
+
+  if (ideChatEditorsModelRows.length > 0) {
+    for (const row of ideChatEditorsModelRows) {
+      // first delete all the null rows
+      await knex('ide_chat_editors_model')
+        .where('day', row.day)
+        .where('editor', row.editor)
+        .where('model', row.model)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('ide_chat_editors_model')
+        .insert({
+          day: row.day,
+          editor: row.editor,
+          model: row.model,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+          total_chat_copy_events: row.total_chat_copy_events,
+          total_chat_insertion_events: row.total_chat_insertion_events,
+          total_chats: row.total_chats,
+        })
+        .onConflict(['day', 'editor', 'model', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('ide_chat_editors_model')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // dotcom_chats
+  const dotcomChatsRows = await knex('dotcom_chats')
+    .select('day', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (dotcomChatsRows.length > 0) {
+    for (const row of dotcomChatsRows) {
+      // first delete all the null rows
+      await knex('dotcom_chats')
+        .where('day', row.day)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('dotcom_chats')
+        .insert({
+          day: row.day,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('dotcom_chats').where('team_name', null).update({ team_name: '' });
+
+  // dotcom_chat_models
+  const dotcomChatModelsRows = await knex('dotcom_chat_models')
+    .select(
+      'day',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_chats',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_chats',
+    )
+    .havingRaw('count(*) > 1');
+
+  if (dotcomChatModelsRows.length > 0) {
+    for (const row of dotcomChatModelsRows) {
+      // first delete all the null rows
+      await knex('dotcom_chat_models')
+        .where('day', row.day)
+        .where('model', row.model)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('dotcom_chat_models')
+        .insert({
+          day: row.day,
+          model: row.model,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+          total_chats: row.total_chats,
+        })
+        .onConflict(['day', 'model', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('dotcom_chat_models')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // dotcom_prs
+  const dotcomPrsRows = await knex('dotcom_prs')
+    .select('day', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (dotcomPrsRows.length > 0) {
+    for (const row of dotcomPrsRows) {
+      // first delete all the null rows
+      await knex('dotcom_prs')
+        .where('day', row.day)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('dotcom_prs')
+        .insert({
+          day: row.day,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'type', 'team_name'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('dotcom_prs').where('team_name', null).update({ team_name: '' });
+
+  // dotcom_pr_repositories
+  const dotcomPrReposRows = await knex('dotcom_pr_repositories')
+    .select('day', 'repository', 'type', 'team_name', 'total_engaged_users')
+    .where('team_name', null)
+    .groupBy('day', 'repository', 'type', 'team_name', 'total_engaged_users')
+    .havingRaw('count(*) > 1');
+
+  if (dotcomPrReposRows.length > 0) {
+    for (const row of dotcomPrReposRows) {
+      // first delete all the null rows
+      await knex('dotcom_pr_repositories')
+        .where('day', row.day)
+        .where('repository', row.repository)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('dotcom_pr_repositories')
+        .insert({
+          day: row.day,
+          repository: row.repository,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+        })
+        .onConflict(['day', 'type', 'team_name', 'repository'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('dotcom_pr_repositories')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // dotcom_pr_repositories_models
+  const dotcomPrReposModelsRows = await knex('dotcom_pr_repositories_models')
+    .select(
+      'day',
+      'repository',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_pr_summaries',
+    )
+    .where('team_name', null)
+    .groupBy(
+      'day',
+      'repository',
+      'model',
+      'type',
+      'team_name',
+      'total_engaged_users',
+      'total_pr_summaries',
+    )
+    .havingRaw('count(*) > 1');
+
+  if (dotcomPrReposModelsRows.length > 0) {
+    for (const row of dotcomPrReposModelsRows) {
+      // first delete all the null rows
+      await knex('dotcom_pr_repositories_models')
+        .where('day', row.day)
+        .where('repository', row.repository)
+        .where('model', row.model)
+        .where('type', row.type)
+        .where('team_name', null)
+        .delete();
+
+      // then insert ONE new with team_name = ''
+      await knex('dotcom_pr_repositories_models')
+        .insert({
+          day: row.day,
+          repository: row.repository,
+          model: row.model,
+          type: row.type,
+          team_name: '',
+          total_engaged_users: row.total_engaged_users,
+          total_pr_summaries: row.total_pr_summaries,
+        })
+        .onConflict(['day', 'type', 'team_name', 'repository', 'model'])
+        .ignore();
+    }
+  }
+
+  // lastly: we need to update all nulls to empty strings
+  await knex('dotcom_pr_repositories_models')
+    .where('team_name', null)
+    .update({ team_name: '' });
+
+  // finally, update all the team_name columns to not null
+  await knex.schema.table('copilot_metrics', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_completions', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_users', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_editors', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_editors_model', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table(
+    'ide_completions_language_editors_model_language',
+    table => {
+      table.string('team_name').notNullable().alter();
+    },
+  );
+  await knex.schema.table('ide_chats', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_chat_editors', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('ide_chat_editors_model', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('dotcom_chats', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('dotcom_chat_models', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('dotcom_prs', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('dotcom_pr_repositories', table => {
+    table.string('team_name').notNullable().alter();
+  });
+  await knex.schema.table('dotcom_pr_repositories_models', table => {
+    table.string('team_name').notNullable().alter();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  // a reverse migration is to update all the team_name columns to nullable
+  await knex.schema.table('copilot_metrics', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_completions', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_users', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_editors', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_completions_language_editors_model', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table(
+    'ide_completions_language_editors_model_language',
+    table => {
+      table.string('team_name').nullable().alter();
+    },
+  );
+  await knex.schema.table('ide_chats', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_chat_editors', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('ide_chat_editors_model', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('dotcom_chats', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('dotcom_chat_models', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('dotcom_prs', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('dotcom_pr_repositories', table => {
+    table.string('team_name').nullable().alter();
+  });
+  await knex.schema.table('dotcom_pr_repositories_models', table => {
+    table.string('team_name').nullable().alter();
+  });
+
+  // Then update all the rows with team_name = '' to null
+  // This makes all duplicates gone, but the possibillity of having
+  // more duplicates until the next migration
+  await knex('copilot_metrics')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_completions')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_completions_language_users')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_completions_language_editors')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_completions_language_editors_model')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_completions_language_editors_model_language')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_chats').where('team_name', '').update({ team_name: null });
+  await knex('ide_chat_editors')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('ide_chat_editors_model')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('dotcom_chats').where('team_name', '').update({ team_name: null });
+  await knex('dotcom_chat_models')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('dotcom_prs').where('team_name', '').update({ team_name: null });
+  await knex('dotcom_pr_repositories')
+    .where('team_name', '')
+    .update({ team_name: null });
+  await knex('dotcom_pr_repositories_models')
+    .where('team_name', '')
+    .update({ team_name: null });
+};

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/metricHelpers.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/metricHelpers.test.ts
@@ -107,6 +107,21 @@ describe('metricHelperTest', () => {
         total_engaged_users: 3,
       },
     ]);
+
+    const nullTeamResult = filterIdeCompletionEditorMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
+        editor: 'VSCode',
+        total_engaged_users: 3,
+      },
+    ]);
   });
 
   it('should handle undefined languages in filterIdeCompletionLanguageMetrics', () => {
@@ -124,6 +139,21 @@ describe('metricHelperTest', () => {
         language: 'JavaScript',
       },
     ]);
+
+    const nullTeamResult = filterIdeCompletionLanguageMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
+        total_engaged_users: 1,
+        language: 'JavaScript',
+      },
+    ]);
   });
 
   it('should handle undefined editors in filterIdeCompletionEditorModelMetrics', () => {
@@ -137,6 +167,22 @@ describe('metricHelperTest', () => {
         day: '2024-01-01',
         type: 'organization',
         team_name: 'team1',
+        editor: 'VSCode',
+        model: 'GPT-3',
+        total_engaged_users: 2,
+      },
+    ]);
+
+    const nullTeamResult = filterIdeCompletionEditorModelMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
         editor: 'VSCode',
         model: 'GPT-3',
         total_engaged_users: 2,
@@ -165,6 +211,27 @@ describe('metricHelperTest', () => {
         total_code_lines_suggested: 40,
       },
     ]);
+
+    const nullTeamResult = filterIdeCompletionEditorModelLanguageMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
+        editor: 'VSCode',
+        model: 'GPT-3',
+        language: 'JavaScript',
+        total_engaged_users: 1,
+        total_code_acceptances: 10,
+        total_code_suggestions: 20,
+        total_code_lines_accepted: 30,
+        total_code_lines_suggested: 40,
+      },
+    ]);
   });
 
   it('should handle undefined editors in filterIdeEditorMetrics', () => {
@@ -174,6 +241,21 @@ describe('metricHelperTest', () => {
         day: '2024-01-01',
         type: 'organization',
         team_name: 'team1',
+        editor: 'VSCode',
+        total_engaged_users: 3,
+      },
+    ]);
+
+    const nullTeamResult = filterIdeEditorMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
         editor: 'VSCode',
         total_engaged_users: 3,
       },
@@ -191,6 +273,25 @@ describe('metricHelperTest', () => {
         day: '2024-01-01',
         type: 'organization',
         team_name: 'team1',
+        editor: 'VSCode',
+        model: 'GPT-3',
+        total_engaged_users: 2,
+        total_chat_copy_events: 10,
+        total_chats: 20,
+        total_chat_insertion_events: 30,
+      },
+    ]);
+
+    const nullTeamResult = filterIdeChatEditorModelMetrics(
+      metrics,
+      'organization',
+      undefined,
+    );
+    expect(nullTeamResult).toEqual([
+      {
+        day: '2024-01-01',
+        type: 'organization',
+        team_name: '',
         editor: 'VSCode',
         model: 'GPT-3',
         total_engaged_users: 2,

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/metricHelpers.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/metricHelpers.ts
@@ -24,10 +24,8 @@ import {
   CopilotIdeCodeCompletionsEditorsDb,
   CopilotIdeCodeCompletionsLanguageDb,
   CopilotMetricsDb,
-  MetricDbRow,
 } from '../db/DatabaseHandler';
 import {
-  Metric,
   MetricsType,
   CopilotMetrics,
   CopilotSeats,
@@ -64,7 +62,7 @@ export function filterBaseMetrics(
     .map(metric => ({
       day: metric.date,
       type: type,
-      team_name: team,
+      team_name: team ?? '',
       total_engaged_users: metric.total_engaged_users,
       total_active_users: metric.total_active_users,
     }))
@@ -80,7 +78,7 @@ export function filterIdeCompletionMetrics(
     .map(metric => ({
       day: metric.date,
       type: type,
-      team_name: team,
+      team_name: team ?? '',
       total_engaged_users:
         metric.copilot_ide_code_completions.total_engaged_users,
     }))
@@ -98,7 +96,7 @@ export function filterIdeCompletionLanguageMetrics(
         metric.copilot_ide_code_completions.languages?.map(language => ({
           day: metric.date,
           type: type,
-          team_name: team,
+          team_name: team ?? '',
           language: language.name,
           total_engaged_users: language.total_engaged_users,
         })) || [],
@@ -116,7 +114,7 @@ export function filterIdeCompletionEditorMetrics(
         metric.copilot_ide_code_completions.editors?.map(editor => ({
           day: metric.date,
           type: type,
-          team_name: team,
+          team_name: team ?? '',
           editor: editor.name,
           total_engaged_users: editor.total_engaged_users,
         })) || [],
@@ -136,7 +134,7 @@ export function filterIdeCompletionEditorModelMetrics(
           editor.models.map(model => ({
             day: metric.date,
             type: type,
-            team_name: team,
+            team_name: team ?? '',
             editor: editor.name,
             model: model.name,
             total_engaged_users: model.total_engaged_users,
@@ -158,7 +156,7 @@ export function filterIdeCompletionEditorModelLanguageMetrics(
             model.languages.map(language => ({
               day: metric.date,
               type: type,
-              team_name: team,
+              team_name: team ?? '',
               editor: editor.name,
               model: model.name,
               language: language.name,
@@ -183,7 +181,7 @@ export function filterIdeChatMetrics(
     .map((metric: CopilotMetrics) => ({
       day: metric.date,
       type: type,
-      team_name: team,
+      team_name: team ?? '',
       total_engaged_users: metric.copilot_ide_chat.total_engaged_users,
     }))
     .filter(chat => chat.total_engaged_users > 0);
@@ -200,7 +198,7 @@ export function filterIdeEditorMetrics(
         metric.copilot_ide_chat.editors?.map(editor => ({
           day: metric.date,
           type: type,
-          team_name: team,
+          team_name: team ?? '',
           editor: editor.name,
           total_engaged_users: editor.total_engaged_users,
         })) || [],
@@ -220,7 +218,7 @@ export function filterIdeChatEditorModelMetrics(
           editor.models.map(model => ({
             day: metric.date,
             type: type,
-            team_name: team,
+            team_name: team ?? '',
             editor: editor.name,
             model: model.name,
             total_engaged_users: model.total_engaged_users,
@@ -231,19 +229,6 @@ export function filterIdeChatEditorModelMetrics(
         ) || [],
     )
     .filter(model => model.total_engaged_users > 0);
-}
-
-export function prepareMetricsForInsert(
-  metrics: Metric[],
-  type: MetricsType,
-  team_name?: string,
-): MetricDbRow[] {
-  return metrics.map(({ breakdown, ...rest }) => ({
-    ...rest,
-    type,
-    team_name,
-    breakdown: JSON.stringify(breakdown),
-  })) as MetricDbRow[];
 }
 
 export function convertToSeatAnalysis(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the team_name column from null to empty string.
This is because PostgreSQL cant handle unique constraints with null. So in some cases, there can be multiple lines of the same day where team_name is null. This also makes the statistics display strange numbers because of joins.

The migration file does this (for all affected tables):
1. Checks for all duplicate rows
2. If found, delete them all (and keep information of the row)
3. Insert a new row with the values, and an empty string instead of null for team_name
4. Update all rows that have null in team_name to be empty strings (non duplicated rows)
5. It changes the column team_name from null to not_null.

All queries that checked for null have also been updated to check for empty string instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
