### PR TITLE
fix(feedback): reset fields after submitting feedback

### DIFF
--- a/workspaces/feedback/.changeset/real-needles-begin.md
+++ b/workspaces/feedback/.changeset/real-needles-begin.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-feedback': patch
+---
+
+reset fields after submitting feedback

--- a/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
+++ b/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
@@ -131,6 +131,14 @@ export const CreateFeedbackModal = (props: {
     setSelectedTag(tag);
   }
 
+  function resetFields() {
+    setSummary(s => ({ ...s, value: '', error: false }));
+    setDescription(d => ({ ...d, value: '', error: false }));
+    setSubmitClicked(false);
+    setFeedbackType('BUG');
+    setSelectedTag(issueTags[0]);
+  }
+
   async function handleSubmitClick() {
     setSubmitClicked(true);
     const resp = await feedbackApi.createFeedback({
@@ -147,6 +155,7 @@ export const CreateFeedbackModal = (props: {
     });
     props.handleModalCloseFn(resp);
     analytics.captureEvent('click', `submit - ${summary.value}`);
+    resetFields();
   }
 
   function handleInputChange(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This MR fixes a minor bug in feedback plugin where the text box were not cleared after submitting feedbacks

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
