### PR TITLE
chore(quay): Remove usage of @spotify/prettier-config (#2477)

### DIFF
--- a/workspaces/quay/.changeset/blue-carrots-crash.md
+++ b/workspaces/quay/.changeset/blue-carrots-crash.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-quay': patch
+'@backstage-community/plugin-quay-backend': patch
+'@backstage-community/plugin-quay-common': patch
+'@backstage-community/plugin-quay': patch
+---
+
+chore: Remove usage of @spotify/prettier-config

--- a/workspaces/quay/plugins/quay-actions/.prettierrc.js
+++ b/workspaces/quay/plugins/quay-actions/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -45,8 +45,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.30.0",
-    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.19",
-    "@spotify/prettier-config": "^15.0.0"
+    "@backstage/plugin-scaffolder-node-test-utils": "^0.1.19"
   },
   "files": [
     "dist"

--- a/workspaces/quay/plugins/quay-backend/.prettierrc.js
+++ b/workspaces/quay/plugins/quay-backend/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/quay/plugins/quay-common/.prettierrc.js
+++ b/workspaces/quay/plugins/quay-common/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -60,7 +60,6 @@
   "devDependencies": {
     "@backstage/cli": "^0.30.0",
     "@backstage/plugin-permission-common": "^0.8.4",
-    "@spotify/prettier-config": "^15.0.0",
     "@types/react": "^18.2.58",
     "react": "16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/quay/plugins/quay/.prettierrc.js
+++ b/workspaces/quay/plugins/quay/.prettierrc.js
@@ -16,7 +16,7 @@
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-  ...require('@spotify/prettier-config'),
+  ...require('@backstage/cli/config/prettier'),
   plugins: ['@ianvs/prettier-plugin-sort-imports'],
   importOrder: [
     '^react(.*)$',

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -63,7 +63,6 @@
     "@backstage/test-utils": "^1.7.5",
     "@playwright/test": "1.51.1",
     "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
-    "@spotify/prettier-config": "^15.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react": "^18.2.58",

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -2667,7 +2667,6 @@ __metadata:
   dependencies:
     "@backstage/cli": "npm:^0.30.0"
     "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@spotify/prettier-config": "npm:^15.0.0"
     "@types/react": "npm:^18.2.58"
     react: "npm:16.13.1 || ^17.0.0 || ^18.0.0"
     react-dom: "npm:16.13.1 || ^17.0.0 || ^18.0.0"
@@ -2700,7 +2699,6 @@ __metadata:
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@playwright/test": "npm:1.51.1"
     "@redhat-developer/red-hat-developer-hub-theme": "npm:0.4.0"
-    "@spotify/prettier-config": "npm:^15.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^18.2.58"
@@ -2727,7 +2725,6 @@ __metadata:
     "@backstage/cli": "npm:^0.30.0"
     "@backstage/plugin-scaffolder-node": "npm:^0.7.0"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.1.19"
-    "@spotify/prettier-config": "npm:^15.0.0"
     yaml: "npm:^2.6.0"
   languageName: unknown
   linkType: soft
@@ -11318,15 +11315,6 @@ __metadata:
     "@typescript-eslint/parser": ">=5"
     eslint: ">=8.x"
   checksum: 10/33627cff3a7ff6360cd73e26d28c50b3a49cc027716e1e0044187cad1fbfd6f9da13c83d2ae16bffa4755c8004f2ee9dafa4d520906905a8c9a7209987c93e5d
-  languageName: node
-  linkType: hard
-
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: 10/ba91f65bc4ee884e8afa0b99eacb1fac27043efa0915ead007af571d66a0f53462d2a65f33e01d3b6e10a804b60ed2957708f939850bc6071e2d28f0e277ab7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Relates to #2477

> In the 1.34.0 release of Backstage the CLI now ships with a replacement for @spotify/prettier-config. Given this change we should remove all usages of @spotify/prettier-config.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
