### PR TITLE
repo-tools - Fixed Create Workspace Command

### DIFF
--- a/workspaces/repo-tools/packages/cli/src/commands/index.ts
+++ b/workspaces/repo-tools/packages/cli/src/commands/index.ts
@@ -17,13 +17,25 @@ import { Command } from 'commander';
 import { exitWithError } from '../lib/errors';
 import { assertError } from '@backstage/errors';
 
+type ActionFunc = (...args: any[]) => Promise<void>;
+type ActionExports<TModule extends object> = {
+  [KName in keyof TModule as TModule[KName] extends ActionFunc
+    ? KName
+    : never]: TModule[KName];
+};
+
 // Wraps an action function so that it always exits and handles errors
-function lazy(
-  getActionFunc: () => Promise<(...args: any[]) => Promise<void>>,
+export function lazy<TModule extends object>(
+  moduleLoader: () => Promise<TModule>,
+  exportName: keyof ActionExports<TModule>,
 ): (...args: any[]) => Promise<never> {
   return async (...args: any[]) => {
     try {
-      const actionFunc = await getActionFunc();
+      const mod = await moduleLoader();
+      const actualModule = (
+        mod as unknown as { default: ActionExports<TModule> }
+      ).default;
+      const actionFunc = actualModule[exportName] as ActionFunc;
       await actionFunc(...args);
 
       process.exit(0);
@@ -45,12 +57,12 @@ export const registerCommands = (program: Command) => {
     )
     .option('--branch [branch]', 'use a branch for deprecation commits')
     .option('--force', 'Overwrite existing workspace', false)
-    .action(lazy(() => import('./plugin/migrate').then(m => m.default)));
+    .action(lazy(() => import('./plugin/migrate'), 'default'));
 
   program
     .command('workspace')
     .command('create')
-    .action(lazy(() => import('./workspace/create').then(m => m.default)));
+    .action(lazy(() => import('./workspace/create'), 'default'));
 
   const lintCommand = program
     .command('lint [command]')
@@ -60,9 +72,5 @@ export const registerCommands = (program: Command) => {
     .description(
       'Lint backend plugin packages for legacy exports and make sure it conforms to the new export pattern',
     )
-    .action(
-      lazy(() =>
-        import('./lint/lint-legacy-backend-exports').then(m => m.lint),
-      ),
-    );
+    .action(lazy(() => import('./lint/lint-legacy-backend-exports'), 'lint'));
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently when running the `yarn create-workspace` as per the Contributing guide you will get the following error:

```text
TypeError: actionFunc is not a function
    at Command.<anonymous> (/Users/user/projects/backstage/plugins/community-plugins/workspaces/repo-tools/packages/cli/src/commands/index.ts:32:19)
```

This looks to be introduced by #3770 which updated the `@backstage/cli` package. The upstream version of `lazy()` that we copied here was changed as part of adding support for ESM - https://github.com/backstage/backstage/pull/28308 - updating that function and some related changes has it working again.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
