### PR TITLE
Announcements | Migrate to PermissionsRegistryService from createPermissionIntegrationRouter

### DIFF
--- a/workspaces/announcements/.changeset/bright-grapes-sparkle.md
+++ b/workspaces/announcements/.changeset/bright-grapes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-backend': patch
+---
+
+Deprecates createPermissionIntegrationRouter in favor of leveraging the new PermissionsRegistryService. There should be no external impact to end users.

--- a/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
@@ -21,6 +21,7 @@ import { createRouter } from './router';
 import { signalsServiceRef } from '@backstage/plugin-signals-node';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { buildAnnouncementsContext } from './service';
+import { announcementEntityPermissions } from '@backstage-community/plugin-announcements-common';
 
 /**
  * A backend for the announcements plugin.
@@ -31,34 +32,41 @@ export const announcementsPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
-        logger: coreServices.logger,
-        http: coreServices.httpRouter,
-        permissions: coreServices.permissions,
-        database: coreServices.database,
-        httpAuth: coreServices.httpAuth,
         config: coreServices.rootConfig,
+        database: coreServices.database,
         events: eventsServiceRef,
+        http: coreServices.httpRouter,
+        httpAuth: coreServices.httpAuth,
+        logger: coreServices.logger,
+        permissions: coreServices.permissions,
+        permissionsRegistry: coreServices.permissionsRegistry,
         signals: signalsServiceRef,
       },
       async init({
+        config,
+        database,
+        events,
         http,
+        httpAuth,
         logger,
         permissions,
-        database,
-        httpAuth,
-        config,
-        events,
+        permissionsRegistry,
         signals,
       }) {
         const context = await buildAnnouncementsContext({
-          events,
-          logger,
           config,
           database,
-          permissions,
-          signals,
+          events,
           httpAuth,
+          logger,
+          permissions,
+          permissionsRegistry,
+          signals,
         });
+
+        permissionsRegistry.addPermissions(
+          Object.values(announcementEntityPermissions),
+        );
 
         const router = await createRouter(context);
 

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -69,6 +69,7 @@ describe('createRouter', () => {
       config: mockServices.rootConfig.mock(),
       persistenceContext: mockPersistenceContext,
       permissions: mockPermissions,
+      permissionsRegistry: mockServices.permissionsRegistry.mock(),
       httpAuth: mockHttpAuth,
     };
 

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -25,9 +25,6 @@ import {
   BasicPermission,
 } from '@backstage/plugin-permission-common';
 import {
-  announcementCreatePermission,
-  announcementDeletePermission,
-  announcementUpdatePermission,
   announcementEntityPermissions,
   EVENTS_TOPIC_ANNOUNCEMENTS,
   EVENTS_ACTION_CREATE_ANNOUNCEMENT,
@@ -39,7 +36,6 @@ import {
   EVENTS_ACTION_DELETE_TAG,
   MAX_TITLE_TAG_LENGTH,
 } from '@backstage-community/plugin-announcements-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import { signalAnnouncement } from './service/signal';
 import { AnnouncementsContext } from './service';
 
@@ -72,18 +68,20 @@ export async function createRouter(
   context: AnnouncementsContext,
 ): Promise<express.Router> {
   const {
+    config,
+    events,
+    httpAuth,
+    logger,
     persistenceContext,
     permissions,
-    httpAuth,
-    config,
-    logger,
-    events,
     signals,
   } = context;
 
-  const permissionIntegrationRouter = createPermissionIntegrationRouter({
-    permissions: Object.values(announcementEntityPermissions),
-  });
+  const {
+    announcementCreatePermission,
+    announcementDeletePermission,
+    announcementUpdatePermission,
+  } = announcementEntityPermissions;
 
   const isRequestAuthorized = async (
     req: Request,
@@ -102,7 +100,6 @@ export async function createRouter(
 
   const router = Router();
   router.use(express.json());
-  router.use(permissionIntegrationRouter);
 
   router.get(
     '/announcements',

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
@@ -14,64 +14,49 @@
  * limitations under the License.
  */
 import { mockServices } from '@backstage/backend-test-utils';
+import { SignalsService } from '@backstage/plugin-signals-node';
 import { buildAnnouncementsContext } from './announcementsContextBuilder';
 import { initializePersistenceContext } from './persistence/persistenceContext';
