### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/six-months-eat.md
+++ b/workspaces/ocm/.changeset/six-months-eat.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
-'@backstage-community/plugin-ocm-common': patch
-'@backstage-community/plugin-ocm': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.5.3
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- Updated dependencies [f84ad73]
+  - @backstage-community/plugin-ocm-common@3.8.2
+
 ## 5.5.2
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.8.2
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 3.8.1
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.4.3
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+- Updated dependencies [f84ad73]
+  - @backstage-community/plugin-ocm-common@3.8.2
+
 ## 5.4.2
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.4.3

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   Updated dependencies [f84ad73]
    -   @backstage-community/plugin-ocm-common@3.8.2

## @backstage-community/plugin-ocm-backend@5.5.3

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
-   Updated dependencies [f84ad73]
    -   @backstage-community/plugin-ocm-common@3.8.2

## @backstage-community/plugin-ocm-common@3.8.2

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
