### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/tricky-hounds-feel.md
+++ b/workspaces/tekton/.changeset/tricky-hounds-feel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Fix issue where the SBOM link does not lead to the SBOM task in the pipeline run log dialog

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 3.22.2
+
+### Patch Changes
+
+- 0a0e19a: Fix issue where the SBOM link does not lead to the SBOM task in the pipeline run log dialog
+
 ## 3.22.1
 
 ### Patch Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.22.2

### Patch Changes

-   0a0e19a: Fix issue where the SBOM link does not lead to the SBOM task in the pipeline run log dialog
