### PR TITLE
azure-devops - Deprecated `getRepoBuilds` on the frontend and backend along with related code

### DIFF
--- a/workspaces/azure-devops/.changeset/nice-needles-taste.md
+++ b/workspaces/azure-devops/.changeset/nice-needles-taste.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-azure-devops-backend': patch
+'@backstage-community/plugin-azure-devops': patch
+---
+
+Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/report.api.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/report.api.md
@@ -112,7 +112,7 @@ export class AzureDevOpsApi {
     url: string;
     content: string;
   }>;
-  // (undocumented)
+  // @deprecated (undocumented)
   getRepoBuilds(
     projectName: string,
     repoName: string,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -215,6 +215,9 @@ export class AzureDevOpsApi {
     );
   }
 
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   public async getRepoBuilds(
     projectName: string,
     repoName: string,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/mappers.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/mappers.ts
@@ -28,6 +28,9 @@ import {
   GitPullRequest,
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 
+/**
+ * @deprecated This method has no usages and will be removed in a future release
+ */
 export function mappedRepoBuild(build: Build): RepoBuild {
   return {
     id: build.id,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
@@ -115,6 +115,9 @@ export async function createRouter(
     res.status(200).json(buildList);
   });
 
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   router.get('/repo-builds/:projectName/:repoName', async (req, res) => {
     const { projectName, repoName } = req.params;
 

--- a/workspaces/azure-devops/plugins/azure-devops/report.api.md
+++ b/workspaces/azure-devops/plugins/azure-devops/report.api.md
@@ -113,7 +113,7 @@ export interface AzureDevOpsApi {
   }>;
   // (undocumented)
   getReadme(opts: ReadmeConfig): Promise<Readme>;
-  // (undocumented)
+  // @deprecated (undocumented)
   getRepoBuilds(
     projectName: string,
     repoName: string,
@@ -185,7 +185,7 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
   }>;
   // (undocumented)
   getReadme(opts: ReadmeConfig): Promise<Readme>;
-  // (undocumented)
+  // @deprecated (undocumented)
   getRepoBuilds(
     projectName: string,
     repoName: string,

--- a/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsApi.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsApi.ts
@@ -37,6 +37,9 @@ export const azureDevOpsApiRef = createApiRef<AzureDevOpsApi>({
 
 /** @public */
 export interface AzureDevOpsApi {
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   getRepoBuilds(
     projectName: string,
     repoName: string,

--- a/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.ts
+++ b/workspaces/azure-devops/plugins/azure-devops/src/api/AzureDevOpsClient.ts
@@ -43,7 +43,9 @@ export class AzureDevOpsClient implements AzureDevOpsApi {
     this.discoveryApi = options.discoveryApi;
     this.fetchApi = options.fetchApi;
   }
-
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   public async getRepoBuilds(
     projectName: string,
     repoName: string,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
