### PR TITLE
Version Packages (multi-source-security-viewer)

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/funny-dogs-promise.md
+++ b/workspaces/multi-source-security-viewer/.changeset/funny-dogs-promise.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-multi-source-security-viewer': patch
----
-
-Use getAnnotationValuesFromEntity from azure-devops-common

--- a/workspaces/multi-source-security-viewer/.changeset/nine-planes-allow.md
+++ b/workspaces/multi-source-security-viewer/.changeset/nine-planes-allow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-multi-source-security-viewer': patch
----
-
-Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-multi-source-security-viewer
 
+## 0.5.1
+
+### Patch Changes
+
+- c8e1803: Use getAnnotationValuesFromEntity from azure-devops-common
+- 5ac4c60: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-multi-source-security-viewer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-multi-source-security-viewer@0.5.1

### Patch Changes

-   c8e1803: Use getAnnotationValuesFromEntity from azure-devops-common
-   5ac4c60: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
