### PR TITLE
update plugin maintainers guide

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -8,7 +8,8 @@
     - [PR Reviews \& Merging](#pr-reviews--merging)
     - [Issue Triage](#issue-triage)
   - [Version Bumping](#version-bumping)
-- [Opt-in to Automatic Version Bump PRs](#opt-in-to-automatic-version-bump-prs)
+  - [Opt-in to Automatic Version Bump PRs](#opt-in-to-automatic-version-bump-prs)
+  - [Opt-in to Knip Reports Check](#opt-in-to-knip-reports-check)
   - [Maintaining and patching an older release line](#maintaining-and-patching-an-older-release-line)
     - [Patching an older release](#patching-an-older-release)
 
@@ -26,13 +27,13 @@ It is also helpful for workspace owners to review and add approvals to PRs that 
 
 ### Issue Triage
 
-Plugin owners should triage issues related to their plugin as needed. The `@backstage/community-plugin-maintainers` group may tag the listed owners on relevant issues.
+Plugin owners should triage issues related to their plugin as needed. The `@backstage/community-plugin-maintainers` group may tag the listed owners on relevant issues. Issues are labeled as `workspace/<workspace_name>` based on their related workspace automatically by a workflow. Plugin maintainers can use these labels to easily filter and track issues relevant to their plugins.
 
 ## Version Bumping
 
 Plugin owners are expected to run the Version Bump script for their workspace. The process follows the guidance outlined in the [Version Bumping Documentation](https://github.com/backstage/community-plugins/blob/main/docs/version-bump.md).
 
-# Opt-in to Automatic Version Bump PRs
+## Opt-in to Automatic Version Bump PRs
 
 Plugin owners can opt in to automatic version bump PRs by creating an empty .auto-version-bump file in the root of their workspace (`workspaces/${WORKSPACE}/.auto-version-bump`). This signals that your plugin should be included in the batch version bump workflow, which is triggered manually by one of the `@backstage/community-plugins-maintainers` .
 
@@ -41,6 +42,12 @@ These automated PRs are intended as a convenience to open the version bump for y
 - Review the PR
 - Make any necessary patches to adopt the upgrade
 - Merge the PR once it's ready
+
+## Opt-in to Knip Reports Check
+
+Plugin owners can opt in to Knip reports check in CI by creating a `bcp.json` file in the root of their workspace (`workspaces/${WORKSPACE}/.auto-version-bump`) and adding `"knip-reports": true`. This ensures that knip reports in your workspace stay up to date.
+
+[Knip](https://knip.dev/) is a tool that helps with clean-up and maintenance by identifying unused dependencies within workspaces. Regularly reviewing and addressing these reports can significantly improve code quality and reduce bloat.
 
 ## Maintaining and patching an older release line
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the Plugin Maintainers Guide with info on:
- How plugin owners can use workspace labels for filtering when triaging issues
- How plugin maintainers can  opt-in to knip reports check

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
