### PR TITLE
Version Packages (github-deployments)

### DIFF
--- a/workspaces/github-deployments/.changeset/large-wombats-sparkle.md
+++ b/workspaces/github-deployments/.changeset/large-wombats-sparkle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-deployments': patch
----
-
-remove unused devDependency `canvas`

--- a/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
+++ b/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-deployments
 
+## 0.6.1
+
+### Patch Changes
+
+- 4aad9f3: remove unused devDependency `canvas`
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/github-deployments/plugins/github-deployments/package.json
+++ b/workspaces/github-deployments/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-deployments",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-deployments@0.6.1

### Patch Changes

-   4aad9f3: remove unused devDependency `canvas`
