### PR TITLE
Heavily improved the speed of querying entities for a playlist

### DIFF
--- a/workspaces/playlist/.changeset/hungry-countries-judge.md
+++ b/workspaces/playlist/.changeset/hungry-countries-judge.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-playlist-backend': patch
+---
+
+Heavily improved the speed of querying entities for a playlist

--- a/workspaces/playlist/plugins/playlist-backend/src/service/router.test.ts
+++ b/workspaces/playlist/plugins/playlist-backend/src/service/router.test.ts
@@ -45,13 +45,13 @@ const sampleEntities = [
     },
   },
 ];
-const mockGetEntties = jest
+const mockGetEntitiesByRefs = jest
   .fn()
   .mockImplementation(async () => ({ items: sampleEntities }));
 jest.mock('@backstage/catalog-client', () => ({
   CatalogClient: jest
     .fn()
-    .mockImplementation(() => ({ getEntities: mockGetEntties })),
+    .mockImplementation(() => ({ getEntitiesByRefs: mockGetEntitiesByRefs })),
 }));
 
 const mockConditionFilter = { key: 'test', values: ['test-val'] };
@@ -410,7 +410,7 @@ describe('createRouter', () => {
         { credentials: mockCredentials.user() },
       );
       expect(mockDbHandler.getPlaylistEntities).not.toHaveBeenCalled();
-      expect(mockGetEntties).not.toHaveBeenCalled();
+      expect(mockGetEntitiesByRefs).not.toHaveBeenCalled();
       expect(response.status).toEqual(403);
     });
 
@@ -419,20 +419,9 @@ describe('createRouter', () => {
       expect(mockDbHandler.getPlaylistEntities).toHaveBeenCalledWith(
         'playlist-id',
       );
-      expect(mockGetEntties).toHaveBeenCalledWith(
+      expect(mockGetEntitiesByRefs).toHaveBeenCalledWith(
         {
-          filter: [
-            {
-              kind: 'component',
-              'metadata.namespace': 'default',
-              'metadata.name': 'test-ent',
-            },
-            {
-              kind: 'system',
-              'metadata.namespace': 'default',
-              'metadata.name': 'test-ent-system',
-            },
-          ],
+          entityRefs: mockEntities,
         },
         {
           token: mockCredentials.service.token({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When querying the entities for a playlist, `getEntities()` is being used which takes a long time (can take several seconds). The source is entity refs, so instead using `getEntitiesByRefs()` reduces this down to milliseconds.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
