### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/dull-adults-visit.md
+++ b/workspaces/azure-devops/.changeset/dull-adults-visit.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Moved `getAnnotationValuesFromEntity` to the common package and deprecated the current location. This will be removed in a future version.

--- a/workspaces/azure-devops/.changeset/lazy-snails-flow.md
+++ b/workspaces/azure-devops/.changeset/lazy-snails-flow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Updated `README` with details regarding spaces in project and repo names

--- a/workspaces/azure-devops/.changeset/modern-pigs-cheer.md
+++ b/workspaces/azure-devops/.changeset/modern-pigs-cheer.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Updated permissions section in `README` to remove legacy backend references and to make the instructions more clear

--- a/workspaces/azure-devops/.changeset/nice-needles-taste.md
+++ b/workspaces/azure-devops/.changeset/nice-needles-taste.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

--- a/workspaces/azure-devops/.changeset/real-trains-kick.md
+++ b/workspaces/azure-devops/.changeset/real-trains-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`

--- a/workspaces/azure-devops/.changeset/sharp-nails-itch.md
+++ b/workspaces/azure-devops/.changeset/sharp-nails-itch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
----
-
-Deprecated `getBuildDefinitions` on the backend and related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.

--- a/workspaces/azure-devops/.changeset/silly-bears-protect.md
+++ b/workspaces/azure-devops/.changeset/silly-bears-protect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
----
-
-Removed the usage of `permissionIntegrationRouter` in favor of using the new `coreServices.permissionsRegistry`

--- a/workspaces/azure-devops/.changeset/sweet-icons-attack.md
+++ b/workspaces/azure-devops/.changeset/sweet-icons-attack.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Added a check to validate that the `dev.azure.com/readme-path` annotation value does not have a relative path and throw an error with details if it does as this is not supported by the Azure DevOps API used for this feature.

--- a/workspaces/azure-devops/.changeset/tender-kangaroos-peel.md
+++ b/workspaces/azure-devops/.changeset/tender-kangaroos-peel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Add a new action (azure:pipeline:create) to create pipeline definition from a YAML file.

--- a/workspaces/azure-devops/.changeset/wild-buckets-double.md
+++ b/workspaces/azure-devops/.changeset/wild-buckets-double.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Added a note to the `README` regarding what value to use for the `dev.azure.com/build-definition` annotation and how you can find it in Azure DevOps if you are unsure.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.17.1
+
+### Patch Changes
+
+- 3622b13: Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
+- aa1889f: Deprecated `getBuildDefinitions` on the backend and related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
+- d813cec: Removed the usage of `permissionIntegrationRouter` in favor of using the new `coreServices.permissionsRegistry`
+- Updated dependencies [ae70011]
+  - @backstage-community/plugin-azure-devops-common@0.11.1
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.11.1
+
+### Patch Changes
+
+- ae70011: Moved `getAnnotationValuesFromEntity` to the common package and deprecated the current location. This will be removed in a future version.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.16.1
+
+### Patch Changes
+
+- ae70011: Moved `getAnnotationValuesFromEntity` to the common package and deprecated the current location. This will be removed in a future version.
+- 837d67f: Updated `README` with details regarding spaces in project and repo names
+- 9cf745c: Updated permissions section in `README` to remove legacy backend references and to make the instructions more clear
+- 3622b13: Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
+- d813cec: Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`
+- 764e1ef: Added a check to validate that the `dev.azure.com/readme-path` annotation value does not have a relative path and throw an error with details if it does as this is not supported by the Azure DevOps API used for this feature.
+- 071eb9b: Added a note to the `README` regarding what value to use for the `dev.azure.com/build-definition` annotation and how you can find it in Azure DevOps if you are unsure.
+- Updated dependencies [ae70011]
+  - @backstage-community/plugin-azure-devops-common@0.11.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [ae70011]
+  - @backstage-community/plugin-azure-devops-common@0.11.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.10.1
+
+### Patch Changes
+
+- 28b2765: Add a new action (azure:pipeline:create) to create pipeline definition from a YAML file.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.16.1

### Patch Changes

-   ae70011: Moved `getAnnotationValuesFromEntity` to the common package and deprecated the current location. This will be removed in a future version.
-   837d67f: Updated `README` with details regarding spaces in project and repo names
-   9cf745c: Updated permissions section in `README` to remove legacy backend references and to make the instructions more clear
-   3622b13: Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
-   d813cec: Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`
-   764e1ef: Added a check to validate that the `dev.azure.com/readme-path` annotation value does not have a relative path and throw an error with details if it does as this is not supported by the Azure DevOps API used for this feature.
-   071eb9b: Added a note to the `README` regarding what value to use for the `dev.azure.com/build-definition` annotation and how you can find it in Azure DevOps if you are unsure.
-   Updated dependencies [ae70011]
    -   @backstage-community/plugin-azure-devops-common@0.11.1

## @backstage-community/plugin-azure-devops-backend@0.17.1

### Patch Changes

-   3622b13: Deprecated `getRepoBuilds` on the frontend and backend along with related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
-   aa1889f: Deprecated `getBuildDefinitions` on the backend and related code. The are no usages of this method as it was replaced by `getBuildRuns` well over a year ago. This will be removed in a future release.
-   d813cec: Removed the usage of `permissionIntegrationRouter` in favor of using the new `coreServices.permissionsRegistry`
-   Updated dependencies [ae70011]
    -   @backstage-community/plugin-azure-devops-common@0.11.1

## @backstage-community/plugin-azure-devops-common@0.11.1

### Patch Changes

-   ae70011: Moved `getAnnotationValuesFromEntity` to the common package and deprecated the current location. This will be removed in a future version.

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.8.1

### Patch Changes

-   Updated dependencies [ae70011]
    -   @backstage-community/plugin-azure-devops-common@0.11.1

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.10.1

### Patch Changes

-   28b2765: Add a new action (azure:pipeline:create) to create pipeline definition from a YAML file.
