### PR TITLE
meta: update some CODEOWNERS references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,8 +93,8 @@ yarn.lock                                                               @backsta
 /workspaces/repo-tools                                                  @backstage/community-plugins-maintainers
 /workspaces/report-portal                                               @backstage/community-plugins-maintainers  @yashoswalyo @deshmukhmayur @riginoommen
 /workspaces/rollbar                                                     @backstage/community-plugins-maintainers  @andrewthauer
-/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @BethGriggs @debsmita1
-/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @BethGriggs @debsmita1
+/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1
+/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1
 /workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @04kash
 /workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @schultzp2020
 /workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @04kash @schultzp2020


### PR DESCRIPTION
Note these ones still have a dedicated CODEOWNERS remaining - updating my designations to better reflect reality. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
