### PR TITLE
ci: update Node.js matrix to [20.x, 22.x] in CI and repository root engines field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         workspace: ${{ fromJSON(needs.find-changed-workspaces.outputs.workspaces) }}
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
       fail-fast: false
     defaults:
       run:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": "git@github.com:backstage/community-plugins.git",
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "create-workspace": "community-cli workspace create",


### PR DESCRIPTION
- Update GitHub Actions CI matrix to test against Node.js 20 and 22 to match the versions supported by Backstage.
- Update package.json "engines" field to reflect support Node.js 20 and 22. Note that this only updates the repository root package.json as a way of communicating the supported Node.js versions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
