### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/old-ads-itch.md
+++ b/workspaces/linguist/.changeset/old-ads-itch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linguist': patch
----
-
-Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist
 
+## 0.8.1
+
+### Patch Changes
+
+- 226bccb: Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist@0.8.1

### Patch Changes

-   226bccb: Updated the `createFrontendPlugin` call to use `pluginId` instead of the deprecated `id`
