### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/giant-turkeys-compare.md
+++ b/workspaces/sonarqube/.changeset/giant-turkeys-compare.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube-backend': patch
----
-
-Fixed a bug in v0.9.1 where basic and bearer auth token types were reversed

--- a/workspaces/sonarqube/packages/backend/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.13
+
+### Patch Changes
+
+- Updated dependencies [65c9891]
+  - @backstage-community/plugin-sonarqube-backend@0.9.2
+
 ## 0.0.12
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/backend/package.json
+++ b/workspaces/sonarqube/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube-backend
 
+## 0.9.2
+
+### Patch Changes
+
+- 65c9891: Fixed a bug in v0.9.1 where basic and bearer auth token types were reversed
+
 ## 0.9.1
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube-backend/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube-backend",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "sonarqube",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube-backend@0.9.2

### Patch Changes

-   65c9891: Fixed a bug in v0.9.1 where basic and bearer auth token types were reversed

## backend@0.0.13

### Patch Changes

-   Updated dependencies [65c9891]
    -   @backstage-community/plugin-sonarqube-backend@0.9.2
