### PR TITLE
Add Support for SonarQube Cloud to SonarQube Plugin

### DIFF
--- a/workspaces/sonarqube/.changeset/proud-jobs-cross.md
+++ b/workspaces/sonarqube/.changeset/proud-jobs-cross.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-sonarqube-backend': minor
+---
+
+Switch from basic auth to recommended<sup>[[1]](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/web-api/#authenticate-to-api), [[2]](https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/web-api/#authenticate-to-api)</sup> bearer auth in order to also support SonarQube Cloud.
+
+Basic auth as used previously is exlusively [supported](https://docs.sonarsource.com/sonarqube-server/10.8/user-guide/managing-tokens/#using-a-token) by Sonarqube Server.

--- a/workspaces/sonarqube/README.md
+++ b/workspaces/sonarqube/README.md
@@ -1,13 +1,5 @@
 # [Backstage](https://backstage.io)
 
-This is your newly scaffolded Backstage App, Good Luck!
-
-For testing sonarqube, set the relevant env variables:
-
-1. [Create an OAuth App](https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/) in the GitHub organization with the callback URL set to `http://localhost:7007/api/auth/github/handler/frame`.
-2. Take the Client ID and Client Secret from the newly created app's settings page and put them into `AUTH_GITHUB_CLIENT_ID` and `AUTH_GITHUB_CLIENT_SECRET` environment variables.
-3. Generate a personal access token and put it into the `GITHUB_TOKEN` enviornment variable. You can generate a personal access token from your GitHub settings. It will need the repo and workflow scopes.
-
 The [backstage example entity](./examples/entities.yaml) has a populated `sonarqube.org/project-key` annotation, but you can modify this to point anywhere your credentials have access to for testing purposes.
 
 To start the app, run:
@@ -16,3 +8,8 @@ To start the app, run:
 yarn install
 yarn dev
 ```
+
+Follow these links to learn more about this plugin:
+
+1. [Frontend](./plugins/sonarqube/README.md)
+2. [Backend](./plugins/sonarqube-backend/README.md)

--- a/workspaces/sonarqube/plugins/sonarqube-backend/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/README.md
@@ -133,6 +133,10 @@ sonarqube:
       instanceKey: mySonarqube
       baseUrl: https://special-project-sonarqube.example.com
       apiKey: abcdef0123456789abcedf0123456789ab
+    - name: cloud
+      instanceKey: sonarcloud
+      baseUrl: https://sonarcloud.io
+      apiKey: 0123456789abcedf012123456789abcdef
 ```
 
 ##### Catalog

--- a/workspaces/sonarqube/plugins/sonarqube-backend/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/README.md
@@ -2,6 +2,13 @@
 
 Welcome to the sonarqube-backend backend plugin!
 
+This plugin needs to be added to an existing backstage instance.
+
+```bash
+# From your Backstage root directory
+yarn --cwd packages/backend add @backstage-community/plugin-sonarqube-backend
+```
+
 ## New Backend System
 
 The Sonarqube backend plugin has support for the [new backend system](https://backstage.io/docs/backend-system/), here's how you can set that up:
@@ -16,14 +23,7 @@ In your `packages/backend/src/index.ts` make the following changes:
   backend.start();
 ```
 
-## Integrating into a backstage instance
-
-This plugin needs to be added to an existing backstage instance.
-
-```bash
-# From your Backstage root directory
-yarn --cwd packages/backend add @backstage-community/plugin-sonarqube-backend
-```
+## Old Backend System
 
 Typically, this means creating a `src/plugins/sonarqube.ts` file and adding a reference to it to `src/index.ts` in the backend package.
 
@@ -83,6 +83,8 @@ index 1942c36ad1..7fdc48ba24 100644
    const service = createServiceBuilder(module)
 
 ```
+
+## SonarqubeInfoProvider
 
 This plugin must be provided with a `SonarqubeInfoProvider`, this is a strategy object for finding Sonarqube instances in configuration and retrieving data from an instance.
 

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.test.ts
@@ -357,10 +357,10 @@ describe('DefaultSonarqubeInfoProvider', () => {
     const checkBasicAuthToken = (req: RestRequest<never>) => {
       if (req.headers && req.headers.has('Authorization')) {
         expect(req.headers.get('Authorization')).toEqual(
-          `Basic MTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc4OWFiY2VkZjAxMjo=`,
+          `Bearer 123456789abcdef0123456789abcedf012`,
         );
       } else {
-        throw new Error('Basic auth token not provided');
+        throw new Error('Bearer token not provided');
       }
     };
 

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.ts
@@ -298,17 +298,12 @@ export class DefaultSonarqubeInfoProvider implements SonarqubeInfoProvider {
     authToken: string,
     query: { [key in string]: any },
   ): Promise<T | undefined> {
-    // Sonarqube auth use basic with token as username and no password
-    // but standard dictate the colon (separator) need to stay here despite the
-    // lack of password
-    const encodedAuthToken = Buffer.from(`${authToken}:`).toString('base64');
-
     const fullUrl = `${url}/${path}?${new URLSearchParams(query).toString()}`;
 
     const response = await fetch(fullUrl, {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Basic ${encodedAuthToken}`,
+        Authorization: `Bearer ${authToken}`,
       },
     });
     if (!response.ok) {

--- a/workspaces/sonarqube/plugins/sonarqube/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube/README.md
@@ -10,7 +10,7 @@ The SonarQube Plugin displays code statistics from [SonarCloud](https://sonarclo
 
 ```bash
 # From your Backstage root directory
-yarn --cwd packages/app add @backstage-community/plugin-sonarqube
+yarn --cwd packages/app add @backstage-community/plugin-sonarqube @backstage-community/plugin-sonarqube-react
 ```
 
 2. Add the `EntitySonarQubeCard` to the EntityPage:
@@ -18,6 +18,7 @@ yarn --cwd packages/app add @backstage-community/plugin-sonarqube
 ```diff
   // packages/app/src/components/catalog/EntityPage.tsx
 + import { EntitySonarQubeCard } from '@backstage-community/plugin-sonarqube';
++ import { isSonarQubeAvailable } from '@backstage-community/plugin-sonarqube-react';
 
  ...
 
@@ -26,9 +27,13 @@ yarn --cwd packages/app add @backstage-community/plugin-sonarqube
      <Grid item md={6}>
        <EntityAboutCard variant="gridItem" />
      </Grid>
-+    <Grid item md={6}>
-+      <EntitySonarQubeCard variant="gridItem" />
-+    </Grid>
++    <EntitySwitch>
++      <EntitySwitch.Case if={isSonarQubeAvailable}>
++        <Grid item md={6}>
++          <EntitySonarQubeCard variant="gridItem" />
++        </Grid>
++      </EntitySwitch.Case>
++    </EntitySwitch>
    </Grid>
  );
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

SonarQube [Cloud](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/web-api/#authenticate-to-api) and [Server](https://docs.sonarsource.com/sonarqube-server/10.8/extension-guide/web-api/#authenticate-to-api) both support bearer auth.

However SonarQube Server also supports [basic auth](https://docs.sonarsource.com/sonarqube-server/10.8/user-guide/managing-tokens/#using-a-token).

By switching to bearer auth we make it work with both.
I tested this locally with both SonarQube Server and SonarQube Cloud and existing Basic Auth tokens work without issues.

I also updated the docs to make it more obvious what changes are necessary for the new backend system.

The commits also include individual explanations for the changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
