### PR TITLE
Version Packages (acs)

### DIFF
--- a/workspaces/acs/.changeset/lovely-terms-give.md
+++ b/workspaces/acs/.changeset/lovely-terms-give.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-This patch fixed local runs of the acs plugin by adding/updating the required resolution in the package.json file. This also fixes a bug where the backend url doesn't get set which causes the query to the ACS API to fail.

--- a/workspaces/acs/.changeset/renovate-290b59b.md
+++ b/workspaces/acs/.changeset/renovate-290b59b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-styles` to `5.4.1`.

--- a/workspaces/acs/.changeset/renovate-4e66174.md
+++ b/workspaces/acs/.changeset/renovate-4e66174.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-charts` to `7.4.9`.

--- a/workspaces/acs/.changeset/renovate-e2275d4.md
+++ b/workspaces/acs/.changeset/renovate-e2275d4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-topology` to `5.4.1`.

--- a/workspaces/acs/.changeset/renovate-fac5de0.md
+++ b/workspaces/acs/.changeset/renovate-fac5de0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-table` to `5.4.16`.

--- a/workspaces/acs/plugins/acs/CHANGELOG.md
+++ b/workspaces/acs/plugins/acs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-acs
 
+## 0.0.4
+
+### Patch Changes
+
+- f9f43e2: This patch fixed local runs of the acs plugin by adding/updating the required resolution in the package.json file. This also fixes a bug where the backend url doesn't get set which causes the query to the ACS API to fail.
+- 74ec6eb: Updated dependency `@patternfly/react-styles` to `5.4.1`.
+- ba3a15f: Updated dependency `@patternfly/react-charts` to `7.4.9`.
+- 0d59491: Updated dependency `@patternfly/react-topology` to `5.4.1`.
+- 900a6d7: Updated dependency `@patternfly/react-table` to `5.4.16`.
+
 ## 0.0.3
 
 ### Patch Changes

--- a/workspaces/acs/plugins/acs/package.json
+++ b/workspaces/acs/plugins/acs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-acs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acs@0.0.4

### Patch Changes

-   f9f43e2: This patch fixed local runs of the acs plugin by adding/updating the required resolution in the package.json file. This also fixes a bug where the backend url doesn't get set which causes the query to the ACS API to fail.
-   74ec6eb: Updated dependency `@patternfly/react-styles` to `5.4.1`.
-   ba3a15f: Updated dependency `@patternfly/react-charts` to `7.4.9`.
-   0d59491: Updated dependency `@patternfly/react-topology` to `5.4.1`.
-   900a6d7: Updated dependency `@patternfly/react-table` to `5.4.16`.
