### PR TITLE
fix(nexus): replaced formatByteSize implementation

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/healthy-melons-kick.md
+++ b/workspaces/nexus-repository-manager/.changeset/healthy-melons-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-nexus-repository-manager': patch
+---
+
+Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -40,6 +40,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "filesize": "^10.1.6",
     "react-use": "^17.4.0"
   },
   "peerDependencies": {

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
@@ -4,7 +4,7 @@ import { Link, Table, type TableColumn } from '@backstage/core-components';
 
 import { Box, Chip, makeStyles } from '@material-ui/core';
 
-import { formatByteSize } from '@janus-idp/shared-react';
+import { formatByteSize } from '../../utils/format-byte-size/format-byte-size';
 
 import type { AssetHash } from '../../types';
 

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.test.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.test.ts
@@ -38,9 +38,8 @@ describe('formatByteSize', () => {
   });
 
   it('formats common sizes correctly', () => {
-    expect(formatByteSize(0)).toBe('N/A');
-    expect(formatByteSize(500)).toMatch(/500 B/);
-    expect(formatByteSize(1500)).toMatch(/1\.5 kB/);
-    expect(formatByteSize(1048576)).toMatch(/1\.05 MB/);
+    expect(formatByteSize(500)).toEqual('500 B');
+    expect(formatByteSize(1500)).toMatch('1.5 kB');
+    expect(formatByteSize(1048576)).toMatch('1.05 MB');
   });
 });

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.test.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatByteSize } from './format-byte-size';
+
+describe('formatByteSize', () => {
+  it('should return N/A if sizeInBytes is not defined', () => {
+    expect(formatByteSize(undefined)).toEqual('N/A');
+  });
+
+  it('should return N/A if sizeInBytes is 0', () => {
+    expect(formatByteSize(0)).toEqual('N/A');
+  });
+
+  it('should format sizeInBytes', () => {
+    expect(formatByteSize(1)).toEqual('1 B');
+    expect(formatByteSize(1_000)).toEqual('1 kB');
+    expect(formatByteSize(1_000_000)).toEqual('1 MB');
+    expect(formatByteSize(1_000_000_000)).toEqual('1 GB');
+    expect(formatByteSize(1_000_000_000_000)).toEqual('1 TB');
+    expect(formatByteSize(1_000_000_000_000_000)).toEqual('1 PB');
+    expect(formatByteSize(1_000_000_000_000_000_000)).toEqual('1 EB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000)).toEqual('1 ZB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000_000)).toEqual('1 YB');
+  });
+
+  it('formats common sizes correctly', () => {
+    expect(formatByteSize(0)).toBe('N/A');
+    expect(formatByteSize(500)).toMatch(/500 B/);
+    expect(formatByteSize(1500)).toMatch(/1\.5 kB/);
+    expect(formatByteSize(1048576)).toMatch(/1\.05 MB/);
+  });
+});

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/format-byte-size.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filesize } from 'filesize';
+
+export function formatByteSize(sizeInBytes: number | undefined): string {
+  if (!sizeInBytes) return 'N/A';
+
+  return filesize(sizeInBytes);
+}

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/index.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/format-byte-size/index.ts
@@ -1,0 +1,1 @@
+export * from './format-byte-size';

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/index.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './get-file-size';
 export * from './get-hash';
 export * from './is-primary-asset';
+export * from './format-byte-size';

--- a/workspaces/nexus-repository-manager/yarn.lock
+++ b/workspaces/nexus-repository-manager/yarn.lock
@@ -2597,6 +2597,7 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@types/node": "npm:22.15.29"
     cross-fetch: "npm:4.0.0"
+    filesize: "npm:^10.1.6"
     msw: "npm:1.3.5"
     react: "npm:^18.0.0"
     react-dom: "npm:^18.0.0"
@@ -14268,6 +14269,13 @@ __metadata:
   version: 2.0.5
   resolution: "file-saver@npm:2.0.5"
   checksum: 10/fbba443d9b682fec0be6676c048a7ac688b9bd33b105c02e8e1a1cb3e354ed441198dc1f15dcbc137fa044bea73f8a7549f2617e3a952fa7d96390356d54a7c3
+  languageName: node
+  linkType: hard
+
+"filesize@npm:^10.1.6":
+  version: 10.1.6
+  resolution: "filesize@npm:10.1.6"
+  checksum: 10/e800837c4fc02303f1944d5a4c7b706df1c5cd95d745181852604fb00a1c2d55d2d3921252722bd2f0c86b59c94edaba23fa224776bbf977455d4034e7be1f45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
