### PR TITLE
fix: null timestamp when using tech-insights-backend with the maturity plugin

### DIFF
--- a/workspaces/tech-insights/.changeset/tricky-bulldogs-admire.md
+++ b/workspaces/tech-insights/.changeset/tricky-bulldogs-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+---
+
+fix null timestamp error when using tech-insights with maturity plugin

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityMetadataFactRetriever.ts
@@ -21,6 +21,7 @@ import {
 import { CatalogClient } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import isEmpty from 'lodash/isEmpty';
+import { DateTime } from 'luxon';
 
 /**
  * Generates facts which indicate the completeness of entity metadata.
@@ -72,6 +73,7 @@ export const entityMetadataFactRetriever: FactRetriever = {
           hasDescription: Boolean(entity.metadata?.description),
           hasTags: !isEmpty(entity.metadata?.tags),
         },
+        timestamp: DateTime.now(),
       };
     });
   },

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/entityOwnershipFactRetriever.ts
@@ -20,6 +20,7 @@ import {
 } from '@backstage-community/plugin-tech-insights-node';
 import { CatalogClient } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
+import { DateTime } from 'luxon';
 
 /**
  * Generates facts which indicate the quality of data in the spec.owner field.
@@ -72,6 +73,7 @@ export const entityOwnershipFactRetriever: FactRetriever = {
               !(entity.spec?.owner as string).startsWith('user:'),
           ),
         },
+        timestamp: DateTime.now(),
       };
     });
   },

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/fact/factRetrievers/techdocsFactRetriever.ts
@@ -21,6 +21,7 @@ import {
 import { CatalogClient } from '@backstage/catalog-client';
 import { Entity } from '@backstage/catalog-model';
 import { entityHasAnnotation, generateAnnotationFactName } from './utils';
+import { DateTime } from 'luxon';
 
 const techdocsAnnotation = 'backstage.io/techdocs-ref';
 const techdocsEntityAnnotation = 'backstage.io/techdocs-entity';
@@ -81,6 +82,7 @@ export const techdocsFactRetriever: FactRetriever = {
             techdocsEntityAnnotation,
           ),
         },
+        timestamp: DateTime.now(),
       };
     });
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When using tech-insights built in fact retrievers specifically `entityOwnershipFactRetriever` , `entityMetadataFactRetriever`  and `techdocsFactRetriever` with the `tech-insights-maturity` plugin. The updated time is always `not run yet` this is because the fact retrievers currently do not provide a timestamp in luxon format. This PR addresses this and adds the timestamp field. We built our own factretriever for github and added the timestamp field and it worked as expected. Please notice the screenshot below, the updated field is shown as ` not run yet` for the `entityOwnershipFactRetriever` retriever as an example. This PR fixes all 3 of the retrievers

![image](https://github.com/user-attachments/assets/0e4e5655-15e4-4a43-a10c-fbccab59c2a6)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
