### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/heavy-bats-live.md
+++ b/workspaces/redhat-argocd/.changeset/heavy-bats-live.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
-'@backstage-community/plugin-redhat-argocd-common': patch
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-remove support and lifecycle keywords in package.json

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.8.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-redhat-argocd-common@1.6.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.6.1
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.21.2
+
+### Patch Changes
+
+- 6a59fcf: remove support and lifecycle keywords in package.json
+- Updated dependencies [6a59fcf]
+  - @backstage-community/plugin-redhat-argocd-common@1.6.1
+
 ## 1.21.1
 
 ### Patch Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.21.2

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-redhat-argocd-common@1.6.1

## @backstage-community/plugin-redhat-argocd-backend@0.8.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
-   Updated dependencies [6a59fcf]
    -   @backstage-community/plugin-redhat-argocd-common@1.6.1

## @backstage-community/plugin-redhat-argocd-common@1.6.1

### Patch Changes

-   6a59fcf: remove support and lifecycle keywords in package.json
