### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/silver-mammals-read.md
+++ b/workspaces/tekton/.changeset/silver-mammals-read.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-PipelineRun list status and duration support i18n

--- a/workspaces/tekton/.changeset/strong-otters-write.md
+++ b/workspaces/tekton/.changeset/strong-otters-write.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 3.26.1
+
+### Patch Changes
+
+- 87918c8: PipelineRun list status and duration support i18n
+- 65f826d: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
+
 ## 3.26.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.26.1

### Patch Changes

-   87918c8: PipelineRun list status and duration support i18n
-   65f826d: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
