### PR TITLE
ci(auto-version-bump): checkout repository in workflow step

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -28,6 +28,8 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
       - name: Delay batches (5 min between)
         if: ${{ strategy.job-index != 0 }}
         run: |


### PR DESCRIPTION
This commit updates the auto-version-bump workflow to check out the repository in the workflow step.

Fixes error shown at https://github.com/backstage/community-plugins/actions/runs/14867862970/job/41749543442

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
