### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/fast-apes-sing.md
+++ b/workspaces/topology/.changeset/fast-apes-sing.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.2.1
+
+### Patch Changes
+
+- 6fb7a4d: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
+
 ## 2.2.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.2.1

### Patch Changes

-   6fb7a4d: Replaced `downloadLogFile` from `@janus-idp/shared-react` with a local version based on PatternFly’s `CodeEditor`, so the plugin no longer depends on `shared-react` for this utility.
