### PR TITLE
Version Packages (github-discussions)

### DIFF
--- a/workspaces/github-discussions/.changeset/perfect-elephants-hunt.md
+++ b/workspaces/github-discussions/.changeset/perfect-elephants-hunt.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-github-discussions': minor
-'@backstage-community/plugin-github-discussions-common': minor
----
-
-Added `githubDiscussionsReadPermission` permission for github-discussions search documents

--- a/workspaces/github-discussions/packages/app/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/app/CHANGELOG.md
@@ -1,5 +1,11 @@
 # app
 
+## 0.0.2
+
+### Patch Changes
+
+- @backstage-community/plugin-github-discussions@0.2.1
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/app/package.json
+++ b/workspaces/github-discussions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-discussions/packages/backend/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies [b21959b]
+  - @backstage-community/plugin-search-backend-module-github-discussions@0.3.0
+
 ## 0.0.1
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/backend/package.json
+++ b/workspaces/github-discussions/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-discussions-common
 
+## 0.3.0
+
+### Minor Changes
+
+- b21959b: Added `githubDiscussionsReadPermission` permission for github-discussions search documents
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/github-discussions-common/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-github-discussions-common",
   "description": "Common functionalities for the github-discussions plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-github-discussions
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [b21959b]
+  - @backstage-community/plugin-github-discussions-common@0.3.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-discussions",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-search-backend-module-github-discussions
 
+## 0.3.0
+
+### Minor Changes
+
+- b21959b: Added `githubDiscussionsReadPermission` permission for github-discussions search documents
+
+### Patch Changes
+
+- Updated dependencies [b21959b]
+  - @backstage-community/plugin-github-discussions-common@0.3.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-github-discussions",
   "description": "The github-discussions backend module for the search plugin.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-discussions-common@0.3.0

### Minor Changes

-   b21959b: Added `githubDiscussionsReadPermission` permission for github-discussions search documents

## @backstage-community/plugin-search-backend-module-github-discussions@0.3.0

### Minor Changes

-   b21959b: Added `githubDiscussionsReadPermission` permission for github-discussions search documents

### Patch Changes

-   Updated dependencies [b21959b]
    -   @backstage-community/plugin-github-discussions-common@0.3.0

## @backstage-community/plugin-github-discussions@0.2.1

### Patch Changes

-   Updated dependencies [b21959b]
    -   @backstage-community/plugin-github-discussions-common@0.3.0

## app@0.0.2

### Patch Changes

-   @backstage-community/plugin-github-discussions@0.2.1

## backend@0.0.2

### Patch Changes

-   Updated dependencies [b21959b]
    -   @backstage-community/plugin-search-backend-module-github-discussions@0.3.0
