### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/late-panthers-clap.md
+++ b/workspaces/quay/.changeset/late-panthers-clap.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
-'@backstage-community/plugin-quay': minor
----
-
-Bump backstage version to v1.38.1

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.7.0
+
+### Minor Changes
+
+- e172aba: Bump backstage version to v1.38.1
+
 ## 2.6.2
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.2.0
+
+### Minor Changes
+
+- e172aba: Bump backstage version to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [e172aba]
+  - @backstage-community/plugin-quay-common@1.8.0
+
 ## 1.1.3
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.8.0
+
+### Minor Changes
+
+- e172aba: Bump backstage version to v1.38.1
+
 ## 1.7.2
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.20.0
+
+### Minor Changes
+
+- e172aba: Bump backstage version to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [e172aba]
+  - @backstage-community/plugin-quay-common@1.8.0
+
 ## 1.19.2
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.20.0

### Minor Changes

-   e172aba: Bump backstage version to v1.38.1

### Patch Changes

-   Updated dependencies [e172aba]
    -   @backstage-community/plugin-quay-common@1.8.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.7.0

### Minor Changes

-   e172aba: Bump backstage version to v1.38.1

## @backstage-community/plugin-quay-backend@1.2.0

### Minor Changes

-   e172aba: Bump backstage version to v1.38.1

### Patch Changes

-   Updated dependencies [e172aba]
    -   @backstage-community/plugin-quay-common@1.8.0

## @backstage-community/plugin-quay-common@1.8.0

### Minor Changes

-   e172aba: Bump backstage version to v1.38.1
