### PR TITLE
feat(rbac): improve rbac performance using multi-value permission filter

### DIFF
--- a/workspaces/rbac/.changeset/spicy-chairs-allow.md
+++ b/workspaces/rbac/.changeset/spicy-chairs-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': minor
+---
+
+Improve rbac performance using multi-value permission filters in the enforcer-delegate.ts.

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -414,22 +414,22 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
     const fileRoles = roleMetadatas.map(meta => meta.roleEntityRef);
 
     if (fileRoles.length > 0) {
-      for (const fileRole of fileRoles) {
-        const filteredPolicies = await this.enforcer.getFilteredGroupingPolicy(
-          1,
-          fileRole,
-        );
-        for (const groupPolicy of filteredPolicies) {
-          this.addGroupPolicyToMap(
-            this.csvFilePolicies.removedGroupPolicies,
-            groupPolicy[1],
-            groupPolicy[0],
-          );
-        }
-        this.csvFilePolicies.removedPolicies.push(
-          ...(await this.enforcer.getFilteredPolicy(0, fileRole)),
+      const fileRoleFilter = fileRoles.map(role => [role]);
+
+      const filteredPolicies = await this.enforcer.getFilteredGroupingPolicy(
+        1,
+        ...fileRoleFilter,
+      );
+      for (const groupPolicy of filteredPolicies) {
+        this.addGroupPolicyToMap(
+          this.csvFilePolicies.removedGroupPolicies,
+          groupPolicy[1],
+          groupPolicy[0],
         );
       }
+      this.csvFilePolicies.removedPolicies.push(
+        ...(await this.enforcer.getFilteredPolicy(0, ...fileRoleFilter)),
+      );
     }
     await this.removePermissionPolicies();
     await this.removeRoles();

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -269,16 +269,16 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     action: string,
     roles: string[],
   ): Promise<boolean> {
+    const filter: string[][] = [];
     for (const role of roles) {
-      const perms = await this.enforcer.getFilteredPolicy(
-        0,
-        role,
-        permissionName,
-        action,
-      );
-      if (perms.length > 0) {
-        return true;
-      }
+      filter.push([role, permissionName, action]);
+    }
+    if (filter.length === 0) {
+      return false;
+    }
+    const perms = await this.enforcer.getFilteredPolicy(0, ...filter);
+    if (perms.length > 0) {
+      return true;
     }
 
     return false;

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -240,6 +240,7 @@ describe('Connection', () => {
         ['user:default/Adam', 'role:default/test-provider'], // to add
       ];
 
+      await provider.applyRoles(roles);
       const roleMeta = {
         createdAt: new Date().toUTCString(),
         lastModified: new Date().toUTCString(),
@@ -247,8 +248,6 @@ describe('Connection', () => {
         source: 'test',
         roleEntityRef: roles[0][1],
       };
-
-      await provider.applyRoles(roles);
       expect(enfAddGroupingPolicySpy).toHaveBeenNthCalledWith(
         1,
         ['user:default/test', 'role:default/test-provider'],
@@ -359,6 +358,11 @@ describe('Connection', () => {
 
       const failingRoleToAdd = `user:default/test,role:default/`;
       const roleToAdd = [['user:default/test', 'role:default/test-provider']];
+
+      await provider.applyRoles(roles);
+      expect(mockLoggerService.warn).toHaveBeenCalledWith(
+        `Failed to validate group policy ${failingRoleToAdd}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
+      );
       const roleMeta = {
         createdAt: new Date().toUTCString(),
         lastModified: new Date().toUTCString(),
@@ -366,11 +370,6 @@ describe('Connection', () => {
         source: 'test',
         roleEntityRef: roleToAdd[0][1],
       };
-
-      await provider.applyRoles(roles);
-      expect(mockLoggerService.warn).toHaveBeenCalledWith(
-        `Failed to validate group policy ${failingRoleToAdd}. Cause: Entity reference "role:default/" was not on the form [<kind>:][<namespace>/]<name>`,
-      );
       expect(enfAddGroupingPolicySpy).toHaveBeenCalledWith(
         ...roleToAdd,
         roleMeta,

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -67,12 +67,11 @@ export class Connection implements RBACProviderConnection {
     const providerRoles = await this.getProviderRoles();
 
     await this.enforcer.loadPolicy();
-    // Get the roles for this provider coming from rbac plugin
-    for (const providerRole of providerRoles) {
-      providerRolesforRemoval.push(
-        ...(await this.enforcer.getFilteredGroupingPolicy(1, providerRole)),
-      );
-    }
+
+    const rolePermFilter = providerRoles.map(role => [role]);
+    providerRolesforRemoval.push(
+      ...(await this.enforcer.getFilteredGroupingPolicy(1, ...rolePermFilter)),
+    );
 
     // Remove role
     // role exists in rbac but does not exist in provider
@@ -97,11 +96,10 @@ export class Connection implements RBACProviderConnection {
 
     await this.enforcer.loadPolicy();
     // Get the roles for this provider coming from rbac plugin
-    for (const providerRole of providerRoles) {
-      providerPermissions.push(
-        ...(await this.enforcer.getFilteredPolicy(0, providerRole)),
-      );
-    }
+    const providerRolePermFilter = providerRoles.map(role => [role]);
+    providerPermissions.push(
+      ...(await this.enforcer.getFilteredPolicy(0, ...providerRolePermFilter)),
+    );
 
     await this.removePermissions(providerPermissions, tempEnforcer);
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -751,31 +751,16 @@ describe('REST policies API', () => {
       enforcerDelegateMock.getFilteredPolicy = jest
         .fn()
         .mockImplementation(
-          async (_fieldIndex: number, ...fieldValues: string[]) => {
-            if (fieldValues[0] === 'role:default/permission_admin') {
-              return [
-                [
-                  'role:default/permission_admin',
-                  'policy.entity.create',
-                  'create',
-                  'allow',
-                ],
-              ];
-            }
-
-            if (fieldValues[0] === 'role:default/guest') {
-              return [
-                [
-                  'role:default/guest',
-                  'policy-entity',
-                  'read',
-                  'allow',
-                  'rest',
-                ],
-              ];
-            }
-
-            return [];
+          async (_fieldIndex: number, ..._fieldValues: string[]) => {
+            return [
+              [
+                'role:default/permission_admin',
+                'policy.entity.create',
+                'create',
+                'allow',
+              ],
+              ['role:default/guest', 'policy-entity', 'read', 'allow', 'rest'],
+            ];
           },
         );
       const result = await request(app).get('/policies').send();
@@ -813,38 +798,23 @@ describe('REST policies API', () => {
       enforcerDelegateMock.getFilteredPolicy = jest
         .fn()
         .mockImplementation(
-          async (_fieldIndex: number, ...fieldValues: string[]) => {
-            if (fieldValues[0] === 'role:default/permission_admin') {
-              return [
-                [
-                  'role:default/permission_admin',
-                  'policy.entity.create',
-                  'create',
-                  'allow',
-                ],
-              ];
-            }
-
-            if (fieldValues[0] === 'role:default/guest') {
-              return [
-                [
-                  'role:default/guest',
-                  'policy-entity',
-                  'read',
-                  'allow',
-                  'rest',
-                ],
-                [
-                  'role:default/guest',
-                  'policy-entity',
-                  'create',
-                  'allow',
-                  'rest',
-                ],
-              ];
-            }
-
-            return [];
+          async (_fieldIndex: number, ..._fieldValues: string[]) => {
+            return [
+              [
+                'role:default/permission_admin',
+                'policy.entity.create',
+                'create',
+                'allow',
+              ],
+              ['role:default/guest', 'policy-entity', 'read', 'allow', 'rest'],
+              [
+                'role:default/guest',
+                'policy-entity',
+                'create',
+                'allow',
+                'rest',
+              ],
+            ];
           },
         );
       const result = await request(app).get('/policies').send();

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -205,14 +205,12 @@ export class PoliciesServer {
             ? await this.enforcer.getFilteredPolicy(0, ...filter)
             : [];
         } else {
-          for (const role of roleMetadata) {
-            policies.push(
-              ...(await this.enforcer.getFilteredPolicy(
-                0,
-                ...[role.roleEntityRef],
-              )),
-            );
-          }
+          const rolePermFilter: string[][] = roleMetadata.map(r => [
+            r.roleEntityRef,
+          ]);
+          policies.push(
+            ...(await this.enforcer.getFilteredPolicy(0, ...rolePermFilter)),
+          );
         }
 
         const body = await this.transformPolicyArray(...policies);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improve rbac performance using multi-value permission filters in the enforcer-delegate.ts

## How to test it

You can use my python script to messuare permission evaluation latency for user assigned to a lot of roles: https://github.com/PatAKnight/catalog-rbac-tests/pull/10

Result from the my laptop:

main branch [commit](https://github.com/backstage/community-plugins/commit/08f71c5eb755c2b4b67ef715744f65f550f30ed0):

```
Max latency value is 0.107 seconds
Min latency value is 0.055 seconds
Average request duration is time: 0.064 seconds
```

And my pr rebase to the same [commit](https://github.com/backstage/community-plugins/commit/08f71c5eb755c2b4b67ef715744f65f550f30ed0):

```
Max latency value is 0.082 seconds
Min latency value is 0.037 seconds
Average request duration is time: 0.042 seconds
```

I used user with generated 50 roles and script made default 1000 requests.

So (((0.064 - 0.042) / 0.064) * 100) = 34,375 %

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
