### PR TITLE
Fix to remove trailing slash in mta.url #4147

### DIFF
--- a/workspaces/mta/.changeset/light-cougars-sort.md
+++ b/workspaces/mta/.changeset/light-cougars-sort.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/backstage-plugin-mta-backend': patch
+---
+
+Added logic to strip off any trailing forward slash in the mta.url string

--- a/workspaces/mta/plugins/mta-backend/src/plugin.ts
+++ b/workspaces/mta/plugins/mta-backend/src/plugin.ts
@@ -41,7 +41,7 @@ export const mtaPlugin = createBackendPlugin({
         // Setup OpenID Authentication Client
         const backstageBaseURL = config.getString('backend.baseUrl');
         const frontEndBaseURL = config.getString('app.baseUrl');
-        const baseUrl = config.getString('mta.url');
+        const baseUrl = config.getString('mta.url').replace(/\/+$/, '');
         const baseURLHub = `${baseUrl}/hub`;
         const realm = config.getString('mta.providerAuth.realm');
         const clientID = config.getString('mta.providerAuth.clientID');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
   This is a fix for #4174 that fixes the trailing slash on the `mta.url`.  

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
