### PR TITLE
fix(azure-devops): use strict build-definitions filtering

### DIFF
--- a/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
+++ b/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
@@ -1,6 +1,6 @@
 ---
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops': patch
+'@backstage-community/plugin-azure-devops-backend': minor
+'@backstage-community/plugin-azure-devops': minor
 ---
 
 If the specified build definition is not found, return no results and display a message explaining why.

--- a/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
+++ b/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-backend': patch
+---
+
+Do not return any results when the specified build definition is not found

--- a/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
+++ b/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
@@ -1,5 +1,6 @@
 ---
 '@backstage-community/plugin-azure-devops-backend': patch
+'@backstage-community/plugin-azure-devops': patch
 ---
 
-Do not return any results when the specified build definition is not found
+If the specified build definition is not found, return no results and display a message explaining why.

--- a/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
+++ b/workspaces/azure-devops/.changeset/popular-rabbits-prove.md
@@ -3,4 +3,4 @@
 '@backstage-community/plugin-azure-devops': minor
 ---
 
-If the specified build definition is not found, return no results and display a message explaining why.
+**BREAKING** If the specified build definition is not found, return no results and display a message explaining why.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.test.ts
@@ -800,6 +800,33 @@ describe('AzureDevOpsApi', () => {
     ]);
   });
 
