### PR TITLE
Enabling New Relic Session Replay for backstage 

### DIFF
--- a/workspaces/analytics/.changeset/two-coats-shake.md
+++ b/workspaces/analytics/.changeset/two-coats-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-newrelic-browser': minor
+---
+
+Adding a sessionReplay config block to the plugin options, allowing users to enable/disable session replay and set options like sampling rate, error sampling rate, masking selectors, and block selectors.

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/README.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/README.md
@@ -68,7 +68,57 @@ app:
       ...
       distributedTracing: true
       cookiesEnabled: true
+      sessionReplay:
+        enabled: true
+        samplingRate: 90
+        errorSamplingRate: 90
+        # Optional:
+        # maskTextSelector: 'input[type="password"]'
+        # maskAllInputs: true
+        # blockSelector: '.private'
 ```
+
+See [`config.d.ts`](./config.d.ts) for all available options.
+
+## Session Replay
+
+Session Replay can be enabled via the `sessionReplay` config block. This allows you to record and replay user sessions for debugging and UX analysis.
+
+### Troubleshooting: Manual Session Replay
+
+If you notice that sessions are **not being recorded automatically**, you can force a manual session replay start by injecting the following React component into your app:
+
+```typescript
+import { useEffect } from 'react';
+
+const UseStartReplay = () => {
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if ((window?.newrelic as any)?.recordReplay) {
+        (window.newrelic as any).recordReplay();
+        clearInterval(interval);
+      }
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+  return null;
+};
+```
+
+Then, add it to your app’s router:
+
+```tsx
+<AppRouter>
+  <UseStartReplay />
+  <Root>{routes}</Root>
+</AppRouter>
+```
+
+This will ensure session recording starts as soon as the New Relic agent is ready.
+
+---
+
+For more details, see the [New Relic Browser documentation](https://docs.newrelic.com/docs/browser/).
 
 ### User IDs
 

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/config.d.ts
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/config.d.ts
@@ -53,6 +53,41 @@ export interface Config {
          * @visibility frontend
          */
         cookiesEnabled: boolean;
+
+        /**
+         * Session Replay configuration
+         * @deepVisibility frontend
+         */
+        sessionReplay?: {
+          /**
+           * Whether to enable Session Replay, defaults to false
+           */
+          enabled: boolean;
+          /**
+           * Sampling rate for session replay, defaults to 0
+           */
+          samplingRate?: number;
+          /**
+           * Error sampling rate for session replay, defaults to 100
+           */
+          errorSamplingRate?: number;
+          /**
+           * Whether to mask all inputs, defaults to false
+           */
+          maskTextSelector?: string;
+          /**
+           * Whether to mask all inputs, defaults to true
+           */
+          maskAllInputs?: boolean;
+          /**
+           * Whether to collect fonts, defaults to true
+           */
+          collectFonts?: boolean;
+          /**
+           * Block selector for session replay, defaults to true
+           */
+          blockSelector?: string;
+        };
       };
     };
   };

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -38,7 +38,7 @@
     "@backstage/core-components": "^0.17.3",
     "@backstage/core-plugin-api": "^1.10.8",
     "@backstage/frontend-plugin-api": "^0.10.3",
-    "@newrelic/browser-agent": "^1.236.0"
+    "@newrelic/browser-agent": "^1.292.1"
   },
   "devDependencies": {
     "@backstage/cli": "^0.33.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/src/apis/implementations/AnalyticsApi/NewRelicBrowser.ts
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/src/apis/implementations/AnalyticsApi/NewRelicBrowser.ts
@@ -35,6 +35,14 @@ type NewRelicBrowserOptions = {
   licenseKey: string;
   distributedTracingEnabled: boolean;
   cookiesEnabled: boolean;
+  sessionReplay?: {
+    enabled?: boolean;
+    samplingRate?: number;
+    errorSamplingRate?: number;
+    maskTextSelector?: string;
+    maskAllInputs?: boolean;
+    blockSelector?: string;
+  };
 };
 
 /**
@@ -60,6 +68,36 @@ export class NewRelicBrowser implements AnalyticsApi, NewAnalyicsApi {
         },
         ajax: {
           deny_list: [options.endpoint],
+        },
+        session_replay: {
+          enabled: options.sessionReplay?.enabled || false,
+          block_selector: options.sessionReplay?.blockSelector || '',
+          mask_text_selector: options.sessionReplay?.maskTextSelector || '',
+          sampling_rate: options.sessionReplay?.samplingRate || 0,
+          error_sampling_rate: options.sessionReplay?.errorSamplingRate || 0,
+          mask_all_inputs: options.sessionReplay?.maskAllInputs || false,
+          collect_fonts: true,
+          inline_images: false,
+          inline_stylesheet: true,
+          fix_stylesheets: true,
+          preload: true,
+          mask_input_options: {
+            color: true,
+            date: true,
+            datetime_local: true,
+            email: true,
+            month: true,
+            number: true,
+            range: true,
+            search: true,
+            tel: true,
+            text: true,
+            time: true,
+            url: true,
+            week: true,
+            select: true,
+            textarea: true,
+          },
         },
       },
       info: {
@@ -117,6 +155,9 @@ export class NewRelicBrowser implements AnalyticsApi, NewAnalyicsApi {
         false,
       cookiesEnabled:
         newRelicBrowserConfig.getOptionalBoolean('cookiesEnabled') ?? false,
+      sessionReplay: {
+        ...newRelicBrowserConfig.getOptionalConfig('sessionReplay')?.get(),
+      }, // Ensure we get the session replay config as plain object
     };
     return new NewRelicBrowser(
       browserOptions,


### PR DESCRIPTION
## New Relic Session replay in backstage
Updated the New Relic Browser analytics integration to support advanced Session Replay configuration via Backstage's app-config.yaml

The changes include:

Adding a sessionReplay config block to the plugin options, allowing users to enable/disable session replay and set options like sampling rate, error sampling rate, masking selectors, and block selectors.
Passing these session replay options to the New Relic Browser agent during initialization.
Ensuring the configuration is read from Backstage config and applied dynamically.
Providing guidance for users to manually trigger session recording if auto-record does not work as expected.
#### :heavy_check_mark: Checklist


- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
