### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/healthy-melons-kick.md
+++ b/workspaces/nexus-repository-manager/.changeset/healthy-melons-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-05df135.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-05df135.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.67.3`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-3c48922.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-3c48922.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@types/node` to `22.15.29`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-5ae1160.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-5ae1160.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.72.2`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-6b4545b.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-6b4545b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@types/node` to `22.14.1`.

--- a/workspaces/nexus-repository-manager/.changeset/spicy-buttons-shop.md
+++ b/workspaces/nexus-repository-manager/.changeset/spicy-buttons-shop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Bump to backstage version 1.39.1

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 1.14.0
+
+### Minor Changes
+
+- 227dae4: Bump to backstage version 1.39.1
+
+### Patch Changes
+
+- 19d4246: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
+- 31b91ce: Updated dependency `@hey-api/openapi-ts` to `0.67.3`.
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+- fd39ec9: Updated dependency `@hey-api/openapi-ts` to `0.72.2`.
+- fcc57ec: Updated dependency `@types/node` to `22.14.1`.
+
 ## 1.13.1
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.14.0

### Minor Changes

-   227dae4: Bump to backstage version 1.39.1

### Patch Changes

-   19d4246: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
-   31b91ce: Updated dependency `@hey-api/openapi-ts` to `0.67.3`.
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.
-   fd39ec9: Updated dependency `@hey-api/openapi-ts` to `0.72.2`.
-   fcc57ec: Updated dependency `@types/node` to `22.14.1`.
