### PR TITLE
Version Packages (git-release-manager)

### DIFF
--- a/workspaces/git-release-manager/.changeset/serious-elephants-nail.md
+++ b/workspaces/git-release-manager/.changeset/serious-elephants-nail.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-git-release-manager': patch
----
-
-remove unused devDependency `canvas`

--- a/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
+++ b/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-git-release-manager
 
+## 0.6.1
+
+### Patch Changes
+
+- 4aad9f3: remove unused devDependency `canvas`
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/git-release-manager/plugins/git-release-manager/package.json
+++ b/workspaces/git-release-manager/plugins/git-release-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-git-release-manager",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Backstage plugin that helps you manage releases in git",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-git-release-manager@0.6.1

### Patch Changes

-   4aad9f3: remove unused devDependency `canvas`
