### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/four-deers-teach.md
+++ b/workspaces/jfrog-artifactory/.changeset/four-deers-teach.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.15.1
+
+### Patch Changes
+
+- 172353e: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
+
 ## 1.15.0
 
 ### Minor Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.15.1

### Patch Changes

-   172353e: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
