### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/wild-cows-sing.md
+++ b/workspaces/nexus-repository-manager/.changeset/wild-cows-sing.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-chore: remove homepage field from package.json and remove legacy maintainers field.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.12.2
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json and remove legacy maintainers field.
+
 ## 1.12.1
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.12.2

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json and remove legacy maintainers field.
