### PR TITLE
Version Packages (3scale)

### DIFF
--- a/workspaces/3scale/.changeset/fluffy-pants-arrive.md
+++ b/workspaces/3scale/.changeset/fluffy-pants-arrive.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-3scale-backend': minor
----
-
-Use the existing config values systemLabel and ownerLabel to ingest entities correctly

--- a/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
+++ b/workspaces/3scale/plugins/3scale-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-plugin-3scale-backend [1.8.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-plugin-3scale-backend@1.7.1...@janus-idp/backstage-plugin-3scale-backend@1.8.0) (2024-07-25)
 
+## 3.5.0
+
+### Minor Changes
+
+- 321413c: Use the existing config values systemLabel and ownerLabel to ingest entities correctly
+
 ## 3.4.0
 
 ### Minor Changes

--- a/workspaces/3scale/plugins/3scale-backend/package.json
+++ b/workspaces/3scale/plugins/3scale-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-3scale-backend",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-3scale-backend@3.5.0

### Minor Changes

-   321413c: Use the existing config values systemLabel and ownerLabel to ingest entities correctly
