### PR TITLE
chore: clean up historical references to vendor products and Janus

### DIFF
--- a/workspaces/3scale/.changeset/violet-moles-grab.md
+++ b/workspaces/3scale/.changeset/violet-moles-grab.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-3scale-backend': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/3scale/plugins/3scale-backend/package.json
+++ b/workspaces/3scale/plugins/3scale-backend/package.json
@@ -68,7 +68,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "author": "Red Hat"
 }

--- a/workspaces/acr/.changeset/young-penguins-invite.md
+++ b/workspaces/acr/.changeset/young-penguins-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-acr': patch
+---
+
+chore: remove homepage field from package.json and remove legacy maintainers field.

--- a/workspaces/acr/plugins/acr/package.json
+++ b/workspaces/acr/plugins/acr/package.json
@@ -92,10 +92,6 @@
     "acr",
     "azure"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
-  "maintainers": [
-    "@janus-idp/maintainers-plugins"
-  ],
   "author": "Red Hat"
 }

--- a/workspaces/analytics/.changeset/serious-goats-suffer.md
+++ b/workspaces/analytics/.changeset/serious-goats-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-provider-segment': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -84,7 +84,6 @@
     "christoph-jerolimov"
   ],
   "author": "Red Hat",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "keywords": [
     "support:production",

--- a/workspaces/feedback/.changeset/metal-comics-pay.md
+++ b/workspaces/feedback/.changeset/metal-comics-pay.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-feedback-backend': patch
+'@backstage-community/plugin-feedback': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -87,7 +87,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "riginoommen",

--- a/workspaces/feedback/plugins/feedback/package.json
+++ b/workspaces/feedback/plugins/feedback/package.json
@@ -88,7 +88,6 @@
       "PluginRoot": "./src/index.ts"
     }
   },
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "riginoommen",

--- a/workspaces/jfrog-artifactory/.changeset/olive-geese-sin.md
+++ b/workspaces/jfrog-artifactory/.changeset/olive-geese-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jfrog-artifactory': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -75,7 +75,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "author": "Red Hat"
 }

--- a/workspaces/keycloak/.changeset/flat-zebras-beg.md
+++ b/workspaces/keycloak/.changeset/flat-zebras-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-keycloak': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -85,7 +85,6 @@
     "works-with:rhbk:^26",
     "works-with:keycloak:~26"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@04kash"

--- a/workspaces/kiali/.changeset/tidy-eyes-wink.md
+++ b/workspaces/kiali/.changeset/tidy-eyes-wink.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-kiali-backend': patch
+'@backstage-community/plugin-kiali': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -79,7 +79,6 @@
     "@aljesusg"
   ],
   "author": "The Backstage Community",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "keywords": [
     "support:tech-preview",

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -109,7 +109,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@aljesusg"

--- a/workspaces/nexus-repository-manager/.changeset/wild-cows-sing.md
+++ b/workspaces/nexus-repository-manager/.changeset/wild-cows-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-nexus-repository-manager': patch
+---
+
+chore: remove homepage field from package.json and remove legacy maintainers field.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -82,10 +82,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
-  "maintainers": [
-    "@janus-idp/maintainers-plugins"
-  ],
   "author": "Red Hat"
 }

--- a/workspaces/ocm/.changeset/six-months-eat.md
+++ b/workspaces/ocm/.changeset/six-months-eat.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-ocm-backend': patch
+'@backstage-community/plugin-ocm-common': patch
+'@backstage-community/plugin-ocm': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -86,7 +86,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@04kash"

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -53,7 +53,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "peerDependencies": {
     "@backstage/plugin-permission-common": "^0.8.4"

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -90,7 +90,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@04kash"

--- a/workspaces/quay/.changeset/forty-lamps-confess.md
+++ b/workspaces/quay/.changeset/forty-lamps-confess.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-quay': patch
+'@backstage-community/plugin-quay-backend': patch
+'@backstage-community/plugin-quay-common': patch
+'@backstage-community/plugin-quay': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -61,7 +61,6 @@
     "christoph-jerolimov"
   ],
   "author": "Red Hat",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "keywords": [
     "support:production",

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -54,7 +54,6 @@
     "dist"
   ],
   "configSchema": "config.d.ts",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@karthikjeeyar"

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -22,7 +22,6 @@
     ]
   },
   "author": "Red Hat",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@karthikjeeyar"

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -93,7 +93,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@karthikjeeyar"

--- a/workspaces/rbac/.changeset/lucky-cooks-wave.md
+++ b/workspaces/rbac/.changeset/lucky-cooks-wave.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+'@backstage-community/plugin-rbac-common': patch
+'@backstage-community/plugin-rbac-node': patch
+'@backstage-community/plugin-rbac': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -89,7 +89,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@PatAKnight"

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -60,7 +60,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@PatAKnight"

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -52,7 +52,6 @@
     "@PatAKnight"
   ],
   "author": "Red Hat",
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "keywords": [
     "support:production",

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -99,7 +99,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@PatAKnight"

--- a/workspaces/redhat-argocd/.changeset/plain-memes-smash.md
+++ b/workspaces/redhat-argocd/.changeset/plain-memes-smash.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-redhat-argocd-backend': patch
+'@backstage-community/plugin-redhat-argocd-common': patch
+'@backstage-community/plugin-redhat-argocd': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -67,7 +67,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "karthikjeeyar",

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -50,7 +50,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "karthikjeeyar",

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -99,7 +99,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "karthikjeeyar",

--- a/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-regex': patch
+---
+
+scaffolder-backend-module-regex

--- a/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-scaffolder-backend-module-regex': patch
 ---
 
-scaffolder-backend-module-regex
+chore: remove homepage field from package.json

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -65,7 +65,6 @@
     "backstage",
     "backend-plugin-module"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@backstage-community/maintainers-plugins"

--- a/workspaces/tekton/.changeset/fluffy-worlds-shop.md
+++ b/workspaces/tekton/.changeset/fluffy-worlds-shop.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-tekton-common': patch
+'@backstage-community/plugin-tekton': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/tekton/plugins/tekton-common/package.json
+++ b/workspaces/tekton/plugins/tekton-common/package.json
@@ -52,7 +52,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "christoph-jerolimov",

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -101,7 +101,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "christoph-jerolimov",

--- a/workspaces/topology/.changeset/giant-pants-trade.md
+++ b/workspaces/topology/.changeset/giant-pants-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+chore: remove homepage field from package.json

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -101,7 +101,6 @@
     "backstage",
     "plugin"
   ],
-  "homepage": "https://red.ht/rhdh",
   "bugs": "https://github.com/backstage/community-plugins/issues",
   "maintainers": [
     "@invincibleJai",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When migrating these plugins over we must have missed some product and Janus references. This PR tidies up lingering references I found in the `package.json` files.  🧹 

Changing the `Author` field probably warrants further discussion depending on whether we consider it to represent the current or original author(s). I've left those as is for now.

I've added changesets to each of these as I figure we do need to republish the `package.json` file.

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))