### PR TITLE
azure-devops - Deprecated `getBuildDefinitions`

### DIFF
--- a/workspaces/azure-devops/.changeset/sharp-nails-itch.md
+++ b/workspaces/azure-devops/.changeset/sharp-nails-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-backend': patch
+---
+
+Deprecated `getBuildDefinitions` on the backend and related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/report.api.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/report.api.md
@@ -32,7 +32,7 @@ export class AzureDevOpsApi {
   ): AzureDevOpsApi;
   // (undocumented)
   getAllTeams(options?: { limit?: number }): Promise<Team[]>;
-  // (undocumented)
+  // @deprecated (undocumented)
   getBuildDefinitions(
     projectName: string,
     definitionName: string,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/api/AzureDevOpsApi.ts
@@ -458,6 +458,9 @@ export class AzureDevOpsApi {
     }));
   }
 
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   public async getBuildDefinitions(
     projectName: string,
     definitionName: string,

--- a/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/src/service/router.ts
@@ -266,6 +266,9 @@ export async function createRouter(
     res.status(200).json(allTeams);
   });
 
+  /**
+   * @deprecated This method has no usages and will be removed in a future release
+   */
   router.get(
     '/build-definitions/:projectName/:definitionName',
     async (req, res) => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Deprecated `getBuildDefinitions` on the backend and related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
