### PR TITLE
chore(mta): Remove usage of @spotify/prettier-config (#2477)

### DIFF
--- a/workspaces/mta/package.json
+++ b/workspaces/mta/package.json
@@ -44,7 +44,6 @@
     "@backstage/repo-tools": "^0.13.1",
     "@changesets/cli": "^2.27.7",
     "@playwright/test": "^1.32.3",
-    "@spotify/prettier-config": "^15.0.0",
     "knip": "^5.27.4",
     "lerna": "^7.3.0",
     "node-gyp": "^9.0.0",
@@ -55,7 +54,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18"
   },
-  "prettier": "@spotify/prettier-config",
+  "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",

--- a/workspaces/mta/yarn.lock
+++ b/workspaces/mta/yarn.lock
@@ -7297,7 +7297,6 @@ __metadata:
     "@backstage/repo-tools": "npm:^0.13.1"
     "@changesets/cli": "npm:^2.27.7"
     "@playwright/test": "npm:^1.32.3"
-    "@spotify/prettier-config": "npm:^15.0.0"
     dotenv: "npm:^16.4.5"
     knip: "npm:^5.27.4"
     lerna: "npm:^7.3.0"
@@ -11639,15 +11638,6 @@ __metadata:
     "@typescript-eslint/parser": ">=5"
     eslint: ">=8.x"
   checksum: 10/33627cff3a7ff6360cd73e26d28c50b3a49cc027716e1e0044187cad1fbfd6f9da13c83d2ae16bffa4755c8004f2ee9dafa4d520906905a8c9a7209987c93e5d
-  languageName: node
-  linkType: hard
-
-"@spotify/prettier-config@npm:^15.0.0":
-  version: 15.0.0
-  resolution: "@spotify/prettier-config@npm:15.0.0"
-  peerDependencies:
-    prettier: 2.x
-  checksum: 10/ba91f65bc4ee884e8afa0b99eacb1fac27043efa0915ead007af571d66a0f53462d2a65f33e01d3b6e10a804b60ed2957708f939850bc6071e2d28f0e277ab7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Relates to #2477

> In the 1.34.0 release of Backstage the CLI now ships with a replacement for @spotify/prettier-config. Given this change we should remove all usages of @spotify/prettier-config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
