### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/happy-lights-smash.md
+++ b/workspaces/kiali/.changeset/happy-lights-smash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali-react': patch
----
-
-Make `@backstage-community/plugin-kiali-react` public

--- a/workspaces/kiali/.changeset/hip-jars-tickle.md
+++ b/workspaces/kiali/.changeset/hip-jars-tickle.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': patch
-'@backstage-community/plugin-kiali': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/kiali/.changeset/purple-cars-add.md
+++ b/workspaces/kiali/.changeset/purple-cars-add.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': minor
----
-
-Create kiali-react component library

--- a/workspaces/kiali/.changeset/renovate-09f2059.md
+++ b/workspaces/kiali/.changeset/renovate-09f2059.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.22`.

--- a/workspaces/kiali/.changeset/renovate-3c48922.md
+++ b/workspaces/kiali/.changeset/renovate-3c48922.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `@types/node` to `22.15.29`.

--- a/workspaces/kiali/.changeset/renovate-4de7e1c.md
+++ b/workspaces/kiali/.changeset/renovate-4de7e1c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.12`.

--- a/workspaces/kiali/.changeset/renovate-6b4545b.md
+++ b/workspaces/kiali/.changeset/renovate-6b4545b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `@types/node` to `22.14.1`.

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.22.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- 098b200: Updated dependency `@types/express` to `4.17.22`.
+
 ## 1.22.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-kiali-react
+
+## 0.1.1
+
+### Patch Changes
+
+- 9e58717: Make `@backstage-community/plugin-kiali-react` public

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,20 @@
 ### Dependencies
 
+## 1.39.0
+
+### Minor Changes
+
+- cdad6af: Create kiali-react component library
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- e958f2f: Updated dependency `@types/node` to `22.15.29`.
+- 7d6d70f: Updated dependency `start-server-and-test` to `2.0.12`.
+- fcc57ec: Updated dependency `@types/node` to `22.14.1`.
+- Updated dependencies [9e58717]
+  - @backstage-community/plugin-kiali-react@0.1.1
+
 ## 1.38.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.39.0

### Minor Changes

-   cdad6af: Create kiali-react component library

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   e958f2f: Updated dependency `@types/node` to `22.15.29`.
-   7d6d70f: Updated dependency `start-server-and-test` to `2.0.12`.
-   fcc57ec: Updated dependency `@types/node` to `22.14.1`.
-   Updated dependencies [9e58717]
    -   @backstage-community/plugin-kiali-react@0.1.1

## @backstage-community/plugin-kiali-backend@1.22.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   098b200: Updated dependency `@types/express` to `4.17.22`.

## @backstage-community/plugin-kiali-react@0.1.1

### Patch Changes

-   9e58717: Make `@backstage-community/plugin-kiali-react` public
