### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/cool-dodos-cough.md
+++ b/workspaces/cicd-statistics/.changeset/cool-dodos-cough.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-github': minor
----
-
-New cicd-satistics for querying github actions metrics

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-cicd-statistics-module-github
+
+## 0.2.0
+
+### Minor Changes
+
+- 84e88ce: New cicd-satistics for querying github actions metrics

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-github",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CI/CD Statistics plugin module; Github CICD",
   "backstage": {
     "role": "frontend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics-module-github@0.2.0

### Minor Changes

-   84e88ce: New cicd-satistics for querying github actions metrics
