### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/funny-flowers-walk.md
+++ b/workspaces/quay/.changeset/funny-flowers-walk.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.

--- a/workspaces/quay/.changeset/healthy-pandas-carry.md
+++ b/workspaces/quay/.changeset/healthy-pandas-carry.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-backend': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.9.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+
 ## 2.9.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.3.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-quay-common@1.9.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.9.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+
 ## 1.9.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.21.1
+
+### Patch Changes
+
+- 042cea7: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-quay-common@1.9.1
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.21.1

### Patch Changes

-   042cea7: Replaced internal usage of `formatByteSize` with a local implementation using the `filesize` library, matching the original output format.
-   6a59fcf: remove support and lifecycle keywords in package.json
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-quay-common@1.9.1

## @backstage-community/plugin-scaffolder-backend-module-quay@2.9.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json

## @backstage-community/plugin-quay-backend@1.3.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-quay-common@1.9.1

## @backstage-community/plugin-quay-common@1.9.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
