### PR TITLE
[jfrog-artifactory]: optional multiple instances support

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/tiny-memes-cry.md
+++ b/workspaces/jfrog-artifactory/.changeset/tiny-memes-cry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jfrog-artifactory': minor
+---
+
+Adds the possibility to use multiple artifactory instances

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
@@ -32,12 +32,11 @@ If you have multiple instances of artifactory supported, you can set up multiple
 ```yaml title="app-config.yaml"
 proxy:
   endpoints:
-    '/jfrog-instance1': # Please, mind, it's more of an alias
+    '/jfrog-instance1': # This is a local alias for the proxy endpoint, not the actual Artifactory hostname
       target: 'https://<hostname1>'
       # Rest of the config for hostname1
-    '/jfrog-instance2': # Please, mind, it's more of an alias
+    '/jfrog-instance2': 
       target: 'https://<hostname2>'
-      # Rest of the config for hostname1
 ```
 
 1. Enable the **JFROG ARTIFACTORY** tab on the entity view page in `packages/app/src/components/catalog/EntityPage.tsx`:

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
@@ -35,7 +35,7 @@ proxy:
     '/jfrog-instance1': # This is a local alias for the proxy endpoint, not the actual Artifactory hostname
       target: 'https://<hostname1>'
       # Rest of the config for hostname1
-    '/jfrog-instance2': 
+    '/jfrog-instance2':
       target: 'https://<hostname2>'
 ```
 

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/README.md
@@ -27,6 +27,19 @@ The Jfrog Artifactory plugin displays information about your container images wi
          secure: true
    ```
 
+If you have multiple instances of artifactory supported, you can set up multiple proxy target paths as follows:
+
+```yaml title="app-config.yaml"
+proxy:
+  endpoints:
+    '/jfrog-instance1': # Please, mind, it's more of an alias
+      target: 'https://<hostname1>'
+      # Rest of the config for hostname1
+    '/jfrog-instance2': # Please, mind, it's more of an alias
+      target: 'https://<hostname2>'
+      # Rest of the config for hostname1
+```
+
 1. Enable the **JFROG ARTIFACTORY** tab on the entity view page in `packages/app/src/components/catalog/EntityPage.tsx`:
 
    ```ts title="packages/app/src/components/catalog/EntityPage.tsx"
@@ -60,6 +73,9 @@ The Jfrog Artifactory plugin displays information about your container images wi
    metadata:
      annotations:
        'jfrog-artifactory/image-name': '<IMAGE-NAME>'
+       # if your app supports multiple artifactory instances,
+       # you'll need to specify the instance proxy target path your image belongs to
+       'jfrog-artifactory/target-proxy': '/<PROXY-TARGET>' # e.g. `/jfrog-instance1` from the example above
    ```
 
 ## For users

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryDashboardPage/JfrogArtifactoryDashboardPage.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryDashboardPage/JfrogArtifactoryDashboardPage.tsx
@@ -20,7 +20,7 @@ import { useJfrogArtifactoryAppData } from '../useJfrogArtifactoryAppData';
 
 export const JfrogArtifactoryDashboardPage = () => {
   const { entity } = useEntity();
-  const { imageName } = useJfrogArtifactoryAppData({ entity });
+  const { imageName, targetProxy } = useJfrogArtifactoryAppData({ entity });
 
-  return <JfrogArtifactoryRepository image={imageName} />;
+  return <JfrogArtifactoryRepository image={imageName} target={targetProxy} />;
 };

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -39,7 +39,7 @@ const useLocalStyles = makeStyles({
   },
 });
 
-export function JfrogArtifactoryRepository({ image }: RepositoryProps) {
+export function JfrogArtifactoryRepository({ image, target }: RepositoryProps) {
   const jfrogArtifactoryClient = useApi(jfrogArtifactoryApiRef);
   const classes = useStyles();
   const localClasses = useLocalStyles();
@@ -47,7 +47,7 @@ export function JfrogArtifactoryRepository({ image }: RepositoryProps) {
   const titleprop = `Jfrog Artifactory repository: ${image}`;
 
   const { loading } = useAsync(async () => {
-    const tagsResponse = await jfrogArtifactoryClient.getTags(image);
+    const tagsResponse = await jfrogArtifactoryClient.getTags(image, target);
 
     setEdges(tagsResponse.data.versions.edges);
 
@@ -99,4 +99,5 @@ export function JfrogArtifactoryRepository({ image }: RepositoryProps) {
 
 interface RepositoryProps {
   image: string;
+  target?: string;
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/useJfrogArtifactoryAppData.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/useJfrogArtifactoryAppData.ts
@@ -18,13 +18,19 @@ import { Entity } from '@backstage/catalog-model';
 export const JFROG_ARTIFACTORY_ANNOTATION_IMAGE_NAME =
   'jfrog-artifactory/image-name';
 
+export const JFROG_ARTIFACTORY_ANNOTATION_TARGET_PROXY =
+  'jfrog-artifactory/target-proxy';
+
 export const useJfrogArtifactoryAppData = ({ entity }: { entity: Entity }) => {
   const imageName =
     entity?.metadata.annotations?.[JFROG_ARTIFACTORY_ANNOTATION_IMAGE_NAME] ??
     '';
 
+  const targetProxy =
+    entity?.metadata.annotations?.[JFROG_ARTIFACTORY_ANNOTATION_TARGET_PROXY];
+
   if (!imageName) {
     throw new Error("'Jfrog Artifactory' annotations are missing");
   }
-  return { imageName };
+  return { imageName, targetProxy };
 };


### PR DESCRIPTION
## Artifactory multiple instances support.

This one adds an optional support for multiple artifactory instances (well, actually multiple proxies :D ).
Now, assuming proxy targets for those instances are configured properly, user may add an additional annotation to their `catalog-info.yaml` to target a specific instance that contains the image. 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
