### PR TITLE
[SonarQube Plugin] Fix handling of wrong project key when retrieving findings

### DIFF
--- a/workspaces/sonarqube/.changeset/green-pillows-doubt.md
+++ b/workspaces/sonarqube/.changeset/green-pillows-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': patch
+---
+
+Fixed handling of wrong component keys in getFindingSummaries

--- a/workspaces/sonarqube/examples/entities.yaml
+++ b/workspaces/sonarqube/examples/entities.yaml
@@ -26,10 +26,22 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
+  name: example-service
+  # intentionally no sonarqube.org/project-key
+spec:
+  type: service
+  lifecycle: experimental
+  owner: guests
+  system: examples
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
   name: example-website
   annotations:
     jenkins.io/job-full-name: folder/job
-    sonarqube.org/project-key: backstage
+    sonarqube.org/project-key: wrong-project-key
 spec:
   type: website
   lifecycle: experimental

--- a/workspaces/sonarqube/plugins/sonarqube/src/api/SonarQubeClient.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube/src/api/SonarQubeClient.test.ts
@@ -197,6 +197,12 @@ describe('SonarQubeClient', () => {
             const componentKey = new URL(input.toString()).searchParams.get(
               'componentKey',
             );
+            if (componentKey === 'unknown') {
+              return {
+                status: 200,
+                json: '',
+              };
+            }
             const findings = {
               analysisDate:
                 componentKey === 'component-1'
@@ -297,6 +303,26 @@ describe('SonarQubeClient', () => {
       const summaries = await client.getFindingSummaries([]);
 
       expect(summaries.size).toBe(0);
+    });
+
+    it('should handle incorrect component keys', async () => {
+      const client = new SonarQubeClient({
+        discoveryApi,
+        fetchApi,
+      });
+
+      const summaries = await client.getFindingSummaries([
+        { projectInstance: 'instance-1', componentKey: 'component-1' },
+        { projectInstance: 'instance-2', componentKey: 'unknown' },
+      ]);
+
+      expect(summaries.size).toBe(1);
+      const summary1 = summaries.get('component-1');
+      expect(summary1).toEqual(
+        expect.objectContaining({
+          projectUrl: 'https://sonarcloud.io/dashboard?id=component-1',
+        }),
+      );
     });
   });
 });

--- a/workspaces/sonarqube/plugins/sonarqube/src/api/SonarQubeClient.ts
+++ b/workspaces/sonarqube/plugins/sonarqube/src/api/SonarQubeClient.ts
@@ -153,7 +153,7 @@ export class SonarQubeClient implements SonarQubeApi {
     });
 
     for await (const summary of summaries) {
-      if (!map.has(summary.title)) {
+      if (summary?.title && !map.has(summary.title)) {
         map.set(summary.title, summary);
       }
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Followup for https://github.com/backstage/community-plugins/issues/446, fixing the handling of wrong component keys in getFindingSummaries (before, the client would throw a TypeError with message `Cannot read properties of undefined (reading 'title')`).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
