### PR TITLE
docs: Remove outdated backend documentation from todo plugin README

### DIFF
--- a/workspaces/todo/plugins/todo/README.md
+++ b/workspaces/todo/plugins/todo/README.md
@@ -2,70 +2,23 @@
 
 This plugin lists `// TODO` comments in source code. It currently exports a single component extension for use on entity pages.
 
-## Setup
+## Prerequisite
+For this plugin to work, you must first install and configure the Todo Backend plugin by following the instructions provided in [this readme file](../todo-backend/README.md)
 
-1. Run:
+
+## Installation
+From the root of your Backstage project, run the following command:
 
 ```bash
-# From your Backstage root directory
 yarn --cwd packages/app add @backstage-community/plugin-todo
-yarn --cwd packages/backend add @backstage-community/plugin-todo-backend
 ```
 
-2. Add the plugin backend:
-
-In a new file named `todo.ts` under `backend/src/plugins`:
-
-```js
-import { Router } from 'express';
-import { CatalogClient } from '@backstage/catalog-client';
-import {
-  createRouter,
-  TodoReaderService,
-  TodoScmReader,
-} from '@backstage-community/plugin-todo-backend';
-import { PluginEnvironment } from '../types';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const todoReader = TodoScmReader.fromConfig(env.config, {
-    logger: env.logger,
-    reader: env.reader,
-  });
-
-  const catalogClient = new CatalogClient({
-    discoveryApi: env.discovery,
-  });
-
-  const todoService = new TodoReaderService({
-    todoReader,
-    catalogClient,
-  });
-
-  return await createRouter({ todoService });
-}
-```
-
-And then add to `packages/backend/src/index.ts`:
-
-```js
-// In packages/backend/src/index.ts
-import todo from './plugins/todo';
-// ...
-async function main() {
-  // ...
-  const todoEnv = useHotMemoize(module, () => createEnv('todo'));
-  // ...
-  apiRouter.use('/todo', await todo(todoEnv));
-```
-
-3. Add the plugin as a tab to your service entities:
+Next, integrate the plugin by adding it as a tab to the catalog entity pages where you want the Todo tab to appear. For example, to enable the tab on service entities, update your EntityPage.tsx file as follows:
 
 ```jsx
 // In packages/app/src/components/catalog/EntityPage.tsx
 import { EntityTodoContent } from '@backstage-community/plugin-todo';
-
+// Adds the Todo tab to the service entity page
 const serviceEntityPage = (
   <EntityLayout>
     {/* other tabs... */}


### PR DESCRIPTION
## Description
The todo frontend plugin README still uses the legacy backend system when the backend plugin already uses the new backend system. Also, the backend readme is updated correctly so I changed the frontend to, instead of duplicating the backend installation documentation, it links to it's README.