### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/tame-bees-suffer.md
+++ b/workspaces/npm/.changeset/tame-bees-suffer.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': patch
----
-
-Improve error handling when the npm plugin is used without the existing `isNpmAvailable` condition for catalog entities and without the `npm/package` annotation. A generic error was shown instead of the expected missing annotation component (`MissingAnnotationEmptyState`).

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm
 
+## 1.6.1
+
+### Patch Changes
+
+- c33ba27: Improve error handling when the npm plugin is used without the existing `isNpmAvailable` condition for catalog entities and without the `npm/package` annotation. A generic error was shown instead of the expected missing annotation component (`MissingAnnotationEmptyState`).
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.6.1

### Patch Changes

-   c33ba27: Improve error handling when the npm plugin is used without the existing `isNpmAvailable` condition for catalog entities and without the `npm/package` annotation. A generic error was shown instead of the expected missing annotation component (`MissingAnnotationEmptyState`).
