### PR TITLE
docs(rbac): Replacing old Janus IDP doc link with RHDH doc, making internal doc links relative

### DIFF
--- a/workspaces/rbac/.changeset/loud-cherries-rescue.md
+++ b/workspaces/rbac/.changeset/loud-cherries-rescue.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+docs(rbac): Removing Janus IDP dynamic plugin installation instructions, switching to relative paths for doc links

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -8,14 +8,11 @@ The RBAC UI plugin offers a streamlined user interface for effectively managing 
 
 #### Installing as a dynamic plugin?
 
-The sections below are relevant for static plugins. If the plugin is expected to be installed as a dynamic one:
-
-- follow https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md#installing-a-dynamic-plugin-package-in-the-showcase
-- add content of `app-config.yaml` into `app-config.local.yaml`.
+The sections below are relevant for static plugins. If the plugin is expected to be installed as a dynamic one, follow the [dynamic plugin installation guide](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/installing-plugins.md).
 
 #### Prerequisites
 
-Follow the RBAC backend plugin [README](https://github.com/backstage/community-plugins/blob/main/workspaces/rbac/plugins/rbac-backend/README.md) to integrate rbac in your Backstage instance.
+Follow the RBAC backend plugin [README](../rbac-backend/README.md) to integrate rbac in your Backstage instance.
 
 ---
 
@@ -34,7 +31,7 @@ g, user:default/<login-id/user-name>, role:default/team_a
 
 > Note: Even after ingesting users/groups in catalog and applying above permissions if the create/edit button is still disabled then please contact your administrator as you might be conditionally restricted from accessing the create/edit button.
 
-- To fetch the permissions from other plugins like `Kubernetes` and `Jenkins` in the Role Form as mentioned [here](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/rbac-backend/docs/permissions.md), add the following configuration in your `app-config.yaml`:
+- To fetch the permissions from other plugins like `Kubernetes` and `Jenkins` in the Role Form as mentioned in the [RBAC permissions documentation](../rbac-backend/docs/permissions.md), add the following configuration in your `app-config.yaml`:
 
 ```yaml title="app-config.yaml"
 permission:

--- a/workspaces/rbac/plugins/rbac/README.md
+++ b/workspaces/rbac/plugins/rbac/README.md
@@ -6,10 +6,6 @@ The RBAC UI plugin offers a streamlined user interface for effectively managing 
 
 ### Installation
 
-#### Installing as a dynamic plugin?
-
-The sections below are relevant for static plugins. If the plugin is expected to be installed as a dynamic one, follow the [dynamic plugin installation guide](https://github.com/redhat-developer/rhdh/blob/main/docs/dynamic-plugins/installing-plugins.md).
-
 #### Prerequisites
 
 Follow the RBAC backend plugin [README](../rbac-backend/README.md) to integrate rbac in your Backstage instance.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small documentation update for the RBAC plugin. The `rbac/README.md` was still referencing the sunset Janus IDP for dynamic plugin documentation. Switched out the link for the corresponding docs in the [RHDH repository](https://github.com/redhat-developer/rhdh). Also updated the absolute internal doc links with relative paths in line with the other plugin documentation.

Changeset not included for simple doc change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
