### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-6b4545b.md
+++ b/workspaces/rbac/.changeset/renovate-6b4545b.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.14.1`.

--- a/workspaces/rbac/.changeset/short-suns-wink.md
+++ b/workspaces/rbac/.changeset/short-suns-wink.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Removed theme package "@redhat-developer/red-hat-developer-hub-theme" in dev.

--- a/workspaces/rbac/.changeset/thick-suns-tickle.md
+++ b/workspaces/rbac/.changeset/thick-suns-tickle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Fixed role actions tooltip delay issue.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 6.2.6
+
+### Patch Changes
+
+- fcc57ec: Updated dependency `@types/node` to `22.14.1`.
+
 ## 6.2.5
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "6.2.5",
+  "version": "6.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 1.41.5
+
+### Patch Changes
+
+- fcc57ec: Updated dependency `@types/node` to `22.14.1`.
+- 4d8a8e9: Removed theme package "@redhat-developer/red-hat-developer-hub-theme" in dev.
+- 79213e4: Fixed role actions tooltip delay issue.
+
 ## 1.41.4
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.41.4",
+  "version": "1.41.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.41.5

### Patch Changes

-   fcc57ec: Updated dependency `@types/node` to `22.14.1`.
-   4d8a8e9: Removed theme package "@redhat-developer/red-hat-developer-hub-theme" in dev.
-   79213e4: Fixed role actions tooltip delay issue.

## @backstage-community/plugin-rbac-backend@6.2.6

### Patch Changes

-   fcc57ec: Updated dependency `@types/node` to `22.14.1`.
