### PR TITLE
Fix bug in `api.listBranches` call pagination to start from page 1

### DIFF
--- a/workspaces/github-actions/.changeset/shiny-goats-compete.md
+++ b/workspaces/github-actions/.changeset/shiny-goats-compete.md
@@ -2,6 +2,4 @@
 '@backstage-community/plugin-github-actions': patch
 ---
 
-Fix bug in `api.listBranches` call pagination to start from page 1
-Iterating from page 0 results in a duplicated branch list in the
-WorkflowRunsCard filter
+Start pagination at page 1 in `api.listBranches` to avoid duplicate branches in WorkflowRunsCard.

--- a/workspaces/github-actions/.changeset/shiny-goats-compete.md
+++ b/workspaces/github-actions/.changeset/shiny-goats-compete.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-github-actions': patch
+---
+
+Fix bug in `api.listBranches` call pagination to start from page 1
+Iterating from page 0 results in a duplicated branch list in the
+WorkflowRunsCard filter

--- a/workspaces/github-actions/plugins/github-actions/src/components/useWorkflowRuns.ts
+++ b/workspaces/github-actions/plugins/github-actions/src/components/useWorkflowRuns.ts
@@ -80,7 +80,7 @@ export function useWorkflowRuns({
 
     const fetchBranches = async () => {
       let next = true;
-      let iteratePage = 0;
+      let iteratePage = 1;
       const branchSet: Branch[] = [];
 
       while (next) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Fix bug in `api.listBranches` call pagination to start from page 1

Iterating from page 0 results in a duplicated branch list in the **`WorkflowRunsCard`** filter
(`WorkflowRunsTable` is not impacted by this bug or this fix)

reference: [GitHub REST API - list branches ](https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#list-branches)

Other GitHub API calls in useWorkflowRuns() already start from page 1, this call was apparently missed.
This issue is more noticeable with fewer branches since the duplicates are obvious without scrolling.

![image](https://github.com/user-attachments/assets/d4743d99-b74a-46b3-a031-af5e466503b0)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
