### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/happy-kids-marry.md
+++ b/workspaces/redhat-argocd/.changeset/happy-kids-marry.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd-common': minor
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Bump backstage version to v1.38.1

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- bfc2838: Bump backstage version to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [bfc2838]
+  - @backstage-community/plugin-redhat-argocd-common@1.5.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.5.0
+
+### Minor Changes
+
+- bfc2838: Bump backstage version to v1.38.1
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.19.0
+
+### Minor Changes
+
+- bfc2838: Bump backstage version to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [bfc2838]
+  - @backstage-community/plugin-redhat-argocd-common@1.5.0
+
 ## 1.18.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.19.0

### Minor Changes

-   bfc2838: Bump backstage version to v1.38.1

### Patch Changes

-   Updated dependencies [bfc2838]
    -   @backstage-community/plugin-redhat-argocd-common@1.5.0

## @backstage-community/plugin-redhat-argocd-backend@0.6.0

### Minor Changes

-   bfc2838: Bump backstage version to v1.38.1

### Patch Changes

-   Updated dependencies [bfc2838]
    -   @backstage-community/plugin-redhat-argocd-common@1.5.0

## @backstage-community/plugin-redhat-argocd-common@1.5.0

### Minor Changes

-   bfc2838: Bump backstage version to v1.38.1
