### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/kind-boats-melt.md
+++ b/workspaces/redhat-argocd/.changeset/kind-boats-melt.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Fix issue where backend does not return instance url in the metadata

--- a/workspaces/redhat-argocd/.changeset/ready-beds-rush.md
+++ b/workspaces/redhat-argocd/.changeset/ready-beds-rush.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-allow appNamespace and project to be used with appName

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- 90b54c9: allow appNamespace and project to be used with appName
+
+### Patch Changes
+
+- 9c78a8d: Fix issue where backend does not return instance url in the metadata
+
 ## 0.6.1
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.20.0
+
+### Minor Changes
+
+- 90b54c9: allow appNamespace and project to be used with appName
+
+### Patch Changes
+
+- 9c78a8d: Fix issue where backend does not return instance url in the metadata
+
 ## 1.19.2
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.19.2",
+  "version": "1.20.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.20.0

### Minor Changes

-   90b54c9: allow appNamespace and project to be used with appName

### Patch Changes

-   9c78a8d: Fix issue where backend does not return instance url in the metadata

## @backstage-community/plugin-redhat-argocd-backend@0.7.0

### Minor Changes

-   90b54c9: allow appNamespace and project to be used with appName

### Patch Changes

-   9c78a8d: Fix issue where backend does not return instance url in the metadata
