### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-ca2264a.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-ca2264a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.78.3`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/weak-needles-cry.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/weak-needles-cry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-add examples for action servicenow backend scaffolder

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 2.7.1
+
+### Patch Changes
+
+- 7cfcb00: Updated dependency `@hey-api/openapi-ts` to `0.78.3`.
+- 042961c: add examples for action servicenow backend scaffolder
+
 ## 2.7.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.7.1

### Patch Changes

-   7cfcb00: Updated dependency `@hey-api/openapi-ts` to `0.78.3`.
-   042961c: add examples for action servicenow backend scaffolder
