### PR TITLE
version-bump - Resolved warning for deprecated feature

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -59,7 +59,7 @@ jobs:
       - name: find location of global yarn cache
         id: yarn-cache
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: cache global yarn cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.cache-modules.outputs.cache-hit != 'true'
@@ -97,7 +97,7 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: Run dedupe
         working-directory: ./workspaces/${{ matrix.workspace }}
-        run: yarn dedupe    
+        run: yarn dedupe   
       - name: 'Check for changes'
         id: check_for_changes
         run: |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolved warning for deprecated feature, followed this doc: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
