### PR TITLE
Make FactRetrieverContext generic to support context extension

### DIFF
--- a/workspaces/tech-insights/.changeset/healthy-cats-visit.md
+++ b/workspaces/tech-insights/.changeset/healthy-cats-visit.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-node': minor
+---
+
+Make FactRetrieverContext generic. This allows consumers to extend it with their own services while maintaining backwards compatibility.

--- a/workspaces/tech-insights/plugins/tech-insights-node/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/report.api.md
@@ -55,12 +55,14 @@ export interface FactCheckerFactory<
 export type FactLifecycle = TTL | MaxItems;
 
 // @public
-export interface FactRetriever {
+export interface FactRetriever<
+  TContext extends FactRetrieverContext = FactRetrieverContext,
+> {
   description?: string;
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
     | Record<string, string | symbol | (string | symbol)[]>;
-  handler: (ctx: FactRetrieverContext) => Promise<TechInsightFact[]>;
+  handler: (ctx: TContext) => Promise<TechInsightFact[]>;
   id: string;
   schema: FactSchema;
   title?: string;
@@ -68,7 +70,7 @@ export interface FactRetriever {
 }
 
 // @public
-export type FactRetrieverContext = {
+export type FactRetrieverContext<TExtension = {}> = {
   config: Config;
   discovery: DiscoveryService;
   logger: LoggerService;
@@ -77,11 +79,13 @@ export type FactRetrieverContext = {
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
     | Record<string, string | symbol | (string | symbol)[]>;
-};
+} & TExtension;
 
 // @public
-export type FactRetrieverRegistration = {
-  factRetriever: FactRetriever;
+export type FactRetrieverRegistration<
+  TContext extends FactRetrieverContext = FactRetrieverContext,
+> = {
+  factRetriever: FactRetriever<TContext>;
   cadence?: string;
   timeout?: Duration | HumanDuration;
   lifecycle?: FactLifecycle;
@@ -99,7 +103,9 @@ export interface FactRetrieverRegistry {
   // (undocumented)
   listRetrievers(): Promise<FactRetriever[]>;
   // (undocumented)
-  register(registration: FactRetrieverRegistration): Promise<void>;
+  register<TContext extends FactRetrieverContext = FactRetrieverContext>(
+    registration: FactRetrieverRegistration<TContext>,
+  ): Promise<void>;
 }
 
 // @public

--- a/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-node/src/facts.ts
@@ -89,7 +89,7 @@ export type FlatTechInsightFact = TechInsightFact & {
  * The context can be used to construct logic to retrieve entities, contact integration points
  * and fetch and calculate fact values from external sources.
  */
-export type FactRetrieverContext = {
+export type FactRetrieverContext<TExtension = {}> = {
   config: Config;
   discovery: DiscoveryService;
   logger: LoggerService;
@@ -98,14 +98,16 @@ export type FactRetrieverContext = {
   entityFilter?:
     | Record<string, string | symbol | (string | symbol)[]>[]
     | Record<string, string | symbol | (string | symbol)[]>;
-};
+} & TExtension;
 
 /**
  * FactRetriever interface
  *
  * @public
  */
-export interface FactRetriever {
+export interface FactRetriever<
+  TContext extends FactRetrieverContext = FactRetrieverContext,
+> {
   /**
    * A unique identifier of the retriever.
    * Used to identify and store individual facts returned from this retriever
@@ -137,7 +139,7 @@ export interface FactRetriever {
    * @param ctx - FactRetrieverContext which can be used to retrieve config and contact integrations
    * @returns - A collection of TechInsightFacts grouped by entities.
    */
-  handler: (ctx: FactRetrieverContext) => Promise<TechInsightFact[]>;
+  handler: (ctx: TContext) => Promise<TechInsightFact[]>;
 
   /**
    * A fact schema defining the shape of data returned from the handler method for each entity
@@ -199,11 +201,13 @@ export type FactSchemaDefinition = Omit<FactRetriever, 'handler'>;
  *
  * @public
  */
-export type FactRetrieverRegistration = {
+export type FactRetrieverRegistration<
+  TContext extends FactRetrieverContext = FactRetrieverContext,
+> = {
   /**
    * Actual FactRetriever implementation
    */
-  factRetriever: FactRetriever;
+  factRetriever: FactRetriever<TContext>;
 
   /**
    * Cron expression to indicate when the retriever should be triggered.
@@ -238,7 +242,9 @@ export type FactRetrieverRegistration = {
  * @public
  */
 export interface FactRetrieverRegistry {
-  register(registration: FactRetrieverRegistration): Promise<void>;
+  register<TContext extends FactRetrieverContext = FactRetrieverContext>(
+    registration: FactRetrieverRegistration<TContext>,
+  ): Promise<void>;
   get(retrieverReference: string): Promise<FactRetrieverRegistration>;
   listRetrievers(): Promise<FactRetriever[]>;
   listRegistrations(): Promise<FactRetrieverRegistration[]>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously, the Tech Insights plugin only supported a fixed set of services in the FactRetrieverContext. This change enables plugin consumers to pass additional custom services into their FactRetriever implementations without modifying the core plugin code, improving extensibility while preserving the plugin's API contract.

* update `FactRetrieverContext` to accept a generic extension type
* make `FactRetriever` interface generic to work with extended context types
* update FactRetrieverRegistration and FactRetrieverRegistry to support generic typing

### Example

```ts
type MyCustomFactRetrieverContext = FactRetrieverContext<{
  customService: MyCustomService;
}>;

handler: async ({ discovery, entityFilter, auth, ..., customService }: MyCustomFactRetrieverContext) => {
   ....

   const somethingCustom = customService.doSomething()
   ...   
}
```

### Alternative

We wrap the creation of the FactRetriever with a factory function that takes our internal `serviceRefs`. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
