### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/cuddly-houses-peel.md
+++ b/workspaces/announcements/.changeset/cuddly-houses-peel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Add support for configurable markdown rendering with two options: "backstage" (default, theme-consistent) and "md-editor" (WYSIWYG-like rendering with richer markdown support)

--- a/workspaces/announcements/.changeset/few-mugs-reflect.md
+++ b/workspaces/announcements/.changeset/few-mugs-reflect.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-announcements-react': patch
-'@backstage-community/plugin-announcements': patch
----
-
-Fix pagination issue when fetching groups. This resolves the issue where the "On-Behalf" team dropdown always displayed only 10 groups.

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.6.1
+
+### Patch Changes
+
+- b5402a7: Fix pagination issue when fetching groups. This resolves the issue where the "On-Behalf" team dropdown always displayed only 10 groups.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-announcements
 
+## 0.7.1
+
+### Patch Changes
+
+- 6a14453: Add support for configurable markdown rendering with two options: "backstage" (default, theme-consistent) and "md-editor" (WYSIWYG-like rendering with richer markdown support)
+- b5402a7: Fix pagination issue when fetching groups. This resolves the issue where the "On-Behalf" team dropdown always displayed only 10 groups.
+- Updated dependencies [b5402a7]
+  - @backstage-community/plugin-announcements-react@0.6.1
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.7.1

### Patch Changes

-   6a14453: Add support for configurable markdown rendering with two options: "backstage" (default, theme-consistent) and "md-editor" (WYSIWYG-like rendering with richer markdown support)
-   b5402a7: Fix pagination issue when fetching groups. This resolves the issue where the "On-Behalf" team dropdown always displayed only 10 groups.
-   Updated dependencies [b5402a7]
    -   @backstage-community/plugin-announcements-react@0.6.1

## @backstage-community/plugin-announcements-react@0.6.1

### Patch Changes

-   b5402a7: Fix pagination issue when fetching groups. This resolves the issue where the "On-Behalf" team dropdown always displayed only 10 groups.
