### PR TITLE
Version Packages (3scale)

### DIFF
--- a/workspaces/3scale/.changeset/fresh-ghosts-stare.md
+++ b/workspaces/3scale/.changeset/fresh-ghosts-stare.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-3scale-backend': patch
----
-
-provider will now catch errors per entity instead of crashing completely when one product is returned faulty from 3scale

--- a/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
+++ b/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-3scale-backend [1.8.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-3scale-backend@1.7.1...@janus-idp/backstage-plugin-3scale-backend@1.8.0) (2024-07-25)
 
+## 3.3.2
+
+### Patch Changes
+
+- f760ec9: provider will now catch errors per entity instead of crashing completely when one product is returned faulty from 3scale
+
 ## 3.3.1
 
 ### Patch Changes

--- a/workspaces/3scale/plugins/3scale-backend/package.json
+++ b/workspaces/3scale/plugins/3scale-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-3scale-backend",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-3scale-backend@3.3.2

### Patch Changes

-   f760ec9: provider will now catch errors per entity instead of crashing completely when one product is returned faulty from 3scale
