### PR TITLE
plugin(grafana): Prevent dashboard queries on `folderTitle` from breaking `DashboardsCard`

### DIFF
--- a/workspaces/grafana/.changeset/quick-toys-sell.md
+++ b/workspaces/grafana/.changeset/quick-toys-sell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': patch
+---
+
+Prevent dashboard queries on folderTitle from breaking

--- a/workspaces/grafana/plugins/grafana/report.api.md
+++ b/workspaces/grafana/plugins/grafana/report.api.md
@@ -31,7 +31,7 @@ export const alertSelectorFromEntity: (entity: Entity) => string | string[];
 
 // @public
 export interface Dashboard {
-  folderTitle: string;
+  folderTitle: string | undefined;
   folderUrl: string;
   tags: string[];
   title: string;

--- a/workspaces/grafana/plugins/grafana/src/api.ts
+++ b/workspaces/grafana/plugins/grafana/src/api.ts
@@ -155,7 +155,10 @@ class Client {
   ): Promise<Dashboard[]> {
     const parsedQuery = this.queryEvaluator.parse(query);
     const response = await this.fetch<Dashboard[]>(`/api/search?type=dash-db`);
-    const allDashboards = this.fullyQualifiedDashboardURLs(domain, response);
+    const allDashboards = this.fullyQualifiedDashboardMetadata(
+      domain,
+      response,
+    );
 
     return allDashboards.filter(dashboard => {
       return this.queryEvaluator.evaluate(parsedQuery, dashboard) === true;
@@ -167,16 +170,17 @@ class Client {
       `/api/search?type=dash-db&tag=${tag}`,
     );
 
-    return this.fullyQualifiedDashboardURLs(domain, response);
+    return this.fullyQualifiedDashboardMetadata(domain, response);
   }
 
-  private fullyQualifiedDashboardURLs(
+  private fullyQualifiedDashboardMetadata(
     domain: string,
     dashboards: Dashboard[],
   ): Dashboard[] {
     return dashboards.map(dashboard => ({
       ...dashboard,
       url: domain + dashboard.url,
+      folderTitle: dashboard.folderTitle ?? '',
       folderUrl: domain + dashboard.folderUrl,
     }));
   }

--- a/workspaces/grafana/plugins/grafana/src/types.ts
+++ b/workspaces/grafana/plugins/grafana/src/types.ts
@@ -35,7 +35,7 @@ export interface Dashboard {
    * The folder title, if any
    * @public
    */
-  folderTitle: string;
+  folderTitle: string | undefined;
   /**
    * The endpoint to the folder
    * @public


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This fixes #4399.

### Changes Made

When retrieving a `Dashboard` from a Grafana instance, the `Client` class will now set an empty string as the fallback value for `folderTitle` if it is missing.

This should prevent the `QueryEvaluator` from throwing an error when it encounters a Dashboard with a missing `folderTitle` attribute during queries on said attribute.

Also updated the `Dashboard` type to reflect that the `folderTitle` attribute is not always provided by the Grafana API, such as when the Dashboard does not reside in a folder.

### Other Notes

Another approach may have been to change the behavior of `QueryEvaluator`, but I think it's still a good idea to throw an Error if a genuinely unexpected identifier is encountered, and I didn't think it was wise to hard code a check for this specific identifier either.

Did not choose to add tests since this is a small change, and I think tests here would require either exporting the `Client` class or using deeper integration tests... But not opposed to adding them if it's deemed necessary! 😅 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
