### PR TITLE
feat(rbac): add default role configuration for authenticated users

### DIFF
--- a/workspaces/rbac/.changeset/hungry-hotels-sneeze.md
+++ b/workspaces/rbac/.changeset/hungry-hotels-sneeze.md
@@ -1,0 +1,15 @@
+---
+'@backstage-community/plugin-rbac-backend': minor
+---
+
+Add support for a default role for authenticated users in RBAC backend
+
+- Introduced a new `defaultRole` configuration option to assign a default role to all authenticated users.
+
+  ```diff
+  permission:
+    rbac:
+  +   defaultRole: role:default/my-default-role
+  ```
+
+- Updated the RBAC permission policy to include the default role in user roles if not already present.

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -85,6 +85,20 @@ permission:
 
 For more information on the available API endpoints accessible to the policy administrators, refer to the [API documentation](./docs/apis.md).
 
+### Configure default role
+
+You can optionally assign a default role to all authenticated users by specifying the `defaultRole` configuration option.
+This ensures that every authenticated user receives the specified role in addition to any other roles they may have.
+This is especially useful when using [Sign-In without Users in the Catalog](https://backstage.io/docs/auth/identity-resolver/#sign-in-without-users-in-the-catalog).
+
+```YAML
+permission:
+  rbac:
+    defaultRole: role:default/my-default-role
+```
+
+If set, the RBAC backend will automatically include the default role in each authenticated user's roles.
+
 ### Configure plugins with permission
 
 In order for the RBAC UI to display the available permissions provided by installed plugins, you must supply the corresponding list of plugin IDs. There are two ways to achieve this:

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -71,6 +71,10 @@ export interface Config {
        * @visibility frontend
        */
       policyDecisionPrecedence?: 'basic' | 'conditional';
+      /**
+       * The default role to assign to all authenticated users.
+       */
+      defaultRole?: string;
     };
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR introduces support for assigning a default role to every authenticated user when using Backstage's [Sign-In without Users in the Catalog](https://backstage.io/docs/auth/identity-resolver/#sign-in-without-users-in-the-catalog) feature.

Currently, when this option is enabled, the @backstage-community/plugin-rbac-backend cannot evaluate permissions for users not present in the catalog. This limitation is also discussed in issue #2077.

With this change, a configurable default role can be specified and automatically assigned to all authenticated users, enabling consistent permission evaluation even without catalog user entries.

You can assing the role "role:default/my-default-role" to all users 

```yaml
permission:
  rbac:
    defaultRole: role:default/my-default-role
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
