### PR TITLE
linguist - Added New Frontend System filter for card

### DIFF
--- a/workspaces/linguist/.changeset/sharp-dots-tan.md
+++ b/workspaces/linguist/.changeset/sharp-dots-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-linguist': patch
+---
+
+Added New Frontend System filter for the Language card to use `isLinguistAvailable` to control its visibility

--- a/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
+++ b/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
@@ -26,11 +26,16 @@ import {
 import { LinguistClient, linguistApiRef } from '../api';
 import { compatWrapper } from '@backstage/core-compat-api';
 import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { isLinguistAvailable } from '../plugin';
 
 /** @alpha */
 export const entityLinguistCard = EntityCardBlueprint.make({
   name: 'languages',
   params: {
+    filter: entity => {
+      if (!isLinguistAvailable(entity)) return false;
+      return true;
+    },
     loader: async () =>
       import('../components/LinguistCard').then(m =>
         compatWrapper(<m.LinguistCard />),

--- a/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
+++ b/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
@@ -32,10 +32,7 @@ import { isLinguistAvailable } from '../plugin';
 export const entityLinguistCard = EntityCardBlueprint.make({
   name: 'languages',
   params: {
-    filter: entity => {
-      if (!isLinguistAvailable(entity)) return false;
-      return true;
-    },
+    filter: isLinguistAvailable,
     loader: async () =>
       import('../components/LinguistCard').then(m =>
         compatWrapper(<m.LinguistCard />),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added New Frontend System filter for the Language card to use `isLinguistAvailable` to control its visibility

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
