### PR TITLE
fix(rbac): use correct permission name when processing conditional policies

### DIFF
--- a/workspaces/rbac/.changeset/gorgeous-ducks-pretend.md
+++ b/workspaces/rbac/.changeset/gorgeous-ducks-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Fixes an issue where the correct permission name was not selected while processing new conditional policies to be added. This scenario happens whenever a plugin exports multiple permissions that have different resource types but similar actions. What would end up happening is the first matched action would be the one selected during processing even though it was not the correct permission and used for the conditional policy. This problem has been fixed and now the correct permission name and action are selected.

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -241,12 +241,19 @@ export async function processConditionMapping(
 
   const permInfo: PermissionInfo[] = [];
   for (const action of roleConditionPolicy.permissionMapping) {
-    const perm = rule.permissions.find(
-      permission =>
-        permission.type === 'resource' &&
-        (action === permission.attributes.action ||
-          (action === 'use' && permission.attributes.action === undefined)),
-    );
+    const perm = rule.permissions.find(permission => {
+      if (permission.type === 'resource') {
+        const isCorrectResourceType =
+          permission.resourceType === roleConditionPolicy.resourceType;
+        const isCorrectAction = action === permission.attributes.action;
+        const undefinedAction =
+          action === 'use' && permission.attributes.action === undefined;
+
+        return isCorrectResourceType && (isCorrectAction || undefinedAction);
+      }
+      return false;
+    });
+
     if (!perm) {
       throw new Error(
         `Unable to find permission to get permission name for resource type '${


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an issue where the incorrect permission name was selected during conditional policy processing. This largely happened whenever a plugin exported multiple permissions with similar actions. Incorrectly, we would just check for the first matching action and return the permission name from the list. Now, we check the resource type and then return the permission name.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
