### PR TITLE
fix(github-actions): use default branch of repository for latest builds where branch unspecified instead of assuming master

### DIFF
--- a/workspaces/github-actions/.changeset/gold-rules-burn.md
+++ b/workspaces/github-actions/.changeset/gold-rules-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-actions': patch
+---
+
+Change default branch to be that of the target repository instead of assuming it is using master.

--- a/workspaces/github-actions/plugins/github-actions/src/components/Cards/Cards.tsx
+++ b/workspaces/github-actions/plugins/github-actions/src/components/Cards/Cards.tsx
@@ -32,6 +32,7 @@ import {
   StructuredMetadataTable,
 } from '@backstage/core-components';
 import { getHostnameFromEntity } from '../getHostnameFromEntity';
+import { useDefaultBranch } from '../useDefaultBranch';
 import Box from '@material-ui/core/Box';
 
 const useStyles = makeStyles({
@@ -81,13 +82,19 @@ export const LatestWorkflowRunCard = (props: {
   branch?: string;
   variant?: InfoCardVariants;
 }) => {
-  const { branch = 'master', variant } = props;
+  const { variant } = props;
   const { entity } = useEntity();
   const errorApi = useApi(errorApiRef);
   const hostname = getHostnameFromEntity(entity);
   const [owner, repo] = (
     entity?.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION] ?? '/'
   ).split('/');
+  const defaultBranch = useDefaultBranch({
+    hostname,
+    owner,
+    repo,
+  });
+  const branch = props.branch ?? defaultBranch;
   const [{ runs, loading, error }] = useWorkflowRuns({
     hostname,
     owner,
@@ -119,8 +126,18 @@ export const LatestWorkflowsForBranchCard = (props: {
   branch?: string;
   variant?: InfoCardVariants;
 }) => {
-  const { branch = 'master', variant } = props;
+  const { variant } = props;
   const { entity } = useEntity();
+  const hostname = getHostnameFromEntity(entity);
+  const [owner, repo] = (
+    entity?.metadata.annotations?.[GITHUB_ACTIONS_ANNOTATION] ?? '/'
+  ).split('/');
+  const defaultBranch = useDefaultBranch({
+    hostname,
+    owner,
+    repo,
+  });
+  const branch = props.branch ?? defaultBranch;
 
   return (
     <InfoCard title={`Last ${branch} build`} variant={variant}>

--- a/workspaces/github-actions/plugins/github-actions/src/components/useDefaultBranch.ts
+++ b/workspaces/github-actions/plugins/github-actions/src/components/useDefaultBranch.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useState } from 'react';
+import useAsyncRetry from 'react-use/esm/useAsyncRetry';
+import { githubActionsApiRef } from '../api/GithubActionsApi';
+import { useApi, errorApiRef } from '@backstage/core-plugin-api';
+
+export function useDefaultBranch({
+  hostname,
+  owner,
+  repo,
+}: {
+  hostname?: string;
+  owner: string;
+  repo: string;
+}) {
+  const api = useApi(githubActionsApiRef);
+  const errorApi = useApi(errorApiRef);
+  const [defaultBranch, setDefaultBranch] = useState<string>('');
+
+  const {
+    loading,
+    value: runs,
+    retry,
+    error,
+  } = useAsyncRetry<string>(async () => {
+    const fetchedDefaultBranch = await api.getDefaultBranch({
+      hostname,
+      owner,
+      repo,
+    });
+
+    setDefaultBranch(fetchedDefaultBranch);
+  });
+
+  return defaultBranch as string;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I have changed the default behavior of the GitHub Actions cards to use the repository default branch instead of defaulting to the fixed value of "master" as was previously the case. 

This way it will work out of the box for all repositories regardless of their naming strategy.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
