### PR TITLE
fix(redhat-argocd): remove plugin level tsconfig

### DIFF
--- a/workspaces/redhat-argocd/plugins/argocd-common/tsconfig.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@backstage/cli/config/tsconfig.json",
-  "include": ["src", "dev"],
-  "exclude": ["node_modules"],
-  "compilerOptions": {
-    "outDir": "../../dist-types/plugins/argocd-common",
-    "rootDir": "."
-  }
-}

--- a/workspaces/redhat-argocd/plugins/argocd/tsconfig.json
+++ b/workspaces/redhat-argocd/plugins/argocd/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "@backstage/cli/config/tsconfig.json",
-  "include": ["src", "dev"],
-  "exclude": ["node_modules"],
-  "compilerOptions": {
-    "outDir": "../../dist-types/plugins/argocd",
-    "rootDir": "."
-  }
-}

--- a/workspaces/tech-insights/.changeset/cyan-ducks-mate.md
+++ b/workspaces/tech-insights/.changeset/cyan-ducks-mate.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-maturity': patch
+---
+
+Fixed entity page integration instructions


### PR DESCRIPTION
Signed-off-by: Florian JUDITH <florian.judith@alithya.com>

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Remove plugin level tsconfig responsible of the 'React is no defined' error introduced since the 1.38.x framework upgrade see: https://github.com/backstage/community-plugins/issues/4047

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
