### PR TITLE
plugin(keycloak): ensure subgroups are fetched from the correct realm

### DIFF
--- a/workspaces/keycloak/.changeset/heavy-papayas-smoke.md
+++ b/workspaces/keycloak/.changeset/heavy-papayas-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-keycloak': patch
+---
+
+ensure subgroups are fetched from the correct realm

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/src/lib/read.ts
@@ -216,6 +216,7 @@ export async function processGroupsRecursively(
         first: 0,
         max: group.subGroupCount,
         briefRepresentation: brief,
+        realm: config.realm,
       });
       const subGroupResults = await processGroupsRecursively(
         kcAdminClient,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Specify `realm` while fetching subgroups in the `listSubGroups` function so that groups are fetched from the correct subgroup.

Fixes: https://github.com/backstage/community-plugins/issues/4050

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
