### PR TITLE
fix(copilot): Fetch enterprise and not organisation seats in enterpriseTask

### DIFF
--- a/workspaces/copilot/.changeset/new-poems-stare.md
+++ b/workspaces/copilot/.changeset/new-poems-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+Change to fetch correct enterprise seats instead of organisation seats in EnterpriseTask

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
@@ -140,7 +140,7 @@ export async function discoverEnterpriseMetrics({
         await db.batchInsertIdeChatEditorModels(chunk);
       });
 
-      const seats = await api.fetchOrganizationSeats();
+      const seats = await api.fetchEnterpriseSeats();
       const seatsToInsert = convertToSeatAnalysis(seats, type);
       await db.insertSeatAnalysys(seatsToInsert);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes #3546 
It called the wrong fetch in EnterpriseTask, so it fetched organisation seats instead of enterprise seats.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
