### PR TITLE
ci: create auto-version-bump workflow

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,47 @@
+name: Auto Version Bump
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Generate workspace matrix
+        id: set-matrix
+        run: |
+          matrix=$(node scripts/ci/generate-auto-bump-matrix.js)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  batch-dispatch:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Delay batches (5 min between)
+        if: ${{ strategy.job-index != 0 }}
+        run: |
+          delay=$(( strategy.job-index * 300 ))
+          echo "Sleeping $delay seconds before triggering batch ${{ strategy.job-index }}..."
+          sleep $delay
+
+      - name: Trigger Version Bump Workflow via GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Triggering version bump for batch ${{ strategy.job-index }}"
+          gh workflow run version-bump.yml \
+            --ref main \
+            --field release_line=main \
+            --field workspace_input="${{ toJson(matrix.batch) }}" \
+            --field version-bump-type=minor

--- a/scripts/ci/generate-auto-bump-matrix.js
+++ b/scripts/ci/generate-auto-bump-matrix.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { log } from 'console';
+import fs from 'fs';
+import path from 'path';
+
+const workspacesDir = path.resolve('workspaces');
+
+function getWorkspaceDirs() {
+  return fs.readdirSync(workspacesDir).filter(entry => {
+    const dirPath = path.join(workspacesDir, entry);
+    const bumpFile = path.join(dirPath, '.auto-version-bump');
+
+    return fs.statSync(dirPath).isDirectory() && fs.existsSync(bumpFile);
+  });
+}
+
+function batch(array) {
+  const BATCH_SIZE = 10;
+  const batchArray = [];
+
+  for (let i = 0; i < array.length; i += BATCH_SIZE) {
+    batchArray.push(array.slice(i, i + BATCH_SIZE));
+  }
+
+  return batchArray;
+}
+
+const workspaces = getWorkspaceDirs().sort();
+const batches = batch(workspaces);
+
+console.log(JSON.stringify({ batch: batches }));

--- a/scripts/ci/generate-auto-bump-matrix.js
+++ b/scripts/ci/generate-auto-bump-matrix.js
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { log } from 'console';
 import fs from 'fs';
 import path from 'path';
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a new GitHub Actions workflow (`auto-version-bump.yml`) to trigger version bumps based on workspaces with a `.auto-version-bump` file.

`generate-auto-bump-matrix.js` generates a matrix of workspaces that contain `.auto-version-bump` file, in batches of 10. Batches are triggered with a 5 minute delay to effort to avoid rate limit issues we hit before.

Initially, only the 'jfrog-artifactory' workspace has the `.auto-version-bump` file. This is to test the workflow and ensure it works as expected before adding to other workspaces.

Refs: https://github.com/backstage/community-plugins/issues/3231

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

---- 
Notes:
* For now, I've only added the `.auto-version-bump` to one workspace for testing purposes. Once landed and tested, I would then propose we add all @backstage/community-plugins-maintainers -owned workspaces.
* I did not implement the auto-trigger after n-days of the Backstage release yet - this is intentional to ensure we add/test the workflow in small increments to avoid the accidental mass triggering of incorrect PRs. 

Once landed/tested, the PR would provide the following benefits:
* Allow workspace owners to 'opt-in' to the creation of automatic versioning bump PRs. I think for some workspace owners this may be more sustainable than relying on workspace owners to remember to manually run the workflow.
* Provide a slight shortcut for `@backstage/community-plugins-maintainers` to trigger version bumps on workspaces owned by us. (Just one job to trigger versus manual batches/etc.).
