### PR TITLE
Implement extension point to provide custom ADR parser for backend

### DIFF
--- a/workspaces/adr/.changeset/dirty-impalas-attack.md
+++ b/workspaces/adr/.changeset/dirty-impalas-attack.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-adr-backend': minor
+'@backstage-community/plugin-adr-common': minor
+---
+
+Added extension point to backend plugin so that a custom ADR parser can be provided in modules to support additional ADR formats.

--- a/workspaces/adr/plugins/adr-backend/report.api.md
+++ b/workspaces/adr/plugins/adr-backend/report.api.md
@@ -4,18 +4,28 @@
 
 ```ts
 import { AdrCollatorFactoryOptions as AdrCollatorFactoryOptions_2 } from '@backstage-community/search-backend-module-adr';
+import { AdrInfoParser } from '@backstage-community/plugin-adr-common';
 import { AdrParser as AdrParser_2 } from '@backstage-community/plugin-adr-common';
 import { AdrParserContext as AdrParserContext_2 } from '@backstage-community/plugin-adr-common';
 import { BackendFeature } from '@backstage/backend-plugin-api';
 import { CacheService } from '@backstage/backend-plugin-api';
 import { DefaultAdrCollatorFactory } from '@backstage-community/search-backend-module-adr';
 import express from 'express';
+import { ExtensionPoint } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { MadrParserOptions as MadrParserOptions_2 } from '@backstage-community/plugin-adr-common';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 // @public @deprecated
 export type AdrCollatorFactoryOptions = AdrCollatorFactoryOptions_2;
+
+// @public
+export type AdrExtensionPoint = {
+  setAdrInfoParser(adrInfoParser: AdrInfoParser): void;
+};
+
+// @public
+export const adrExtensionPoint: ExtensionPoint<AdrExtensionPoint>;
 
 // @public @deprecated
 export type AdrParser = AdrParser_2;
@@ -32,6 +42,7 @@ export type AdrRouterOptions = {
   reader: UrlReaderService;
   cacheClient: CacheService;
   logger: LoggerService;
+  parser?: AdrInfoParser;
 };
 
 // @public @deprecated

--- a/workspaces/adr/plugins/adr-backend/src/index.ts
+++ b/workspaces/adr/plugins/adr-backend/src/index.ts
@@ -21,5 +21,9 @@
  */
 
 export * from './service';
-export { adrPlugin as default } from './plugin';
+export {
+  adrPlugin as default,
+  adrExtensionPoint,
+  type AdrExtensionPoint,
+} from './plugin';
 export * from './deprecated';

--- a/workspaces/adr/plugins/adr-backend/src/service/router.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.ts
@@ -17,7 +17,11 @@
 import { NotModifiedError, stringifyError } from '@backstage/errors';
 import express from 'express';
 import Router from 'express-promise-router';
-import { madrParser } from '@backstage-community/plugin-adr-common';
+import {
+  AdrInfo,
+  AdrInfoParser,
+  madrParser,
+} from '@backstage-community/plugin-adr-common';
 import {
   CacheService,
   LoggerService,
@@ -29,13 +33,14 @@ export type AdrRouterOptions = {
   reader: UrlReaderService;
   cacheClient: CacheService;
   logger: LoggerService;
+  parser?: AdrInfoParser;
 };
 
 /** @public */
 export async function createRouter(
   options: AdrRouterOptions,
 ): Promise<express.Router> {
-  const { reader, cacheClient, logger } = options;
+  const { reader, cacheClient, logger, parser } = options;
 
   const router = Router();
   router.use(express.json());
@@ -69,7 +74,9 @@ export async function createRouter(
             const fileContent = await file.content();
 
             try {
-              const adrInfo = madrParser(fileContent.toString());
+              const adrInfo: AdrInfo = parser
+                ? parser(fileContent.toString())
+                : madrParser(fileContent.toString());
               return {
                 type: 'file',
                 name: file.path.substring(file.path.lastIndexOf('/') + 1),

--- a/workspaces/adr/plugins/adr-common/report.api.md
+++ b/workspaces/adr/plugins/adr-common/report.api.md
@@ -19,6 +19,19 @@ export interface AdrDocument extends IndexableDocument {
 export type AdrFilePathFilterFn = (path: string) => boolean;
 
 // @public
+export interface AdrInfo {
+  // (undocumented)
+  date?: string;
+  // (undocumented)
+  status?: string;
+  // (undocumented)
+  title?: string;
+}
+
+// @public
+export type AdrInfoParser = (content: string, dateFormat?: string) => AdrInfo;
+
+// @public
 export type AdrParser = (ctx: AdrParserContext) => Promise<AdrDocument>;
 
 // @public
@@ -55,14 +68,7 @@ export const MADR_DATE_FORMAT = 'yyyy-MM-dd';
 export const madrFilePathFilter: AdrFilePathFilterFn;
 
 // @public
-export const madrParser: (
-  content: string,
-  dateFormat?: string,
-) => {
-  title: string | undefined;
-  status: string | undefined;
-  date: string | undefined;
-};
+export const madrParser: (content: string, dateFormat?: string) => AdrInfo;
 
 // @public
 export type MadrParserOptions = {

--- a/workspaces/adr/plugins/adr-common/src/index.ts
+++ b/workspaces/adr/plugins/adr-common/src/index.ts
@@ -18,10 +18,7 @@
  * @packageDocumentation
  */
 import { Entity, getEntitySourceLocation } from '@backstage/catalog-model';
-import { IndexableDocument } from '@backstage/plugin-search-common';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import frontMatter from 'front-matter';
-import { DateTime } from 'luxon';
 
 export * from './search';
 
@@ -30,12 +27,6 @@ export * from './search';
  * @public
  */
 export const ANNOTATION_ADR_LOCATION = 'backstage.io/adr-location';
-
-/**
- * Standard luxon DateTime format string for MADR dates.
- * @public
- */
-export const MADR_DATE_FORMAT = 'yyyy-MM-dd';
 
 /**
  * Utility function to get the value of an entity ADR annotation.
@@ -89,68 +80,3 @@ export type AdrFilePathFilterFn = (path: string) => boolean;
  */
 export const madrFilePathFilter: AdrFilePathFilterFn = (path: string) =>
   /^(?:.*\/)?\d{4}-.+\.md$/.test(path);
-
-/**
- * ADR indexable document interface
- * @public
- */
-export interface AdrDocument extends IndexableDocument {
-  /**
-   * Ref of the entity associated with this ADR
-   */
-  entityRef: string;
-  /**
-   * Title of the entity associated with this ADR
-   */
-  entityTitle?: string;
-  /**
-   * ADR status label
-   */
-  status?: string;
-  /**
-   * ADR date
-   */
-  date?: string;
-}
-
-/**
- * Parsed MADR document with front matter (if present) parsed and extracted from the main markdown content.
- * @public
- */
-export interface ParsedMadr {
-  /**
-   * Main body of ADR content (with any front matter removed)
-   */
-  content: string;
-  /**
-   * ADR status
-   */
-  status?: string;
-  /**
-   * ADR date
-   */
-  date?: string;
-  /**
-   * All attributes parsed from front matter
-   */
-  attributes: Record<string, unknown>;
-}
-
-/**
- * Utility function to parse raw markdown content for an ADR and extract any metadata found as "front matter" at the top of the Markdown document.
- * @param content - Raw markdown content which may (optionally) include front matter
- * @public
- */
-export const parseMadrWithFrontmatter = (content: string): ParsedMadr => {
-  const parsed = frontMatter<Record<string, unknown>>(content);
-  const status = parsed.attributes.status;
-  const date = parsed.attributes.date;
-  const luxdate = DateTime.fromJSDate(new Date(`${date}`));
-  const formattedDate = luxdate.toISODate();
-  return {
-    content: parsed.body,
-    status: status ? String(status) : undefined,
-    date: date ? String(formattedDate) : undefined,
-    attributes: parsed.attributes,
-  };
-};


### PR DESCRIPTION
## ADR - Custom parser for backend plugin

As proposed in #3456.

Added a [Plugin Extension Point](https://backstage.io/docs/backend-system/architecture/extension-points/) to the ADR plugin backend that allows users to register a [Plugin Module](https://backstage.io/docs/backend-system/architecture/modules) for custom ADR parsing. This will enable support for formats beyond MADR, such as the widely used [Nygard format](https://www.cognitect.com/blog/2011/11/15/documenting-architecture-decisions).

The goal was to keep existing functionality intact while allowing teams to support additional ADR formats as needed.

**Notable remarks:**
* The main logic changes have been done in the `adr-backend` plugin (extension point, custom parser usage if defined), and is shipped with unit tests
* The new interface `AdrInfo` and type`AdrInfoParser` have been created in `adr-common`, similarly to what had been done for the search parser.
* In `adr-common`, and because of a circular dependency issue, a few existing types/interfaces/functions (`ADR_DATE_FORMAT`, `AdrDocument`, `ParsedMadr`, `parseMadrWithFrontmatter`) have been moved from `index.ts` to `search.ts`.
* The idea was to keep the spirit of existing structure / design, and to leave the code as untouched as possible (i.e. no code improvement, no refactoring, etc), aiming at minimizing potential breaking changes.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
