### PR TITLE
fix(mssv): prevent patternfly css overrides

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/spotty-cows-applaud.md
+++ b/workspaces/multi-source-security-viewer/.changeset/spotty-cows-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-multi-source-security-viewer': patch
+---
+
+Fix issue where patternfly overrides plugin css

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '@patternfly/react-core/dist/styles/base-no-reset.css';
-import '@patternfly/patternfly/patternfly.css';
 
 import {
   configApiRef,

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import '@patternfly/patternfly/utilities/Accessibility/accessibility.css';
 import '@patternfly/react-core/dist/styles/base-no-reset.css';
 
 import {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes an issue where Patternfly was overriding the Jenkins plugin's CSS, leading to a larger icon:

![image](https://github.com/user-attachments/assets/bb494f4b-6b0b-433f-b158-f7acfd034ea0)

![image](https://github.com/user-attachments/assets/a6ed0c7f-51c0-489f-8691-913b12b10679)

Removing the base patternfly.css and leaving the base-no-reset css seems to fix this issue:

![image](https://github.com/user-attachments/assets/4d7b6bb9-8500-45c2-be53-a04d20e87383)

![image](https://github.com/user-attachments/assets/78de04f7-8e0f-4fe4-8484-eb2e59ed206f)

This looks to be a result of this patternfly css height attribute:

![image](https://github.com/user-attachments/assets/f6de5d6f-7418-40d9-b212-fb7c0c3e47ac)

You can see it in action below:

https://github.com/user-attachments/assets/18f54f6e-6a31-4dec-8379-ff98d37384eb


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
