### PR TITLE
workspaces: add Node.js 22 to engines field across all workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         workspace: ${{ fromJSON(needs.find-changed-workspaces.outputs.workspaces) }}
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
       fail-fast: false
     defaults:
       run:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": "git@github.com:backstage/community-plugins.git",
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "create-workspace": "community-cli workspace create",

--- a/workspaces/3scale/package.json
+++ b/workspaces/3scale/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/acr/package.json
+++ b/workspaces/acr/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/adr/package.json
+++ b/workspaces/adr/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/airbrake/package.json
+++ b/workspaces/airbrake/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/allure/package.json
+++ b/workspaces/allure/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/amplication/package.json
+++ b/workspaces/amplication/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/analytics/package.json
+++ b/workspaces/analytics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/announcements/package.json
+++ b/workspaces/announcements/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/apache-airflow/package.json
+++ b/workspaces/apache-airflow/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/apollo-explorer/package.json
+++ b/workspaces/apollo-explorer/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/azure-devops/package.json
+++ b/workspaces/azure-devops/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/azure-resources/package.json
+++ b/workspaces/azure-resources/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/azure-sites/package.json
+++ b/workspaces/azure-sites/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/azure-storage-explorer/package.json
+++ b/workspaces/azure-storage-explorer/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/badges/package.json
+++ b/workspaces/badges/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/bazaar/package.json
+++ b/workspaces/bazaar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/bitrise/package.json
+++ b/workspaces/bitrise/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/blackduck/package.json
+++ b/workspaces/blackduck/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/cloudbuild/package.json
+++ b/workspaces/cloudbuild/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/code-climate/package.json
+++ b/workspaces/code-climate/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/code-coverage/package.json
+++ b/workspaces/code-coverage/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/codescene/package.json
+++ b/workspaces/codescene/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/confluence/package.json
+++ b/workspaces/confluence/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/copilot/package.json
+++ b/workspaces/copilot/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/cost-insights/package.json
+++ b/workspaces/cost-insights/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/dynatrace/package.json
+++ b/workspaces/dynatrace/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/entity-feedback/package.json
+++ b/workspaces/entity-feedback/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/entity-validation/package.json
+++ b/workspaces/entity-validation/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/explore/package.json
+++ b/workspaces/explore/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/feedback/package.json
+++ b/workspaces/feedback/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include @backstage-community/plugin-feedback-backend --include @backstage-community/plugin-feedback --parallel -v -i run start",

--- a/workspaces/firehydrant/package.json
+++ b/workspaces/firehydrant/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/fossa/package.json
+++ b/workspaces/fossa/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/gcalendar/package.json
+++ b/workspaces/gcalendar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/gcp-projects/package.json
+++ b/workspaces/gcp-projects/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/git-release-manager/package.json
+++ b/workspaces/git-release-manager/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/github-actions/package.json
+++ b/workspaces/github-actions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/github-deployments/package.json
+++ b/workspaces/github-deployments/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/github-discussions/package.json
+++ b/workspaces/github-discussions/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/github-issues/package.json
+++ b/workspaces/github-issues/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/github-pull-requests-board/package.json
+++ b/workspaces/github-pull-requests-board/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/gitops-profiles/package.json
+++ b/workspaces/gitops-profiles/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/gocd/package.json
+++ b/workspaces/gocd/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/grafana/package.json
+++ b/workspaces/grafana/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/graphiql/package.json
+++ b/workspaces/graphiql/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/graphql-voyager/package.json
+++ b/workspaces/graphql-voyager/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/ilert/package.json
+++ b/workspaces/ilert/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/jenkins/package.json
+++ b/workspaces/jenkins/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/kafka/package.json
+++ b/workspaces/kafka/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/keycloak/package.json
+++ b/workspaces/keycloak/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/lighthouse/package.json
+++ b/workspaces/lighthouse/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/linguist/package.json
+++ b/workspaces/linguist/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include @backstage-community/plugin-linguist-backend --include @backstage-community/plugin-linguist --parallel -v -i run start",

--- a/workspaces/linkerd/package.json
+++ b/workspaces/linkerd/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/manage/package.json
+++ b/workspaces/manage/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel --jobs unlimited -v -i run start",

--- a/workspaces/mend/package.json
+++ b/workspaces/mend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/microsoft-calendar/package.json
+++ b/workspaces/microsoft-calendar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/multi-source-security-viewer/package.json
+++ b/workspaces/multi-source-security-viewer/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/newrelic/package.json
+++ b/workspaces/newrelic/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/nomad/package.json
+++ b/workspaces/nomad/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/noop/package.json
+++ b/workspaces/noop/package.json
@@ -2,7 +2,7 @@
   "name": "@internal/noop",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "backstage-cli": "exit 0",

--- a/workspaces/npm/package.json
+++ b/workspaces/npm/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/ocm/package.json
+++ b/workspaces/ocm/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/octopus-deploy/package.json
+++ b/workspaces/octopus-deploy/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/odo/package.json
+++ b/workspaces/odo/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/opencost/package.json
+++ b/workspaces/opencost/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/periskop/package.json
+++ b/workspaces/periskop/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/pingidentity/package.json
+++ b/workspaces/pingidentity/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/playlist/package.json
+++ b/workspaces/playlist/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/puppetdb/package.json
+++ b/workspaces/puppetdb/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/quay/package.json
+++ b/workspaces/quay/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/rbac/package.json
+++ b/workspaces/rbac/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/repo-tools/package.json
+++ b/workspaces/repo-tools/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "workspaces": {
     "packages": [

--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/rollbar/package.json
+++ b/workspaces/rollbar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-backend-module-annotator/package.json
+++ b/workspaces/scaffolder-backend-module-annotator/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-backend-module-kubernetes/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-backend-module-regex/package.json
+++ b/workspaces/scaffolder-backend-module-regex/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-backend-module-sonarqube/package.json
+++ b/workspaces/scaffolder-backend-module-sonarqube/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/sentry/package.json
+++ b/workspaces/sentry/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/shortcuts/package.json
+++ b/workspaces/shortcuts/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/sonarqube/package.json
+++ b/workspaces/sonarqube/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/splunk/package.json
+++ b/workspaces/splunk/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/stack-overflow/package.json
+++ b/workspaces/stack-overflow/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/stackstorm/package.json
+++ b/workspaces/stackstorm/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/tech-insights/package.json
+++ b/workspaces/tech-insights/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/tech-radar/package.json
+++ b/workspaces/tech-radar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/tekton/package.json
+++ b/workspaces/tekton/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "18 || 20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include backend --include app --parallel -v -i run start",

--- a/workspaces/todo/package.json
+++ b/workspaces/todo/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",

--- a/workspaces/vault/package.json
+++ b/workspaces/vault/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include @backstage-community/plugin-vault --include @backstage-community/plugin-vault-backend --parallel -v -i run start",

--- a/workspaces/xcmetrics/package.json
+++ b/workspaces/xcmetrics/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "18 || 20"
+    "node": "20 || 22"
   },
   "scripts": {
     "tsc": "tsc",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Manually updates the "engines" field of all workspace package.json files
to include Node.js 22. This intentionally replaces part of the generated
rennovate PR which attempted to replace rather than add Node.js 22 to the
engines field.

Note that this is only updates the workspace package.json - therefore it
should not impact end users installing plugins.

Refs: https://github.com/backstage/community-plugins/pull/2403

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
