### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/fair-spiders-glow.md
+++ b/workspaces/announcements/.changeset/fair-spiders-glow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed missing markdownRenderer prop in router that prevented setting the Markdown renderer `backstage` or `md-editor`.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements
 
+## 0.7.2
+
+### Patch Changes
+
+- 822489e: Fixed missing markdownRenderer prop in router that prevented setting the Markdown renderer `backstage` or `md-editor`.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.7.2

### Patch Changes

-   822489e: Fixed missing markdownRenderer prop in router that prevented setting the Markdown renderer `backstage` or `md-editor`.
