### PR TITLE
Version Packages (github-discussions)

### DIFF
--- a/workspaces/github-discussions/.changeset/version-bump-1-38-1.md
+++ b/workspaces/github-discussions/.changeset/version-bump-1-38-1.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-github-discussions': minor
-'@backstage-community/plugin-github-discussions-common': minor
-'@backstage-community/plugin-search-backend-module-github-discussions': minor
----
-
-Backstage version bump to v1.38.1

--- a/workspaces/github-discussions/packages/app/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [d6b5172]
+  - @backstage-community/plugin-github-discussions@0.3.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/app/package.json
+++ b/workspaces/github-discussions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-discussions/packages/backend/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [d6b5172]
+  - @backstage-community/plugin-search-backend-module-github-discussions@0.4.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/backend/package.json
+++ b/workspaces/github-discussions/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-discussions-common
 
+## 0.4.0
+
+### Minor Changes
+
+- d6b5172: Backstage version bump to v1.38.1
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/github-discussions-common/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-github-discussions-common",
   "description": "Common functionalities for the github-discussions plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-github-discussions
 
+## 0.3.0
+
+### Minor Changes
+
+- d6b5172: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [d6b5172]
+  - @backstage-community/plugin-github-discussions-common@0.4.0
+
 ## 0.2.1
 
 ### Patch Changes

--- a/workspaces/github-discussions/plugins/github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-discussions",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-search-backend-module-github-discussions
 
+## 0.4.0
+
+### Minor Changes
+
+- d6b5172: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- Updated dependencies [d6b5172]
+  - @backstage-community/plugin-github-discussions-common@0.4.0
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-github-discussions",
   "description": "The github-discussions backend module for the search plugin.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-discussions@0.3.0

### Minor Changes

-   d6b5172: Backstage version bump to v1.38.1

### Patch Changes

-   Updated dependencies [d6b5172]
    -   @backstage-community/plugin-github-discussions-common@0.4.0

## @backstage-community/plugin-github-discussions-common@0.4.0

### Minor Changes

-   d6b5172: Backstage version bump to v1.38.1

## @backstage-community/plugin-search-backend-module-github-discussions@0.4.0

### Minor Changes

-   d6b5172: Backstage version bump to v1.38.1

### Patch Changes

-   Updated dependencies [d6b5172]
    -   @backstage-community/plugin-github-discussions-common@0.4.0

## app@0.0.3

### Patch Changes

-   Updated dependencies [d6b5172]
    -   @backstage-community/plugin-github-discussions@0.3.0

## backend@0.0.3

### Patch Changes

-   Updated dependencies [d6b5172]
    -   @backstage-community/plugin-search-backend-module-github-discussions@0.4.0
