### PR TITLE
Version Packages (scaffolder-backend-module-sonarqube)

### DIFF
--- a/workspaces/scaffolder-backend-module-sonarqube/.changeset/lemon-planes-switch.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/.changeset/lemon-planes-switch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-sonarqube': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.7.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+
 ## 2.7.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
+++ b/workspaces/scaffolder-backend-module-sonarqube/plugins/scaffolder-backend-module-sonarqube/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-sonarqube",
   "description": "The sonarqube module for @backstage/plugin-scaffolder-backend",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-sonarqube@2.7.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
