### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/dry-terms-lay.md
+++ b/workspaces/kiali/.changeset/dry-terms-lay.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Support kiali > 1.86

--- a/workspaces/kiali/.changeset/odd-shirts-worry.md
+++ b/workspaces/kiali/.changeset/odd-shirts-worry.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Upgrade backstage to version 1.38.1

--- a/workspaces/kiali/.changeset/renovate-0a015cb.md
+++ b/workspaces/kiali/.changeset/renovate-0a015cb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `@playwright/test` to `1.51.1`.

--- a/workspaces/kiali/.changeset/renovate-5e37955.md
+++ b/workspaces/kiali/.changeset/renovate-5e37955.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `canvas` to `^3.0.0`.

--- a/workspaces/kiali/.changeset/renovate-80aa311.md
+++ b/workspaces/kiali/.changeset/renovate-80aa311.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `cytoscape` to `3.31.2`.

--- a/workspaces/kiali/.changeset/renovate-a43be6f.md
+++ b/workspaces/kiali/.changeset/renovate-a43be6f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.11`.

--- a/workspaces/kiali/.changeset/renovate-e2275d4.md
+++ b/workspaces/kiali/.changeset/renovate-e2275d4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `@patternfly/react-topology` to `5.4.1`.

--- a/workspaces/kiali/.changeset/strange-experts-punch.md
+++ b/workspaces/kiali/.changeset/strange-experts-punch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': patch
----
-
-remove prettier from devDependencies

--- a/workspaces/kiali/.changeset/tidy-eyes-wink.md
+++ b/workspaces/kiali/.changeset/tidy-eyes-wink.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': patch
-'@backstage-community/plugin-kiali': patch
----
-
-chore: remove homepage field from package.json

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.21.0
+
+### Minor Changes
+
+- f181693: Support kiali > 1.86
+- a428c5d: Upgrade backstage to version 1.38.1
+
+### Patch Changes
+
+- 973a5ef: remove prettier from devDependencies
+- f84ad73: chore: remove homepage field from package.json
+
 ## 1.20.1
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,21 @@
 ### Dependencies
 
+## 1.37.0
+
+### Minor Changes
+
+- f181693: Support kiali > 1.86
+- a428c5d: Upgrade backstage to version 1.38.1
+
+### Patch Changes
+
+- c31699d: Updated dependency `@playwright/test` to `1.51.1`.
+- d170116: Updated dependency `canvas` to `^3.0.0`.
+- 44ec099: Updated dependency `cytoscape` to `3.31.2`.
+- f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
+- 0d59491: Updated dependency `@patternfly/react-topology` to `5.4.1`.
+- f84ad73: chore: remove homepage field from package.json
+
 ## 1.36.4
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.36.4",
+  "version": "1.37.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.37.0

### Minor Changes

-   f181693: Support kiali > 1.86
-   a428c5d: Upgrade backstage to version 1.38.1

### Patch Changes

-   c31699d: Updated dependency `@playwright/test` to `1.51.1`.
-   d170116: Updated dependency `canvas` to `^3.0.0`.
-   44ec099: Updated dependency `cytoscape` to `3.31.2`.
-   f16f56e: Updated dependency `start-server-and-test` to `2.0.11`.
-   0d59491: Updated dependency `@patternfly/react-topology` to `5.4.1`.
-   f84ad73: chore: remove homepage field from package.json

## @backstage-community/plugin-kiali-backend@1.21.0

### Minor Changes

-   f181693: Support kiali > 1.86
-   a428c5d: Upgrade backstage to version 1.38.1

### Patch Changes

-   973a5ef: remove prettier from devDependencies
-   f84ad73: chore: remove homepage field from package.json
