### PR TITLE
ci: enable npm provenance on publish (supported in Yarn 4.9.0+)

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -107,6 +107,9 @@ jobs:
   release:
     name: Release workspace ${{ inputs.workspace }} on branch ${{ inputs.branch }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # needed for publish provenance
     needs: changesets-pr
     if: needs.changesets-pr.outputs.needs_release == 'true' || inputs.force_release == true
     defaults:
@@ -154,7 +157,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -W -v --no-private npm publish --access public --tolerate-republish
+          yarn workspaces foreach -W -v --no-private npm publish --access public --provenance --tolerate-republish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -123,6 +123,9 @@ jobs:
   release:
     name: Prior Version Release workspace ${{ needs.check-merged-pr.outputs.workspace_name }} on branch ${{ github.ref }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # needed for publish provenance
     needs: check-merged-pr
     if: needs.check-merged-pr.outputs.is_version_pr == 'true'
     defaults:
@@ -171,7 +174,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --tolerate-republish --tag "maintenance"
+          yarn workspaces foreach -v --no-private npm publish --access public --provenance --tolerate-republish --tag "maintenance"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       


### PR DESCRIPTION
Adds `--provenance` flag to the publish step and `id-token: write` permission to support npm provenance. Supported via Yarn v4.9.0+.

See: https://docs.npmjs.com/generating-provenance

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
----

All published packages would have then have provenance information similar to this on npm:
<img width="841" alt="image" src="https://github.com/user-attachments/assets/c35b86fd-ca08-40e7-bbac-97eee906cc30" />