### PR TITLE
Version Packages (gcalendar)

### DIFF
--- a/workspaces/gcalendar/.changeset/version-bump-1-39-0.md
+++ b/workspaces/gcalendar/.changeset/version-bump-1-39-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gcalendar': minor
----
-
-Backstage version bump to v1.39.0

--- a/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
+++ b/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gcalendar
 
+## 0.9.0
+
+### Minor Changes
+
+- 4b10cdd: Backstage version bump to v1.39.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/gcalendar/plugins/gcalendar/package.json
+++ b/workspaces/gcalendar/plugins/gcalendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gcalendar",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gcalendar@0.9.0

### Minor Changes

-   4b10cdd: Backstage version bump to v1.39.0
