### PR TITLE
Added a way to dynamically detect the plugin version from package.jso…

### DIFF
--- a/workspaces/mta/.changeset/many-paws-trade.md
+++ b/workspaces/mta/.changeset/many-paws-trade.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/backstage-plugin-mta-backend': patch
+---
+
+Add ability to dynamically detect plugin version instead of requiring it in the configuration

--- a/workspaces/mta/plugins/mta-backend/src/plugin.ts
+++ b/workspaces/mta/plugins/mta-backend/src/plugin.ts
@@ -58,8 +58,11 @@ export const mtaPlugin = createBackendPlugin({
         dotenv.config();
         const isDevelopment = process.env.NODE_ENV === 'development';
 
+        // Get version from package.json
+        const { version } = require('../package.json');
+
         const mtaVersion =
-          config.getOptionalString('mta.backendPluginVersion') ?? '0.2.2'; // Set in config
+          config.getOptionalString('mta.backendPluginVersion') ?? version; // Set in config
         const defaultBase = process.env.APP_ROOT ?? '/opt/app-root';
         const defaultPluginRoot = path.join(
           defaultBase,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
   Added the ability to dynamically detect the version of the backend plugin so it is no longer a required config

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
