### PR TITLE
refactor: remove EntityPeekAheadPopover 

### DIFF
--- a/workspaces/announcements/.changeset/dirty-starfishes-compare.md
+++ b/workspaces/announcements/.changeset/dirty-starfishes-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Remove redundant `EntityPeekAheadPopover` when hovering over user or group entity.

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -28,10 +28,7 @@ import {
   useRouteRef,
   useRouteRefParams,
 } from '@backstage/core-plugin-api';
-import {
-  EntityPeekAheadPopover,
-  EntityRefLink,
-} from '@backstage/plugin-catalog-react';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { announcementViewRouteRef, rootRouteRef } from '../../routes';
 import { announcementsApiRef } from '@backstage-community/plugin-announcements-react';
 import { Announcement } from '@backstage-community/plugin-announcements-common';
@@ -57,14 +54,10 @@ const AnnouncementDetails = ({
   const subHeader = (
     <Typography>
       By{' '}
-      <EntityPeekAheadPopover
+      <EntityRefLink
         entityRef={announcement.on_behalf_of || announcement.publisher}
-      >
-        <EntityRefLink
-          entityRef={announcement.on_behalf_of || announcement.publisher}
-          hideIcon
-        />
-      </EntityPeekAheadPopover>
+        hideIcon
+      />
       , {DateTime.fromISO(announcement.created_at).toRelative()}
     </Typography>
   );

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -34,10 +34,7 @@ import {
   LinkButton,
 } from '@backstage/core-components';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import {
-  EntityPeekAheadPopover,
-  EntityRefLink,
-} from '@backstage/plugin-catalog-react';
+import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
@@ -130,14 +127,10 @@ const AnnouncementCard = ({
     <>
       <Typography variant="body2" color="textSecondary" component="span">
         {t('announcementsPage.card.by')}{' '}
-        <EntityPeekAheadPopover
+        <EntityRefLink
           entityRef={announcement.on_behalf_of || announcement.publisher}
-        >
-          <EntityRefLink
-            entityRef={announcement.on_behalf_of || announcement.publisher}
-            hideIcon
-          />
-        </EntityPeekAheadPopover>
+          hideIcon
+        />
         {announcement.category && (
           <>
             {' '}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small change to prevent multiple entityDisplay tooltips on hover.

Previously, two components displayed the entity:

![image](https://github.com/user-attachments/assets/068ea002-c164-43f8-9e1a-65ee4525bf42)

Now it only use `EntityRefLink`, as used in the Backstage catalog

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
