### PR TITLE
fix(acs): batch vuln workloads fetch to fix async bug in useFetchACSData

### DIFF
--- a/workspaces/acs/.changeset/fast-pears-wait.md
+++ b/workspaces/acs/.changeset/fast-pears-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-acs': patch
+---
+
+Resolve async handling bug in useFetchACSData by consolidating vulnerability workload fetch into a single batched query

--- a/workspaces/acs/plugins/acs/src/components/VulnerabilitiesComponent/VulnerabilitiesComponent.test.tsx
+++ b/workspaces/acs/plugins/acs/src/components/VulnerabilitiesComponent/VulnerabilitiesComponent.test.tsx
@@ -26,9 +26,9 @@ jest.mock('../../common/useFetchACSData', () => ({
 describe('VulnerabilitiesComponent', () => {
   test('displays loading state initially', () => {
     (useFetchACSData as jest.Mock).mockReturnValue({
-      result: null,
-      loaded: false,
-      error: null,
+      result: { jsonData: [] },
+      isLoading: true,
+      error: false,
     });
 
     render(<VulnerabilitiesComponent deploymentName="Test" />);
@@ -38,9 +38,9 @@ describe('VulnerabilitiesComponent', () => {
 
   test('displays error message when data fetch fails', () => {
     (useFetchACSData as jest.Mock).mockReturnValue({
-      result: null,
-      loaded: true,
-      error: new Error('Test error'),
+      result: { jsonData: [] },
+      isLoading: false,
+      error: true,
     });
 
     render(<VulnerabilitiesComponent deploymentName="Test" />);

--- a/workspaces/acs/plugins/acs/src/components/VulnerabilitiesComponent/VulnerabilitiesComponent.tsx
+++ b/workspaces/acs/plugins/acs/src/components/VulnerabilitiesComponent/VulnerabilitiesComponent.tsx
@@ -39,11 +39,7 @@ export const VulnerabilitiesComponent = ({
   deploymentName,
 }: VulnerabilitiesProps) => {
   /* eslint-disable new-cap */
-  const {
-    result: ACSDataResult,
-    isLoading: ACSDataLoaded,
-    error: ACSDataError,
-  } = useFetchACSData(deploymentName);
+  const { result, isLoading, error } = useFetchACSData(deploymentName);
   /* eslint-enable new-cap */
 
   const useStyles = makeStyles(theme => ({
@@ -65,7 +61,15 @@ export const VulnerabilitiesComponent = ({
     selectedCveStatusOptions: [],
   });
 
-  if (ACSDataError) {
+  if (isLoading) {
+    return (
+      <InfoCard className={classes.root}>
+        <LinearProgress />
+      </InfoCard>
+    );
+  }
+
+  if (error) {
     return (
       <InfoCard>
         <Typography align="center" variant="button">
@@ -75,15 +79,7 @@ export const VulnerabilitiesComponent = ({
     );
   }
 
-  if (!ACSDataLoaded) {
-    return (
-      <InfoCard className={classes.root}>
-        <LinearProgress />
-      </InfoCard>
-    );
-  }
-
-  if (ACSDataResult.length === 0) {
+  if (result.jsonData.length === 0) {
     return (
       <InfoCard>
         <Typography variant="h5" component="h5" align="center">
@@ -106,7 +102,7 @@ export const VulnerabilitiesComponent = ({
     <Box sx={{ minHeight: '500px' }}>
       <DataFilterComponent setFilters={setFilters} />
 
-      <SecurityFindingsComponent data={ACSDataResult} filters={filters} />
+      <SecurityFindingsComponent data={result} filters={filters} />
     </Box>
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This PR is the first of many that deal with bug fixes, refactoring, and improvements. The issue centered on the use of multiple deployments as the annotation value in `test-app.yaml`. We looped through the deployment names, did an API call to fetch vulnerability workloads for each deployment, and combined them into a result value. There was an improper asynchronous handling within the loop that resulted in race conditions. We now pass the comma-separated deployment names directly in the query. This removes the need for multiple API calls.

Add multiple deployments (comma-separated) as the annotation value in `test-app.yaml`
![Screenshot 2025-06-23 at 9 31 25 AM](https://github.com/user-attachments/assets/5d82ea0d-e828-4017-9acd-4a157609ad1b)

Vulnerability workloads for the `nginx` deployment should show up 
![Screenshot 2025-06-23 at 9 33 02 AM](https://github.com/user-attachments/assets/09feb6a3-e2e9-4633-af45-5f4aae5ac8f9)

Vulnerability workloads for the `shaggy` deployment should show up 
![Screenshot 2025-06-23 at 9 33 07 AM](https://github.com/user-attachments/assets/ee1783d8-bc92-4848-a0f3-7762467d774b)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
