### PR TITLE
chore(rbac): Remove usage of @spotify/prettier-config (#2477)

### DIFF
--- a/workspaces/rbac/.changeset/tidy-experts-pay.md
+++ b/workspaces/rbac/.changeset/tidy-experts-pay.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+'@backstage-community/plugin-rbac-common': patch
+'@backstage-community/plugin-rbac-node': patch
+'@backstage-community/plugin-rbac': patch
+---
+
+chore: Remove usage of @spotify/prettier-config

--- a/workspaces/rbac/.prettierrc.js
+++ b/workspaces/rbac/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/rbac/package.json
+++ b/workspaces/rbac/package.json
@@ -40,7 +40,6 @@
     "@backstage/repo-tools": "^0.13.2",
     "@changesets/cli": "^2.27.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
-    "@spotify/prettier-config": "^15.0.0",
     "knip": "^5.27.4",
     "node-gyp": "^9.0.0",
     "prettier": "^3.3.3",
@@ -51,7 +50,7 @@
     "@types/react-dom": "^18",
     "prettier": "3.x.x"
   },
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/rbac/plugins/rbac-backend/.prettierrc.js
+++ b/workspaces/rbac/plugins/rbac-backend/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -63,7 +63,6 @@
     "@backstage/config": "^1.3.2",
     "@backstage/core-plugin-api": "^1.10.6",
     "@backstage/types": "^1.2.1",
-    "@spotify/prettier-config": "^15.0.0",
     "@types/express": "4.17.21",
     "@types/knex": "^0.16.1",
     "@types/lodash": "^4.14.151",
@@ -95,7 +94,7 @@
     "@PatAKnight"
   ],
   "author": "Red Hat",
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/rbac/plugins/rbac-common/.prettierrc.js
+++ b/workspaces/rbac/plugins/rbac-common/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -43,7 +43,6 @@
     "@backstage/cli": "^0.32.0",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-permission-common": "^0.8.4",
-    "@spotify/prettier-config": "^15.0.0",
     "prettier": "^3.3.3"
   },
   "files": [
@@ -65,7 +64,7 @@
     "@PatAKnight"
   ],
   "author": "Red Hat",
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/rbac/plugins/rbac-node/.prettierrc.js
+++ b/workspaces/rbac/plugins/rbac-node/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -34,8 +34,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.32.0",
-    "@spotify/prettier-config": "^15.0.0"
+    "@backstage/cli": "^0.32.0"
   },
   "files": [
     "dist"
@@ -57,7 +56,7 @@
     "support:production",
     "lifecycle:active"
   ],
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/rbac/plugins/rbac/.prettierrc.js
+++ b/workspaces/rbac/plugins/rbac/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -69,7 +69,6 @@
     "@backstage/test-utils": "^1.7.7",
     "@playwright/test": "1.51.1",
     "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
-    "@spotify/prettier-config": "^15.0.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
@@ -104,7 +103,7 @@
     "@PatAKnight"
   ],
   "author": "Red Hat",
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/rbac/yarn.lock
+++ b/workspaces/rbac/yarn.lock
@@ -2707,7 +2707,6 @@ __metadata:
     "@backstage/plugin-permission-node": "npm:^0.9.1"
     "@backstage/types": "npm:^1.2.1"
     "@dagrejs/graphlib": "npm:^2.1.13"
-    "@spotify/prettier-config": "npm:^15.0.0"
     "@types/express": "npm:4.17.21"
     "@types/knex": "npm:^0.16.1"
     "@types/lodash": "npm:^4.14.151"
@@ -2737,7 +2736,6 @@ __metadata:
     "@backstage/cli": "npm:^0.32.0"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@spotify/prettier-config": "npm:^15.0.0"
     prettier: "npm:^3.3.3"
   peerDependencies:
     "@backstage/errors": ^1.2.7
@@ -2751,7 +2749,6 @@ __metadata:
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.3.0"
     "@backstage/cli": "npm:^0.32.0"
-    "@spotify/prettier-config": "npm:^15.0.0"
   languageName: unknown
   linkType: soft
 
@@ -2782,7 +2779,6 @@ __metadata:
     "@rjsf/mui": "npm:^5.21.2"
     "@rjsf/utils": "npm:^5.21.2"
     "@rjsf/validator-ajv8": "npm:^5.21.2"
-    "@spotify/prettier-config": "npm:^15.0.0"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -7182,7 +7178,6 @@ __metadata:
     "@backstage/repo-tools": "npm:^0.13.2"
     "@changesets/cli": "npm:^2.27.1"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.3.1"
-    "@spotify/prettier-config": "npm:^15.0.0"
     knip: "npm:^5.27.4"
     node-gyp: "npm:^9.0.0"
     prettier: "npm:^3.3.3"
@@ -11462,15 +11457,6 @@ __metadata:
     "@typescript-eslint/parser": ">=5"
     eslint: ">=8.x"
   checksum: 10/33627cff3a7ff6360cd73e26d28c50b3a49cc027716e1e0044187cad1fbfd6f9da13c83d2ae16bffa4755c8004f2ee9dafa4d520906905a8c9a7209987c93e5d
-  languageName: node
-  linkType: hard
-
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: 10/ba91f65bc4ee884e8afa0b99eacb1fac27043efa0915ead007af571d66a0f53462d2a65f33e01d3b6e10a804b60ed2957708f939850bc6071e2d28f0e277ab7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Relates to #2477

> In the 1.34.0 release of Backstage the CLI now ships with a replacement for @spotify/prettier-config. Given this change we should remove all usages of @spotify/prettier-config.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
