### PR TITLE
Version Packages (scaffolder-backend-module-annotator)

### DIFF
--- a/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-39-0.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-39-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-annotator': minor
----
-
-Backstage version bump to v1.39.0

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @janus-idp/backstage-scaffolder-backend-module-annotator [1.3.0](https://github.com/janus-idp/backstage-plugins/compare/@janus-idp/backstage-scaffolder-backend-module-annotator@1.2.1...@janus-idp/backstage-scaffolder-backend-module-annotator@1.3.0) (2024-07-25)
 
+## 2.7.0
+
+### Minor Changes
+
+- fb16cf3: Backstage version bump to v1.39.0
+
 ## 2.6.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-annotator",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-annotator@2.7.0

### Minor Changes

-   fb16cf3: Backstage version bump to v1.39.0
