### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/loud-plums-cross.md
+++ b/workspaces/ocm/.changeset/loud-plums-cross.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
-'@backstage-community/plugin-ocm-common': patch
-'@backstage-community/plugin-ocm': patch
----
-
-remove @spotify/prettier-config direct dependency

--- a/workspaces/ocm/.changeset/renovate-cf9f02f.md
+++ b/workspaces/ocm/.changeset/renovate-cf9f02f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.19.1`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 5.5.4
+
+### Patch Changes
+
+- 1ac3b94: remove @spotify/prettier-config direct dependency
+- 5d032e5: Updated dependency `@openapitools/openapi-generator-cli` to `2.19.1`.
+- Updated dependencies [1ac3b94]
+  - @backstage-community/plugin-ocm-common@3.8.3
+
 ## 5.5.3
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.8.3
+
+### Patch Changes
+
+- 1ac3b94: remove @spotify/prettier-config direct dependency
+
 ## 3.8.2
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.4.4
+
+### Patch Changes
+
+- 1ac3b94: remove @spotify/prettier-config direct dependency
+- Updated dependencies [1ac3b94]
+  - @backstage-community/plugin-ocm-common@3.8.3
+
 ## 5.4.3
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.4.4

### Patch Changes

-   1ac3b94: remove @spotify/prettier-config direct dependency
-   Updated dependencies [1ac3b94]
    -   @backstage-community/plugin-ocm-common@3.8.3

## @backstage-community/plugin-ocm-backend@5.5.4

### Patch Changes

-   1ac3b94: remove @spotify/prettier-config direct dependency
-   5d032e5: Updated dependency `@openapitools/openapi-generator-cli` to `2.19.1`.
-   Updated dependencies [1ac3b94]
    -   @backstage-community/plugin-ocm-common@3.8.3

## @backstage-community/plugin-ocm-common@3.8.3

### Patch Changes

-   1ac3b94: remove @spotify/prettier-config direct dependency
