### PR TITLE
rbac: add file extension while importing `getInnerSchemaForArrayItem`

### DIFF
--- a/workspaces/rbac/.changeset/metal-elephants-remain.md
+++ b/workspaces/rbac/.changeset/metal-elephants-remain.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+resolve module import error while importing from `@rjsf/utils/lib/schema/getDefaultFormState`

--- a/workspaces/rbac/plugins/rbac/src/components/ConditionalAccess/CustomArrayField.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/ConditionalAccess/CustomArrayField.tsx
@@ -19,7 +19,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { getDefaultRegistry } from '@rjsf/core';
 import { FieldProps } from '@rjsf/utils';
-import { getInnerSchemaForArrayItem } from '@rjsf/utils/lib/schema/getDefaultFormState';
+import { getInnerSchemaForArrayItem } from '@rjsf/utils/lib/schema/getDefaultFormState.js';
 
 export const CustomArrayField = (props: FieldProps) => {
   const { name, required, schema: sch, formData, onChange } = props;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Starting from version `v5.24.7`, `@rjsf/utils` defines [explicit exports](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/package.json#L8) in its `package.json`. 

Since `getInnerSchemaForArrayItem` is not directly exported by the package, attempting to import it using a deep path without a file extension may lead to module resolution errors.

A potential fix is to update the import to:

```js
import { getInnerSchemaForArrayItem } from '@rjsf/utils/lib/schema/getDefaultFormState.js';
```
This matches the allowed `"import": "./lib/*.js"` pattern defined in the [exports field](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/package.json#L21), which should potentially resolve the issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
