### PR TITLE
fix: Basic and Bearer auth token creation logic was reversed

### DIFF
--- a/workspaces/sonarqube/.changeset/giant-turkeys-compare.md
+++ b/workspaces/sonarqube/.changeset/giant-turkeys-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube-backend': patch
+---
+
+v0.9.0 introduced a bug where basic and bearer auth token types were reversed

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.test.ts
@@ -368,11 +368,11 @@ describe('DefaultSonarqubeInfoProvider', () => {
       if (req.headers && req.headers.has('Authorization')) {
         if (tokenType === 'Basic') {
           expect(req.headers.get('Authorization')).toEqual(
-            `${tokenType} 123456789abcdef0123456789abcedf012`,
+            `${tokenType} MTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc4OWFiY2VkZjAxMjo=`,
           );
         } else {
           expect(req.headers.get('Authorization')).toEqual(
-            `${tokenType} MTIzNDU2Nzg5YWJjZGVmMDEyMzQ1Njc4OWFiY2VkZjAxMjo=`,
+            `${tokenType} ${DUMMY_API_KEY}`,
           );
         }
       } else {

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/service/sonarqubeInfoProvider.ts
@@ -322,7 +322,7 @@ export class DefaultSonarqubeInfoProvider implements SonarqubeInfoProvider {
     const fullUrl = `${url}/${path}?${new URLSearchParams(query).toString()}`;
 
     const encodedAuthToken =
-      authType === 'Bearer'
+      authType === 'Basic'
         ? Buffer.from(`${authToken}:`).toString('base64')
         : authToken;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In #3870, through a number of changes, the Base64 encoding logic was mistakenly applied to Bearer tokens when it should have been applied to Basic auth. This resolves that issue and updates the tests accordingly.

#### :heavy_check_mark: Checklist


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
