### PR TITLE
chore(regex): Remove usage of @spotify/prettier-config (#2477)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/polite-kangaroos-hunt.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/polite-kangaroos-hunt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-regex': patch
+---
+
+chore: Remove usage of @spotify/prettier-config

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/.prettierrc.js
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -46,8 +46,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.30.0",
-    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.19",
-    "@spotify/prettier-config": "^15.0.0"
+    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.19"
   },
   "files": [
     "dist",

--- a/workspaces/scaffolder-backend-module-regex/yarn.lock
+++ b/workspaces/scaffolder-backend-module-regex/yarn.lock
@@ -2534,7 +2534,6 @@ __metadata:
     "@backstage/cli": "npm:^0.30.0"
     "@backstage/plugin-scaffolder-node": "npm:^0.7.0"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.1.19"
-    "@spotify/prettier-config": "npm:^15.0.0"
     yaml: "npm:^2.3.3"
     zod: "npm:^3.22.4"
   languageName: unknown
@@ -6387,15 +6386,6 @@ __metadata:
     "@typescript-eslint/parser": ">=5"
     eslint: ">=8.x"
   checksum: 10/33627cff3a7ff6360cd73e26d28c50b3a49cc027716e1e0044187cad1fbfd6f9da13c83d2ae16bffa4755c8004f2ee9dafa4d520906905a8c9a7209987c93e5d
-  languageName: node
-  linkType: hard
-
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: 10/ba91f65bc4ee884e8afa0b99eacb1fac27043efa0915ead007af571d66a0f53462d2a65f33e01d3b6e10a804b60ed2957708f939850bc6071e2d28f0e277ab7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related to #2477

> In the 1.34.0 release of Backstage the CLI now ships with a replacement for @spotify/prettier-config. Given this change we should remove all usages of @spotify/prettier-config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