-import {
-  HttpAuthService,
-  PermissionsService,
-} from '@backstage/backend-plugin-api';
-import { EventsService } from '@backstage/plugin-events-node';
-import { SignalsService } from '@backstage/plugin-signals-node';
-
-jest.mock('./persistence/persistenceContext', () => ({
-  initializePersistenceContext: jest.fn(),
-}));
 
 describe('buildAnnouncementsContext', () => {
-  it('returns context with logger, persistenceContext, permissions and httpAuth properties', async () => {
+  it('returns initialized context with persistence', async () => {
     const logger = mockServices.logger.mock();
-    const config = mockServices.rootConfig.mock();
-    const database = {
-      getClient: jest.fn(),
-      url: 'url',
-    };
-    const permissions: PermissionsService = {
-      authorize: jest.fn(),
-      authorizeConditional: jest.fn(),
-    };
-
-    const httpAuth: HttpAuthService = {
-      credentials: jest.fn(),
-      issueUserCookie: jest.fn(),
-    };
-
-    const events: EventsService = {
-      publish: jest.fn(),
-      subscribe: jest.fn(),
-    };
+    const config = mockServices.rootConfig();
+    const database = mockServices.database.mock({
+      migrations: {
+        skip: true,
+      },
+    });
+    const permissions = mockServices.permissions();
+    const httpAuth = mockServices.httpAuth();
+    const permissionsRegistry = mockServices.permissionsRegistry.mock();
+    const events = mockServices.events();
 
     const signals: SignalsService = {
       publish: jest.fn(),
     };
 
     const context = await buildAnnouncementsContext({
-      logger,
       config,
       database,
-      permissions,
-      permissionsRegistry: mockServices.permissionsRegistry.mock(),
-      httpAuth,
       events,
+      httpAuth,
+      logger,
+      permissions,
+      permissionsRegistry,
       signals,
     });
 
+    const persistenceContext = await initializePersistenceContext(database);
+
     expect(context).toStrictEqual({
-      logger,
       config,
-      persistenceContext: await initializePersistenceContext(database),
-      permissions,
-      httpAuth,
       events,
+      httpAuth,
+      logger,
+      permissions,
+      permissionsRegistry,
+      persistenceContext,
       signals,
     });
   });

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
@@ -39,6 +39,7 @@ describe('buildAnnouncementsContext', () => {
       authorize: jest.fn(),
       authorizeConditional: jest.fn(),
     };
+
     const httpAuth: HttpAuthService = {
       credentials: jest.fn(),
       issueUserCookie: jest.fn(),
@@ -58,6 +59,7 @@ describe('buildAnnouncementsContext', () => {
       config,
       database,
       permissions,
+      permissionsRegistry: mockServices.permissionsRegistry.mock(),
       httpAuth,
       events,
       signals,

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
@@ -21,6 +21,7 @@ import {
   DatabaseService,
   HttpAuthService,
   LoggerService,
+  PermissionsRegistryService,
   PermissionsService,
   RootConfigService,
 } from '@backstage/backend-plugin-api';
@@ -33,12 +34,13 @@ import { SignalsService } from '@backstage/plugin-signals-node';
  * @public
  */
 export type AnnouncementsContext = {
-  logger: LoggerService;
   config: RootConfigService;
-  persistenceContext: PersistenceContext;
-  permissions: PermissionsService;
-  httpAuth: HttpAuthService;
   events?: EventsService;
+  httpAuth: HttpAuthService;
+  logger: LoggerService;
+  permissions: PermissionsService;
+  permissionsRegistry: PermissionsRegistryService;
+  persistenceContext: PersistenceContext;
   signals?: SignalsService;
 };
 
@@ -60,21 +62,23 @@ export type AnnouncementsContextOptions = Omit<
  * @public
  */
 export const buildAnnouncementsContext = async ({
-  logger,
   config,
   database,
-  permissions,
-  httpAuth,
   events,
+  httpAuth,
+  logger,
+  permissions,
+  permissionsRegistry,
   signals,
 }: AnnouncementsContextOptions): Promise<AnnouncementsContext> => {
   return {
-    logger,
     config,
-    persistenceContext: await initializePersistenceContext(database),
-    permissions,
-    httpAuth,
     events,
+    httpAuth,
+    logger,
+    permissions,
+    permissionsRegistry,
+    persistenceContext: await initializePersistenceContext(database),
     signals,
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Leverage the new PermissionsRegistryService to manage permissions by following these [docs](https://backstage.io/docs/backend-system/core-services/permissions-registry/#migrating-from-createpermissionintegrationrouter) to deprecate `createPermissionIntegrationRouter`.

I also elected to clean things up a bit by ordering the service deps alphabetically and replacing manually mocked versions of core services.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
