### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/renovate-62bed1f.md
+++ b/workspaces/analytics/.changeset/renovate-62bed1f.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `18.19.103`.

--- a/workspaces/analytics/.changeset/renovate-aa00b7f.md
+++ b/workspaces/analytics/.changeset/renovate-aa00b7f.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `18.19.100`.

--- a/workspaces/analytics/.changeset/renovate-c5d3244.md
+++ b/workspaces/analytics/.changeset/renovate-c5d3244.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `18.19.100`.

--- a/workspaces/analytics/.changeset/renovate-e95df43.md
+++ b/workspaces/analytics/.changeset/renovate-e95df43.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/react` to `18.3.23`.

--- a/workspaces/analytics/.changeset/version-bump-1-38-1.md
+++ b/workspaces/analytics/.changeset/version-bump-1-38-1.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga': minor
-'@backstage-community/plugin-analytics-module-ga4': minor
-'@backstage-community/plugin-analytics-module-matomo': minor
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Backstage version bump to v1.38.1

--- a/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga
 
+## 0.7.0
+
+### Minor Changes
+
+- 8b665f9: Backstage version bump to v1.38.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-ga/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.7.0
+
+### Minor Changes
+
+- 8b665f9: Backstage version bump to v1.38.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.15.0
+
+### Minor Changes
+
+- 8b665f9: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- df57926: Updated dependency `@types/node` to `18.19.103`.
+- 66db576: Updated dependency `@types/node` to `18.19.100`.
+- 66db576: Updated dependency `@types/node` to `18.19.100`.
+
 ## 1.14.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.6.0
+
+### Minor Changes
+
+- 8b665f9: Backstage version bump to v1.38.1
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Dependencies
 
+## 1.15.0
+
+### Minor Changes
+
+- 8b665f9: Backstage version bump to v1.38.1
+
+### Patch Changes
+
+- df57926: Updated dependency `@types/node` to `18.19.103`.
+- 66db576: Updated dependency `@types/node` to `18.19.100`.
+- 66db576: Updated dependency `@types/node` to `18.19.100`.
+- 9d260e1: Updated dependency `@types/react` to `18.3.23`.
+
 ## 1.14.4
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.14.4",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga@0.7.0

### Minor Changes

-   8b665f9: Backstage version bump to v1.38.1

## @backstage-community/plugin-analytics-module-ga4@0.7.0

### Minor Changes

-   8b665f9: Backstage version bump to v1.38.1

## @backstage-community/plugin-analytics-module-matomo@1.15.0

### Minor Changes

-   8b665f9: Backstage version bump to v1.38.1

### Patch Changes

-   df57926: Updated dependency `@types/node` to `18.19.103`.
-   66db576: Updated dependency `@types/node` to `18.19.100`.
-   66db576: Updated dependency `@types/node` to `18.19.100`.

## @backstage-community/plugin-analytics-module-newrelic-browser@0.6.0

### Minor Changes

-   8b665f9: Backstage version bump to v1.38.1

## @backstage-community/plugin-analytics-provider-segment@1.15.0

### Minor Changes

-   8b665f9: Backstage version bump to v1.38.1

### Patch Changes

-   df57926: Updated dependency `@types/node` to `18.19.103`.
-   66db576: Updated dependency `@types/node` to `18.19.100`.
-   66db576: Updated dependency `@types/node` to `18.19.100`.
-   9d260e1: Updated dependency `@types/react` to `18.3.23`.
