### PR TITLE
acr - Add support for multiple registries

### DIFF
--- a/workspaces/acr/.changeset/mean-points-retire.md
+++ b/workspaces/acr/.changeset/mean-points-retire.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-acr': minor
+---
+
+Added functionality to define multiple ACR registries within Backstage.

--- a/workspaces/acr/examples/entities.yaml
+++ b/workspaces/acr/examples/entities.yaml
@@ -24,6 +24,20 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
+  name: another-registry-example
+  annotations:
+    azure-container-registry/registry-name: mysecondregistry
+    azure-container-registry/repository-name: samples/hello-world
+spec:
+  type: service
+  lifecycle: testing
+  owner: guests
+  system: backstage
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
   name: acr-not-found-example
   annotations:
     azure-container-registry/repository-name: samples/container-not-found

--- a/workspaces/acr/plugins/acr/README.md
+++ b/workspaces/acr/plugins/acr/README.md
@@ -29,6 +29,31 @@ The Azure Container Registry (ACR) plugin displays information about your contai
          secure: true
    ```
 
+   #### (Optional) Specify a Custom Registry Path to Support Multiple Registries
+
+   ```yaml
+   # app-config.yaml
+   proxy:
+     endpoints:
+       '/acr/api':
+         target: 'https://mycontainerregistry.azurecr.io/acr/v1/'
+         credentials: require
+         changeOrigin: true
+         headers:
+           # If you use Bearer Token for authorization, replace 'Basic' with 'Bearer'
+           Authorization: 'Basic ${ACR_AUTH_TOKEN}'
+         # Set to false if using a self-hosted ACR instance with a self-signed certificate
+         secure: true
+
+       '/acr/custom/api/mysecondregistry':
+         target: 'https://mysecondregistry.azurecr.io/acr/v1/'
+         credentials: require
+         changeOrigin: true
+         headers:
+           Authorization: 'Basic ${SECOND_ACR_AUTH_TOKEN}'
+         secure: true
+   ```
+
    > [!NOTE]
    > The value inside each route is either a simple URL string, or an object on the format accepted by [http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware). Additionally, it has an optional `credentials` key which can have the following values:
    >
@@ -87,6 +112,15 @@ The Azure Container Registry (ACR) plugin displays information about your contai
      annotations:
        'azure-container-registry/repository-name': `<REPOSITORY-NAME>',
    ```
+
+#### (Optional) Specify a Custom Registry Path to Support Multiple Registries
+
+```yaml
+  metadata:
+    annotations:
+      'azure-container-registry/repository-name': `<REPOSITORY-NAME>',
+      'azure-container-registry/registry-name': `<REGISTRY-NAME>',
+```
 
 ### Use new frontend system
 

--- a/workspaces/acr/plugins/acr/app-config.dynamic.yaml
+++ b/workspaces/acr/plugins/acr/app-config.dynamic.yaml
@@ -8,6 +8,14 @@ proxy:
         Authorization: 'Bearer ${ACR_AUTH_TOKEN}'
       # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
       secure: true
+    '/acr/custom/api/otherrepository':
+      target: ${ACR_URL_2}
+      changeOrigin: true
+      headers:
+        # If you use Bearer Token for authorization, please replace the 'Basic' with 'Bearer' in the following line.
+        Authorization: 'Bearer ${ACR_AUTH_TOKEN}'
+      # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
+      secure: true
 
 dynamicPlugins:
   frontend:

--- a/workspaces/acr/plugins/acr/app-config.yaml
+++ b/workspaces/acr/plugins/acr/app-config.yaml
@@ -8,3 +8,11 @@ proxy:
         Authorization: 'Bearer ${ACR_AUTH_TOKEN}'
       # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
       secure: true
+    '/acr/api/otherrepository':
+      target: ${ACR_URL_2}
+      changeOrigin: true
+      headers:
+        # If you use Bearer Token for authorization, please replace the 'Basic' with 'Bearer' in the following line.
+        Authorization: 'Bearer ${ACR_AUTH_TOKEN}'
+      # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
+      secure: true

--- a/workspaces/acr/plugins/acr/app-config.yaml
+++ b/workspaces/acr/plugins/acr/app-config.yaml
@@ -8,7 +8,7 @@ proxy:
         Authorization: 'Bearer ${ACR_AUTH_TOKEN}'
       # Change to "false" in case of using self hosted artifactory instance with a self-signed certificate
       secure: true
-    '/acr/api/otherrepository':
+    '/acr/custom/api/otherrepository':
       target: ${ACR_URL_2}
       changeOrigin: true
       headers:

--- a/workspaces/acr/plugins/acr/src/annotations.ts
+++ b/workspaces/acr/plugins/acr/src/annotations.ts
@@ -15,3 +15,6 @@
  */
 export const AZURE_CONTAINER_REGISTRY_ANNOTATION_IMAGE_NAME =
   'azure-container-registry/repository-name';
+
+export const AZURE_CONTAINER_REGISTRY_ANNOTATION_REGISTRY_NAME =
+  'azure-container-registry/registry-name';

--- a/workspaces/acr/plugins/acr/src/api/index.ts
+++ b/workspaces/acr/plugins/acr/src/api/index.ts
@@ -25,7 +25,7 @@ import { TagsResponse } from '../types';
 const DEFAULT_PROXY_PATH = '/acr/api';
 
 export interface AzureContainerRegistryApiV1 {
-  getTags(repo: string): Promise<TagsResponse>;
+  getTags(repo: string, registryName?: string): Promise<TagsResponse>;
 }
 
 export const AzureContainerRegistryApiRef =
@@ -52,9 +52,12 @@ export class AzureContainerRegistryApiClient
     this.identityApi = options.identityApi;
   }
 
-  private async getBaseUrl() {
-    const proxyPath =
+  private async getBaseUrl(registryName?: string) {
+    const defaultPath =
       this.configApi.getOptionalString('acr.proxyPath') || DEFAULT_PROXY_PATH;
+
+    const proxyPath = registryName ? `/acr/api/${registryName}` : defaultPath;
+
     return `${await this.discoveryApi.getBaseUrl('proxy')}${proxyPath}`;
   }
 
@@ -75,8 +78,8 @@ export class AzureContainerRegistryApiClient
     return await response.json();
   }
 
-  async getTags(repo: string) {
-    const proxyUrl = await this.getBaseUrl();
+  async getTags(repo: string, registryName?: string) {
+    const proxyUrl = await this.getBaseUrl(registryName);
 
     return (await this.fetcher(
       `${proxyUrl}/${repo}/_tags?orderby=timedesc&n=100`,

--- a/workspaces/acr/plugins/acr/src/api/index.ts
+++ b/workspaces/acr/plugins/acr/src/api/index.ts
@@ -56,7 +56,9 @@ export class AzureContainerRegistryApiClient
     const defaultPath =
       this.configApi.getOptionalString('acr.proxyPath') || DEFAULT_PROXY_PATH;
 
-    const proxyPath = registryName ? `/acr/api/${registryName}` : defaultPath;
+    const proxyPath = registryName
+      ? `/acr/custom/api/${registryName}`
+      : defaultPath;
 
     return `${await this.discoveryApi.getBaseUrl('proxy')}${proxyPath}`;
   }

--- a/workspaces/acr/plugins/acr/src/api/index.ts
+++ b/workspaces/acr/plugins/acr/src/api/index.ts
@@ -57,7 +57,7 @@ export class AzureContainerRegistryApiClient
       this.configApi.getOptionalString('acr.proxyPath') || DEFAULT_PROXY_PATH;
 
     const proxyPath = registryName
-      ? `/acr/custom/api/${registryName}`
+      ? `/acr/custom/api/${encodeURIComponent(registryName)}`
       : defaultPath;
 
     return `${await this.discoveryApi.getBaseUrl('proxy')}${proxyPath}`;
@@ -84,7 +84,7 @@ export class AzureContainerRegistryApiClient
     const proxyUrl = await this.getBaseUrl(registryName);
 
     return (await this.fetcher(
-      `${proxyUrl}/${repo}/_tags?orderby=timedesc&n=100`,
+      `${proxyUrl}/${encodeURIComponent(repo)}/_tags?orderby=timedesc&n=100`,
     )) as TagsResponse;
   }
 }

--- a/workspaces/acr/plugins/acr/src/components/AcrImages/AcrImages.tsx
+++ b/workspaces/acr/plugins/acr/src/components/AcrImages/AcrImages.tsx
@@ -19,7 +19,6 @@ import useAsync from 'react-use/esm/useAsync';
 import { ErrorPanel, Table } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { Box } from '@material-ui/core';
-
 import { formatDate } from '@janus-idp/shared-react';
 
 import { AzureContainerRegistryApiRef } from '../../api';
@@ -28,13 +27,15 @@ import { columns } from './tableHeading';
 
 type AcrImagesProps = {
   image: string;
+  registryName?: string;
 };
 
-export const AcrImages = ({ image }: AcrImagesProps) => {
+export const AcrImages = ({ image, registryName }: AcrImagesProps) => {
   const AzureContainerRegistryClient = useApi(AzureContainerRegistryApiRef);
+
   const title = `Azure Container Registry Repository: ${image}`;
   const { loading, value, error } = useAsync(() =>
-    AzureContainerRegistryClient.getTags(image),
+    AzureContainerRegistryClient.getTags(image, registryName),
   );
 
   // TODO: it should be possible to just pass the tags to the table.

--- a/workspaces/acr/plugins/acr/src/components/AcrImages/AcrImages.tsx
+++ b/workspaces/acr/plugins/acr/src/components/AcrImages/AcrImages.tsx
@@ -31,11 +31,11 @@ type AcrImagesProps = {
 };
 
 export const AcrImages = ({ image, registryName }: AcrImagesProps) => {
-  const AzureContainerRegistryClient = useApi(AzureContainerRegistryApiRef);
+  const apiClient = useApi(AzureContainerRegistryApiRef);
 
   const title = `Azure Container Registry Repository: ${image}`;
   const { loading, value, error } = useAsync(() =>
-    AzureContainerRegistryClient.getTags(image, registryName),
+    apiClient.getTags(image, registryName),
   );
 
   // TODO: it should be possible to just pass the tags to the table.

--- a/workspaces/acr/plugins/acr/src/components/AcrImagesEntityContent/AcrImagesEntityContent.tsx
+++ b/workspaces/acr/plugins/acr/src/components/AcrImagesEntityContent/AcrImagesEntityContent.tsx
@@ -20,7 +20,10 @@ import {
   useEntity,
 } from '@backstage/plugin-catalog-react';
 
-import { AZURE_CONTAINER_REGISTRY_ANNOTATION_IMAGE_NAME } from '../../annotations';
+import {
+  AZURE_CONTAINER_REGISTRY_ANNOTATION_IMAGE_NAME,
+  AZURE_CONTAINER_REGISTRY_ANNOTATION_REGISTRY_NAME,
+} from '../../annotations';
 import { AcrImages } from '../AcrImages';
 
 export const AcrImagesEntityContent = () => {
@@ -28,6 +31,11 @@ export const AcrImagesEntityContent = () => {
   const imageName =
     entity.metadata.annotations?.[
       AZURE_CONTAINER_REGISTRY_ANNOTATION_IMAGE_NAME
+    ];
+
+  const registryName =
+    entity.metadata.annotations?.[
+      AZURE_CONTAINER_REGISTRY_ANNOTATION_REGISTRY_NAME
     ];
 
   if (!imageName) {
@@ -38,5 +46,5 @@ export const AcrImagesEntityContent = () => {
     );
   }
 
-  return <AcrImages image={imageName} />;
+  return <AcrImages image={imageName} registryName={registryName} />;
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added the functionality to define multiple ACR registries in config and point to whichever an entity uses with a new annotation. This will allow organizations with more than one ACR registry to use the plugin for all applicable components.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
