### PR TITLE
Add timestamp to FactResponse so that it's included in CheckResults

### DIFF
--- a/workspaces/tech-insights/.changeset/real-shoes-yell.md
+++ b/workspaces/tech-insights/.changeset/real-shoes-yell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+Adds missing timestamp to the fact response produced when running checks. This is the timestamp of when the fact was produced by a fact retriever.

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
@@ -285,6 +285,7 @@ export class JsonRulesEngineFactChecker
             `Failed to determine tech insight check with id ${result.name}. Discrepancy between ran rule engine and configured checks.`,
           );
         }
+
         const factResponse = await this.constructFactInformationResponse(
           facts,
           techInsightCheck,
@@ -347,13 +348,17 @@ export class JsonRulesEngineFactChecker
       .filter(factContainer =>
         techInsightCheck.factIds.includes(factContainer.id),
       )
-      .reduce(
-        (acc, factContainer) => ({
+      .reduce((acc, factContainer) => {
+        const factWithTimestamp = {
+          ...factContainer.facts,
+          timestamp: factContainer.timestamp,
+        };
+
+        return {
           ...acc,
-          ...pick(factContainer.facts, individualFacts),
-        }),
-        {},
-      );
+          ...pick(factWithTimestamp, individualFacts),
+        };
+      }, {});
     return Object.entries(factValues).reduce((acc, [key, value]) => {
       return {
         ...acc,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It's possible to save the timestamp during fact generation, but I don't understand how to get that value on the frontend when calling `runChecks` on the fly. 

I've updated the code where I believe this to be the case.

Thanks!

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
