### PR TITLE
feat(npm): change overview card links from html links to backstage links

### DIFF
--- a/workspaces/npm/.changeset/moody-spiders-know.md
+++ b/workspaces/npm/.changeset/moody-spiders-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-npm': minor
+---
+
+Change overview card links from html links to Backstage Links to make them more readable and enable analytics support.

--- a/workspaces/npm/plugins/npm/src/components/EntityNpmInfoCard.tsx
+++ b/workspaces/npm/plugins/npm/src/components/EntityNpmInfoCard.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 
-import { ErrorPanel, InfoCard } from '@backstage/core-components';
+import { ErrorPanel, InfoCard, Link } from '@backstage/core-components';
 import {
   MissingAnnotationEmptyState,
   useEntity,
@@ -197,9 +197,9 @@ export const EntityNpmInfoCard = () => {
           <GridItem
             label="Npm repository"
             value={
-              <a href={npmLink} target="_blank">
+              <Link to={npmLink} externalLinkIcon>
                 {npmLink}
-              </a>
+              </Link>
             }
           />
         ) : null}
@@ -208,9 +208,9 @@ export const EntityNpmInfoCard = () => {
           <GridItem
             label="Code repository"
             value={
-              <a href={repositoryLink} target="_blank">
+              <Link to={repositoryLink} externalLinkIcon>
                 {repositoryLink}
-              </a>
+              </Link>
             }
           />
         ) : null}
@@ -219,9 +219,9 @@ export const EntityNpmInfoCard = () => {
           <GridItem
             label="Issue tracker"
             value={
-              <a href={bugsLink} target="_blank">
+              <Link to={bugsLink} externalLinkIcon>
                 {bugsLink}
-              </a>
+              </Link>
             }
           />
         ) : null}
@@ -230,9 +230,9 @@ export const EntityNpmInfoCard = () => {
           <GridItem
             label="Homepage"
             value={
-              <a href={homepageLink} target="_blank">
+              <Link to={homepageLink} externalLinkIcon>
                 {homepageLink}
-              </a>
+              </Link>
             }
           />
         ) : null}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small UI change.

Before:

![image](https://github.com/user-attachments/assets/91099b54-6e37-4cfe-a491-1352aa31bc7a)

With this PR:

![image](https://github.com/user-attachments/assets/c7e910de-c38f-4b6e-8c23-4dfb7bd08276)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
