### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/shiny-goats-compete.md
+++ b/workspaces/github-actions/.changeset/shiny-goats-compete.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Start pagination at page 1 in `api.listBranches` to avoid duplicate branches in WorkflowRunsCard.

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 0.9.2
+
+### Patch Changes
+
+- 58c5ad5: Start pagination at page 1 in `api.listBranches` to avoid duplicate branches in WorkflowRunsCard.
+
 ## 0.9.1
 
 ### Patch Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.9.2

### Patch Changes

-   58c5ad5: Start pagination at page 1 in `api.listBranches` to avoid duplicate branches in WorkflowRunsCard.
