### PR TITLE
make the kiali-react plugin public

### DIFF
--- a/workspaces/kiali/.changeset/happy-lights-smash.md
+++ b/workspaces/kiali/.changeset/happy-lights-smash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-kiali-react': patch
+---
+
+Make `@backstage-community/plugin-kiali-react` public

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -2,7 +2,6 @@
   "name": "@backstage-community/plugin-kiali-react",
   "version": "0.1.0",
   "license": "Apache-2.0",
-  "private": true,
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `Release Kiali plugins step` has been failing for a while because the `@backstage-community/plugin-kiali` plugin depends on `@backstage-community/plugin-kiali-react` which is private.

- https://github.com/backstage/community-plugins/actions/runs/15420925454/job/43395575862
- https://github.com/backstage/community-plugins/actions/runs/15398771692/job/43326058172

This PR removes `private: true` from the `kiali-react` plugin to prevent failures with kiali plugin releases.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
