### PR TITLE
Version Packages (multi-source-security-viewer)

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/little-balloons-complain.md
+++ b/workspaces/multi-source-security-viewer/.changeset/little-balloons-complain.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-multi-source-security-viewer': patch
----
-
-Fixes disabled sbom link when step is present

--- a/workspaces/multi-source-security-viewer/.changeset/renovate-dfc2349.md
+++ b/workspaces/multi-source-security-viewer/.changeset/renovate-dfc2349.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-multi-source-security-viewer': patch
----
-
-Updated dependency `@backstage-community/plugin-github-actions` to `^0.11.0`.

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-multi-source-security-viewer
 
+## 0.5.3
+
+### Patch Changes
+
+- 28e2aa1: Fixes disabled sbom link when step is present
+- b21ffcd: Updated dependency `@backstage-community/plugin-github-actions` to `^0.11.0`.
+
 ## 0.5.2
 
 ### Patch Changes

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-multi-source-security-viewer",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-multi-source-security-viewer@0.5.3

### Patch Changes

-   28e2aa1: Fixes disabled sbom link when step is present
-   b21ffcd: Updated dependency `@backstage-community/plugin-github-actions` to `^0.11.0`.
