### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/nervous-toys-swim.md
+++ b/workspaces/keycloak/.changeset/nervous-toys-swim.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Adds the `sanitizeGroupNameTransformer` and `sanitizeUserNameTransformer` transformers and sets them to be applied by default.

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 3.12.1
+
+### Patch Changes
+
+- 4dce226: Adds the `sanitizeGroupNameTransformer` and `sanitizeUserNameTransformer` transformers and sets them to be applied by default.
+
 ## 3.12.0
 
 ### Minor Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.12.1

### Patch Changes

-   4dce226: Adds the `sanitizeGroupNameTransformer` and `sanitizeUserNameTransformer` transformers and sets them to be applied by default.
