### PR TITLE
feat(sonarqube): support basic auth with optional authType config option

### DIFF
--- a/workspaces/sonarqube/.changeset/spicy-turkeys-work.md
+++ b/workspaces/sonarqube/.changeset/spicy-turkeys-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube-backend': minor
+---
+
+Add optional support for basic auth for older SonarQube instances that do not support bearer tokens

--- a/workspaces/sonarqube/plugins/sonarqube-backend/README.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/README.md
@@ -103,6 +103,8 @@ sonarqube:
   baseUrl: https://sonarqube.example.com
   instanceKey: mySonarqube
   apiKey: 123456789abcdef0123456789abcedf012
+  # Optional to use old basic authentication in Sonarqube < v10.5
+  # authType: basic
 ```
 
 ##### Catalog
@@ -129,6 +131,8 @@ sonarqube:
       instanceKey: mySonarqube
       baseUrl: https://default-sonarqube.example.com
       apiKey: 123456789abcdef0123456789abcedf012
+      # Optional to use old basic authentication in Sonarqube < v10.5
+      # authType: basic
     - name: specialProject
       instanceKey: mySonarqube
       baseUrl: https://special-project-sonarqube.example.com

--- a/workspaces/sonarqube/plugins/sonarqube-backend/config.d.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/config.d.ts
@@ -37,6 +37,13 @@ export interface Config {
     apiKey?: string;
 
     /**
+     * The type of authentication key used for the SonarQube instance.
+     * Can be 'basic' for basic authentication or 'token' for token-based authentication.
+     * Defaults to 'token'.
+     */
+    authType?: 'basic' | 'token';
+
+    /**
      * The optional sonarqube instances.
      * @visibility frontend
      */
@@ -65,6 +72,13 @@ export interface Config {
        * @visibility secret
        */
       apiKey: string;
+
+      /**
+       * The type of authentication key used for the SonarQube instance.
+       * Can be 'basic' for basic authentication or 'token' for token-based authentication.
+       * Defaults to 'token'.
+       */
+      authType?: 'basic' | 'token';
     }>;
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#3469 changed the `sonarqube-backend` to use bearer token auth to call to SonarQube. However, this is not supported in older versions of SonarQube (e.g. < v10.5). This means it is not possible to use this plugin on older self hosted instances without upgrading.

This adds a new optional `sonarqube.authType` configuration key that can be set to `basic` to use the old behaviour. The default is `token` which uses the existing behaviour introduced in #3469.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- ~~[ ] Screenshots attached (for UI changes)~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
