### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/breezy-queens-tell.md
+++ b/workspaces/manage/.changeset/breezy-queens-tell.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage-react': major
----
-
-Moved logic to fetch ownership and entities to the new @backstage-community/plugin-manage-backend
-
-BREAKING CHANGE: This package now requires the backend to be installed.

--- a/workspaces/manage/.changeset/new-package-backend.md
+++ b/workspaces/manage/.changeset/new-package-backend.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage-backend': patch
----
-
-Initial version of the package.

--- a/workspaces/manage/.changeset/new-package-common.md
+++ b/workspaces/manage/.changeset/new-package-common.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage-common': patch
----
-
-Initial version of the package.

--- a/workspaces/manage/.changeset/new-package-node.md
+++ b/workspaces/manage/.changeset/new-package-node.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage-node': patch
----
-
-Initial version of the package.

--- a/workspaces/manage/plugins/manage-backend/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-backend/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @backstage-community/plugin-manage-backend
+
+## 1.0.1
+
+### Patch Changes
+
+- 6e2fffe: Initial version of the package.
+- Updated dependencies [6e2fffe]
+- Updated dependencies [6e2fffe]
+  - @backstage-community/plugin-manage-common@1.0.1
+  - @backstage-community/plugin-manage-node@1.0.1

--- a/workspaces/manage/plugins/manage-backend/package.json
+++ b/workspaces/manage/plugins/manage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/manage/plugins/manage-common/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-manage-common
+
+## 1.0.1
+
+### Patch Changes
+
+- 6e2fffe: Initial version of the package.

--- a/workspaces/manage/plugins/manage-common/package.json
+++ b/workspaces/manage/plugins/manage-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "description": "Common functionalities for the manage plugin",
   "main": "src/index.ts",

--- a/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-manage-module-tech-insights
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies [6e2fffe]
+  - @backstage-community/plugin-manage-react@1.0.0
+
 ## 0.1.5
 
 ### Patch Changes

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-module-tech-insights",
   "description": "Manage plugin - Tech Insights module",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage-node/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-node/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-manage-node
+
+## 1.0.1
+
+### Patch Changes
+
+- 6e2fffe: Initial version of the package.

--- a/workspaces/manage/plugins/manage-node/package.json
+++ b/workspaces/manage/plugins/manage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "description": "Node.js library for the manage plugin",
   "main": "src/index.ts",

--- a/workspaces/manage/plugins/manage-react/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-manage-react
 
+## 1.0.0
+
+### Major Changes
+
+- 6e2fffe: Moved logic to fetch ownership and entities to the new @backstage-community/plugin-manage-backend
+
+  BREAKING CHANGE: This package now requires the backend to be installed.
+
+### Patch Changes
+
+- Updated dependencies [6e2fffe]
+  - @backstage-community/plugin-manage-common@1.0.1
+
 ## 0.1.2
 
 ### Patch Changes

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-react",
   "description": "Manage plugin - react package",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "backstage": {
     "role": "web-library",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-manage
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [6e2fffe]
+  - @backstage-community/plugin-manage-react@1.0.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage",
   "description": "Manage plugin - Shows a Manage page relevant to the user",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "manage",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage-react@1.0.0

### Major Changes

-   6e2fffe: Moved logic to fetch ownership and entities to the new @backstage-community/plugin-manage-backend

    BREAKING CHANGE: This package now requires the backend to be installed.

### Patch Changes

-   Updated dependencies [6e2fffe]
    -   @backstage-community/plugin-manage-common@1.0.1

## @backstage-community/plugin-manage@0.2.1

### Patch Changes

-   Updated dependencies [6e2fffe]
    -   @backstage-community/plugin-manage-react@1.0.0

## @backstage-community/plugin-manage-backend@1.0.1

### Patch Changes

-   6e2fffe: Initial version of the package.
-   Updated dependencies [6e2fffe]
-   Updated dependencies [6e2fffe]
    -   @backstage-community/plugin-manage-common@1.0.1
    -   @backstage-community/plugin-manage-node@1.0.1

## @backstage-community/plugin-manage-common@1.0.1

### Patch Changes

-   6e2fffe: Initial version of the package.

## @backstage-community/plugin-manage-module-tech-insights@0.1.6

### Patch Changes

-   Updated dependencies [6e2fffe]
    -   @backstage-community/plugin-manage-react@1.0.0

## @backstage-community/plugin-manage-node@1.0.1

### Patch Changes

-   6e2fffe: Initial version of the package.
