### PR TITLE
Version Packages (mta)

### DIFF
--- a/workspaces/mta/.changeset/loud-zebras-applaud.md
+++ b/workspaces/mta/.changeset/loud-zebras-applaud.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update Backstage to v1.36.1

--- a/workspaces/mta/.changeset/moody-tables-clap.md
+++ b/workspaces/mta/.changeset/moody-tables-clap.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.33.6

--- a/workspaces/mta/.changeset/serious-spiders-leave.md
+++ b/workspaces/mta/.changeset/serious-spiders-leave.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.31.3

--- a/workspaces/mta/.changeset/short-cherries-sip.md
+++ b/workspaces/mta/.changeset/short-cherries-sip.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.34.2

--- a/workspaces/mta/.changeset/spotty-icons-brush.md
+++ b/workspaces/mta/.changeset/spotty-icons-brush.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.37.1

--- a/workspaces/mta/.changeset/weak-spiders-draw.md
+++ b/workspaces/mta/.changeset/weak-spiders-draw.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.32.5

--- a/workspaces/mta/.changeset/wise-yaks-drum.md
+++ b/workspaces/mta/.changeset/wise-yaks-drum.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': minor
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': minor
-'@backstage-community/backstage-plugin-mta-frontend': minor
-'@backstage-community/backstage-plugin-mta-backend': minor
----
-
-update to Backstage v1.35.1

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider
 
+## 0.3.0
+
+### Minor Changes
+
+- 8a364c5: update Backstage to v1.36.1
+- 63609e9: update to Backstage v1.33.6
+- 03dde0e: update to Backstage v1.31.3
+- 440ab1a: update to Backstage v1.34.2
+- fea01d4: update to Backstage v1.37.1
+- 3a64cc5: update to Backstage v1.32.5
+- 8a364c5: update to Backstage v1.35.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider",
   "description": "The mta-entity-provider backend module for the catalog plugin.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-backend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/backstage-plugin-mta-backend
 
+## 0.4.0
+
+### Minor Changes
+
+- 8a364c5: update Backstage to v1.36.1
+- 63609e9: update to Backstage v1.33.6
+- 03dde0e: update to Backstage v1.31.3
+- 440ab1a: update to Backstage v1.34.2
+- fea01d4: update to Backstage v1.37.1
+- 3a64cc5: update to Backstage v1.32.5
+- 8a364c5: update to Backstage v1.35.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/mta-backend/package.json
+++ b/workspaces/mta/plugins/mta-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-backend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/backstage-plugin-mta-frontend
 
+## 0.3.0
+
+### Minor Changes
+
+- 8a364c5: update Backstage to v1.36.1
+- 63609e9: update to Backstage v1.33.6
+- 03dde0e: update to Backstage v1.31.3
+- 440ab1a: update to Backstage v1.34.2
+- fea01d4: update to Backstage v1.37.1
+- 3a64cc5: update to Backstage v1.32.5
+- 8a364c5: update to Backstage v1.35.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/mta-frontend/package.json
+++ b/workspaces/mta/plugins/mta-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-frontend",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/backstage-plugin-scaffolder-backend-module-mta
 
+## 0.4.0
+
+### Minor Changes
+
+- 8a364c5: update Backstage to v1.36.1
+- 63609e9: update to Backstage v1.33.6
+- 03dde0e: update to Backstage v1.31.3
+- 440ab1a: update to Backstage v1.34.2
+- fea01d4: update to Backstage v1.37.1
+- 3a64cc5: update to Backstage v1.32.5
+- 8a364c5: update to Backstage v1.35.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-scaffolder-backend-module-mta",
   "description": "The mta module for @backstage/plugin-scaffolder-backend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider@0.3.0

### Minor Changes

-   8a364c5: update Backstage to v1.36.1
-   63609e9: update to Backstage v1.33.6
-   03dde0e: update to Backstage v1.31.3
-   440ab1a: update to Backstage v1.34.2
-   fea01d4: update to Backstage v1.37.1
-   3a64cc5: update to Backstage v1.32.5
-   8a364c5: update to Backstage v1.35.1

## @backstage-community/backstage-plugin-mta-backend@0.4.0

### Minor Changes

-   8a364c5: update Backstage to v1.36.1
-   63609e9: update to Backstage v1.33.6
-   03dde0e: update to Backstage v1.31.3
-   440ab1a: update to Backstage v1.34.2
-   fea01d4: update to Backstage v1.37.1
-   3a64cc5: update to Backstage v1.32.5
-   8a364c5: update to Backstage v1.35.1

## @backstage-community/backstage-plugin-mta-frontend@0.3.0

### Minor Changes

-   8a364c5: update Backstage to v1.36.1
-   63609e9: update to Backstage v1.33.6
-   03dde0e: update to Backstage v1.31.3
-   440ab1a: update to Backstage v1.34.2
-   fea01d4: update to Backstage v1.37.1
-   3a64cc5: update to Backstage v1.32.5
-   8a364c5: update to Backstage v1.35.1

## @backstage-community/backstage-plugin-scaffolder-backend-module-mta@0.4.0

### Minor Changes

-   8a364c5: update Backstage to v1.36.1
-   63609e9: update to Backstage v1.33.6
-   03dde0e: update to Backstage v1.31.3
-   440ab1a: update to Backstage v1.34.2
-   fea01d4: update to Backstage v1.37.1
-   3a64cc5: update to Backstage v1.32.5
-   8a364c5: update to Backstage v1.35.1
