### PR TITLE
linguist - Fix deprecated code

### DIFF
--- a/workspaces/linguist/.changeset/old-ads-itch.md
+++ b/workspaces/linguist/.changeset/old-ads-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-linguist': patch
+---
+
+Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`

--- a/workspaces/linguist/plugins/linguist/report-alpha.api.md
+++ b/workspaces/linguist/plugins/linguist/report-alpha.api.md
@@ -20,7 +20,7 @@ const _default: FrontendPlugin<
   {},
   {},
   {
-    [x: `api:${string}`]: ExtensionDefinition<{
+    'api:linguist': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
       config: {};
@@ -35,7 +35,7 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    [x: `entity-card:${string}/languages`]: ExtensionDefinition<{
+    'entity-card:linguist/languages': ExtensionDefinition<{
       kind: 'entity-card';
       name: 'languages';
       config: {

--- a/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
+++ b/workspaces/linguist/plugins/linguist/src/alpha/plugin.tsx
@@ -56,6 +56,6 @@ export const linguistApi = ApiBlueprint.make({
 
 /** @alpha */
 export default createFrontendPlugin({
-  id: 'linguist',
+  pluginId: 'linguist',
   extensions: [linguistApi, entityLinguistCard],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
