### PR TITLE
plugin(announcements): remove @types/node to resolve global 'require' conflict

### DIFF
--- a/workspaces/announcements/.changeset/bright-foxes-hope.md
+++ b/workspaces/announcements/.changeset/bright-foxes-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+remove direct dependency on '@types/node'

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -90,7 +90,6 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",
     "@types/luxon": "^3.3.3",
-    "@types/node": "^18.18.7",
     "cross-fetch": "^3.1.8",
     "msw": "^1.3.2",
     "react": "^17.0.0 || ^18.0.0",

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -2749,7 +2749,6 @@ __metadata:
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.5.1"
     "@types/luxon": "npm:^3.3.3"
-    "@types/node": "npm:^18.18.7"
     "@types/react": "npm:^17.0.0 || ^18.0.0"
     "@uiw/react-md-editor": "npm:^4.0.3"
     add: "npm:^2.0.6"
@@ -11909,7 +11908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.11.18, @types/node@npm:^18.11.9, @types/node@npm:^18.18.7":
+"@types/node@npm:^18.11.18, @types/node@npm:^18.11.9":
   version: 18.19.68
   resolution: "@types/node@npm:18.19.68"
   dependencies:


### PR DESCRIPTION
Removing `@types/node` from direct devDependencies eliminates a type conflict between `@types/node` and `@types/webpack-env` over the global 'require' variable. Other dependencies already include @types/node where needed.

----
This is currently blocking https://github.com/backstage/community-plugins/pull/2403 from being merged with the following error:

```console
Run yarn tsc:full
node_modules/@types/node/module.d.ts:757:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'require' must be of type 'NodeRequire', but here has type 'Require'.

757         var require: NodeJS.Require;
                ~~~~~~~

  node_modules/@types/webpack-env/index.d.ts:277:13
    277 declare var require: NodeRequire;
                    ~~~~~~~
    'require' was also declared here.


Found 1 error in node_modules/@types/node/module.d.ts:757
```
----
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
