### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/big-pears-sing.md
+++ b/workspaces/kiali/.changeset/big-pears-sing.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
-'@backstage-community/plugin-kiali-common': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Migrate types to kiali-common

--- a/workspaces/kiali/.changeset/icy-clouds-feel.md
+++ b/workspaces/kiali/.changeset/icy-clouds-feel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': minor
----
-
-Fix provider selector

--- a/workspaces/kiali/.changeset/kind-hounds-win.md
+++ b/workspaces/kiali/.changeset/kind-hounds-win.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-remove unused dependency `@playwright/test`

--- a/workspaces/kiali/.changeset/salty-shoes-build.md
+++ b/workspaces/kiali/.changeset/salty-shoes-build.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': minor
----
-
-Create a common library

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.22.0
+
+### Minor Changes
+
+- 8cb76ee: Migrate types to kiali-common
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-kiali-common
+
+## 0.2.0
+
+### Minor Changes
+
+- 8cb76ee: Migrate types to kiali-common

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 1.38.0
+
+### Minor Changes
+
+- 8cb76ee: Migrate types to kiali-common
+- fe9f230: Fix provider selector
+- e53d4ba: Create a common library
+
+### Patch Changes
+
+- 29fb22e: remove unused dependency `@playwright/test`
+- Updated dependencies [8cb76ee]
+  - @backstage-community/plugin-kiali-common@0.2.0
+
 ## 1.37.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.38.0

### Minor Changes

-   8cb76ee: Migrate types to kiali-common
-   fe9f230: Fix provider selector
-   e53d4ba: Create a common library

### Patch Changes

-   29fb22e: remove unused dependency `@playwright/test`
-   Updated dependencies [8cb76ee]
    -   @backstage-community/plugin-kiali-common@0.2.0

## @backstage-community/plugin-kiali-backend@1.22.0

### Minor Changes

-   8cb76ee: Migrate types to kiali-common

## @backstage-community/plugin-kiali-common@0.2.0

### Minor Changes

-   8cb76ee: Migrate types to kiali-common
