### PR TITLE
announcements: document and add missing markdownRenderer prop to Router

### DIFF
--- a/workspaces/announcements/.changeset/fair-spiders-glow.md
+++ b/workspaces/announcements/.changeset/fair-spiders-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Fixed missing markdownRenderer prop in router that prevented setting the Markdown renderer `backstage` or `md-editor`.

--- a/workspaces/announcements/plugins/announcements/report.api.md
+++ b/workspaces/announcements/plugins/announcements/report.api.md
@@ -79,6 +79,7 @@ export const AnnouncementsPage: (props: {
     | undefined;
   hideInactive?: boolean | undefined;
   hideStartAt?: boolean | undefined;
+  markdownRenderer?: MarkdownRendererTypeProps | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)
@@ -109,6 +110,9 @@ export type AnnouncementsTimelineProps = {
   sortBy?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
 };
+
+// @public
+export type MarkdownRendererTypeProps = 'backstage' | 'md-editor';
 
 // @public (undocumented)
 export const NewAnnouncementBanner: (props: {

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -37,14 +37,17 @@ import { announcementsApiRef } from '@backstage-community/plugin-announcements-r
 import { Announcement } from '@backstage-community/plugin-announcements-common';
 import { Grid, Typography } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
-import { MarkdownRenderer, MarkdownRendererType } from '../MarkdownRenderer';
+import {
+  MarkdownRenderer,
+  MarkdownRendererTypeProps,
+} from '../MarkdownRenderer';
 
 const AnnouncementDetails = ({
   announcement,
   markdownRenderer,
 }: {
   announcement: Announcement;
-  markdownRenderer?: MarkdownRendererType;
+  markdownRenderer?: MarkdownRendererTypeProps;
 }) => {
   const announcementsLink = useRouteRef(rootRouteRef);
   const deepLink = {
@@ -84,7 +87,7 @@ type AnnouncementPageProps = {
   themeId: string;
   title: string;
   subtitle?: ReactNode;
-  markdownRenderer?: MarkdownRendererType;
+  markdownRenderer?: MarkdownRendererTypeProps;
 };
 
 export const AnnouncementPage = (props: AnnouncementPageProps) => {

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -70,7 +70,7 @@ import {
 } from '@material-ui/core';
 import { Alert, Pagination } from '@material-ui/lab';
 import { formatAnnouncementStartTime } from '../utils/announcementDateUtils';
-import { MarkdownRendererType } from '../MarkdownRenderer/MarkdownRenderer';
+import { MarkdownRendererTypeProps } from '../MarkdownRenderer/MarkdownRenderer';
 
 const useStyles = makeStyles(theme => {
   return {
@@ -370,7 +370,7 @@ export type AnnouncementsPageProps = {
   hideContextMenu?: boolean;
   hideInactive?: boolean;
   hideStartAt?: boolean;
-  markdownRenderer?: MarkdownRendererType;
+  markdownRenderer?: MarkdownRendererTypeProps;
   sortby?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
 };

--- a/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -17,11 +17,19 @@ import { MarkdownContent } from '@backstage/core-components';
 import MDEditor from '@uiw/react-md-editor';
 import { makeStyles, useTheme } from '@material-ui/core';
 
-export type MarkdownRendererType = 'backstage' | 'md-editor';
+/**
+ * @public
+ * Use this props to specify which rendering mode the MarkdownRenderer should operate in.
+ *
+ * - `'backstage'`: Indicates that the renderer should use the Backstage built-in style.
+ * - `'md-editor'`: Indicates that the renderer should use the Markdown Editor (WYSIWYG) style.
+ *
+ */
+export type MarkdownRendererTypeProps = 'backstage' | 'md-editor';
 
 export interface MarkdownRendererProps {
   content: string;
-  rendererType?: MarkdownRendererType;
+  rendererType?: MarkdownRendererTypeProps;
 }
 
 // Custom styles for the MDEditor to match Backstage MUI theme

--- a/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 export { MarkdownRenderer } from './MarkdownRenderer';
-export type { MarkdownRendererType } from './MarkdownRenderer';
+export type { MarkdownRendererTypeProps } from './MarkdownRenderer';

--- a/workspaces/announcements/plugins/announcements/src/components/Router.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/Router.tsx
@@ -32,6 +32,7 @@ import { CreateAnnouncementPage } from './CreateAnnouncementPage';
 import { EditAnnouncementPage } from './EditAnnouncementPage';
 import { CategoriesPage } from './CategoriesPage';
 import { AdminPortal } from './Admin';
+import { MarkdownRendererTypeProps } from './MarkdownRenderer';
 
 type RouterProps = {
   themeId?: string;
@@ -47,6 +48,7 @@ type RouterProps = {
   };
   hideInactive?: boolean;
   hideStartAt?: boolean;
+  markdownRenderer?: MarkdownRendererTypeProps;
 };
 
 export const Router = (props: RouterProps) => {

--- a/workspaces/announcements/plugins/announcements/src/components/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/components/index.ts
@@ -17,3 +17,4 @@ export * from './AnnouncementsTimeline';
 export { AdminPortal, AnnouncementsContent } from './Admin';
 export type { AnnouncementsTimelineProps } from './AnnouncementsTimeline';
 export type { AnnouncementSearchResultProps } from './AnnouncementSearchResultListItem';
+export type { MarkdownRendererTypeProps } from './MarkdownRenderer';

--- a/workspaces/announcements/plugins/announcements/src/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/index.ts
@@ -18,4 +18,5 @@ export * from './plugin';
 export type {
   AnnouncementsTimelineProps,
   AnnouncementSearchResultProps,
+  MarkdownRendererTypeProps,
 } from './components';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I miss this one when adding the Markdown renderer: https://github.com/backstage/community-plugins/pull/4310

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
