### PR TITLE
fix(quay): replaced formatByteSize implementation

### DIFF
--- a/workspaces/quay/.changeset/funny-flowers-walk.md
+++ b/workspaces/quay/.changeset/funny-flowers-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-quay': patch
+---
+
+Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -49,6 +49,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "filesize": "^10.1.6",
     "react-use": "^17.4.0"
   },
   "peerDependencies": {

--- a/workspaces/quay/plugins/quay/src/hooks/quay.tsx
+++ b/workspaces/quay/plugins/quay/src/hooks/quay.tsx
@@ -20,11 +20,12 @@ import { Entity } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
-import { formatByteSize, formatDate } from '@janus-idp/shared-react';
+import { formatDate } from '@janus-idp/shared-react';
 import { Box, Chip, makeStyles } from '@material-ui/core';
 
 import { quayApiRef } from '../api';
 import { Layer, QuayTagData, Tag } from '../types';
+import { formatByteSize } from '../utils';
 
 const useLocalStyles = makeStyles({
   chip: {

--- a/workspaces/quay/plugins/quay/src/utils.test.ts
+++ b/workspaces/quay/plugins/quay/src/utils.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatByteSize } from './utils';
+
+describe('formatByteSize', () => {
+  it('should return N/A if sizeInBytes is not defined', () => {
+    expect(formatByteSize(undefined)).toEqual('N/A');
+  });
+
+  it('should return N/A if sizeInBytes is 0', () => {
+    expect(formatByteSize(0)).toEqual('N/A');
+  });
+
+  it('should format sizeInBytes', () => {
+    expect(formatByteSize(1)).toEqual('1 B');
+    expect(formatByteSize(1_000)).toEqual('1 kB');
+    expect(formatByteSize(1_000_000)).toEqual('1 MB');
+    expect(formatByteSize(1_000_000_000)).toEqual('1 GB');
+    expect(formatByteSize(1_000_000_000_000)).toEqual('1 TB');
+    expect(formatByteSize(1_000_000_000_000_000)).toEqual('1 PB');
+    expect(formatByteSize(1_000_000_000_000_000_000)).toEqual('1 EB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000)).toEqual('1 ZB');
+    expect(formatByteSize(1_000_000_000_000_000_000_000_000)).toEqual('1 YB');
+  });
+
+  it('formats common sizes correctly', () => {
+    expect(formatByteSize(0)).toBe('N/A');
+    expect(formatByteSize(500)).toMatch(/500 B/);
+    expect(formatByteSize(1500)).toMatch(/1\.5 kB/);
+    expect(formatByteSize(1048576)).toMatch(/1\.05 MB/);
+  });
+});

--- a/workspaces/quay/plugins/quay/src/utils.ts
+++ b/workspaces/quay/plugins/quay/src/utils.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filesize } from 'filesize';
+
+export function formatByteSize(sizeInBytes: number | undefined): string {
+  if (!sizeInBytes) return 'N/A';
+
+  return filesize(sizeInBytes);
+}

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -2704,6 +2704,7 @@ __metadata:
     "@types/react": "npm:^18.2.58"
     "@types/react-dom": "npm:^18.2.19"
     cross-fetch: "npm:4.0.0"
+    filesize: "npm:^10.1.6"
     msw: "npm:1.3.5"
     react: "npm:^17.0.0 || ^18.0.0"
     react-dom: "npm:^17.0.0 || ^18.0.0"
@@ -19610,6 +19611,13 @@ __metadata:
   version: 1.0.0
   resolution: "file-uri-to-path@npm:1.0.0"
   checksum: 10/b648580bdd893a008c92c7ecc96c3ee57a5e7b6c4c18a9a09b44fb5d36d79146f8e442578bc0e173dc027adf3987e254ba1dfd6e3ec998b7c282873010502144
+  languageName: node
+  linkType: hard
+
+"filesize@npm:^10.1.6":
+  version: 10.1.6
+  resolution: "filesize@npm:10.1.6"
+  checksum: 10/e800837c4fc02303f1944d5a4c7b706df1c5cd95d745181852604fb00a1c2d55d2d3921252722bd2f0c86b59c94edaba23fa224776bbf977455d4034e7be1f45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
