### PR TITLE
fix(auto-version-bump): use correct github actions variable expression

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Delay batches (5 min between)
         if: ${{ strategy.job-index != 0 }}
         run: |
-          delay=$(( strategy.job-index * 300 ))
+          delay=$(( ${{ strategy.job-index }} * 300 ))
           echo "Sleeping $delay seconds before triggering batch ${{ strategy.job-index }}..."
           sleep $delay
 


### PR DESCRIPTION
Just a small PR to use the correct GitHub Actions variable expression, otherwise the n+1 batch will throw an error:

![Schermafbeelding_2025-05-27_om_16 50 17](https://github.com/user-attachments/assets/3d12a12d-45fa-4b2b-8a04-5461cf872565)

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))