### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/gorgeous-colts-sort.md
+++ b/workspaces/jenkins/.changeset/gorgeous-colts-sort.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-jenkins': minor
----
-
-Introduced `jenkins:job:build`, `jenkins:job:copy`, `jenkins:job:destroy`, `jenkins:job:disable`, `jenkins:job:enable` actions.
-
-The `jenkins:job:create` action now accepts a `jobXml` as input, containing the configuration of the job.

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-scaffolder-backend-module-jenkins
 
+## 0.9.0
+
+### Minor Changes
+
+- 99d57a7: Introduced `jenkins:job:build`, `jenkins:job:copy`, `jenkins:job:destroy`, `jenkins:job:disable`, `jenkins:job:enable` actions.
+
+  The `jenkins:job:create` action now accepts a `jobXml` as input, containing the configuration of the job.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-jenkins",
   "description": "Scaffolder plugin for Jenkins",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-jenkins@0.9.0

### Minor Changes

-   99d57a7: Introduced `jenkins:job:build`, `jenkins:job:copy`, `jenkins:job:destroy`, `jenkins:job:disable`, `jenkins:job:enable` actions.

    The `jenkins:job:create` action now accepts a `jobXml` as input, containing the configuration of the job.
