### PR TITLE
refactor: move optional fields below editor

### DIFF
--- a/workspaces/announcements/.changeset/long-singers-vanish.md
+++ b/workspaces/announcements/.changeset/long-singers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Reorganized the Create Announcement form: optional fields have been moved below the Markdown editor for improved layout. This change also includes MUI component updates, upgrading them to MUI v5.

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -67,6 +67,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@types/react": "^17.0.0 || ^18.0.0",
     "@uiw/react-md-editor": "^4.0.7",

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -15,31 +15,33 @@
  */
 import { useState, type ChangeEvent, type FormEvent } from 'react';
 import MDEditor from '@uiw/react-md-editor';
+import { DateTime } from 'luxon';
+import slugify from 'slugify';
 import { InfoCard } from '@backstage/core-components';
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+
 import {
   CreateAnnouncementRequest,
   useAnnouncementsTranslation,
   announcementsApiRef,
 } from '@backstage-community/plugin-announcements-react';
 import { Announcement } from '@backstage-community/plugin-announcements-common';
+
 import CategoryInput from './CategoryInput';
 import OnBehalfTeamDropdown from './OnBehalfTeamDropdown';
 import TagsInput from './TagsInput';
-import {
-  Box,
-  Button,
-  Divider,
-  FormControlLabel,
-  FormGroup,
-  Grid,
-  Switch,
-  TextField,
-  Typography,
-} from '@material-ui/core';
-import SaveAltIcon from '@material-ui/icons/SaveAlt';
-import { DateTime } from 'luxon';
-import slugify from 'slugify';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Divider from '@mui/material/Divider';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import SaveAltIcon from '@mui/icons-material/SaveAlt';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 
 type AnnouncementFormProps = {
   initialData: Announcement;
@@ -141,6 +143,7 @@ export const AnnouncementForm = ({
             ? t('announcementForm.editAnnouncement')
             : t('announcementForm.newAnnouncement')}
         </Typography>
+        <Divider sx={{ mb: 3 }} />
         <form onSubmit={handleSubmit}>
           <Grid container spacing={3}>
             <Grid item xs={12}>
@@ -152,43 +155,6 @@ export const AnnouncementForm = ({
                 variant="outlined"
                 fullWidth
                 required
-              />
-            </Grid>
-
-            <Grid item xs={12} sm={3}>
-              <CategoryInput
-                setForm={setForm}
-                form={form}
-                initialValue={initialData.category?.title ?? ''}
-              />
-            </Grid>
-
-            <Grid item xs={12} sm={3}>
-              <TagsInput setForm={setForm} form={form} />
-            </Grid>
-
-            <Grid item xs={12} sm={3}>
-              <OnBehalfTeamDropdown
-                selectedTeam={onBehalfOfSelectedTeam}
-                onChange={setOnBehalfOfSelectedTeam}
-              />
-            </Grid>
-
-            <Grid item xs={12} sm={3}>
-              <TextField
-                variant="outlined"
-                label={t('announcementForm.startAt')}
-                id="start-at-date"
-                type="date"
-                value={form.start_at}
-                InputLabelProps={{ shrink: true }}
-                required
-                onChange={e =>
-                  setForm({
-                    ...form,
-                    start_at: e.target.value,
-                  })
-                }
               />
             </Grid>
 
@@ -206,11 +172,53 @@ export const AnnouncementForm = ({
             </Grid>
 
             <Grid item xs={12}>
-              <MDEditor
-                value={form.body}
-                style={{ minHeight: '30rem' }}
-                onChange={value =>
-                  setForm({ ...form, ...{ body: value || '' } })
+              <Paper
+                variant="outlined"
+                sx={{ borderRadius: 2, borderColor: 'divider', p: 2 }}
+              >
+                <MDEditor
+                  value={form.body}
+                  style={{ minHeight: '30rem' }}
+                  onChange={value =>
+                    setForm({ ...form, ...{ body: value || '' } })
+                  }
+                />
+              </Paper>
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <CategoryInput
+                setForm={setForm}
+                form={form}
+                initialValue={initialData.category?.title ?? ''}
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <OnBehalfTeamDropdown
+                selectedTeam={onBehalfOfSelectedTeam}
+                onChange={setOnBehalfOfSelectedTeam}
+              />
+            </Grid>
+
+            <Grid item xs={12} sm={6}>
+              <TagsInput setForm={setForm} form={form} />
+            </Grid>
+
+            <Grid item xs={12} sm={3}>
+              <TextField
+                variant="outlined"
+                label={t('announcementForm.startAt')}
+                id="start-at-date"
+                type="date"
+                value={form.start_at}
+                InputLabelProps={{ shrink: true }}
+                required
+                onChange={e =>
+                  setForm({
+                    ...form,
+                    start_at: e.target.value,
+                  })
                 }
               />
             </Grid>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/TagsInput.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/TagsInput.test.tsx
@@ -91,7 +91,7 @@ describe('TagsInput', () => {
     expect(autocomplete).toBeInTheDocument();
     expect(screen.getByLabelText('Tags')).toBeInTheDocument();
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('combobox');
     await userEvent.click(input);
 
     await waitFor(() => {
@@ -106,7 +106,7 @@ describe('TagsInput', () => {
   it('should set tag when a tag is selected', async () => {
     await render();
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole('combobox');
     await userEvent.click(input);
 
     await waitFor(() => {

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/TagsInput.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/TagsInput.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { useMemo } from 'react';
-import Autocomplete, {
-  createFilterOptions,
-} from '@material-ui/lab/Autocomplete';
-import { TextField, Chip, CircularProgress } from '@material-ui/core';
+import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
 import {
   useTags,
   useAnnouncementsTranslation,
@@ -112,10 +112,7 @@ export default function TagsInput({ setForm, form }: TagsInputProps) {
               ? { title: option, slug: option.toLocaleLowerCase('en-US') }
               : option;
 
-          const tagProps = getTagProps({ index }) as {
-            key: string;
-            [key: string]: any;
-          };
+          const tagProps = getTagProps({ index });
           const { key, ...chipProps } = tagProps;
 
           return (

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -2743,6 +2743,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@mui/icons-material": "npm:^5.15.6"
     "@mui/material": "npm:^5.15.6"
     "@testing-library/jest-dom": "npm:^6.3.0"
     "@testing-library/react": "npm:^14.0.0"
@@ -7235,6 +7236,22 @@ __metadata:
   version: 5.16.13
   resolution: "@mui/core-downloads-tracker@npm:5.16.13"
   checksum: 10/d9c6837dabd873e05b0bf81389c3dfb60fbc577cceff7f98f94c60f688f02d33a9200082e1a6756a0de4bd1985aa27932c677376ba7e6b1ad206a8b6887bda07
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^5.15.6":
+  version: 5.18.0
+  resolution: "@mui/icons-material@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+  peerDependencies:
+    "@mui/material": ^5.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f55f3da3c375ec3bad5417f5588122587ccf6a02093de286ca723bb6d01692f2cdf81dea413abc396eba87d6f7ab7443cc51e3dd024da8099764e55e12fa4176
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Updated MUI components to use MUI v5 (updating imports was enough without breaking changes)
- Moved optional fields below editor
- Added  `<Paper sx={{ borderRadius: 2, borderColor: 'divider', p: 2 }}>` to have border around Markdown editor


<img width="1185" height="1152" alt="image" src="https://github.com/user-attachments/assets/1848af28-b9f7-4c50-a4bf-031148a85581" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
