### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/great-pianos-raise.md
+++ b/workspaces/keycloak/.changeset/great-pianos-raise.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/keycloak/.changeset/renovate-926fee7.md
+++ b/workspaces/keycloak/.changeset/renovate-926fee7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Updated dependency `@types/lodash` to `4.17.17`.

--- a/workspaces/keycloak/.changeset/version-bump-1-39-0.md
+++ b/workspaces/keycloak/.changeset/version-bump-1-39-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': minor
----
-
-Backstage version bump to v1.39.0

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 3.12.0
+
+### Minor Changes
+
+- e37a7a6: Backstage version bump to v1.39.0
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- 8fa8ece: Updated dependency `@types/lodash` to `4.17.17`.
+
 ## 3.11.1
 
 ### Patch Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.11.1",
+  "version": "3.12.0",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.12.0

### Minor Changes

-   e37a7a6: Backstage version bump to v1.39.0

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   8fa8ece: Updated dependency `@types/lodash` to `4.17.17`.
