### PR TITLE
feat(announcements): add hideStartAt prop for conditional start at date rendering

### DIFF
--- a/workspaces/announcements/.changeset/unlucky-emus-smile.md
+++ b/workspaces/announcements/.changeset/unlucky-emus-smile.md
@@ -1,0 +1,10 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+- Add `hideStartAt` React prop to allow hiding the "Start at" date label on announcements card
+
+```diff
+- <AnnouncementsCard max={2} />
++ <AnnouncementsCard max={2} hideStartAt />
+```

--- a/workspaces/announcements/plugins/announcements/report.api.md
+++ b/workspaces/announcements/plugins/announcements/report.api.md
@@ -33,6 +33,7 @@ export const AnnouncementsCard: ({
   variant,
   sortBy,
   order,
+  hideStartAt,
 }: {
   title?: string | undefined;
   max?: number | undefined;
@@ -41,6 +42,7 @@ export const AnnouncementsCard: ({
   variant?: InfoCardVariants | undefined;
   sortBy?: 'created_at' | 'start_at' | undefined;
   order?: 'desc' | 'asc' | undefined;
+  hideStartAt?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -76,6 +78,7 @@ export const AnnouncementsPage: (props: {
       }
     | undefined;
   hideInactive?: boolean | undefined;
+  hideStartAt?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
@@ -50,6 +50,27 @@ const renderAnnouncementsCard = async (announcements: AnnouncementsList) => {
   );
 };
 
+const renderAnnouncementsCardWithProps = async (
+  announcements: AnnouncementsList,
+  props: any = {},
+) => {
+  await renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [announcementsApiRef, mockAnnouncementsApi(announcements)],
+        [permissionApiRef, mockApis.permission()],
+      ]}
+    >
+      <AnnouncementsCard {...props} />
+    </TestApiProvider>,
+    {
+      mountedRoutes: {
+        '/announcements': rootRouteRef,
+      },
+    },
+  );
+};
+
 describe('AnnouncementsCard', () => {
   afterEach(() => {
     jest.resetAllMocks();
@@ -115,5 +136,29 @@ describe('AnnouncementsCard', () => {
 
     await renderAnnouncementsCard(announcementsList);
     expect(screen.getByText(/Scheduled Today/i)).toBeInTheDocument();
+  });
+
+  it('does not display start time when hideStartAt is true', async () => {
+    const announcementsList: AnnouncementsList = {
+      count: 1,
+      results: [
+        {
+          id: '1',
+          title: 'Hidden Start Time Announcement',
+          excerpt: 'This announcement hides start time',
+          body: 'Body 1',
+          publisher: 'Publisher 1',
+          created_at: '2025-01-01',
+          active: true,
+          start_at: '2025-01-01',
+        },
+      ],
+    };
+
+    await renderAnnouncementsCardWithProps(announcementsList, {
+      hideStartAt: true,
+    });
+
+    expect(screen.queryByText(/Scheduled/i)).not.toBeInTheDocument();
   });
 });

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -61,6 +61,7 @@ type AnnouncementsCardOpts = {
   variant?: InfoCardVariants;
   sortBy?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
+  hideStartAt?: boolean;
 };
 
 export const AnnouncementsCard = ({
@@ -71,6 +72,7 @@ export const AnnouncementsCard = ({
   variant = 'gridItem',
   sortBy,
   order,
+  hideStartAt,
 }: AnnouncementsCardOpts) => {
   const classes = useStyles();
   const announcementsApi = useApi(announcementsApiRef);
@@ -151,14 +153,16 @@ export const AnnouncementsCard = ({
                   <Typography variant="body2" color="textSecondary">
                     {announcement.excerpt}
                   </Typography>
-                  <Typography variant="caption" color="textSecondary">
-                    {formatAnnouncementStartTime(
-                      announcement.start_at,
-                      t('announcementsCard.occurred'),
-                      t('announcementsCard.scheduled'),
-                      t('announcementsCard.today'),
-                    )}
-                  </Typography>
+                  {!hideStartAt && (
+                    <Typography variant="caption" color="textSecondary">
+                      {formatAnnouncementStartTime(
+                        announcement.start_at,
+                        t('announcementsCard.occurred'),
+                        t('announcementsCard.scheduled'),
+                        t('announcementsCard.today'),
+                      )}
+                    </Typography>
+                  )}
                 </Box>
               }
             />{' '}

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.test.tsx
@@ -199,5 +199,45 @@ describe('AnnouncementsPage', () => {
       );
       expect(screen.getByText(/Scheduled Today/i)).toBeInTheDocument();
     });
+
+    it('should hide start date when hideStartAt is true', async () => {
+      const today = DateTime.now().toISODate();
+      const todayAnnouncement: AnnouncementsList = {
+        count: 1,
+        results: [
+          {
+            id: '1',
+            title: 'Hidden Start Date Announcement',
+            excerpt: 'This announcement hides the start date.',
+            body: 'This is the full body of the announcement.',
+            publisher: 'default:user/user',
+            created_at: today,
+            active: true,
+            start_at: today,
+          },
+        ],
+      };
+      const mockAnnouncementsTodayApi = {
+        announcements: jest.fn().mockResolvedValue(todayAnnouncement),
+      };
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [permissionApiRef, mockApis.permission()],
+            [announcementsApiRef, mockAnnouncementsTodayApi],
+            [catalogApiRef, mockCatalogApi],
+          ]}
+        >
+          <AnnouncementsPage themeId="home" title="Announcements" hideStartAt />
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/announcements': rootRouteRef,
+            '/catalog/:namespace/:kind/:name': entityRouteRef,
+          },
+        },
+      );
+      expect(screen.queryByText(/Scheduled Today/i)).toBeNull();
+    });
   });
 });

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -100,10 +100,12 @@ const AnnouncementCard = ({
   announcement,
   onDelete,
   options: { titleLength = 50 },
+  hideStartAt,
 }: {
   announcement: Announcement;
   onDelete: () => void;
   options: AnnouncementCardProps;
+  hideStartAt?: boolean;
 }) => {
   const classes = useStyles();
   const announcementsLink = useRouteRef(rootRouteRef);
@@ -152,14 +154,16 @@ const AnnouncementCard = ({
         , {DateTime.fromISO(announcement.created_at).toRelative()}
       </Typography>
       <Box>
-        <Typography variant="caption" color="textSecondary">
-          {formatAnnouncementStartTime(
-            announcement.start_at,
-            t('announcementsCard.occurred'),
-            t('announcementsCard.scheduled'),
-            t('announcementsCard.today'),
-          )}
-        </Typography>
+        {!hideStartAt && (
+          <Typography variant="caption" color="textSecondary">
+            {formatAnnouncementStartTime(
+              announcement.start_at,
+              t('announcementsCard.occurred'),
+              t('announcementsCard.scheduled'),
+              t('announcementsCard.today'),
+            )}
+          </Typography>
+        )}
       </Box>
     </>
   );
@@ -244,6 +248,7 @@ const AnnouncementsGrid = ({
   active,
   sortBy,
   order,
+  hideStartAt,
 }: {
   maxPerPage: number;
   category?: string;
@@ -251,6 +256,7 @@ const AnnouncementsGrid = ({
   active?: boolean;
   sortBy?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
+  hideStartAt?: boolean;
 }) => {
   const classes = useStyles();
   const announcementsApi = useApi(announcementsApiRef);
@@ -322,6 +328,7 @@ const AnnouncementsGrid = ({
             announcement={announcement}
             onDelete={() => openDeleteDialog(announcement)}
             options={{ titleLength: cardTitleLength }}
+            hideStartAt={hideStartAt}
           />
         ))}
       </ItemCardGrid>
@@ -363,6 +370,7 @@ export type AnnouncementsPageProps = {
   cardOptions?: AnnouncementCardProps;
   hideContextMenu?: boolean;
   hideInactive?: boolean;
+  hideStartAt?: boolean;
   sortby?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
 };
@@ -378,6 +386,7 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
   const {
     hideContextMenu,
     hideInactive,
+    hideStartAt,
     themeId,
     title,
     subtitle,
@@ -418,6 +427,7 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
           active={hideInactive ? true : false}
           sortBy={sortby ?? 'created_at'}
           order={order ?? 'desc'}
+          hideStartAt={hideStartAt}
         />
       </Content>
     </Page>

--- a/workspaces/announcements/plugins/announcements/src/components/Router.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/Router.tsx
@@ -47,6 +47,7 @@ type RouterProps = {
     name: string | undefined;
   };
   hideInactive?: boolean;
+  hideStartAt?: boolean;
 };
 
 export const Router = (props: RouterProps) => {
@@ -54,6 +55,7 @@ export const Router = (props: RouterProps) => {
     themeId: 'home',
     title: 'Announcements',
     hideInactive: false,
+    hideStartAt: false,
     ...props,
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change add an option to hide the start date on announcement cards

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
