### PR TITLE
doc: document permissions for workspace branches

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -46,6 +46,23 @@ When patching an older release, follow the steps below to ensure the correct wor
    - Ensure that a branch named `workspace/${workspace}` exists, with appropriate branch protections in place. This branch will be used for patch releases.
    - The `${workspace}` should correspond to the specific plugin or component you are patching.
 
+   <details>
+   <summary>Community Plugins Maintainers - Branch Protection Settings</summary>
+
+   In **GitHub > Repo > Settings > Branches**, add a rule for the requested `workspace/${workspace}` branch and apply these settings:
+
+   - ☑ Require pull request before merging
+     - ☑ Require approvals
+     - ☑ Dismiss stale approvals when new commits are pushed
+     - ☑ Require review from Code Owners
+   - ☑ Require status checks to pass before merging
+   - ☑ Restrict who can push: **CODEOWNERS for the workspace**
+   - ☑ Restrict pushes that create matching branches
+   - ☑ Allow force pushes
+     - ☑ Specify who can force push: **CODEOWNERS for the workspace**
+
+   </details>
+
 2. Reset the `workspace` branch:
 
    - Reset the `workspace/${workspace}` branch to the version of the plugin you need to patch.


### PR DESCRIPTION
Adds a collapsible section to the steps with the GitHub settings. This is to ensure that when maintainers create `workspace/${workspace}` branches they have the appropriate permissions set.

Refs: #860

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->


- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
