### PR TITLE
acr - Add query string to sort images latest first

### DIFF
--- a/workspaces/acr/.changeset/rich-ties-brush.md
+++ b/workspaces/acr/.changeset/rich-ties-brush.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-acr': minor
+---
+
+Limit returned images to 100 and sort latest first.

--- a/workspaces/acr/plugins/acr/src/api/index.ts
+++ b/workspaces/acr/plugins/acr/src/api/index.ts
@@ -78,6 +78,8 @@ export class AzureContainerRegistryApiClient
   async getTags(repo: string) {
     const proxyUrl = await this.getBaseUrl();
 
-    return (await this.fetcher(`${proxyUrl}/${repo}/_tags`)) as TagsResponse;
+    return (await this.fetcher(
+      `${proxyUrl}/${repo}/_tags?orderby=timedesc&n=100`,
+    )) as TagsResponse;
   }
 }


### PR DESCRIPTION
Added query string to api call to sort tags by newest at top and specify only getting 100 tags. If you have over 100 tags in your registry you will not get the most recent in backstage and it is not sorted by most recent at the top. 