### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/sharp-tomatoes-rescue.md
+++ b/workspaces/announcements/.changeset/sharp-tomatoes-rescue.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': minor
-'@backstage-community/plugin-announcements-react': minor
-'@backstage-community/plugin-announcements': minor
-'@backstage-community/plugin-announcements-common': patch
----
-
-Added support for tags in announcements

--- a/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-announcements-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- 8c803d8: Added support for tags in announcements
+
+### Patch Changes
+
+- Updated dependencies [8c803d8]
+  - @backstage-community/plugin-announcements-common@0.5.1
+  - @backstage-community/plugin-search-backend-module-announcements@0.4.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements-backend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-common
 
+## 0.5.1
+
+### Patch Changes
+
+- 8c803d8: Added support for tags in announcements
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-common/package.json
+++ b/workspaces/announcements/plugins/announcements-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-common",
   "description": "Common functionalities for the announcements plugin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements-node
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [8c803d8]
+  - @backstage-community/plugin-announcements-common@0.5.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-node/package.json
+++ b/workspaces/announcements/plugins/announcements-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-node",
   "description": "Node.js library for the announcements plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.7.0
+
+### Minor Changes
+
+- 8c803d8: Added support for tags in announcements
+
+### Patch Changes
+
+- Updated dependencies [8c803d8]
+  - @backstage-community/plugin-announcements-common@0.5.1
+
 ## 0.6.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-announcements
 
+## 0.8.0
+
+### Minor Changes
+
+- 8c803d8: Added support for tags in announcements
+
+### Patch Changes
+
+- Updated dependencies [8c803d8]
+  - @backstage-community/plugin-announcements-react@0.7.0
+  - @backstage-community/plugin-announcements-common@0.5.1
+
 ## 0.7.2
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [8c803d8]
+  - @backstage-community/plugin-announcements-common@0.5.1
+  - @backstage-community/plugin-announcements-node@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/search-backend-module-announcements/package.json
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-announcements",
   "description": "The announcements backend module for the search plugin.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.8.0

### Minor Changes

-   8c803d8: Added support for tags in announcements

### Patch Changes

-   Updated dependencies [8c803d8]
    -   @backstage-community/plugin-announcements-react@0.7.0
    -   @backstage-community/plugin-announcements-common@0.5.1

## @backstage-community/plugin-announcements-backend@0.6.0

### Minor Changes

-   8c803d8: Added support for tags in announcements

### Patch Changes

-   Updated dependencies [8c803d8]
    -   @backstage-community/plugin-announcements-common@0.5.1
    -   @backstage-community/plugin-search-backend-module-announcements@0.4.1

## @backstage-community/plugin-announcements-react@0.7.0

### Minor Changes

-   8c803d8: Added support for tags in announcements

### Patch Changes

-   Updated dependencies [8c803d8]
    -   @backstage-community/plugin-announcements-common@0.5.1

## @backstage-community/plugin-announcements-common@0.5.1

### Patch Changes

-   8c803d8: Added support for tags in announcements

## @backstage-community/plugin-announcements-node@0.4.1

### Patch Changes

-   Updated dependencies [8c803d8]
    -   @backstage-community/plugin-announcements-common@0.5.1

## @backstage-community/plugin-search-backend-module-announcements@0.4.1

### Patch Changes

-   Updated dependencies [8c803d8]
    -   @backstage-community/plugin-announcements-common@0.5.1
    -   @backstage-community/plugin-announcements-node@0.4.1
