### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/giant-pants-trade.md
+++ b/workspaces/topology/.changeset/giant-pants-trade.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.0.1
+
+### Patch Changes
+
+- f84ad73: chore: remove homepage field from package.json
+
 ## 2.0.0
 
 ### Major Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.0.1

### Patch Changes

-   f84ad73: chore: remove homepage field from package.json
