### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/khaki-bees-lie.md
+++ b/workspaces/analytics/.changeset/khaki-bees-lie.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': patch
-'@backstage-community/plugin-analytics-module-matomo': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/analytics/.changeset/renovate-3c48922.md
+++ b/workspaces/analytics/.changeset/renovate-3c48922.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `22.15.29`.

--- a/workspaces/analytics/.changeset/swift-mugs-battle.md
+++ b/workspaces/analytics/.changeset/swift-mugs-battle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Updated the SegmentAnalytics class .fromConfig signature to better conform with Backstage recommended API

--- a/workspaces/analytics/.changeset/version-bump-1-39-0.md
+++ b/workspaces/analytics/.changeset/version-bump-1-39-0.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga': minor
-'@backstage-community/plugin-analytics-module-ga4': minor
-'@backstage-community/plugin-analytics-module-matomo': minor
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Backstage version bump to v1.39.0

--- a/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga
 
+## 0.8.0
+
+### Minor Changes
+
+- 4ed9028: Backstage version bump to v1.39.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.8.0
+
+### Minor Changes
+
+- 4ed9028: Backstage version bump to v1.39.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.16.0
+
+### Minor Changes
+
+- 4ed9028: Backstage version bump to v1.39.0
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+
 ## 1.15.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.7.0
+
+### Minor Changes
+
+- 4ed9028: Backstage version bump to v1.39.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.16.0
+
+### Minor Changes
+
+- e86934c: Updated the SegmentAnalytics class .fromConfig signature to better conform with Backstage recommended API
+- 4ed9028: Backstage version bump to v1.39.0
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+
 ## 1.15.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga@0.8.0

### Minor Changes

-   4ed9028: Backstage version bump to v1.39.0

## @backstage-community/plugin-analytics-module-ga4@0.8.0

### Minor Changes

-   4ed9028: Backstage version bump to v1.39.0

## @backstage-community/plugin-analytics-module-matomo@1.16.0

### Minor Changes

-   4ed9028: Backstage version bump to v1.39.0

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.

## @backstage-community/plugin-analytics-module-newrelic-browser@0.7.0

### Minor Changes

-   4ed9028: Backstage version bump to v1.39.0

## @backstage-community/plugin-analytics-provider-segment@1.16.0

### Minor Changes

-   e86934c: Updated the SegmentAnalytics class .fromConfig signature to better conform with Backstage recommended API
-   4ed9028: Backstage version bump to v1.39.0

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.
