### PR TITLE
3scale-backend: catch errors per entity

### DIFF
--- a/workspaces/3scale/.changeset/fresh-ghosts-stare.md
+++ b/workspaces/3scale/.changeset/fresh-ghosts-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-3scale-backend': patch
+---
+
+provider will now catch errors per entity instead of crashing completely when one product is returned faulty from 3scale


### PR DESCRIPTION
## Hey, I just made a Pull Request!

provider will now catch errors per entity instead of crashing completely when one product is returned faulty from 3scale

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
