### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/pink-tables-remember.md
+++ b/workspaces/azure-devops/.changeset/pink-tables-remember.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Added New Frontend System filter for cards and tabs so they use `isAzureDevOpsAvailable` and `isAzurePipelinesAvailable` to control their visibility

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.13.1
+
+### Patch Changes
+
+- 7f32b36: Added New Frontend System filter for cards and tabs so they use `isAzureDevOpsAvailable` and `isAzurePipelinesAvailable` to control their visibility
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.13.1

### Patch Changes

-   7f32b36: Added New Frontend System filter for cards and tabs so they use `isAzureDevOpsAvailable` and `isAzurePipelinesAvailable` to control their visibility
