### PR TITLE
feat(copilot): Allow url to be relative instead of absolute

### DIFF
--- a/workspaces/copilot/.changeset/eight-donuts-invent.md
+++ b/workspaces/copilot/.changeset/eight-donuts-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+Allows url for copilot to be relative instead of absolute.

--- a/workspaces/copilot/plugins/copilot/src/hooks/useSetMetricsTypeFromRoute.ts
+++ b/workspaces/copilot/plugins/copilot/src/hooks/useSetMetricsTypeFromRoute.ts
@@ -16,16 +16,19 @@
 
 import { MetricsType } from '@backstage-community/plugin-copilot-common';
 import { useEffect, useState } from 'react';
-import { mappingRoutes } from '../utils';
+import { findMetricsTypeFromPath } from '../utils';
 
 export function useSetMetricsTypeFromRoute(): MetricsType | undefined {
   const [type, setType] = useState<MetricsType>();
 
   useEffect(() => {
-    if (!mappingRoutes[window.location.pathname])
-      throw Error('Mapping not implemented');
+    const metricsType = findMetricsTypeFromPath(window.location.pathname);
 
-    setType(mappingRoutes[window.location.pathname]);
+    if (!metricsType) {
+      throw Error('Mapping not implemented for this route');
+    }
+
+    setType(metricsType);
   }, []);
 
   return type;

--- a/workspaces/copilot/plugins/copilot/src/utils/index.test.ts
+++ b/workspaces/copilot/plugins/copilot/src/utils/index.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { findMetricsTypeFromPath } from './index';
+
+describe('findMetricsTypeFromPath', () => {
+  it('should return enterprise metrics type for enterprise path', () => {
+    expect(findMetricsTypeFromPath('/copilot/enterprise')).toBe('enterprise');
+    expect(findMetricsTypeFromPath('/copilot/enterprise/dashboard')).toBe(
+      'enterprise',
+    );
+    expect(findMetricsTypeFromPath('/suburl/copilot/enterprise')).toBe(
+      'enterprise',
+    );
+  });
+
+  it('should return organization metrics type for organization path', () => {
+    expect(findMetricsTypeFromPath('/copilot/organization')).toBe(
+      'organization',
+    );
+    expect(findMetricsTypeFromPath('/copilot/organization/stats')).toBe(
+      'organization',
+    );
+    expect(findMetricsTypeFromPath('/suburl/copilot/organization')).toBe(
+      'organization',
+    );
+  });
+
+  it('should return undefined for non-matching paths', () => {
+    expect(findMetricsTypeFromPath('/copilot')).toBeUndefined();
+    expect(findMetricsTypeFromPath('/some/other/path')).toBeUndefined();
+    expect(findMetricsTypeFromPath('')).toBeUndefined();
+  });
+});

--- a/workspaces/copilot/plugins/copilot/src/utils/index.ts
+++ b/workspaces/copilot/plugins/copilot/src/utils/index.ts
@@ -69,3 +69,14 @@ export const mappingRoutes: Record<string, MetricsType> = {
   '/copilot/enterprise': 'enterprise',
   '/copilot/organization': 'organization',
 };
+
+export function findMetricsTypeFromPath(
+  pathname: string,
+): MetricsType | undefined {
+  for (const [route, metricsType] of Object.entries(mappingRoutes)) {
+    if (pathname.includes(route)) {
+      return metricsType;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change allows Copilot statistics to be placed under a suburl.
For example /stats/copilot instead of just /copilot.

This is handy if you place copilot statistics under a submenu-item. In order for the main menu-item to be hilighted (if one have more stats under /stats/*), Copilot needs to be placed under that first part of url.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
