### PR TITLE
Version Packages (copilot)

### DIFF
--- a/workspaces/copilot/.changeset/grumpy-garlics-shop.md
+++ b/workspaces/copilot/.changeset/grumpy-garlics-shop.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-copilot-backend': patch
-'@backstage-community/plugin-copilot-common': patch
-'@backstage-community/plugin-copilot': patch
----
-
-- Upgraded to Backstage release 1.38
-- Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)

--- a/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-copilot-backend
 
+## 0.9.1
+
+### Patch Changes
+
+- cd78d85: - Upgraded to Backstage release 1.38
+  - Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
+- Updated dependencies [cd78d85]
+  - @backstage-community/plugin-copilot-common@0.9.1
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot-backend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "homepage": "https://backstage.io",
   "license": "Apache-2.0",
   "main": "src/index.ts",

--- a/workspaces/copilot/plugins/copilot-common/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-copilot-common
 
+## 0.9.1
+
+### Patch Changes
+
+- cd78d85: - Upgraded to Backstage release 1.38
+  - Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/copilot/plugins/copilot-common/package.json
+++ b/workspaces/copilot/plugins/copilot-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-copilot-common",
   "description": "Common functionalities for the copilot plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/copilot/plugins/copilot/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-copilot
 
+## 0.9.2
+
+### Patch Changes
+
+- cd78d85: - Upgraded to Backstage release 1.38
+  - Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
+- Updated dependencies [cd78d85]
+  - @backstage-community/plugin-copilot-common@0.9.1
+
 ## 0.9.1
 
 ### Patch Changes

--- a/workspaces/copilot/plugins/copilot/package.json
+++ b/workspaces/copilot/plugins/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-copilot@0.9.2

### Patch Changes

-   cd78d85: - Upgraded to Backstage release 1.38
    -   Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
-   Updated dependencies [cd78d85]
    -   @backstage-community/plugin-copilot-common@0.9.1

## @backstage-community/plugin-copilot-backend@0.9.1

### Patch Changes

-   cd78d85: - Upgraded to Backstage release 1.38
    -   Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
-   Updated dependencies [cd78d85]
    -   @backstage-community/plugin-copilot-common@0.9.1

## @backstage-community/plugin-copilot-common@0.9.1

### Patch Changes

-   cd78d85: - Upgraded to Backstage release 1.38
    -   Applied migration to the [New JXS Transform](https://backstage.io/docs/tutorials/jsx-transform-migration/)
