### PR TITLE
build(deps): Update xml-crypto package to version 6.1.0 across multiple workspaces

### DIFF
--- a/workspaces/3scale/yarn.lock
+++ b/workspaces/3scale/yarn.lock
@@ -32378,13 +32378,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/acr/yarn.lock
+++ b/workspaces/acr/yarn.lock
@@ -33780,13 +33780,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/acs/yarn.lock
+++ b/workspaces/acs/yarn.lock
@@ -35787,13 +35787,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/airbrake/yarn.lock
+++ b/workspaces/airbrake/yarn.lock
@@ -27057,13 +27057,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -32887,13 +32887,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/azure-devops/yarn.lock
+++ b/workspaces/azure-devops/yarn.lock
@@ -33185,13 +33185,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "xml-crypto@npm:6.0.1"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/703d40b54333a50f74f2d4f3e37a7b9de7aa2dfde48b0418205261d2f66c9e3869babd96d7be18ec1661aaa3aea03a018279846f844cea607a57183a21a4748a
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/azure-sites/yarn.lock
+++ b/workspaces/azure-sites/yarn.lock
@@ -26746,13 +26746,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/azure-storage-explorer/yarn.lock
+++ b/workspaces/azure-storage-explorer/yarn.lock
@@ -33143,13 +33143,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/bazaar/yarn.lock
+++ b/workspaces/bazaar/yarn.lock
@@ -27750,13 +27750,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/blackduck/yarn.lock
+++ b/workspaces/blackduck/yarn.lock
@@ -33297,13 +33297,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/cicd-statistics/yarn.lock
+++ b/workspaces/cicd-statistics/yarn.lock
@@ -31984,13 +31984,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/confluence/yarn.lock
+++ b/workspaces/confluence/yarn.lock
@@ -31194,13 +31194,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -34128,13 +34128,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/entity-feedback/yarn.lock
+++ b/workspaces/entity-feedback/yarn.lock
@@ -28394,13 +28394,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/explore/yarn.lock
+++ b/workspaces/explore/yarn.lock
@@ -27216,13 +27216,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/feedback/yarn.lock
+++ b/workspaces/feedback/yarn.lock
@@ -29076,13 +29076,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/github-actions/yarn.lock
+++ b/workspaces/github-actions/yarn.lock
@@ -30827,13 +30827,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/github-discussions/yarn.lock
+++ b/workspaces/github-discussions/yarn.lock
@@ -30013,13 +30013,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/jaeger/yarn.lock
+++ b/workspaces/jaeger/yarn.lock
@@ -33612,13 +33612,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/jenkins/yarn.lock
+++ b/workspaces/jenkins/yarn.lock
@@ -33236,13 +33236,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/kiali/yarn.lock
+++ b/workspaces/kiali/yarn.lock
@@ -35848,13 +35848,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/linguist/yarn.lock
+++ b/workspaces/linguist/yarn.lock
@@ -28014,13 +28014,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/linkerd/yarn.lock
+++ b/workspaces/linkerd/yarn.lock
@@ -33123,13 +33123,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/manage/yarn.lock
+++ b/workspaces/manage/yarn.lock
@@ -32775,13 +32775,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/mend/yarn.lock
+++ b/workspaces/mend/yarn.lock
@@ -26956,13 +26956,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/mta/yarn.lock
+++ b/workspaces/mta/yarn.lock
@@ -36427,23 +36427,23 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^3.0.1":
-  version: 3.2.0
-  resolution: "xml-crypto@npm:3.2.0"
+  version: 3.2.1
+  resolution: "xml-crypto@npm:3.2.1"
   dependencies:
     "@xmldom/xmldom": "npm:^0.8.8"
     xpath: "npm:0.0.32"
-  checksum: 10/ea9c3ecf60fbe54b947aff86f56f5b50ecc6713f5e514b268262610c97d1f602aacfff07bc4e972d1c1dd5ca4f591aeadb723abe081eae5033c701bcecfaa765
+  checksum: 10/488fe2a8cea138f8a49ac1bbc62613379d8e31802d5da2a865a5553f450fa5962ae7e37dac24a96c732d4df5adf3b03d3284c7e72d16cddc854cf62b1ecef315
   languageName: node
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/multi-source-security-viewer/yarn.lock
+++ b/workspaces/multi-source-security-viewer/yarn.lock
@@ -35322,13 +35322,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "xml-crypto@npm:6.0.1"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/703d40b54333a50f74f2d4f3e37a7b9de7aa2dfde48b0418205261d2f66c9e3869babd96d7be18ec1661aaa3aea03a018279846f844cea607a57183a21a4748a
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/nomad/yarn.lock
+++ b/workspaces/nomad/yarn.lock
@@ -26809,13 +26809,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/npm/yarn.lock
+++ b/workspaces/npm/yarn.lock
@@ -33287,13 +33287,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/ocm/yarn.lock
+++ b/workspaces/ocm/yarn.lock
@@ -34057,13 +34057,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/periskop/yarn.lock
+++ b/workspaces/periskop/yarn.lock
@@ -26807,13 +26807,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/pingidentity/yarn.lock
+++ b/workspaces/pingidentity/yarn.lock
@@ -33190,13 +33190,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/playlist/yarn.lock
+++ b/workspaces/playlist/yarn.lock
@@ -31364,13 +31364,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -34197,13 +34197,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/rbac/yarn.lock
+++ b/workspaces/rbac/yarn.lock
@@ -34491,13 +34491,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/redhat-argocd/yarn.lock
+++ b/workspaces/redhat-argocd/yarn.lock
@@ -35072,13 +35072,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/redhat-resource-optimization/yarn.lock
+++ b/workspaces/redhat-resource-optimization/yarn.lock
@@ -36092,13 +36092,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/report-portal/yarn.lock
+++ b/workspaces/report-portal/yarn.lock
@@ -33616,13 +33616,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/rollbar/yarn.lock
+++ b/workspaces/rollbar/yarn.lock
@@ -27048,13 +27048,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/sentry/yarn.lock
+++ b/workspaces/sentry/yarn.lock
@@ -33365,13 +33365,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/sonarqube/yarn.lock
+++ b/workspaces/sonarqube/yarn.lock
@@ -31820,13 +31820,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -34684,13 +34684,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/tech-radar/yarn.lock
+++ b/workspaces/tech-radar/yarn.lock
@@ -33256,13 +33256,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/tekton/yarn.lock
+++ b/workspaces/tekton/yarn.lock
@@ -35749,13 +35749,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/topology/yarn.lock
+++ b/workspaces/topology/yarn.lock
@@ -35138,13 +35138,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 

