### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/proud-jobs-cross.md
+++ b/workspaces/sonarqube/.changeset/proud-jobs-cross.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': minor
----
-
-Switch from basic auth to recommended<sup>[[1]](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/web-api/#authenticate-to-api), [[2]](https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/web-api/#authenticate-to-api)</sup> bearer auth in order to also support SonarQube Cloud.
-
-Basic auth as used previously is exlusively [supported](https://docs.sonarsource.com/sonarqube-server/10.8/user-guide/managing-tokens/#using-a-token) by Sonarqube Server.

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [5399669]
+  - @backstage-community/plugin-sonarqube-backend@0.7.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- 5399669: Switch from basic auth to recommended<sup>[[1]](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/web-api/#authenticate-to-api), [[2]](https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/web-api/#authenticate-to-api)</sup> bearer auth in order to also support SonarQube Cloud.
+
+  Basic auth as used previously is exlusively [supported](https://docs.sonarsource.com/sonarqube-server/10.8/user-guide/managing-tokens/#using-a-token) by Sonarqube Server.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.7.0

### Minor Changes

-   5399669: Switch from basic auth to recommended<sup>[\[1\]](https://docs.sonarsource.com/sonarqube-cloud/advanced-setup/web-api/#authenticate-to-api), [\[2\]](https://docs.sonarsource.com/sonarqube-server/2025.1/extension-guide/web-api/#authenticate-to-api)</sup> bearer auth in order to also support SonarQube Cloud.

    Basic auth as used previously is exlusively [supported](https://docs.sonarsource.com/sonarqube-server/10.8/user-guide/managing-tokens/#using-a-token) by Sonarqube Server.

## backend@0.0.9

### Patch Changes

-   Updated dependencies [5399669]
    -   @backstage-community/plugin-sonarqube-backend@0.7.0
