### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/eleven-guests-obey.md
+++ b/workspaces/ocm/.changeset/eleven-guests-obey.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
-'@backstage-community/plugin-ocm-common': patch
-'@backstage-community/plugin-ocm': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/ocm/.changeset/renovate-09f2059.md
+++ b/workspaces/ocm/.changeset/renovate-09f2059.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.22`.

--- a/workspaces/ocm/.changeset/renovate-3420539.md
+++ b/workspaces/ocm/.changeset/renovate-3420539.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.20.2`.

--- a/workspaces/ocm/.changeset/renovate-37a7597.md
+++ b/workspaces/ocm/.changeset/renovate-37a7597.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.20.0`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 5.6.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- 098b200: Updated dependency `@types/express` to `4.17.22`.
+- c2146d3: Updated dependency `@openapitools/openapi-generator-cli` to `2.20.2`.
+- 9ef8dfd: Updated dependency `@openapitools/openapi-generator-cli` to `2.20.0`.
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-ocm-common@3.9.1
+
 ## 5.6.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.9.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+
 ## 3.9.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 5.5.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-ocm-common@3.9.1
+
 ## 5.5.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.5.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-ocm-common@3.9.1

## @backstage-community/plugin-ocm-backend@5.6.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   098b200: Updated dependency `@types/express` to `4.17.22`.
-   c2146d3: Updated dependency `@openapitools/openapi-generator-cli` to `2.20.2`.
-   9ef8dfd: Updated dependency `@openapitools/openapi-generator-cli` to `2.20.0`.
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-ocm-common@3.9.1

## @backstage-community/plugin-ocm-common@3.9.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
