### PR TITLE
fix(tekton): SBOM link not followed

### DIFF
--- a/workspaces/tekton/.changeset/tricky-hounds-feel.md
+++ b/workspaces/tekton/.changeset/tricky-hounds-feel.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Fix issue where the SBOM link does not lead to the SBOM task in the pipeline run log dialog

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -54,18 +54,15 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     pipelineRun?.metadata?.name,
     taskRuns,
   );
-  const activeTaskName = sbomTaskRun?.metadata?.name;
-  const [task, setTask] = React.useState(activeTaskName);
-  const handleTaskChange = (newTask: string) => {
-    setTask(newTask);
-  };
+  const activeTask = sbomTaskRun?.metadata?.name;
+  const [forSBOM, toggleForSBOM] = React.useState(activeTask !== undefined);
 
   const hasKubernetesProxyAccess = usePermission({
     permission: kubernetesProxyPermission,
   });
 
-  const openDialog = (forSBOM?: boolean) => {
-    if (forSBOM && activeTaskName) setTask(activeTaskName);
+  const openDialog = (opts: { forSBOM: boolean }) => {
+    toggleForSBOM(opts.forSBOM);
     setOpen(true);
   };
 
@@ -75,6 +72,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
 
   const closeDialog = () => {
     setOpen(false);
+    toggleForSBOM(false);
   };
 
   const {
@@ -111,8 +109,8 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
         closeDialog={closeDialog}
         pods={pods}
         taskRuns={taskRuns}
-        activeTask={task}
-        setActiveTask={handleTaskChange}
+        activeTask={activeTask}
+        forSBOM={forSBOM}
       />
 
       <PipelineRunOutputDialog
@@ -135,7 +133,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
             <IconButton
               size="small"
               data-testid="view-logs-icon"
-              onClick={() => openDialog()}
+              onClick={() => openDialog({ forSBOM: false })}
               disabled={!hasKubernetesProxyAccess.allowed}
               style={{ pointerEvents: 'auto', padding: 0 }}
             >
@@ -158,7 +156,9 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
               size="small"
               onClick={
                 !hasExternalLink(sbomTaskRun)
-                  ? () => openDialog(true)
+                  ? () => {
+                      openDialog({ forSBOM: true });
+                    }
                   : undefined
               }
               style={{ pointerEvents: 'auto', padding: 0 }}

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -54,8 +54,8 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     pipelineRun?.metadata?.name,
     taskRuns,
   );
-  const activeTask = sbomTaskRun?.metadata?.name;
-  const [forSBOM, toggleForSBOM] = React.useState(activeTask !== undefined);
+  const activeTaskName = sbomTaskRun?.metadata?.name;
+  const [forSBOM, toggleForSBOM] = React.useState(activeTaskName !== undefined);
 
   const hasKubernetesProxyAccess = usePermission({
     permission: kubernetesProxyPermission,
@@ -109,7 +109,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
         closeDialog={closeDialog}
         pods={pods}
         taskRuns={taskRuns}
-        activeTask={activeTask}
+        activeTask={activeTaskName}
         forSBOM={forSBOM}
       />
 

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -190,4 +190,4 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     </>
   );
 };
-export default PipelineRunRowActions;
+export default React.memo(PipelineRunRowActions);

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -48,7 +48,6 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
   const [open, setOpen] = React.useState<boolean>(false);
 
   const [openOutput, setOpenOutput] = React.useState<boolean>(false);
-  const [noActiveTask, setNoActiveTask] = React.useState(false);
   const pods = watchResourcesData?.pods?.data || [];
   const taskRuns = watchResourcesData?.taskruns?.data || [];
   const { sbomTaskRun } = getTaskrunsOutputGroup(
@@ -56,13 +55,17 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     taskRuns,
   );
   const activeTaskName = sbomTaskRun?.metadata?.name;
+  const [task, setTask] = React.useState(activeTaskName);
+  const handleTaskChange = (newTask: string) => {
+    setTask(newTask);
+  };
 
   const hasKubernetesProxyAccess = usePermission({
     permission: kubernetesProxyPermission,
   });
 
-  const openDialog = (viewLogs?: boolean) => {
-    if (viewLogs) setNoActiveTask(true);
+  const openDialog = (forSBOM?: boolean) => {
+    if (forSBOM && activeTaskName) setTask(activeTaskName);
     setOpen(true);
   };
 
@@ -71,7 +74,6 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
   };
 
   const closeDialog = () => {
-    setNoActiveTask(false);
     setOpen(false);
   };
 
@@ -109,7 +111,8 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
         closeDialog={closeDialog}
         pods={pods}
         taskRuns={taskRuns}
-        activeTask={noActiveTask ? undefined : activeTaskName}
+        activeTask={task}
+        setActiveTask={handleTaskChange}
       />
 
       <PipelineRunOutputDialog
@@ -132,7 +135,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
             <IconButton
               size="small"
               data-testid="view-logs-icon"
-              onClick={() => openDialog(true)}
+              onClick={() => openDialog()}
               disabled={!hasKubernetesProxyAccess.allowed}
               style={{ pointerEvents: 'auto', padding: 0 }}
             >
@@ -154,7 +157,9 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
               disabled={!sbomTaskRun || !isSbomTaskRun(sbomTaskRun)}
               size="small"
               onClick={
-                !hasExternalLink(sbomTaskRun) ? () => openDialog() : undefined
+                !hasExternalLink(sbomTaskRun)
+                  ? () => openDialog(true)
+                  : undefined
               }
               style={{ pointerEvents: 'auto', padding: 0 }}
             >
@@ -185,4 +190,4 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     </>
   );
 };
