### PR TITLE
meta: proof-of-concept team management via config

### DIFF
--- a/.github/plugin-teams.json
+++ b/.github/plugin-teams.json
@@ -1,0 +1,15 @@
+{
+  "teams": [
+    {
+      "name": "community-plugins-rbac",
+      "description": "Maintainers of community RBAC team",
+      "members": [
+        "@AndrienkoAleksandr",
+        "@christoph-jerolimov",
+        "@divyanshiGupta",
+        "@PatAKnight",
+        "@dzemanov"
+      ]
+    }
+  ]
+}

--- a/scripts/setup-teams.js
+++ b/scripts/setup-teams.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'fs';
+import path from 'path';
+
+const CONFIG_PATH = path.resolve('.github/plugin-teams.json');
+
+const mockGitHubState = {
+  'community-plugins-rbac': ['@christoph-jerolimov', 'unexpected_user'],
+};
+
+function readConfig(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.error(`Config file not found at: ${filePath}`);
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`Failed to parse JSON: ${err.message}`);
+  }
+  return null;
+}
+
+function syncTeams(config) {
+  console.log(`Syncing community-plugins team creation from config:\n`);
+
+  for (const team of config.teams) {
+    const expectedMembers = team.members;
+    const actualMembers = mockGitHubState[team.name] || [];
+
+    console.log(`\nVerify or create team "${team.name}:"`);
+
+    for (const user of expectedMembers) {
+      if (!actualMembers.includes(user)) {
+        console.log(`   ➕ Adding "${user}" to team "${team.name}"`);
+      } else {
+        console.log(`   ✅ "${user}" is already a member of "${team.name}"`);
+      }
+    }
+
+    const extras = actualMembers.filter(u => !expectedMembers.includes(u));
+    for (const user of extras) {
+      console.log(
+        `   ➖ Removing unexpected member "${user}" from team "${team.name}"`,
+      );
+    }
+  }
+
+  console.log(`\nFinished syncing teams with ${CONFIG_PATH}.`);
+}
+
+function main() {
+  const config = readConfig(CONFIG_PATH);
+  syncTeams(config);
+}
+
+main();


### PR DESCRIPTION
This proof-of-concept script would sync GitHub teams to a configuration file defined in `.github/plugin-teams.json`.

It reads the config, simulates team creation, and compares expected vs. actual team members using a mock GitHub state.

This is to enable us to assign GitHub teams as codeowners for certain plugins rather than listing multiple individual codeowners. This would allow those maintainers to adopt a similar round-robin approach to reviews. I think this will improve review responsiveness as it will be clearer who is responsible for reviewing each PR.

My expectation would be that this script would be updated to actually make the necessary GitHub API calls to create and manage teams - but it would require a GitHub token with the necessary permissions. So for now, it's all simulated.

Based on the config so far, this is what would be output:
```console
$ node scripts/setup-teams.js
Syncing community-plugins team creation from config:

Verify or create team "community-plugins-rbac:"
   ➕ Adding "AndrienkoAleksandr" to team "community-plugins-rbac"
   ✅ "@christoph-jerolimov" is already a member of "community-plugins-rbac"
   ➕ Adding "divyanshiGupta" to team "community-plugins-rbac"
   ➕ Adding "PatAKnight" to team "community-plugins-rbac"
   ➕ Adding "dzemanov" to team "community-plugins-rbac"
   ➖ Removing unexpected member "unexpected_user" from team "community-plugins-rbac"

Finished syncing teams with .github/plugin-teams.json.
```

I wouldn't anticipate every plugin needing a dedicated GitHub team - only ones where there are several codeowners. Also the assumption is that all members in these lists would already be Backstage organization members.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
