### PR TITLE
Add changesets for recent tech-insights permissions updates

### DIFF
--- a/workspaces/tech-insights/.changeset/early-hounds-explain.md
+++ b/workspaces/tech-insights/.changeset/early-hounds-explain.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-tech-insights-backend': major
+'@backstage-community/plugin-tech-insights-backend': minor
 ---
 
 This version includes breaking changes related to permissions. Please review the changes carefully before upgrading:

--- a/workspaces/tech-insights/.changeset/early-hounds-explain.md
+++ b/workspaces/tech-insights/.changeset/early-hounds-explain.md
@@ -1,0 +1,14 @@
+---
+'@backstage-community/plugin-tech-insights-backend': major
+---
+
+This version includes breaking changes related to permissions. Please review the changes carefully before upgrading:
+
+- Added required permissions for accessing Tech Insights features
+- Users must now have the appropriate policies added to their roles to access Tech Insights functionality
+- This change enforces better security by ensuring explicit permission grants for Tech Insights operations
+
+To upgrade, you'll need to:
+
+1. Update your permission policies to include the necessary Tech Insights permissions
+2. Ensure your users' roles have the appropriate policies assigned

--- a/workspaces/tech-insights/.changeset/early-hounds-explain.md
+++ b/workspaces/tech-insights/.changeset/early-hounds-explain.md
@@ -2,13 +2,4 @@
 '@backstage-community/plugin-tech-insights-backend': minor
 ---
 
-This version includes breaking changes related to permissions. Please review the changes carefully before upgrading:
-
-- Added required permissions for accessing Tech Insights features
-- Users must now have the appropriate policies added to their roles to access Tech Insights functionality
-- This change enforces better security by ensuring explicit permission grants for Tech Insights operations
-
-To upgrade, you'll need to:
-
-1. Update your permission policies to include the necessary Tech Insights permissions
-2. Ensure your users' roles have the appropriate policies assigned
+This version adds `techInsightsCheckReadPermission`, `techInsightsCheckUpdatePermission`, and `techInsightsFactRetrieverReadPermission`, which can be used to permission Tech Insights functionalities.

--- a/workspaces/tech-insights/.changeset/sixty-grapes-sit.md
+++ b/workspaces/tech-insights/.changeset/sixty-grapes-sit.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-common': minor
+---
+
+Adds permissions for use by the `tech-insights` apis.

--- a/workspaces/tech-insights/plugins/tech-insights-backend/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/README.md
@@ -2,23 +2,6 @@
 
 The backend plugin for Tech Insights.
 
-## Breaking Changes in v3.0.0
-
-This version includes breaking changes related to permissions. Please review the changes carefully before upgrading:
-
-- Added required permissions for accessing Tech Insights features
-- Users must now have the appropriate policies added to their roles to access Tech Insights functionality
-- This change enforces better security by ensuring explicit permission grants for Tech Insights operations
-
-To upgrade, you'll need to:
-
-1. Update your permission policies to include the necessary Tech Insights permissions
-2. Ensure your users' roles have the appropriate policies assigned
-
-It provides the API for the frontend tech insights, scorecards and fact visualization functionality, as well as a framework to run fact retrievers and store fact values in to a data store.
-
-Looking for the old backend installation docs? Visit [here](./docs/old-backend-system.md).
-
 ## Installation
 
 ### Install the package

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -58,7 +58,6 @@
     "@backstage/config": "^1.3.2",
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-permission-common": "^0.8.4",
-    "@backstage/plugin-permission-node": "^0.8.7",
     "@backstage/types": "^1.2.1",
     "@types/express": "^4.17.6",
     "@types/luxon": "^3.0.0",

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "3.0.0",
+  "version": "2.2.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.test.ts
@@ -42,9 +42,10 @@ describe('techInsightsPlugin', () => {
           },
         }),
         mockServices.scheduler.factory(),
+        mockServices.permissionsRegistry.factory(),
       ],
     });
 
-    expect(httpRouterMock.use).toHaveBeenCalledTimes(1);
+    expect(httpRouterMock.use).toHaveBeenCalledTimes(2);
   });
 });

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/plugin.ts
@@ -21,6 +21,7 @@ import {
 import {
   CheckResult,
   Check,
+  techInsightsPermissions,
 } from '@backstage-community/plugin-tech-insights-common';
 import {
   FactCheckerFactory,
@@ -105,6 +106,7 @@ export const techInsightsPlugin = createBackendPlugin({
         urlReader: coreServices.urlReader,
         httpAuth: coreServices.httpAuth,
         permissions: coreServices.permissions,
+        permissionsRegistry: coreServices.permissionsRegistry,
       },
       async init({
         config,
@@ -117,7 +119,10 @@ export const techInsightsPlugin = createBackendPlugin({
         urlReader,
         httpAuth,
         permissions,
+        permissionsRegistry,
       }) {
+        permissionsRegistry.addPermissions(techInsightsPermissions);
+
         const factRetrievers: FactRetrieverRegistration[] = Object.entries(
           addedFactRetrievers,
         )

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/router.ts
@@ -27,7 +27,6 @@ import {
   Check,
   techInsightsCheckReadPermission,
   techInsightsCheckUpdatePermission,
-  techInsightsPermissions,
   techInsightsFactRetrieverReadPermission,
 } from '@backstage-community/plugin-tech-insights-common';
 import { DateTime } from 'luxon';
@@ -47,7 +46,6 @@ import {
   AuthorizeResult,
   BasicPermission,
 } from '@backstage/plugin-permission-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import { NotAllowedError } from '@backstage/errors';
 import pLimit from 'p-limit';
 
@@ -109,12 +107,7 @@ export async function createRouter<
 >(options: RouterOptions<CheckType, CheckResultType>): Promise<express.Router> {
   const router = Router();
 
-  const permissionsIntegrationRouter = createPermissionIntegrationRouter({
-    permissions: techInsightsPermissions,
-  });
-
   router.use(express.json());
-  router.use(permissionsIntegrationRouter);
 
   const {
     persistenceContext,

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -2779,7 +2779,6 @@ __metadata:
     "@backstage/config": "npm:^1.3.2"
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/plugin-permission-node": "npm:^0.8.7"
     "@backstage/types": "npm:^1.2.1"
     "@types/express": "npm:^4.17.6"
     "@types/lodash": "npm:^4.14.151"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add changelogs for recent tech-insights permissions updates

This PR created new permissions and permission validation on the tech-insights apis, but no changesets were created https://github.com/backstage/community-plugins/pull/3867.

This PR attempts to add changesets so that it is released correctly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
