### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/grumpy-doors-smell.md
+++ b/workspaces/rbac/.changeset/grumpy-doors-smell.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Replaced `getTitleCase` from `shared-react` with the `capitalizeFirstLetter` utility from the RBAC plugin as part of sunsetting the `shared-react` package.

--- a/workspaces/rbac/.changeset/kind-buckets-punch.md
+++ b/workspaces/rbac/.changeset/kind-buckets-punch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Introduce API to store additional plugin ID list

--- a/workspaces/rbac/.changeset/modern-buttons-breathe.md
+++ b/workspaces/rbac/.changeset/modern-buttons-breathe.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Improve `useRoles` hook to support paginated role condition fetching using `Promise.allSettled`, ensuring partial data availability even if individual condition fetch fails.

--- a/workspaces/rbac/.changeset/renovate-09f2059.md
+++ b/workspaces/rbac/.changeset/renovate-09f2059.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.22`.

--- a/workspaces/rbac/.changeset/renovate-3c48922.md
+++ b/workspaces/rbac/.changeset/renovate-3c48922.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.15.29`.

--- a/workspaces/rbac/.changeset/renovate-4de7e1c.md
+++ b/workspaces/rbac/.changeset/renovate-4de7e1c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.12`.

--- a/workspaces/rbac/.changeset/small-kids-explain.md
+++ b/workspaces/rbac/.changeset/small-kids-explain.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Migrate rbac-backend to use permission registry service.

--- a/workspaces/rbac/.changeset/wise-jokes-perform.md
+++ b/workspaces/rbac/.changeset/wise-jokes-perform.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-common': minor
----
-
-Introduce a type that defines an additional list of plugin IDs.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 6.3.0
+
+### Minor Changes
+
+- a42945e: Introduce API to store additional plugin ID list
+- 3e3f346: Migrate rbac-backend to use permission registry service.
+
+### Patch Changes
+
+- 098b200: Updated dependency `@types/express` to `4.17.22`.
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+- Updated dependencies [a42945e]
+  - @backstage-community/plugin-rbac-common@1.17.0
+
 ## 6.2.6
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "6.2.6",
+  "version": "6.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.17.0
+
+### Minor Changes
+
+- a42945e: Introduce a type that defines an additional list of plugin IDs.
+
 ## 1.16.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.41.6
+
+### Patch Changes
+
+- 6c4ee27: Replaced `getTitleCase` from `shared-react` with the `capitalizeFirstLetter` utility from the RBAC plugin as part of sunsetting the `shared-react` package.
+- e141237: Improve `useRoles` hook to support paginated role condition fetching using `Promise.allSettled`, ensuring partial data availability even if individual condition fetch fails.
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+- 7d6d70f: Updated dependency `start-server-and-test` to `2.0.12`.
+- Updated dependencies [a42945e]
+  - @backstage-community/plugin-rbac-common@1.17.0
+
 ## 1.41.5
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.41.5",
+  "version": "1.41.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@6.3.0

### Minor Changes

-   a42945e: Introduce API to store additional plugin ID list
-   3e3f346: Migrate rbac-backend to use permission registry service.

### Patch Changes

-   098b200: Updated dependency `@types/express` to `4.17.22`.
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.
-   Updated dependencies [a42945e]
    -   @backstage-community/plugin-rbac-common@1.17.0

## @backstage-community/plugin-rbac-common@1.17.0

### Minor Changes

-   a42945e: Introduce a type that defines an additional list of plugin IDs.

## @backstage-community/plugin-rbac@1.41.6

### Patch Changes

-   6c4ee27: Replaced `getTitleCase` from `shared-react` with the `capitalizeFirstLetter` utility from the RBAC plugin as part of sunsetting the `shared-react` package.
-   e141237: Improve `useRoles` hook to support paginated role condition fetching using `Promise.allSettled`, ensuring partial data availability even if individual condition fetch fails.
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.
-   7d6d70f: Updated dependency `start-server-and-test` to `2.0.12`.
-   Updated dependencies [a42945e]
    -   @backstage-community/plugin-rbac-common@1.17.0
