### PR TITLE
fix(tekton): replaced downloadLogFile implementation

### DIFF
--- a/workspaces/tekton/.changeset/strong-otters-write.md
+++ b/workspaces/tekton/.changeset/strong-otters-write.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Replaced usage of `downloadLogFile` from `@janus-idp/shared-react` with a local implementation based on PatternFly’s `CodeEditor`. This also removes the `file-saver` dependency.

--- a/workspaces/tekton/.changeset/strong-otters-write.md
+++ b/workspaces/tekton/.changeset/strong-otters-write.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-tekton': patch
 ---
 
-Replaced usage of `downloadLogFile` from `@janus-idp/shared-react` with a local implementation based on PatternFly’s `CodeEditor`. This also removes the `file-saver` dependency.
+Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PodLogsDownloadLink.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PodLogsDownloadLink.tsx
@@ -24,8 +24,6 @@ import { createStyles, Link, makeStyles, Theme } from '@material-ui/core';
 import DownloadIcon from '@mui/icons-material/FileDownloadOutlined';
 import classNames from 'classnames';
 
-import { downloadLogFile } from '@janus-idp/shared-react';
-
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { ContainerScope } from '../../hooks/usePodLogsOfPipelineRun';
 import {
@@ -35,6 +33,7 @@ import {
 import { getPodLogs } from '../../utils/log-downloader-utils';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { tektonTranslationRef } from '../../translation';
+import { downloadLogFile } from '../../utils/download-log-file-utils';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/__tests__/PodLogsDownloadLink.test.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/__tests__/PodLogsDownloadLink.test.tsx
@@ -15,10 +15,9 @@
  */
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { downloadLogFile } from '@janus-idp/shared-react';
-
 import { testPipelineRunPods } from '../../../__fixtures__/pods-data';
 import { getPodLogs } from '../../../utils/log-downloader-utils';
+import { downloadLogFile } from '../../../utils/download-log-file-utils';
 import PodLogsDownloadLink from '../PodLogsDownloadLink';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { kubernetesProxyApiRef } from '../../../types/types';
@@ -27,8 +26,7 @@ jest.mock('../../../utils/log-downloader-utils', () => ({
   getPodLogs: jest.fn(),
 }));
 
-jest.mock('@janus-idp/shared-react', () => ({
-  ...jest.requireActual('@janus-idp/shared-react'),
+jest.mock('../../../utils/download-log-file-utils', () => ({
   downloadLogFile: jest.fn(),
 }));
 

--- a/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.test.ts
+++ b/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { downloadLogFile } from './download-log-file-utils';
+
+describe('downloadLogFile', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn(() => 'blob:http://localhost/blobid');
+    URL.revokeObjectURL = jest.fn();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    jest.restoreAllMocks();
+  });
+
+  it('should trigger a file download with correct filename and content', () => {
+    const clickMock = jest.fn();
+    const link = document.createElement('a');
+
+    jest.spyOn(document, 'createElement').mockImplementation(() => {
+      link.click = clickMock;
+      return link;
+    });
+
+    const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+    const removeChildSpy = jest.spyOn(document.body, 'removeChild');
+
+    downloadLogFile('hello world', 'log.txt');
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(clickMock).toHaveBeenCalled();
+    expect(appendChildSpy).toHaveBeenCalledWith(link);
+    expect(removeChildSpy).toHaveBeenCalledWith(link);
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+});

--- a/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.test.ts
+++ b/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.test.ts
@@ -35,21 +35,16 @@ describe('downloadLogFile', () => {
   it('should trigger a file download with correct filename and content', () => {
     const clickMock = jest.fn();
     const link = document.createElement('a');
+    link.click = clickMock;
 
-    jest.spyOn(document, 'createElement').mockImplementation(() => {
-      link.click = clickMock;
-      return link;
-    });
-
-    const appendChildSpy = jest.spyOn(document.body, 'appendChild');
-    const removeChildSpy = jest.spyOn(document.body, 'removeChild');
+    jest.spyOn(document, 'createElement').mockReturnValue(link);
 
     downloadLogFile('hello world', 'log.txt');
 
     expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(link.download).toBe('log.txt');
+    expect(link.href).toBe('blob:http://localhost/blobid');
     expect(clickMock).toHaveBeenCalled();
-    expect(appendChildSpy).toHaveBeenCalledWith(link);
-    expect(removeChildSpy).toHaveBeenCalledWith(link);
     expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 });

--- a/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.ts
+++ b/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.ts
@@ -19,15 +19,12 @@
  * @param data - The content to download
  * @param filename - The name of the file to save as
  */
-export const downloadLogFile = (data: string, filename: string): void => {
+export const downloadLogFile = (data: string, filename: string) => {
   const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
   link.download = filename;
-
-  document.body.appendChild(link); // Required for Firefox
   link.click();
-  document.body.removeChild(link);
   URL.revokeObjectURL(url);
 };

--- a/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.ts
+++ b/workspaces/tekton/plugins/tekton/src/utils/download-log-file-utils.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Triggers a download of the given string data as a file with the specified filename.
+ *
+ * @param data - The content to download
+ * @param filename - The name of the file to save as
+ */
+export const downloadLogFile = (data: string, filename: string): void => {
+  const blob = new Blob([data], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+
+  document.body.appendChild(link); // Required for Firefox
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
