### PR TITLE
fix(rbac): applying pagination on condition api call

### DIFF
--- a/workspaces/rbac/.changeset/modern-buttons-breathe.md
+++ b/workspaces/rbac/.changeset/modern-buttons-breathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Improve `useRoles` hook to support paginated role condition fetching using `Promise.allSettled`, ensuring partial data availability even if individual condition fetch fails.

--- a/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
@@ -36,8 +36,10 @@ export const RolesList = () => {
   const { openDialog, setOpenDialog, deleteComponent } = useDeleteDialog();
   useLocationToast(setToastMessage);
   const [searchText, setSearchText] = useState<string>();
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(5);
   const { loading, data, retry, createRoleAllowed, createRoleLoading, error } =
-    useRoles();
+    useRoles(page, pageSize);
 
   const closeDialog = () => {
     setOpenDialog(false);
@@ -117,6 +119,11 @@ export const RolesList = () => {
           </Box>
         }
         onSearchChange={setSearchText}
+        onPageChange={setPage}
+        onRowsPerPageChange={newPageSize => {
+          setPageSize(newPageSize);
+          setPage(0);
+        }}
       />
       {isLicensePluginEnabled.isEnabled && <DownloadCSVLink />}
       {openDialog && (


### PR DESCRIPTION
## Description

Previously, the Roles endpoint (`/api/permission/roles`) fetched all roles at once without pagination and the Conditions API (`/api/permission/roles/conditions?roleEntityRef=`) was triggered individually for each role. For example, if a user had 1000 roles, this would result in 1000 simultaneous API calls, leading to significant performance bottlenecks.

### This PR includes:

1. Implements **pagination-aware Conditions API calls** — only fetches conditions for roles visible on the current page.
2. Replaces `Promise.all` with `Promise.allSettled` to ensure that condition data is shown for available roles, even if some condition calls fail.

## Impact

- Reduces number of condition API calls from N (total roles) to P (roles per page).
- Improves frontend performance, stability, and scalability in environments with large numbers of roles.

### Fixes
Fix : https://issues.redhat.com/browse/RHIDP-5049

### Screen Recording of API calls before Fix 

https://github.com/user-attachments/assets/fb95e120-8d06-41dc-9bc0-d80719aabf63


### Screen Recording of API calls after Fix 

https://github.com/user-attachments/assets/6cc4f5f3-3854-4d4f-ac82-6762bc9e1133

