### PR TITLE
include knip report checks in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,20 @@ jobs:
 
       - name: prettier
         run: yarn prettier:check
+      
+      - name: read knip-reports flag from bcp.json
+        id: bcp
+        run: |
+          if [ -f workspaces/${{ matrix.workspace }}/bcp.json ]; then
+            KNIP_REPORTS=$(jq -r '.["knip-reports"]' workspaces/${{ matrix.workspace }}/bcp.json)
+            echo "knip_reports=$KNIP_REPORTS" >> $GITHUB_OUTPUT
+          else
+            echo "knip_reports=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: check knip reports
+        if: ${{ steps.bcp.outputs.knip_reports == 'true' }}
+        run: yarn backstage-repo-tools knip-reports --ci
 
       - name: check api reports and generate API reference
         run: yarn build:api-reports:only --ci

--- a/workspaces/scaffolder-relation-processor/bcp.json
+++ b/workspaces/scaffolder-relation-processor/bcp.json
@@ -1,0 +1,3 @@
+{
+  "knip-reports": true
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds an optional check for knip reports in the ci by using the --ci flag for the knip-reports command provided by @backstage/repo-tools. Knip reports are checked only if the workspace has a bcp.json file where the `knip-reports` field is set to true.

Currently, only the scaffolder-relation-processor workspace has the bcp.json file for testing purposes.

Addresses: https://github.com/backstage/community-plugins/issues/3933

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
