### PR TITLE
azure-devops - Added New Frontend System filter for cards and tabs

### DIFF
--- a/workspaces/azure-devops/.changeset/pink-tables-remember.md
+++ b/workspaces/azure-devops/.changeset/pink-tables-remember.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops': patch
+---
+
+Added New Frontend System filter for cards and tabs so they use `isAzureDevOpsAvailable` and `isAzurePipelinesAvailable` to control their visibility

--- a/workspaces/azure-devops/plugins/azure-devops/src/alpha/plugin.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/alpha/plugin.tsx
@@ -33,6 +33,7 @@ import {
   EntityContentBlueprint,
 } from '@backstage/plugin-catalog-react/alpha';
 import { azurePullRequestDashboardRouteRef } from '../routes';
+import { isAzureDevOpsAvailable, isAzurePipelinesAvailable } from '../plugin';
 
 /** @alpha */
 export const azureDevOpsApi = ApiBlueprint.make({
@@ -67,6 +68,10 @@ export const azureDevOpsPipelinesEntityContent = EntityContentBlueprint.make({
   params: {
     defaultPath: '/pipelines',
     defaultTitle: 'Pipelines',
+    filter: entity => {
+      if (!isAzurePipelinesAvailable(entity)) return false;
+      return true;
+    },
     loader: () =>
       import('../components/EntityPageAzurePipelines').then(m =>
         compatWrapper(<m.EntityPageAzurePipelines />),
@@ -80,6 +85,10 @@ export const azureDevOpsGitTagsEntityContent = EntityContentBlueprint.make({
   params: {
     defaultPath: '/git-tags',
     defaultTitle: 'Git Tags',
+    filter: entity => {
+      if (!isAzureDevOpsAvailable(entity)) return false;
+      return true;
+    },
     loader: () =>
       import('../components/EntityPageAzureGitTags').then(m =>
         compatWrapper(<m.EntityPageAzureGitTags />),
@@ -94,6 +103,10 @@ export const azureDevOpsPullRequestsEntityContent = EntityContentBlueprint.make(
     params: {
       defaultPath: '/pull-requests',
       defaultTitle: 'Pull Requests',
+      filter: entity => {
+        if (!isAzureDevOpsAvailable(entity)) return false;
+        return true;
+      },
       loader: () =>
         import('../components/EntityPageAzurePullRequests').then(m =>
           compatWrapper(<m.EntityPageAzurePullRequests />),
@@ -106,6 +119,10 @@ export const azureDevOpsPullRequestsEntityContent = EntityContentBlueprint.make(
 export const azureDevOpsReadmeEntityCard = EntityCardBlueprint.make({
   name: 'readme',
   params: {
+    filter: entity => {
+      if (!isAzureDevOpsAvailable(entity)) return false;
+      return true;
+    },
     loader: async () =>
       import('../components/ReadmeCard').then(m =>
         compatWrapper(<m.ReadmeCard />),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added New Frontend System filter for cards and tabs so they use `isAzureDevOpsAvailable` and `isAzurePipelinesAvailable` to control their visibility
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
