### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/swift-terms-cut.md
+++ b/workspaces/redhat-argocd/.changeset/swift-terms-cut.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
-'@backstage-community/plugin-redhat-argocd-common': patch
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Update supported version metadata to 1.38.1

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.6.1
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+- Updated dependencies [1d7aaba]
+  - @backstage-community/plugin-redhat-argocd-common@1.5.1
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.5.1
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.19.2
+
+### Patch Changes
+
+- 1d7aaba: Update supported version metadata to 1.38.1
+- Updated dependencies [1d7aaba]
+  - @backstage-community/plugin-redhat-argocd-common@1.5.1
+
 ## 1.19.1
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.19.2

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
-   Updated dependencies [1d7aaba]
    -   @backstage-community/plugin-redhat-argocd-common@1.5.1

## @backstage-community/plugin-redhat-argocd-backend@0.6.1

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
-   Updated dependencies [1d7aaba]
    -   @backstage-community/plugin-redhat-argocd-common@1.5.1

## @backstage-community/plugin-redhat-argocd-common@1.5.1

### Patch Changes

-   1d7aaba: Update supported version metadata to 1.38.1
