### PR TITLE
fix(sonarqube): missing projectInstance in SonarQubeRelatedEntitiesOverview

### DIFF
--- a/workspaces/sonarqube/.changeset/stupid-rivers-relate.md
+++ b/workspaces/sonarqube/.changeset/stupid-rivers-relate.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-sonarqube': patch
+'@backstage-community/plugin-sonarqube-react': patch
+---
+
+Fixed bug in SonarQubeRelatedEntitiesOverview where the projectInstance was always undefined

--- a/workspaces/sonarqube/plugins/sonarqube-react/report.api.md
+++ b/workspaces/sonarqube/plugins/sonarqube-react/report.api.md
@@ -24,6 +24,12 @@ export interface FindingSummary {
   title: string;
 }
 
+// @public
+export function getProjectInfo(entity: Entity): {
+  projectInstance: string | undefined;
+  projectKey: string | undefined;
+};
+
 // @public (undocumented)
 export const isSonarQubeAvailable: (entity: Entity) => boolean;
 

--- a/workspaces/sonarqube/plugins/sonarqube-react/src/hooks/index.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-react/src/hooks/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { useProjectInfo } from './useProjectInfo';
+export { useProjectInfo, getProjectInfo } from './useProjectInfo';

--- a/workspaces/sonarqube/plugins/sonarqube-react/src/hooks/useProjectInfo.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-react/src/hooks/useProjectInfo.ts
@@ -35,6 +35,25 @@ export const useProjectInfo = (
   projectInstance: string | undefined;
   projectKey: string | undefined;
 } => {
+  return getProjectInfo(entity);
+};
+
+/**
+ * Try to parse sonarqube information from an entity.
+ *
+ * If part or all info are not found, they will default to undefined
+ *
+ * Note: This function exists to avoid rule of hooks:
+ * Do not call Hooks inside conditions or loops.
+ *
+ * @public
+ * @param entity - entity to find the sonarqube information from.
+ * @returns a ProjectInfo properly populated.
+ */
+export function getProjectInfo(entity: Entity): {
+  projectInstance: string | undefined;
+  projectKey: string | undefined;
+} {
   let projectInstance = undefined;
   let projectKey = undefined;
   const annotation =
@@ -55,4 +74,4 @@ export const useProjectInfo = (
     }
   }
   return { projectInstance, projectKey };
-};
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### Problem

If we configure an additional sonarqube instance, the Overview fails to display the information for the added instance. The following error ist displayed: `There is no SonarQube project with key: 'edge/com.example:service'`

Inside the `SonarQubeRelatedEntitiesOverview` the `projectInstance` is hardcoded to `undefined`. 

It only works for the default instance, as you can see in the Screenshot:

<img width="540" height="308" alt="sonarqube-initial-problem-setup" src="https://github.com/user-attachments/assets/3c5658f7-6822-4ac1-bc76-04fc889469e3" />

Note: For the purpose of the screenshot, the key has been altered.


#### Expected Behaviour
 
The Overview should show information for both the default and any additionally configured instances. 

Here is a screenshot which includes the fix:

<img width="767" height="288" alt="sonarqube-screeenshot-with-implemented-fix-with-more-info" src="https://github.com/user-attachments/assets/4751582a-67b2-4887-9aef-bfd4edc51bb8" />


#### Note about the code changes

In order to extract the `projectInstance`, I first used the `useProjectInfo`-hook from the react package. My IDE warned me about the following: `ESLint: React Hook "useProjectInfo" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render. (react-hooks/rules-of-hooks)`

I opted to extract the function from the existing hook. Do you have any guidance for a better approach?

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
