### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/tidy-experts-pay.md
+++ b/workspaces/rbac/.changeset/tidy-experts-pay.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac-common': patch
-'@backstage-community/plugin-rbac-node': patch
-'@backstage-community/plugin-rbac': patch
----
-
-chore: Remove usage of @spotify/prettier-config

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 6.2.5
+
+### Patch Changes
+
+- 658c51c: chore: Remove usage of @spotify/prettier-config
+- Updated dependencies [658c51c]
+  - @backstage-community/plugin-rbac-common@1.16.1
+  - @backstage-community/plugin-rbac-node@1.11.1
+
 ## 6.2.4
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.16.1
+
+### Patch Changes
+
+- 658c51c: chore: Remove usage of @spotify/prettier-config
+
 ## 1.16.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.11.1
+
+### Patch Changes
+
+- 658c51c: chore: Remove usage of @spotify/prettier-config
+
 ## 1.11.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.41.3
+
+### Patch Changes
+
+- 658c51c: chore: Remove usage of @spotify/prettier-config
+- Updated dependencies [658c51c]
+  - @backstage-community/plugin-rbac-common@1.16.1
+
 ## 1.41.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.41.2",
+  "version": "1.41.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.41.3

### Patch Changes

-   658c51c: chore: Remove usage of @spotify/prettier-config
-   Updated dependencies [658c51c]
    -   @backstage-community/plugin-rbac-common@1.16.1

## @backstage-community/plugin-rbac-backend@6.2.5

### Patch Changes

-   658c51c: chore: Remove usage of @spotify/prettier-config
-   Updated dependencies [658c51c]
    -   @backstage-community/plugin-rbac-common@1.16.1
    -   @backstage-community/plugin-rbac-node@1.11.1

## @backstage-community/plugin-rbac-common@1.16.1

### Patch Changes

-   658c51c: chore: Remove usage of @spotify/prettier-config

## @backstage-community/plugin-rbac-node@1.11.1

### Patch Changes

-   658c51c: chore: Remove usage of @spotify/prettier-config
