### PR TITLE
Version Packages (scaffolder-backend-module-kubernetes)

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/stale-lamps-jam.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/stale-lamps-jam.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': patch
----
-
-remove lifecycle keywords from package.json

--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-38-1.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-38-1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': minor
----
-
-Backstage version bump to v1.38.1

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 2.7.0
+
+### Minor Changes
+
+- eca0a59: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- 475b232: remove lifecycle keywords from package.json
+
 ## 2.6.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.7.0

### Minor Changes

-   eca0a59: Backstage version bump to v1.38.1

### Patch Changes

-   475b232: remove lifecycle keywords from package.json
