### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/flat-plants-dream.md
+++ b/workspaces/manage/.changeset/flat-plants-dream.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage': minor
----
-
-Remove extra content padding on manage page

--- a/workspaces/manage/.changeset/polite-flies-poke.md
+++ b/workspaces/manage/.changeset/polite-flies-poke.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage': patch
-'@backstage-community/plugin-manage-module-tech-insights': patch
-'@backstage-community/plugin-manage-react': patch
----
-
-Bump backastage dependencies to 1.37.0

--- a/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-manage-module-tech-insights
 
+## 0.1.4
+
+### Patch Changes
+
+- d8b448d: Bump backastage dependencies to 1.37.0
+- Updated dependencies [d8b448d]
+  - @backstage-community/plugin-manage-react@0.1.2
+
 ## 0.1.3
 
 ### Patch Changes

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-module-tech-insights",
   "description": "Manage plugin - Tech Insights module",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage-react/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-manage-react
 
+## 0.1.2
+
+### Patch Changes
+
+- d8b448d: Bump backastage dependencies to 1.37.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-react",
   "description": "Manage plugin - react package",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "backstage": {
     "role": "web-library",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-manage
 
+## 0.2.0
+
+### Minor Changes
+
+- d8b448d: Remove extra content padding on manage page
+
+### Patch Changes
+
+- d8b448d: Bump backastage dependencies to 1.37.0
+- Updated dependencies [d8b448d]
+  - @backstage-community/plugin-manage-react@0.1.2
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage",
   "description": "Manage plugin - Shows a Manage page relevant to the user",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "manage",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage@0.2.0

### Minor Changes

-   d8b448d: Remove extra content padding on manage page

### Patch Changes

-   d8b448d: Bump backastage dependencies to 1.37.0
-   Updated dependencies [d8b448d]
    -   @backstage-community/plugin-manage-react@0.1.2

## @backstage-community/plugin-manage-module-tech-insights@0.1.4

### Patch Changes

-   d8b448d: Bump backastage dependencies to 1.37.0
-   Updated dependencies [d8b448d]
    -   @backstage-community/plugin-manage-react@0.1.2

## @backstage-community/plugin-manage-react@0.1.2

### Patch Changes

-   d8b448d: Bump backastage dependencies to 1.37.0
