### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/cyan-dogs-drum.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-regex': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.5.2
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 2.5.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-regex@2.5.2

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