-export default React.memo(PipelineRunRowActions);
+export default PipelineRunRowActions;

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PipelineRunRowActions.tsx
@@ -55,7 +55,7 @@ const PipelineRunRowActions: React.FC<{ pipelineRun: PipelineRunKind }> = ({
     taskRuns,
   );
   const activeTaskName = sbomTaskRun?.metadata?.name;
-  const [forSBOM, toggleForSBOM] = React.useState(activeTaskName !== undefined);
+  const [forSBOM, toggleForSBOM] = React.useState(false);
 
   const hasKubernetesProxyAccess = usePermission({
     permission: kubernetesProxyPermission,

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
@@ -123,4 +123,4 @@ const PipelineRunLogDialog = ({
   );
 };
 
-export default PipelineRunLogDialog;
+export default React.memo(PipelineRunLogDialog);

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
@@ -60,6 +60,7 @@ type PipelineRunLogDialogProps = {
   taskRuns: TaskRunKind[];
   pods: V1Pod[];
   activeTask?: string;
+  setActiveTask: (t: string) => void;
 };
 const PipelineRunLogDialog = ({
   open,
@@ -68,10 +69,9 @@ const PipelineRunLogDialog = ({
   pods,
   taskRuns,
   activeTask,
+  setActiveTask,
 }: PipelineRunLogDialogProps) => {
   const classes = useStyles();
-
-  const [task, setTask] = React.useState(activeTask);
 
   return (
     <Dialog
@@ -101,15 +101,15 @@ const PipelineRunLogDialog = ({
         <ErrorBoundary>
           <PipelineRunLogDownloader
             pods={pods}
-            activeTask={task}
+            activeTask={activeTask}
             pipelineRun={pipelineRun}
           />
           <PipelineRunLogs
             pipelineRun={pipelineRun}
             taskRuns={taskRuns}
             pods={pods}
-            activeTask={task}
-            setActiveTask={setTask}
+            activeTask={activeTask}
+            setActiveTask={setActiveTask}
           />
         </ErrorBoundary>
       </DialogContent>
@@ -117,4 +117,4 @@ const PipelineRunLogDialog = ({
   );
 };
 
-export default React.memo(PipelineRunLogDialog);
+export default PipelineRunLogDialog;

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
@@ -60,7 +60,7 @@ type PipelineRunLogDialogProps = {
   taskRuns: TaskRunKind[];
   pods: V1Pod[];
   activeTask?: string;
-  setActiveTask: (t: string) => void;
+  forSBOM?: boolean;
 };
 const PipelineRunLogDialog = ({
   open,
@@ -69,9 +69,15 @@ const PipelineRunLogDialog = ({
   pods,
   taskRuns,
   activeTask,
-  setActiveTask,
+  forSBOM,
 }: PipelineRunLogDialogProps) => {
   const classes = useStyles();
+
+  const [task, changeTask] = React.useState(activeTask);
+  React.useEffect(() => {
+    // If we trigger this dialog for SBOM task, update the current active task.
+    changeTask(forSBOM ? activeTask : undefined);
+  }, [forSBOM, activeTask]);
 
   return (
     <Dialog
@@ -108,8 +114,8 @@ const PipelineRunLogDialog = ({
             pipelineRun={pipelineRun}
             taskRuns={taskRuns}
             pods={pods}
-            activeTask={activeTask}
-            setActiveTask={setActiveTask}
+            activeTask={task}
+            setActiveTask={changeTask}
           />
         </ErrorBoundary>
       </DialogContent>

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
@@ -74,9 +74,12 @@ const PipelineRunLogDialog = ({
   const classes = useStyles();
 
   const [task, changeTask] = React.useState(activeTask);
+
   React.useEffect(() => {
-    // If we trigger this dialog for SBOM task, update the current active task.
-    changeTask(forSBOM ? activeTask : undefined);
+    // If we trigger this dialog for the SBOM task, update the current active task.
+    if (forSBOM && activeTask) {
+      changeTask(activeTask);
+    }
   }, [forSBOM, activeTask]);
 
   return (

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PipelineRunLogDialog.tsx
@@ -73,12 +73,12 @@ const PipelineRunLogDialog = ({
 }: PipelineRunLogDialogProps) => {
   const classes = useStyles();
 
-  const [task, changeTask] = React.useState(activeTask);
+  const [task, setTask] = React.useState(activeTask);
 
   React.useEffect(() => {
     // If we trigger this dialog for the SBOM task, update the current active task.
     if (forSBOM && activeTask) {
-      changeTask(activeTask);
+      setTask(activeTask);
     }
   }, [forSBOM, activeTask]);
 
@@ -110,7 +110,7 @@ const PipelineRunLogDialog = ({
         <ErrorBoundary>
           <PipelineRunLogDownloader
             pods={pods}
-            activeTask={activeTask}
+            activeTask={task}
             pipelineRun={pipelineRun}
           />
           <PipelineRunLogs
@@ -118,7 +118,7 @@ const PipelineRunLogDialog = ({
             taskRuns={taskRuns}
             pods={pods}
             activeTask={task}
-            setActiveTask={changeTask}
+            setActiveTask={setTask}
           />
         </ErrorBoundary>
       </DialogContent>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

When clicking the 'View SBOM' icon it does not appear that the SBOM task
is actually selected when bringing up the dialog box.

Instead the last location is used. This appears to be a state issue.

**Before**

https://github.com/user-attachments/assets/1890d0ba-1f2b-4e9a-8196-15c2cfcb783b

Clicking SBOM link does not work.


**After**

https://github.com/user-attachments/assets/e6910329-c8c9-40b2-9ebb-a2d91989a8c5

SBOM link takes user to the SBOM task

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
