### PR TITLE
Version Packages (mta)

### DIFF
--- a/workspaces/mta/.changeset/light-cougars-sort.md
+++ b/workspaces/mta/.changeset/light-cougars-sort.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Added logic to strip off any trailing forward slash in the mta.url string

--- a/workspaces/mta/.changeset/many-paws-trade.md
+++ b/workspaces/mta/.changeset/many-paws-trade.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Add ability to dynamically detect plugin version instead of requiring it in the configuration

--- a/workspaces/mta/plugins/mta-backend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/backstage-plugin-mta-backend
 
+## 0.4.1
+
+### Patch Changes
+
+- ff34bd4: Added logic to strip off any trailing forward slash in the mta.url string
+- 1612393: Add ability to dynamically detect plugin version instead of requiring it in the configuration
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/mta-backend/package.json
+++ b/workspaces/mta/plugins/mta-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-backend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/backstage-plugin-mta-backend@0.4.1

### Patch Changes

-   ff34bd4: Added logic to strip off any trailing forward slash in the mta.url string
-   1612393: Add ability to dynamically detect plugin version instead of requiring it in the configuration