--- a/workspaces/vault/yarn.lock
+++ b/workspaces/vault/yarn.lock
@@ -28061,13 +28061,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.1.0
+  resolution: "xml-crypto@npm:6.1.0"
   dependencies:
     "@xmldom/is-dom-node": "npm:^1.0.1"
     "@xmldom/xmldom": "npm:^0.8.10"
     xpath: "npm:^0.0.33"
-  checksum: 10/bc8f634618e8c30844546cf7a19d3c80634f8134118a2d2b9b76f0bb094b745c53ad94214cd3577fba93327d5d992c7570903e4463ce078d9699e45008246400
+  checksum: 10/70bdedf276038248906493047250c0e72d248b41c2626e8a563bb0e578f08f1028c850de53385988106d78e5bdbf9e6a3c685cc8d2b6ddf2b8b167fe5cc7587f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Updates xml-crypto dependency 

### Yarn why changes

```diff
Workspaces: mta
 └─ `@backstage/plugin-auth-backend@npm:0.22.12 (npm:^0.22.4)`
        └─ `@node-saml/passport-saml@npm:4.0.4 (npm:^4.0.4)`
                └─ `@node-saml/node-saml@npm:4.0.5 (npm:^4.0.4)`
-                       └─ `xml-crypto@npm:3.2.0 (npm:^3.0.1)`
+                       └─ `xml-crypto@npm:3.2.1 (npm:^3.0.1)`
 
 
 Workspaces: mta
 └─ `@backstage/plugin-auth-backend@npm:0.23.1 (npm:^0.23.0)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
 Workspaces: feedback
 └─ `@backstage/plugin-auth-backend@npm:0.24.1 (npm:^0.24.1)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
 Workspaces: redhat-resource-optimization
 └─ `@backstage/plugin-auth-backend@npm:0.24.2 (npm:^0.24.1)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
 Workspaces: kiali, manage, report-portal, tech-insights
 └─ `@backstage/plugin-auth-backend@npm:0.24.2 (npm:^0.24.2)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
 Workspaces: acs
 └─ `@backstage/plugin-auth-backend@npm:0.24.3 (npm:^0.24.2)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
-Workspaces: 3scale, github-discussions, ocm, pingidentity, quay, rbac, redhat-argocd, tekton, topology
+Workspaces: 3scale, github-discussions, multi-source-security-viewer, ocm, pingidentity, quay, rbac, redhat-argocd, tekton, topology
 └─ `@backstage/plugin-auth-backend@npm:0.24.3 (npm:^0.24.3)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
-Workspaces: multi-source-security-viewer
-└─ `@backstage/plugin-auth-backend@npm:0.24.3 (npm:^0.24.3)`
-       └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
-               └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.1 (npm:^6.0.0)`
-
-
 Workspaces: acr
 └─ `@backstage/plugin-auth-backend@npm:0.24.4 (npm:^0.24.3)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
-Workspaces: airbrake, announcements, azure-sites, azure-storage-explorer, bazaar, blackduck, cicd-statistics, confluence, copilot, entity-feedback, explore, github-actions, jaeger, jenkins, linguist, linkerd, mend, nomad, npm, periskop, playlist, rollbar, sentry, sonarqube, tech-radar, vault
+Workspaces: airbrake, announcements, azure-devops, azure-sites, azure-storage-explorer, bazaar, blackduck, cicd-statistics, confluence, copilot, entity-feedback, explore, github-actions, jaeger, jenkins, linguist, linkerd, mend, nomad, npm, periskop, playlist, rollbar, sentry, sonarqube, tech-radar, vault
 └─ `@backstage/plugin-auth-backend@npm:0.24.4 (npm:^0.24.4)`
        └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
                └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.0 (npm:^6.0.0)`
+                       └─ `xml-crypto@npm:6.1.0 (npm:^6.0.0)`
 
 
-Workspaces: azure-devops
-└─ `@backstage/plugin-auth-backend@npm:0.24.4 (npm:^0.24.4)`
-       └─ `@node-saml/passport-saml@npm:5.0.0 (npm:^5.0.0)`
-               └─ `@node-saml/node-saml@npm:5.0.0 (npm:^5.0.0)`
-                       └─ `xml-crypto@npm:6.0.1 (npm:^6.0.0)`
-
-
```
<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
