### PR TITLE
chore(renovate): use forkProcessing instead of includeForks

### DIFF
--- a/.github/renovate-action.json
+++ b/.github/renovate-action.json
@@ -1,6 +1,6 @@
 {
   "platform": "github",
-  "includeForks": false,
+  "forkProcessing": "disabled",
   "repositories": ["backstage/community-plugins"],
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>"
 }


### PR DESCRIPTION
This small PR migrates the `includeForks` property of the Renovate config to the new [`forkProcessing`](https://docs.renovatebot.com/configuration-options/#forkprocessing) property. This saves the config migration that takes place in the Renovate step, although the impact of that is probably negligible.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
