### PR TITLE
doc: add section on stepping down as plugin owner

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -7,6 +7,7 @@
   - [Plugin Owner Expectations](#plugin-owner-expectations)
     - [PR Reviews \& Merging](#pr-reviews--merging)
     - [Issue Triage](#issue-triage)
+    - [Stepping Down as a Plugin Owner](#stepping-down-as-a-plugin-owner)
   - [Version Bumping](#version-bumping)
 - [Opt-in to Automatic Version Bump PRs](#opt-in-to-automatic-version-bump-prs)
   - [Maintaining and patching an older release line](#maintaining-and-patching-an-older-release-line)
@@ -27,6 +28,25 @@ It is also helpful for workspace owners to review and add approvals to PRs that 
 ### Issue Triage
 
 Plugin owners should triage issues related to their plugin as needed. The `@backstage/community-plugin-maintainers` group may tag the listed owners on relevant issues.
+
+### Stepping Down as a Plugin Owner
+
+It's okay to step down as a plugin owner — priorities, roles, and availability naturally change over time. It’s better to reflect current reality than to appear active when you’re not available. If you remain listed as a CODEOWNER, GitHub will continue to assign you to issues and reviews, which can lead to confusion or delays for contributors.
+
+If you are no longer maintaining a plugin, please take the following steps to formally step down:
+
+1. Remove yourself from the CODEOWNERS file:
+
+   - Edit the [CODEOWNERS](https://github.com/backstage/community-plugins/blob/main/.github/CODEOWNERS) file to remove your GitHub handle from the plugin or workspace you no longer maintain.
+   - Open a pull request with a description stating that you are stepping down as a maintainer.
+
+2. Leave any associated GitHub teams:
+
+   - If you were added to any GitHub teams specifically for plugin ownership or maintenance, please leave those teams.
+
+3. If you are the last remaining CODEOWNER:
+   - The `@backstage/community-plugins-maintainers` group will provide best-effort support for issues and maintenance. Without a dedicated owner, plugin updates and support may be slower or limited.
+   - To help with this, opt into automatic version bump PRs by creating an empty `.auto-version-bump` file in the plugin’s workspace (i.e., `workspaces/${WORKSPACE}/.auto-version-bump`).
 
 ## Version Bumping
 


### PR DESCRIPTION
Refs: https://github.com/backstage/community-plugins/issues/3184

cc: @backstage/community-plugins-maintainers 
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
