### PR TITLE
fix: undo breaking Authorization header change while allowing Bearer auth to be configured

### DIFF
--- a/workspaces/sonarqube/.changeset/long-gorillas-notice.md
+++ b/workspaces/sonarqube/.changeset/long-gorillas-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube-backend': minor
+---
+
+This undoes the breaking Authorization header change introduced in v0.7.0 and allows configuring Bearer tokens, while maintaining the old default of Basic.

--- a/workspaces/sonarqube/plugins/sonarqube-backend/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/README.md
@@ -103,6 +103,7 @@ sonarqube:
   baseUrl: https://sonarqube.example.com
   instanceKey: mySonarqube
   apiKey: 123456789abcdef0123456789abcedf012
+  tokenKind: Bearer # this defaults to Basic, which maintains the pre-0.7.0 behavior. It can be set to Bearer or Basic
 ```
 
 ##### Catalog


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes the "breakingness" of a breaking change in the sonarqube-backend plugin introduced in v0.7.0 via  a breaking change introduced in https://github.com/backstage/community-plugins/pull/3469.

This PR makes `Basic` auth once again the default, and adds a new optional configuration parameter `tokenKind`. It is an optional string, and when set to either `bearer` or `Bearer` will enable `Bearer` tokens to be used. Any other value (including undefined) for `tokenKind` should result in reverting to the previous behavior of `Basic` auth.

The 0.7.0 change broke our working setup with self-hosted Sonarqube Enterprise Edition v9.9.9.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
