### PR TITLE
3scale: Use existing owner and system config to ingest entities

### DIFF
--- a/workspaces/3scale/.changeset/fluffy-pants-arrive.md
+++ b/workspaces/3scale/.changeset/fluffy-pants-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-3scale-backend': minor
+---
+
+Use the existing config values systemLabel and ownerLabel to ingest entities correctly

--- a/workspaces/3scale/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.test.ts
+++ b/workspaces/3scale/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.test.ts
@@ -65,6 +65,7 @@ describe('ThreeScaleApiEntityProvider', () => {
             test: {
               baseUrl: 'test',
               accessToken: 'test',
+              ownerLabel: 'test',
             },
           },
         },
@@ -321,7 +322,7 @@ function createExpectedEntity(
         type: 'openapi',
         lifecycle: 'test',
         system: '3scale',
-        owner: '3scale',
+        owner: 'test',
         definition: JSON.stringify(
           readTestJSONFile(fileWithExpectedOpenAPISpec),
           null,

--- a/workspaces/3scale/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.ts
+++ b/workspaces/3scale/plugins/3scale-backend/src/providers/ThreeScaleApiEntityProvider.ts
@@ -34,11 +34,7 @@ import {
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
 
-import {
-  getProxyConfig,
-  listApiDocs,
-  listServices,
-} from '../clients/ThreeScaleAPIConnector';
+import { getProxyConfig, listApiDocs, listServices } from '../clients';
 import type {
   APIDocElement,
   APIDocs,
@@ -64,6 +60,8 @@ export class ThreeScaleApiEntityProvider implements EntityProvider {
   private readonly env: string;
   private readonly baseUrl: string;
   private readonly accessToken: string;
+  private readonly ownerLabel: string;
+  private readonly systemLabel: string;
   private readonly logger: LoggerService;
   private readonly scheduleFn: () => Promise<void>;
   private readonly openApiMerger: OpenAPIMergerAndConverter;
@@ -123,6 +121,8 @@ export class ThreeScaleApiEntityProvider implements EntityProvider {
     this.env = config.id;
     this.baseUrl = config.baseUrl;
     this.accessToken = config.accessToken;
+    this.ownerLabel = config.ownerLabel || '3scale';
+    this.systemLabel = config.systemLabel || '3scale';
     this.logger = logger.child({
       target: this.getProviderName(),
     });
@@ -334,8 +334,8 @@ export class ThreeScaleApiEntityProvider implements EntityProvider {
       spec: {
         type: 'openapi',
         lifecycle: this.env,
-        system: '3scale',
-        owner: '3scale',
+        system: this.systemLabel,
+        owner: this.ownerLabel,
         definition: JSON.stringify(swaggerDocJSON, null, 2),
       },
     };


### PR DESCRIPTION
Signed-off-by: Jefwillems <jefwillems100@gmail.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR makes it so the ThreeScaleApiEntityProvider actually uses the config `systemLabel` and `ownerLabel`, which already existed, when processing 3scale services. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
