### PR TITLE
Version Packages (jaeger)

### DIFF
--- a/workspaces/jaeger/.changeset/version-bump-1-37-0.md
+++ b/workspaces/jaeger/.changeset/version-bump-1-37-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jaeger': minor
-'@backstage-community/plugin-jaeger-common': minor
----
-
-Backstage version bump to v1.37.0

--- a/workspaces/jaeger/.changeset/version-bump-1-38-1.md
+++ b/workspaces/jaeger/.changeset/version-bump-1-38-1.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jaeger': minor
-'@backstage-community/plugin-jaeger-common': minor
----
-
-Backstage version bump to v1.38.1

--- a/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-jaeger-common
 
+## 0.5.0
+
+### Minor Changes
+
+- e3bbfb6: Backstage version bump to v1.37.0
+- 39cbb61: Backstage version bump to v1.38.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/jaeger/plugins/jaeger-common/package.json
+++ b/workspaces/jaeger/plugins/jaeger-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-jaeger-common",
   "description": "Common functionalities for the jaeger plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-jaeger
 
+## 0.5.0
+
+### Minor Changes
+
+- e3bbfb6: Backstage version bump to v1.37.0
+- 39cbb61: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [e3bbfb6]
+- Updated dependencies [39cbb61]
+  - @backstage-community/plugin-jaeger-common@0.5.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/jaeger/plugins/jaeger/package.json
+++ b/workspaces/jaeger/plugins/jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jaeger",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jaeger@0.5.0

### Minor Changes

-   e3bbfb6: Backstage version bump to v1.37.0
-   39cbb61: Backstage version bump to v1.38.1

### Patch Changes

-   Updated dependencies [e3bbfb6]
-   Updated dependencies [39cbb61]
    -   @backstage-community/plugin-jaeger-common@0.5.0

## @backstage-community/plugin-jaeger-common@0.5.0

### Minor Changes

-   e3bbfb6: Backstage version bump to v1.37.0
-   39cbb61: Backstage version bump to v1.38.1
