### PR TITLE
implement tag filtering for announcements

### DIFF
--- a/workspaces/announcements/.changeset/itchy-cougars-end.md
+++ b/workspaces/announcements/.changeset/itchy-cougars-end.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-announcements-backend': minor
+'@backstage-community/plugin-announcements-react': minor
+'@backstage-community/plugin-announcements': minor
+---
+
+This change introduces tag filtering to announcements, allowing users to filter by tag by clicking on a tag on an announcement card.

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -176,5 +176,105 @@ describe('createRouter', () => {
         },
       ]);
     });
+    it('filters announcements by single tag', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [
+          {
+            id: 'uuid1',
+            title: 'Tagged Announcement',
+            excerpt: 'This has tag1',
+            body: 'Full content',
+            publisher: 'user:default/name',
+            created_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            tags: [{ slug: 'tag1', title: 'Tag 1' }],
+          },
+        ],
+        count: 1,
+      });
+
+      const response = await request(app).get('/announcements?tags=tag1');
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: undefined,
+        sortBy: 'created_at',
+        order: 'desc',
+        tags: ['tag1'],
+      });
+
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].tags).toEqual([
+        { slug: 'tag1', title: 'Tag 1' },
+      ]);
+    });
+
+    it('filters announcements by multiple tags', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [
+          {
+            id: 'uuid1',
+            title: 'Multi-tagged Announcement',
+            excerpt: 'This has multiple tags',
+            body: 'Full content',
+            publisher: 'user:default/name',
+            created_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            tags: [
+              { slug: 'tag1', title: 'Tag 1' },
+              { slug: 'tag2', title: 'Tag 2' },
+            ],
+          },
+        ],
+        count: 1,
+      });
+
+      const response = await request(app).get('/announcements?tags=tag1,tag2');
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: undefined,
+        sortBy: 'created_at',
+        order: 'desc',
+        tags: ['tag1', 'tag2'],
+      });
+
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].tags).toEqual([
+        { slug: 'tag1', title: 'Tag 1' },
+        { slug: 'tag2', title: 'Tag 2' },
+      ]);
+    });
+
+    it('returns empty results when no announcements match tags', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [],
+        count: 0,
+      });
+
+      const response = await request(app).get(
+        '/announcements?tags=nonexistent',
+      );
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: undefined,
+        sortBy: 'created_at',
+        order: 'desc',
+        tags: ['nonexistent'],
+      });
+
+      expect(response.body.results).toHaveLength(0);
+      expect(response.body.count).toEqual(0);
+    });
   });
 });

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -62,6 +62,7 @@ type GetAnnouncementsQueryParams = {
   active?: boolean;
   sortby?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
+  tags?: string[];
 };
 
 export async function createRouter(
@@ -103,7 +104,10 @@ export async function createRouter(
 
   router.get(
     '/announcements',
-    async (req: Request<{}, {}, {}, GetAnnouncementsQueryParams>, res) => {
+    async (
+      req: Request<{}, {}, {}, GetAnnouncementsQueryParams & { tags?: string }>,
+      res,
+    ) => {
       const {
         query: {
           category,
@@ -112,8 +116,11 @@ export async function createRouter(
           active,
           sortby = 'created_at',
           order = 'desc',
+          tags,
         },
       } = req;
+
+      const tagsFilter = tags ? tags.split(',') : undefined;
 
       const results = await persistenceContext.announcementsStore.announcements(
         {
@@ -125,6 +132,7 @@ export async function createRouter(
             ? sortby
             : 'created_at',
           order: ['asc', 'desc'].includes(order) ? order : 'desc',
+          tags: tagsFilter,
         },
       );
 

--- a/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
@@ -132,7 +132,7 @@ export class AnnouncementsClient implements AnnouncementsApi {
     if (category) {
       params.append('category', category);
     }
-    if (tags) {
+    if (tags && tags.length > 0) {
       params.append('tags', tags.join(','));
     }
     if (max) {

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MouseEvent, useState, ReactNode } from 'react';
+import { MouseEvent, useState, ReactNode, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { usePermission } from '@backstage/plugin-permission-react';
 import {
@@ -256,6 +256,7 @@ const AnnouncementCard = ({
 const AnnouncementsGrid = ({
   maxPerPage,
   category,
+  tags,
   cardTitleLength,
   active,
   sortBy,
@@ -264,6 +265,7 @@ const AnnouncementsGrid = ({
 }: {
   maxPerPage: number;
   category?: string;
+  tags?: string[];
   cardTitleLength?: number;
   active?: boolean;
   sortBy?: 'created_at' | 'start_at';
@@ -273,11 +275,18 @@ const AnnouncementsGrid = ({
   const classes = useStyles();
   const announcementsApi = useApi(announcementsApiRef);
   const alertApi = useApi(alertApiRef);
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
 
   const [page, setPage] = useState(1);
   const handleChange = (_event: any, value: number) => {
     setPage(value);
   };
+
+  const tagsParam = queryParams.get('tags');
+  const tagsFromUrl = useMemo(() => {
+    return tagsParam ? tagsParam.split(',') : undefined;
+  }, [tagsParam]);
 
   const {
     announcements,
@@ -289,11 +298,12 @@ const AnnouncementsGrid = ({
       max: maxPerPage,
       page: page,
       category,
+      tags: tags || tagsFromUrl,
       active,
       sortBy,
       order,
     },
-    { dependencies: [maxPerPage, page, category] },
+    { dependencies: [maxPerPage, page, category, tagsFromUrl] },
   );
 
   const { t } = useAnnouncementsTranslation();
@@ -437,6 +447,7 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
         <AnnouncementsGrid
           maxPerPage={maxPerPage ?? 10}
           category={category ?? queryParams.get('category') ?? undefined}
+          tags={props.tags}
           cardTitleLength={cardOptions?.titleLength}
           active={!!hideInactive}
           sortBy={sortby ?? 'created_at'}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I previously added tags to announcements. Categories on an announcement card can already be clicked to filter the announcements by that category. I'm adding the same functionality for tags here.

You will need to be signed in as non-admin. The url after clicking a tag should be like: http://localhost:3000/announcements/?tags=tag2

You can also filter by multiple tags by changing the url to ?tags=tag1,tag2

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
