### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/yellow-dolls-cough.md
+++ b/workspaces/topology/.changeset/yellow-dolls-cough.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-topology': major
----
-
-**BREAKING** Use Kubernetes plugin permissions `kubernetes.clusters.read` and `kubernetes.resources.read` in Topology plugin, remove topology-specific permission `topology.view.read`.
-If you are importing `topologyViewPermission` or `topologyPermissions` from `@backstage-community/plugin-topology-common`, the imports need to be updated to instead import from `@backstage/plugin-kubernetes-common`.

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 2.0.0
+
+### Major Changes
+
+- 215f3c6: **BREAKING** Use Kubernetes plugin permissions `kubernetes.clusters.read` and `kubernetes.resources.read` in Topology plugin, remove topology-specific permission `topology.view.read`.
+  If you are importing `topologyViewPermission` or `topologyPermissions` from `@backstage-community/plugin-topology-common`, the imports need to be updated to instead import from `@backstage/plugin-kubernetes-common`.
+
 ## 1.33.1
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "1.33.1",
+  "version": "2.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.0.0

### Major Changes

-   215f3c6: **BREAKING** Use Kubernetes plugin permissions `kubernetes.clusters.read` and `kubernetes.resources.read` in Topology plugin, remove topology-specific permission `topology.view.read`.
    If you are importing `topologyViewPermission` or `topologyPermissions` from `@backstage-community/plugin-topology-common`, the imports need to be updated to instead import from `@backstage/plugin-kubernetes-common`.
