### PR TITLE
fix(search-backend-module-confluence-collator): refine CQL query generation for spaces and query

### DIFF
--- a/workspaces/confluence/.changeset/kind-doors-trade.md
+++ b/workspaces/confluence/.changeset/kind-doors-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Refined CQL query generation in the Confluence collator to correctly handle combinations of 'spaces' and 'query' parameters, preventing invalid queries when 'spaces' is empty but 'query' is present. Updated tests and documentation accordingly.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -70,6 +70,13 @@ confluence:
 
 Documentation about CQL can be found [here](https://developer.atlassian.com/server/confluence/advanced-searching-using-cql)
 
+**Behavior of `spaces` and `query`:**
+
+- If both `spaces` and `query` are provided, they will be combined with an `AND` operator. For example, if `spaces` is `["SPACE1", "SPACE2"]` and `query` is `type = page`, the resulting CQL will be `(space="SPACE1" or space="SPACE2") and (type = page)`.
+- If only `spaces` is provided, only pages from those spaces will be indexed. For example, if `spaces` is `["SPACE1", "SPACE2"]`, the resulting CQL will be `space="SPACE1" or space="SPACE2"`.
+- If only `query` is provided, the query will be applied to all accessible spaces. For example, if `query` is `type = page`, the resulting CQL will be `type = page`.
+- If neither `spaces` nor `query` is provided, all pages, blogposts, comments, and attachments from all accessible spaces will be indexed. The default CQL in this case is `type IN (page, blogpost, comment, attachment)`.
+
 The sections below will go into more details about the Base URL and Auth Methods.
 
 #### Base URL

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
@@ -269,11 +269,19 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
 
   private async getConfluenceQuery(): Promise<string> {
     const spaceList = await this.getSpacesConfig();
-    const spaceQuery = spaceList.map(s => `space="${s}"`).join(' or ');
-    let query = spaceQuery;
-    const additionalQuery = this.query;
-    if (additionalQuery !== '') {
+    const spaceQuery =
+      spaceList.length > 0
+        ? spaceList.map(s => `space="${s}"`).join(' or ')
+        : '';
+    const additionalQuery = this.query?.trim() ?? '';
+
+    let query = '';
+    if (spaceQuery && additionalQuery) {
       query = `(${spaceQuery}) and (${additionalQuery})`;
+    } else if (spaceQuery) {
+      query = spaceQuery;
+    } else if (additionalQuery) {
+      query = additionalQuery;
     }
     // If no query is provided, default to fetching all pages, blogposts, comments and attachments (which encompasses all content)
     // https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/#type


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #4016

Previously, the Confluence collator would generate an invalid CQL query of the form `() and (label="test")` if the `spaces` 
configuration was empty or not provided, but a `query` was specified. This resulted in no search results.

This commit refines the CQL query generation logic to correctly handle different combinations of `spaces` and `query` parameters:
- If only `spaces` are provided, the query will be `space=S1 or space=S2`.
- If only `query` is provided, the query will be `your_query_here`.
- If both `spaces` and `query` are provided, they will be combined as `(space="S1" or space="S2") and (your_query_here)`.
- If neither is provided, the default query to fetch all content types (`type IN (page, blogpost, comment, attachment)`) is used.

Additionally, new test cases have been added to cover these scenarios, and the plugin documentation has been updated to clarify the behavior of these parameters.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
