### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/fifty-horses-attack.md
+++ b/workspaces/npm/.changeset/fifty-horses-attack.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': patch
----
-
-Add missing backend api ref to alpha export to support private or alternative npm registries also with the new frontend system.

--- a/workspaces/npm/.changeset/kind-bananas-give.md
+++ b/workspaces/npm/.changeset/kind-bananas-give.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': minor
----
-
-Add translation support and demo translation for German

--- a/workspaces/npm/.changeset/moody-spiders-know.md
+++ b/workspaces/npm/.changeset/moody-spiders-know.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': minor
----
-
-Change overview card links from html links to Backstage Links to make them more readable and enable analytics support.

--- a/workspaces/npm/.changeset/tender-kings-walk.md
+++ b/workspaces/npm/.changeset/tender-kings-walk.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-npm-backend': minor
-'@backstage-community/plugin-npm-common': minor
-'@backstage-community/plugin-npm': minor
----
-
-Backstage version bump to v1.36.1

--- a/workspaces/npm/plugins/npm-backend/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-npm-backend
 
+## 1.4.0
+
+### Minor Changes
+
+- 841f97f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- Updated dependencies [841f97f]
+  - @backstage-community/plugin-npm-common@1.4.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-backend/package.json
+++ b/workspaces/npm/plugins/npm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-npm-backend",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm-common/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm-common
 
+## 1.4.0
+
+### Minor Changes
+
+- 841f97f: Backstage version bump to v1.36.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-common/package.json
+++ b/workspaces/npm/plugins/npm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm-common",
   "description": "Common functionalities for the npm plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-npm
 
+## 1.4.0
+
+### Minor Changes
+
+- 7bbeaca: Add translation support and demo translation for German
+- b1fc69d: Change overview card links from html links to Backstage Links to make them more readable and enable analytics support.
+- 841f97f: Backstage version bump to v1.36.1
+
+### Patch Changes
+
+- 6819636: Add missing backend api ref to alpha export to support private or alternative npm registries also with the new frontend system.
+- Updated dependencies [841f97f]
+  - @backstage-community/plugin-npm-common@1.4.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.4.0

### Minor Changes

-   7bbeaca: Add translation support and demo translation for German
-   b1fc69d: Change overview card links from html links to Backstage Links to make them more readable and enable analytics support.
-   841f97f: Backstage version bump to v1.36.1

### Patch Changes

-   6819636: Add missing backend api ref to alpha export to support private or alternative npm registries also with the new frontend system.
-   Updated dependencies [841f97f]
    -   @backstage-community/plugin-npm-common@1.4.0

## @backstage-community/plugin-npm-backend@1.4.0

### Minor Changes

-   841f97f: Backstage version bump to v1.36.1

### Patch Changes

-   Updated dependencies [841f97f]
    -   @backstage-community/plugin-npm-common@1.4.0

## @backstage-community/plugin-npm-common@1.4.0

### Minor Changes

-   841f97f: Backstage version bump to v1.36.1
