### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/khaki-panthers-do.md
+++ b/workspaces/quay/.changeset/khaki-panthers-do.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-backend': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-Update supported version metadata to 1.38.1

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.7.1
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+
 ## 2.7.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.2.1
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+- Updated dependencies [1d7aaba]
+  - @backstage-community/plugin-quay-common@1.8.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.8.1
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+
 ## 1.8.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.20.2
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+- Updated dependencies [1d7aaba]
+  - @backstage-community/plugin-quay-common@1.8.1
+
 ## 1.20.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.20.2

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
-   Updated dependencies [1d7aaba]
    -   @backstage-community/plugin-quay-common@1.8.1

## @backstage-community/plugin-scaffolder-backend-module-quay@2.7.1

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1

## @backstage-community/plugin-quay-backend@1.2.1

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
-   Updated dependencies [1d7aaba]
    -   @backstage-community/plugin-quay-common@1.8.1

## @backstage-community/plugin-quay-common@1.8.1

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
