### PR TITLE
feat(grafana): Use pagination for Grafana Dashboard search

### DIFF
--- a/workspaces/grafana/.changeset/silent-maps-wash.md
+++ b/workspaces/grafana/.changeset/silent-maps-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': minor
+---
+
+Use pagination for Grafana Dashboard search

--- a/workspaces/grafana/plugins/grafana/config.d.ts
+++ b/workspaces/grafana/plugins/grafana/config.d.ts
@@ -34,5 +34,17 @@ export interface Config {
      * @visibility frontend
      */
     unifiedAlerting?: boolean;
+
+    /**
+     * Limit value to pass in Grafana Dashboard search query.
+     * @visibility frontend
+     */
+    grafanaDashboardSearchLimit?: number;
+
+    /**
+     * Max pages of Grafana Dashboard search query to fetch.
+     * @visibility frontend
+     */
+    grafanaDashboardMaxPages?: number;
   };
 }

--- a/workspaces/grafana/plugins/grafana/docs/setup.md
+++ b/workspaces/grafana/plugins/grafana/docs/setup.md
@@ -27,6 +27,14 @@ grafana:
   # See: https://grafana.com/blog/2021/06/14/the-new-unified-alerting-system-for-grafana-everything-you-need-to-know/
   # Optional. Default: false
   unifiedAlerting: false
+
+  # How many pages of Grafana Dashboard search results to check for dashboards?
+  # Optional. Default: 1
+  grafanaDashboardMaxPages: 1
+
+  # What limit value to pass for each query to the Grafana Dashboard search endpoint?
+  # Optional. Default: 1000
+  grafanaDashboardSearchLimit: 1000
 ```
 
 Expose the plugin to Backstage:


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Grafana's Search API endpoint applies a default of limit of 1000 results - cutting off any dashboards past that point. Apply a trivial pagination wrapper to fetch up to 1M dashboards.

Reference: https://github.com/backstage/community-plugins/issues/3735#issuecomment-2832849034

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
