### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/long-gorillas-notice.md
+++ b/workspaces/sonarqube/.changeset/long-gorillas-notice.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': patch
----
-
-**BREAKING** This undoes the breaking Authorization header change introduced in v0.7.0 and allows configuring Bearer tokens, while maintaining the old default of Basic. This change will impact SonarQube Cloud users, [details on the config changes needed](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube-backend) in this case are in the `README`.

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [65ea416]
+  - @backstage-community/plugin-sonarqube-backend@0.9.1
+
 ## 0.0.11
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.9.1
+
+### Patch Changes
+
+- 65ea416: **BREAKING** This undoes the breaking Authorization header change introduced in v0.7.0 and allows configuring Bearer tokens, while maintaining the old default of Basic. This change will impact SonarQube Cloud users, [details on the config changes needed](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube-backend) in this case are in the `README`.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.9.1

### Patch Changes

-   65ea416: **BREAKING** This undoes the breaking Authorization header change introduced in v0.7.0 and allows configuring Bearer tokens, while maintaining the old default of Basic. This change will impact SonarQube Cloud users, [details on the config changes needed](https://github.com/backstage/community-plugins/tree/main/workspaces/sonarqube/plugins/sonarqube-backend) in this case are in the `README`.

## backend@0.0.12

### Patch Changes

-   Updated dependencies [65ea416]
    -   @backstage-community/plugin-sonarqube-backend@0.9.1
