### PR TITLE
fix(renovate): support disabling caching

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -70,12 +70,16 @@ jobs:
           mkdir -p $cache_dir
           tar -xzf cache-download/$cache_archive -C $cache_dir
 
-          # Unfortunately, the permissions expected within renovate's docker container
-          # are different than the ones given after the cache is restored. We have to
-          # change ownership to solve this. We also need to have correct permissions in
-          # the entire /tmp/renovate tree, not just the section with the repo cache.
+      # Unfortunately, the permissions expected within renovate's docker container
+      # are different than the ones given after the cache is restored. We have to
+      # change ownership to solve this. We also need to have correct permissions in
+      # the entire /tmp/renovate tree, not just the section with the repo cache.
+      - name: Fix temporary directory permissions
+        run: |
+          # Make sure the temporary directory exists. If cache is disabled, the directory won't exist yet.
+          mkdir -p /tmp/renovate
+
           sudo chown -R 12021:0 /tmp/renovate/
-          ls -R $cache_dir
 
       - uses: renovatebot/github-action@v41.0.2
         with:
@@ -90,6 +94,7 @@ jobs:
 
       # Compression helps performance in the upload step!
       - name: Compress renovate cache
+        if: github.event.inputs.repoCache != 'disabled'
         run: |
           ls $cache_dir
           # The -C is important -- otherwise we end up extracting the files with


### PR DESCRIPTION
During forking the `community-plugins` repo, we encountered some issues with the Renovate workflow when disabling caching:

If caching is disabled, the commands in the `Extract renovate cache` step are not being executed, some of which are crucial for the next steps to succeed. More specifically, the temporary directory doesn't get created and of course the permissions of it also don't get fixed, leading to the Renovate step to fail. In addition, the `$cache_dir` directory is never created, which leads to the `Compress renovate cache` to fail.

This PR moves these commands to a separate step to run them regardless of the previous step and only executes the `Compress renovate cache` step when caching is disabled.

We are using self-hosted runners, so I'm not sure if this behaviour is specific to our environment, so please verify whether disabling cache is actually not working on this repository either.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
