### PR TITLE
[copilot] Improve error-log in the case the error is a Promise rejection.

### DIFF
--- a/workspaces/copilot/.changeset/nervous-vans-smell.md
+++ b/workspaces/copilot/.changeset/nervous-vans-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+Improves the error-log to await if the error is of type Promise.

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
@@ -151,9 +151,25 @@ export async function discoverEnterpriseMetrics({
       logger.info('[discoverEnterpriseMetrics] No new metrics found to insert');
     }
   } catch (error) {
-    logger.error(
-      `[discoverEnterpriseMetrics] An error occurred while processing Github Copilot metrics: ${error}`,
-    );
+    let actualError = error;
+    if (error instanceof Promise) {
+      try {
+        await error;
+      } catch (inner) {
+        actualError = inner;
+      }
+    }
+    if (actualError instanceof Error) {
+      logger.error(
+        `[discoverEnterpriseMetrics] An error occurred while processing Github Copilot metrics: ${actualError.message}\n${actualError.stack}`,
+      );
+    } else {
+      logger.error(
+        `[discoverEnterpriseMetrics] An error occurred while processing Github Copilot metrics: ${JSON.stringify(
+          actualError,
+        )}`,
+      );
+    }
     throw error;
   }
 }

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
@@ -178,9 +178,25 @@ export async function discoverEnterpriseTeamMetrics({
           );
         }
       } catch (error) {
-        logger.error(
-          `[discoverEnterpriseTeamMetrics] Error processing metrics for team ${team.slug}: ${error}`,
-        );
+        let actualError = error;
+        if (error instanceof Promise) {
+          try {
+            await error;
+          } catch (inner) {
+            actualError = inner;
+          }
+        }
+        if (actualError instanceof Error) {
+          logger.error(
+            `[discoverEnterpriseTeamMetrics] Error processing metrics for team ${team.slug}: ${actualError.message}\n${actualError.stack}`,
+          );
+        } else {
+          logger.error(
+            `[discoverEnterpriseTeamMetrics] Error processing metrics for team ${
+              team.slug
+            }: ${JSON.stringify(actualError)}`,
+          );
+        }
       }
     }
   } catch (error) {

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
@@ -153,9 +153,25 @@ export async function discoverOrganizationMetrics({
       );
     }
   } catch (error) {
-    logger.error(
-      `[discoverOrganizationMetrics] An error occurred while processing Github Copilot metrics: ${error}`,
-    );
+    let actualError = error;
+    if (error instanceof Promise) {
+      try {
+        await error;
+      } catch (inner) {
+        actualError = inner;
+      }
+    }
+    if (actualError instanceof Error) {
+      logger.error(
+        `[discoverOrganizationMetrics] An error occurred while processing Github Copilot metrics: ${actualError.message}\n${actualError.stack}`,
+      );
+    } else {
+      logger.error(
+        `[discoverOrganizationMetrics] An error occurred while processing Github Copilot metrics: ${JSON.stringify(
+          actualError,
+        )}`,
+      );
+    }
     throw error;
   }
 }

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
@@ -179,9 +179,25 @@ export async function discoverOrganizationTeamMetrics({
           );
         }
       } catch (error) {
-        logger.error(
-          `[discoverOrganizationTeamMetrics] Error processing metrics for team ${team.slug}: ${error}`,
-        );
+        let actualError = error;
+        if (error instanceof Promise) {
+          try {
+            await error;
+          } catch (inner) {
+            actualError = inner;
+          }
+        }
+        if (actualError instanceof Error) {
+          logger.error(
+            `[discoverOrganizationTeamMetrics] Error processing metrics for team ${team.slug}: ${actualError.message}\n${actualError.stack}`,
+          );
+        } else {
+          logger.error(
+            `[discoverOrganizationTeamMetrics] Error processing metrics for team ${
+              team.slug
+            }: ${JSON.stringify(actualError)}`,
+          );
+        }
       }
     }
   } catch (error) {

--- a/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagement.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagement.ts
@@ -54,13 +54,22 @@ export default class TaskManagement {
       try {
         await task();
       } catch (e) {
-        if (e instanceof Error) {
+        // If e is a Promise, await it to get the actual error
+        let error = e;
+        if (e instanceof Promise) {
+          try {
+            await e;
+          } catch (inner) {
+            error = inner;
+          }
+        }
+        if (error instanceof Error) {
           this.options.logger.error(
-            `[TaskManagement] Failed to process task: ${e.message}`,
+            `[TaskManagement] Failed to process task: ${error.message}\n${error.stack}`,
           );
         } else {
           this.options.logger.error(
-            `[TaskManagement] Failed to process task: ${e}`,
+            `[TaskManagement] Failed to process task: ${JSON.stringify(error)}`,
           );
         }
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We started getting a lot of these errors in random: [TaskManagement] Failed to process task: [object Promise]

But we cant really figure out why they fail.
So this improves the logging to await if the error is a Promise rejection, in order to figure out what is going on.

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
