### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/great-monkeys-fry.md
+++ b/workspaces/keycloak/.changeset/great-monkeys-fry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': minor
----
-
-remove inclusion and use dynamic imports to load ESM modules instead

--- a/workspaces/keycloak/.changeset/small-geckos-invite.md
+++ b/workspaces/keycloak/.changeset/small-geckos-invite.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-remove unused dependencies (@spotify/prettier-config and @common.js/p-limit)

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 3.9.0
+
+### Minor Changes
+
+- 3836318: remove inclusion and use dynamic imports to load ESM modules instead
+
+### Patch Changes
+
+- 3836318: remove unused dependencies (@spotify/prettier-config and @common.js/p-limit)
+
 ## 3.8.1
 
 ### Patch Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.9.0

### Minor Changes

-   3836318: remove inclusion and use dynamic imports to load ESM modules instead

### Patch Changes

-   3836318: remove unused dependencies (@spotify/prettier-config and @common.js/p-limit)
