### PR TITLE
fix(announcements): Respect MUI theme colors & typography

### DIFF
--- a/workspaces/announcements/.changeset/bright-jobs-doubt.md
+++ b/workspaces/announcements/.changeset/bright-jobs-doubt.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements-react': patch
+'@backstage-community/plugin-announcements': patch
+---
+
+fix(ui): Respect MUI theme options for typography, colors

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -158,8 +158,8 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementsPage.genericNew': 'New';
     readonly 'announcementsPage.card.by': 'By';
     readonly 'announcementsPage.card.in': 'in';
-    readonly 'announcementsPage.card.delete': 'DELETE';
-    readonly 'announcementsPage.card.edit': 'EDIT';
+    readonly 'announcementsPage.card.delete': 'Delete';
+    readonly 'announcementsPage.card.edit': 'Edit';
     readonly 'announcementsPage.card.occurred': 'Occurred ';
     readonly 'announcementsPage.card.scheduled': 'Scheduled ';
     readonly 'announcementsPage.card.today': 'Today';
@@ -278,8 +278,8 @@ export const useAnnouncementsTranslation: () => {
     readonly 'announcementsPage.genericNew': 'New';
     readonly 'announcementsPage.card.by': 'By';
     readonly 'announcementsPage.card.in': 'in';
-    readonly 'announcementsPage.card.delete': 'DELETE';
-    readonly 'announcementsPage.card.edit': 'EDIT';
+    readonly 'announcementsPage.card.delete': 'Delete';
+    readonly 'announcementsPage.card.edit': 'Edit';
     readonly 'announcementsPage.card.occurred': 'Occurred ';
     readonly 'announcementsPage.card.scheduled': 'Scheduled ';
     readonly 'announcementsPage.card.today': 'Today';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -38,8 +38,8 @@ export const announcementsTranslationRef = createTranslationRef({
       card: {
         by: 'By',
         in: 'in',
-        edit: 'EDIT',
-        delete: 'DELETE',
+        edit: 'Edit',
+        delete: 'Delete',
         occurred: 'Occurred ',
         scheduled: 'Scheduled ',
         today: 'Today',

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -59,7 +59,7 @@ const AnnouncementDetails = ({
     <Typography>
       By{' '}
       <EntityPeekAheadPopover entityRef={announcement.publisher}>
-        <Link to={entityLink(publisherRef)}>
+        <Link to={entityLink(publisherRef)} variant="inherit">
           <EntityDisplayName entityRef={announcement.publisher} hideIcon />
         </Link>
       </EntityPeekAheadPopover>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -23,18 +23,15 @@ import {
   Content,
   MarkdownContent,
   InfoCard,
-  Link,
 } from '@backstage/core-components';
 import {
   useApi,
   useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
-import { parseEntityRef } from '@backstage/catalog-model';
 import {
-  EntityDisplayName,
   EntityPeekAheadPopover,
-  entityRouteRef,
+  EntityRefLink,
 } from '@backstage/plugin-catalog-react';
 import { announcementViewRouteRef, rootRouteRef } from '../../routes';
 import { announcementsApiRef } from '@backstage-community/plugin-announcements-react';
@@ -48,20 +45,15 @@ const AnnouncementDetails = ({
   announcement: Announcement;
 }) => {
   const announcementsLink = useRouteRef(rootRouteRef);
-  const entityLink = useRouteRef(entityRouteRef);
   const deepLink = {
     link: announcementsLink(),
     title: 'Back to announcements',
   };
-
-  const publisherRef = parseEntityRef(announcement.publisher);
   const subHeader = (
     <Typography>
       By{' '}
       <EntityPeekAheadPopover entityRef={announcement.publisher}>
-        <Link to={entityLink(publisherRef)} variant="inherit">
-          <EntityDisplayName entityRef={announcement.publisher} hideIcon />
-        </Link>
+        <EntityRefLink entityRef={announcement.publisher} hideIcon />
       </EntityPeekAheadPopover>
       , {DateTime.fromISO(announcement.created_at).toRelative()}
     </Typography>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementSearchResultListItem/AnnouncementSearchResultListItem.tsx
@@ -35,7 +35,6 @@ const useStyles = makeStyles({
     display: 'block',
     marginTop: '0.2rem',
     marginBottom: '0.8rem',
-    fontSize: '0.8rem',
   },
   excerpt: {
     lineHeight: '1.55',

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -128,7 +128,10 @@ export const AnnouncementsCard = ({
             </ListItemIcon>
             <ListItemText
               primary={
-                <Link to={viewAnnouncementLink({ id: announcement.id })}>
+                <Link
+                  to={viewAnnouncementLink({ id: announcement.id })}
+                  variant="inherit"
+                >
                   {announcement.title}
                 </Link>
               }
@@ -143,6 +146,7 @@ export const AnnouncementsCard = ({
                           to={`${announcementsLink()}?category=${
                             announcement.category.slug
                           }`}
+                          variant="inherit"
                         >
                           {announcement.category.title}
                         </Link>
@@ -171,7 +175,7 @@ export const AnnouncementsCard = ({
           <ListItem>
             <ListItemText>
               {`${t('announcementsCard.noAnnouncements')} `}
-              <Link to={createAnnouncementLink()}>
+              <Link to={createAnnouncementLink()} variant="inherit">
                 {t('announcementsCard.addOne')}
               </Link>
               ?

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -34,11 +34,9 @@ import {
   LinkButton,
 } from '@backstage/core-components';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import { parseEntityRef } from '@backstage/catalog-model';
 import {
-  EntityDisplayName,
   EntityPeekAheadPopover,
-  entityRouteRef,
+  EntityRefLink,
 } from '@backstage/plugin-catalog-react';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
@@ -77,7 +75,6 @@ const useStyles = makeStyles(theme => {
   return {
     cardHeader: {
       color: theme?.palette?.text?.primary || '#000',
-      fontSize: '1.5rem',
     },
     pagination: {
       display: 'flex',
@@ -111,10 +108,8 @@ const AnnouncementCard = ({
   const announcementsLink = useRouteRef(rootRouteRef);
   const viewAnnouncementLink = useRouteRef(announcementViewRouteRef);
   const editAnnouncementLink = useRouteRef(announcementEditRouteRef);
-  const entityLink = useRouteRef(entityRouteRef);
   const { t } = useAnnouncementsTranslation();
 
-  const publisherRef = parseEntityRef(announcement.publisher);
   const title = (
     <Tooltip
       title={announcement.title}
@@ -134,9 +129,7 @@ const AnnouncementCard = ({
       <Typography variant="body2" color="textSecondary" component="span">
         {t('announcementsPage.card.by')}{' '}
         <EntityPeekAheadPopover entityRef={announcement.publisher}>
-          <Link to={entityLink(publisherRef)}>
-            <EntityDisplayName entityRef={announcement.publisher} hideIcon />
-          </Link>
+          <EntityRefLink entityRef={announcement.publisher} hideIcon />
         </EntityPeekAheadPopover>
         {announcement.category && (
           <>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/ContextMenu.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/ContextMenu.tsx
@@ -34,11 +34,11 @@ import {
 import MoreVert from '@material-ui/icons/MoreVert';
 import Description from '@material-ui/icons/Description';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   button: {
-    color: 'white',
+    color: theme.page.fontColor,
   },
-});
+}));
 
 export function ContextMenu() {
   const classes = useStyles();

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -96,10 +96,17 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
 
   const message = (
     <>
-      <Typography component="span" className={classes.bannerIcon}>
+      <Typography
+        component="span"
+        className={classes.bannerIcon}
+        variant="inherit"
+      >
         📣
       </Typography>
-      <Link to={viewAnnouncementLink({ id: announcement.id })}>
+      <Link
+        to={viewAnnouncementLink({ id: announcement.id })}
+        variant="inherit"
+      >
         {announcement.title}
       </Link>
       &nbsp;– {announcement.excerpt}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hey :wave:

Small PR to improve the experience when using custom themes.

There are a lot of small overrides that won't work well when the colors or typography has been changed with a custom MUI theme (e.g. menu button set to white, font-sizes not from the theme typography, etc...).

We could also add some keys to let users customize the theme even more.

Have a great day :) 

TODO: Screenshots


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
