### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/bright-grapes-sparkle.md
+++ b/workspaces/announcements/.changeset/bright-grapes-sparkle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': patch
----
-
-Deprecates createPermissionIntegrationRouter in favor of leveraging the new PermissionsRegistryService. There should be no external impact to end users.

--- a/workspaces/announcements/.changeset/pink-pumas-jump.md
+++ b/workspaces/announcements/.changeset/pink-pumas-jump.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': minor
-'@backstage-community/plugin-announcements-node': minor
----
-
-Potentially BREAKING CHANGES for those who were still using the deprecated code.
-
-- Removes code related to deprecated search collator from `@backstage-community/plugin-announcements-backend` (import from `@backstage-community/plugin-search-backend-module-announcements`)
-- Removes code related to deprecated `announcementsService` from `@backstage-community/plugin-announcements-node` in favor of `announcementsServiceRef`

--- a/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-announcements-backend
 
+## 0.8.0
+
+### Minor Changes
+
+- 1a231d9: Potentially BREAKING CHANGES for those who were still using the deprecated code.
+
+  - Removes code related to deprecated search collator from `@backstage-community/plugin-announcements-backend` (import from `@backstage-community/plugin-search-backend-module-announcements`)
+  - Removes code related to deprecated `announcementsService` from `@backstage-community/plugin-announcements-node` in favor of `announcementsServiceRef`
+
+### Patch Changes
+
+- cbc8c92: Deprecates createPermissionIntegrationRouter in favor of leveraging the new PermissionsRegistryService. There should be no external impact to end users.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements-backend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-announcements-node
 
+## 0.6.0
+
+### Minor Changes
+
+- 1a231d9: Potentially BREAKING CHANGES for those who were still using the deprecated code.
+
+  - Removes code related to deprecated search collator from `@backstage-community/plugin-announcements-backend` (import from `@backstage-community/plugin-search-backend-module-announcements`)
+  - Removes code related to deprecated `announcementsService` from `@backstage-community/plugin-announcements-node` in favor of `announcementsServiceRef`
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-node/package.json
+++ b/workspaces/announcements/plugins/announcements-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-node",
   "description": "Node.js library for the announcements plugin",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [1a231d9]
+  - @backstage-community/plugin-announcements-node@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/search-backend-module-announcements/package.json
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-announcements",
   "description": "The announcements backend module for the search plugin.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements-backend@0.8.0

### Minor Changes

-   1a231d9: Potentially BREAKING CHANGES for those who were still using the deprecated code.

    -   Removes code related to deprecated search collator from `@backstage-community/plugin-announcements-backend` (import from `@backstage-community/plugin-search-backend-module-announcements`)
    -   Removes code related to deprecated `announcementsService` from `@backstage-community/plugin-announcements-node` in favor of `announcementsServiceRef`

### Patch Changes

-   cbc8c92: Deprecates createPermissionIntegrationRouter in favor of leveraging the new PermissionsRegistryService. There should be no external impact to end users.

## @backstage-community/plugin-announcements-node@0.6.0

### Minor Changes

-   1a231d9: Potentially BREAKING CHANGES for those who were still using the deprecated code.

    -   Removes code related to deprecated search collator from `@backstage-community/plugin-announcements-backend` (import from `@backstage-community/plugin-search-backend-module-announcements`)
    -   Removes code related to deprecated `announcementsService` from `@backstage-community/plugin-announcements-node` in favor of `announcementsServiceRef`

## @backstage-community/plugin-search-backend-module-announcements@0.5.1

### Patch Changes

-   Updated dependencies [1a231d9]
    -   @backstage-community/plugin-announcements-node@0.6.0
