### PR TITLE
meta: update CODEOWNERS based on discussions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@ yarn.lock                                                               @backsta
 /workspaces/jenkins                                                     @backstage/community-plugins-maintainers
 /workspaces/jfrog-artifactory                                           @backstage/community-plugins-maintainers  @BethGriggs
 /workspaces/kafka                                                       @backstage/community-plugins-maintainers  @andrewthauer
-/workspaces/keycloak                                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @schultzp2020 @dzemanov
+/workspaces/keycloak                                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov
 /workspaces/kiali                                                       @backstage/community-plugins-maintainers  @aljesusg @josunect @leandroberetta
 /workspaces/lighthouse                                                  @backstage/community-plugins-maintainers
 /workspaces/linguist                                                    @backstage/community-plugins-maintainers  @awanlin
@@ -75,13 +75,13 @@ yarn.lock                                                               @backsta
 /workspaces/mta                                                         @backstage/community-plugins-maintainers  @ibolton336
 /workspaces/multi-source-security-viewer                                @backstage/community-plugins-maintainers  @caugello @cryptorodeo
 /workspaces/newrelic                                                    @backstage/community-plugins-maintainers
-/workspaces/nexus-repository-manager                                    @backstage/community-plugins-maintainers  @schultzp2020
+/workspaces/nexus-repository-manager                                    @backstage/community-plugins-maintainers  @ciiay @debsmita1 @jessicajhee
 /workspaces/nomad                                                       @backstage/community-plugins-maintainers
 /workspaces/noop                                                        @backstage/community-plugins-maintainers
 /workspaces/npm                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @karthikjeeyar
 /workspaces/ocm                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
 /workspaces/octopus-deploy                                              @backstage/community-plugins-maintainers  @jmezach
-/workspaces/odo                                                         @backstage/community-plugins-maintainers  @rm3l
+/workspaces/odo                                                         @backstage/community-plugins-maintainers
 /workspaces/opencost                                                    @backstage/community-plugins-maintainers
 /workspaces/periskop                                                    @backstage/community-plugins-maintainers
 /workspaces/pingidentity                                                @backstage/community-plugins-maintainers  @jessicajhee
@@ -95,10 +95,10 @@ yarn.lock                                                               @backsta
 /workspaces/rollbar                                                     @backstage/community-plugins-maintainers  @andrewthauer
 /workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1
 /workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1
-/workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @04kash
-/workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @schultzp2020
-/workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @04kash @schultzp2020
-/workspaces/scaffolder-relation-processor                               @backstage/community-plugins-maintainers  @04kash
+/workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
+/workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
+/workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
+/workspaces/scaffolder-relation-processor                               @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr @christoph-jerolimov @divyanshiGupta @PatAKnight @dzemanov
 /workspaces/sentry                                                      @backstage/community-plugins-maintainers
 /workspaces/servicenow                                                  @backstage/community-plugins-maintainers  @AndrienkoAleksandr @ciiay @PatAKnight @christoph-jerolimov
 /workspaces/shortcuts                                                   @backstage/community-plugins-maintainers


### PR DESCRIPTION
Proposed changes to Red Hat CODEOWNERS after discussions. This should better reflect activity/reality.

Note: the odo workspace owner was removed as they are not a member of the Backstage GitHub org, and the plugin is planned for imminent archival/deprecation (listed in #4619).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
