### PR TITLE
azure-devops - Added build definition name `README` note

### DIFF
--- a/workspaces/azure-devops/.changeset/wild-buckets-double.md
+++ b/workspaces/azure-devops/.changeset/wild-buckets-double.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops': patch
+---
+
+Added a note to the `README` regarding what value to use for the `dev.azure.com/build-definition` annotation and how you can find it in Azure DevOps if you are unsure.

--- a/workspaces/azure-devops/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/azure-devops/packages/app/src/components/catalog/EntityPage.tsx
@@ -74,6 +74,7 @@ import {
   EntityAzurePullRequestsContent,
   EntityAzureReadmeCard,
   isAzureDevOpsAvailable,
+  isAzurePipelinesAvailable,
 } from '@backstage-community/plugin-azure-devops';
 
 const techdocsContent = (
@@ -88,7 +89,7 @@ const cicdContent = (
   // This is an example of how you can implement your company's logic in entity page.
   // You can for example enforce that all components of type 'service' should use Azure DevOps Pipelines
   <EntitySwitch>
-    <EntitySwitch.Case if={isAzureDevOpsAvailable}>
+    <EntitySwitch.Case if={isAzurePipelinesAvailable || isAzureDevOpsAvailable}>
       <EntityAzurePipelinesContent defaultLimit={25} />
     </EntitySwitch.Case>
 

--- a/workspaces/azure-devops/plugins/azure-devops/README.md
+++ b/workspaces/azure-devops/plugins/azure-devops/README.md
@@ -97,6 +97,8 @@ dev.azure.com/build-definition: <build-definition-name>
 
 In this case `<project-name>` will be the name of your Team Project and `<build-definition-name>` will be the name of the Build Definition you would like to see Builds for, and it's possible to add more Builds separated by a comma. If the Build Definition name has spaces in it make sure to put quotes around it.
 
+> Note: If you are unsure what your Build Definition name is you can confirm this value by going to the [Pipeline Settings in Azure DevOps](https://learn.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline?view=azure-devops#pipeline-settings) and clicking on "Rename/move" from the context menu. The current Build Definition name will be in the dialog box that opens, use this value. It will not be `<some-definition-name>.yml`.
+
 #### Multiple Organizations
 
 If you have multiple organizations you'll need to also add this annotation:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a note to the `README` regarding what value to use for the `dev.azure.com/build-definition` annotation and how you can find it in Azure DevOps if you are unsure.

**Note:** there is already a feature in place when no build are found it will list out what values it used to help the user fix the issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
