### PR TITLE
fix(quay): update quay repository to use apiUrl

### DIFF
--- a/workspaces/quay/.changeset/rich-apricots-train.md
+++ b/workspaces/quay/.changeset/rich-apricots-train.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-quay': patch
+---
+
+Fixed a bug where link to Quay repository was not displayed when `@backstage-community/plugin-quay-backend` was used with key `quay.apiUrl`

--- a/workspaces/quay/app-config.yaml
+++ b/workspaces/quay/app-config.yaml
@@ -61,5 +61,5 @@ catalog:
         - allow: [User, Group]
 
 quay:
-  uiUrl: 'https://quay.io'
+  apiUrl: 'https://quay.io'
   apiKey: ''

--- a/workspaces/quay/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/workspaces/quay/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -29,7 +29,9 @@ export function QuayRepository(_props: QuayRepositoryProps) {
   const { repository, organization } = useRepository();
   const classes = useStyles();
   const configApi = useApi(configApiRef);
-  const quayUiUrl = configApi.getOptionalString('quay.uiUrl');
+  const quayUiUrl =
+    configApi.getOptionalString('quay.apiUrl') ??
+    configApi.getOptionalString('quay.uiUrl');
 
   const hasViewPermission = useQuayViewPermission();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Updates `app-config.yaml` to use `apiKey` instead of uiKey as it is required for quay backend to work, fixes:
`Missing required config value at 'quay.apiUrl' in 'app-config.yaml'`
- Fixes link pointing to Quay repo when only apiUrl key is used.

### Demo

https://github.com/user-attachments/assets/a8ca4e76-bd71-4cd8-b447-d5e0995903fe



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->



- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
