### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/fifty-brooms-brake.md
+++ b/workspaces/rbac/.changeset/fifty-brooms-brake.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Added optional pagination support to getMembers API

--- a/workspaces/rbac/.changeset/hot-beds-fry.md
+++ b/workspaces/rbac/.changeset/hot-beds-fry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Updated readme example on conditional policy yaml to be well formed (removed quotes)

--- a/workspaces/rbac/.changeset/loud-cherries-rescue.md
+++ b/workspaces/rbac/.changeset/loud-cherries-rescue.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-docs(rbac): Removing Janus IDP dynamic plugin installation instructions, switching to relative paths for doc links

--- a/workspaces/rbac/.changeset/renovate-7b8f554.md
+++ b/workspaces/rbac/.changeset/renovate-7b8f554.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.23`.

--- a/workspaces/rbac/.changeset/serious-snails-care.md
+++ b/workspaces/rbac/.changeset/serious-snails-care.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-removed shared-react dependencies

--- a/workspaces/rbac/.changeset/slimy-icons-clean.md
+++ b/workspaces/rbac/.changeset/slimy-icons-clean.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Fix to remove entire permission when no policy is selected.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 7.1.0
+
+### Minor Changes
+
+- 8db28a0: Updated readme example on conditional policy yaml to be well formed (removed quotes)
+
+### Patch Changes
+
+- 4c49556: Updated dependency `@types/express` to `4.17.23`.
+
 ## 7.0.0
 
 ### Major Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,14 @@
 ### Dependencies
 
+## 1.42.1
+
+### Patch Changes
+
+- a2e5d4e: Added optional pagination support to getMembers API
+- aec6bc2: docs(rbac): Removing Janus IDP dynamic plugin installation instructions, switching to relative paths for doc links
+- ac39bff: removed shared-react dependencies
+- 4719a0e: Fix to remove entire permission when no policy is selected.
+
 ## 1.42.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@7.1.0

### Minor Changes

-   8db28a0: Updated readme example on conditional policy yaml to be well formed (removed quotes)

### Patch Changes

-   4c49556: Updated dependency `@types/express` to `4.17.23`.

## @backstage-community/plugin-rbac@1.42.1

### Patch Changes

-   a2e5d4e: Added optional pagination support to getMembers API
-   aec6bc2: docs(rbac): Removing Janus IDP dynamic plugin installation instructions, switching to relative paths for doc links
-   ac39bff: removed shared-react dependencies
-   4719a0e: Fix to remove entire permission when no policy is selected.