+  it('should not return build runs if the build definition does not exist', async () => {
+    const mockBuildClient = {
+      getBuilds: jest.fn().mockResolvedValue([]),
+      getDefinitions: jest.fn().mockResolvedValue([]),
+    };
+
+    const mockApi = {
+      getBuildApi: jest.fn().mockReturnValue(mockBuildClient),
+    };
+
+    (WebApi as unknown as jest.Mock).mockImplementation(() => mockApi);
+
+    const api = AzureDevOpsApi.fromConfig(mockConfig, {
+      logger: mockLogger,
+      urlReader: mockUrlReader,
+    });
+
+    const result = await api.getBuildRuns(
+      'project',
+      10,
+      undefined,
+      'definition-not-exist',
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it('should get the build logs', async () => {
     const getBuildLogsResultMock = [
       {

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -545,6 +545,11 @@ export class AzureDevOpsApi {
         host,
         org,
       );
+
+      if (buildDefinitions.length === 0) {
+        return [];
+      }
+
       definitions = buildDefinitions
         .map(bd => bd.id)
         .filter((bd): bd is number => Boolean(bd));

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/BuildTable.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/BuildTable.tsx
@@ -227,6 +227,17 @@ export const BuildTable = ({ items, loading, error }: BuildTableProps) => {
     },
   ];
 
+  const emptyContent = (
+    <div>
+      <Typography component="p" align="center">
+        No records to display
+      </Typography>
+      <Typography component="p" align="center">
+        The repo name or build definition you have specified could not be found
+      </Typography>
+    </div>
+  );
+
   return (
     <>
       <Table
@@ -246,6 +257,7 @@ export const BuildTable = ({ items, loading, error }: BuildTableProps) => {
           </Box>
         }
         data={items ?? []}
+        emptyContent={emptyContent}
       />
 
       <BuildLogDrawer

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/BuildTable.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/BuildTable.tsx
@@ -39,6 +39,8 @@ import { AzurePipelinesIcon } from '../AzurePipelinesIcon';
 import { DateTime } from 'luxon';
 import { getDurationFromDates } from '../../utils/getDurationFromDates';
 import { BuildLogDrawer } from './lib/BuildLogDrawer';
+import { EmptyBuildResults } from './lib/EmptyBuildResults';
+import { Entity } from '@backstage/catalog-model';
 
 export const getBuildResultComponent = (result: number | undefined) => {
   switch (result) {
@@ -121,9 +123,15 @@ type BuildTableProps = {
   items?: BuildRun[];
   loading: boolean;
   error?: Error;
+  entity?: Entity;
 };
 
-export const BuildTable = ({ items, loading, error }: BuildTableProps) => {
+export const BuildTable = ({
+  items,
+  loading,
+  error,
+  entity,
+}: BuildTableProps) => {
   // State for log drawer
   const [selectedBuildId, setSelectedBuildId] = useState<number | undefined>(
     undefined,
@@ -227,17 +235,6 @@ export const BuildTable = ({ items, loading, error }: BuildTableProps) => {
     },
   ];
 
-  const emptyContent = (
-    <div>
-      <Typography component="p" align="center">
-        No records to display
-      </Typography>
-      <Typography component="p" align="center">
-        The repo name or build definition you have specified could not be found
-      </Typography>
-    </div>
-  );
-
   return (
     <>
       <Table
@@ -257,7 +254,7 @@ export const BuildTable = ({ items, loading, error }: BuildTableProps) => {
           </Box>
         }
         data={items ?? []}
-        emptyContent={emptyContent}
+        emptyContent={<EmptyBuildResults entity={entity} />}
       />
 
       <BuildLogDrawer

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import {
+  AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
+  AZURE_DEVOPS_REPO_ANNOTATION,
+} from '@backstage-community/plugin-azure-devops-common';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import React from 'react';
+
+export const EmptyBuildResults = ({ entity }: { entity?: Entity }) => {
+  const buildDefinitionName =
+    entity?.metadata?.annotations?.[AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION] ??
+    'unknown';
+  const repoName =
+    entity?.metadata?.annotations?.[AZURE_DEVOPS_REPO_ANNOTATION] ?? 'unknown';
+
+  return (
+    <Box padding={2}>
+      <Typography component="p" align="center" variant="body1">
+        No records to display
+      </Typography>
+      <Typography component="p" align="center" variant="body2">
+        The repo name "{repoName}" or build definition "{buildDefinitionName}"
+        you have specified could not be found.
+      </Typography>
+    </Box>
+  );
+};

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
@@ -20,7 +20,6 @@ import {
 } from '@backstage-community/plugin-azure-devops-common';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
-import React from 'react';
 
 export const EmptyBuildResults = ({ entity }: { entity?: Entity }) => {
   const buildDefinitionName =

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/EmptyBuildResults.tsx
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import {
-  AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
-  AZURE_DEVOPS_REPO_ANNOTATION,
-} from '@backstage-community/plugin-azure-devops-common';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
+import { getAnnotationValuesFromEntity } from '../../../../utils';
 
 export const EmptyBuildResults = ({ entity }: { entity?: Entity }) => {
-  const buildDefinitionName =
-    entity?.metadata?.annotations?.[AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION] ??
-    'unknown';
-  const repoName =
-    entity?.metadata?.annotations?.[AZURE_DEVOPS_REPO_ANNOTATION] ?? 'unknown';
+  const annotations = entity
+    ? getAnnotationValuesFromEntity(entity)
+    : undefined;
+  const repoName = annotations?.repo;
+  const buildDefinition = annotations?.definition;
 
   return (
     <Box padding={2}>
@@ -34,8 +31,9 @@ export const EmptyBuildResults = ({ entity }: { entity?: Entity }) => {
         No records to display
       </Typography>
       <Typography component="p" align="center" variant="body2">
-        The repo name "{repoName}" or build definition "{buildDefinitionName}"
-        you have specified could not be found.
+        No builds could be found with repository name{' '}
+        {repoName ?? '(no value provided)'} or build definition{' '}
+        {buildDefinition ?? '(no value provided)'}.
       </Typography>
     </Box>
   );

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/index.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/BuildTable/lib/EmptyBuildResults/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { EmptyBuildResults } from './EmptyBuildResults';

--- a/workspaces/azure-devops/plugins/azure-devops/src/components/EntityPageAzurePipelines/EntityPageAzurePipelines.tsx
+++ b/workspaces/azure-devops/plugins/azure-devops/src/components/EntityPageAzurePipelines/EntityPageAzurePipelines.tsx
@@ -32,7 +32,12 @@ export const EntityPageAzurePipelines = (props: { defaultLimit?: number }) => {
       resourceRef={stringifyEntityRef(entity)}
       errorPage={null}
     >
-      <BuildTable items={items} loading={loading} error={error} />
+      <BuildTable
+        items={items}
+        loading={loading}
+        error={error}
+        entity={entity}
+      />
     </RequirePermission>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It looks like when we pass build definitions to the `getBuilds` function from the `azure-devops-node-api` package it treats them as a [query value](https://github.com/microsoft/azure-devops-node-api/blob/master/api/BuildApi.ts#L970) and not a strict filter / search requirement.

This can cause unexpected behavior like the one mentioned in #3643 .

This should fix #3643 .

---

Running a simple test locally with a pipeline called `main-pipeline`. When I set have this annotation set with that build definition:
```
dev.azure.com/build-definition: main-pipeline
```

I get the correct pipeline:

![image](https://github.com/user-attachments/assets/6acf2a08-24cb-4b60-b3cd-95aacfc0ecdb)


When I use a build-definition that does not exist, I now get nothing returned and a message on why nothing gets returned.

```
dev.azure.com/build-definition: fake-pipeline
```

![image](https://github.com/user-attachments/assets/c71126f6-70a6-44eb-a762-8a1632419801)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
