### PR TITLE
splitting up runBulkChecks into chunks (a 750 entities) to not run into Payload too large errors ...

### DIFF
--- a/workspaces/tech-insights/.changeset/grumpy-seas-wash.md
+++ b/workspaces/tech-insights/.changeset/grumpy-seas-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-common': minor
+---
+
+run bulk checks in chunks (a 750)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

splitting up `runBulkChecks` into chunks (a 750 entities) to not run into `Payload too large` errors ...

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~  Not applicable
- [ ] ~Tests for new functionality and regression tests for bug fixes~ Not applicable
- [ ] ~Screenshots attached (for UI changes)~ Not applicable
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
