### PR TITLE
fix(tekton): apply temporary fix for invisible horizontal bars

### DIFF
--- a/workspaces/tekton/.changeset/funny-turkeys-cough.md
+++ b/workspaces/tekton/.changeset/funny-turkeys-cough.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Apply a temporary fix for the horizontal bar issue under the Task Status column

--- a/workspaces/tekton/plugins/tekton/src/components/Charts/PipelineBars.css
+++ b/workspaces/tekton/plugins/tekton/src/components/Charts/PipelineBars.css
@@ -1,0 +1,34 @@
+/**
+* NOTE: These styles are derived from janus-idp/shared-react/src/components/pipeline/HorizontalStackedBars.css.
+* At the time of this writing there are plans to migrate that library somewhere else.
+* This is a TEMPORARY fix. Once the library is migrated and updated we should check if these styles can be removed.
+* If the issue still persists, report it in the new library.
+* **/
+
+.bs-shared-horizontal-stacked-bars {
+  --bar-gap: 3px;
+  display: block;
+  height: 100%;
+  overflow: hidden;
+  width: 100%;
+  cursor: pointer;
+}
+
+.bs-shared-horizontal-stacked-bars.is-inline {
+  display: inline-block;
+}
+
+.bs-shared-horizontal-stacked-bars__bars {
+  display: flex !important;
+  flex-direction: row;
+  height: 100%;
+  outline: none;
+  width: calc(100% + var(--bar-gap));
+}
+
+.bs-shared-horizontal-stacked-bars__data-bar {
+  --bar-gap-neg: calc(var(--bar-gap) * -1);
+  box-shadow: inset var(--bar-gap-neg) 0 0 #fff;
+  height: 100%;
+  transition: flex-grow 300ms linear;
+}

--- a/workspaces/tekton/plugins/tekton/src/components/Charts/PipelineBars.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/Charts/PipelineBars.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useContext, useState } from 'react';
-
+import './PipelineBars.css';
 import { Tooltip } from '@patternfly/react-core';
 
 import {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

These changes apply a simple temporary fix that allow the horizontal stacked bars under "Task Status" to appear.

**Before:**
<img width="1496" height="621" alt="image" src="https://github.com/user-attachments/assets/6b15fae3-3fd5-4a2f-857d-7bc0fd996f47" />

**After:**
<img width="1496" height="621" alt="image" src="https://github.com/user-attachments/assets/2f0497e9-33d0-4bde-b7fc-eddd481c5036" />

The issue originates from the `@janus-idp/shared-react` package. For whatever reason the styling for the [HorizontalStackedBars](https://github.com/janus-idp/backstage-plugins/blob/release-1.7/plugins/shared-react/src/components/pipeline/HorizontalStackedBars.tsx) component is not getting exported correctly. 

I believe they'll be moving this package at some point to a new package and deprecating the existing one. They also haven't really looked at recent issues or PRs, so temporarily fixing this locally seems like the fastest and easiest option.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
