### PR TITLE
fix(rbac): fix issue with extra delimiter in conditional yaml

### DIFF
--- a/workspaces/rbac/plugins/rbac-backend/__fixtures__/data/valid-conditions/extra-delimiter-conditions.yaml
+++ b/workspaces/rbac/plugins/rbac-backend/__fixtures__/data/valid-conditions/extra-delimiter-conditions.yaml
@@ -1,0 +1,29 @@
+---
+result: CONDITIONAL
+roleEntityRef: 'role:default/test-2'
+pluginId: catalog
+resourceType: catalog-entity
+permissionMapping:
+  - update
+conditions:
+  rule: IS_ENTITY_OWNER
+  resourceType: catalog-entity
+  params:
+    claims:
+      - 'group:default/team-a'
+---
+result: CONDITIONAL
+roleEntityRef: 'role:default/test-3'
+pluginId: catalog
+resourceType: catalog-entity
+permissionMapping:
+  - read
+  - delete
+conditions:
+  rule: IS_ENTITY_OWNER
+  resourceType: catalog-entity
+  params:
+    claims:
+      - 'group:default/team-a'
+      - 'group:default/team-b'
+---

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -366,6 +366,91 @@ describe('YamlConditionalFileWatcher', () => {
     expectAuditorLog([]);
   });
 
+  test('should not fail on initialization, when conditional policies file contains extra delimiter', async () => {
+    conditionalStorageMock.filterConditions = jest
+      .fn()
+      .mockImplementation(() => []);
+    roleMetadataStorageMock.filterRoleMetadata = jest
+      .fn()
+      .mockImplementation(() => [
+        {
+          roleEntityRef: 'role:default/test-2',
+          source: 'csv-file',
+          author: 'user:default/tom',
+          modifiedBy: 'user:default/tom',
+          createdAt: '2021-09-01T00:00:00Z',
+        },
+        {
+          roleEntityRef: 'role:default/test-3',
+          source: 'csv-file',
+          author: 'user:default/tom',
+          modifiedBy: 'user:default/tom',
+          createdAt: '2021-09-01T00:00:00Z',
+        },
+      ]);
+
+    csvFileName = resolve(
+      __dirname,
+      '../../__fixtures__/data/valid-conditions/extra-delimiter-conditions.yaml',
+    );
+    const watcher = createWatcher(csvFileName);
+    await watcher.initialize();
+    const expectedCondition1 = {
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test-2',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [{ name: 'catalog.entity.refresh', action: 'update' }],
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: {
+          claims: ['group:default/team-a'],
+        },
+      },
+    };
+    const expectedCondition2 = {
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test-3',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' },
+        { name: 'catalog.entity.delete', action: 'delete' },
+      ],
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: {
+          claims: ['group:default/team-a', 'group:default/team-b'],
+        },
+      },
+    };
+
+    expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
+      expectedCondition1,
+    );
+    expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
+      expectedCondition2,
+    );
+    expectAuditorLog([
+      {
+        event: {
+          eventId: ConditionEvents.CONDITION_WRITE,
+          meta: { actionType: ActionType.CREATE },
+        },
+        success: { ...mappedConditionMeta(expectedCondition1 as any) },
+      },
+      {
+        event: {
+          eventId: ConditionEvents.CONDITION_WRITE,
+          meta: { actionType: ActionType.CREATE },
+        },
+        success: { ...mappedConditionMeta(expectedCondition2 as any) },
+      },
+    ]);
+  });
+
   test(`should not apply conditions if corresponding role is present, but with non 'csv-file' source`, async () => {
     conditionalStorageMock.filterConditions = jest
       .fn()

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -93,7 +93,7 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
 
   async onChange(): Promise<void> {
     try {
-      const newConds = this.parse().filter(c => c);
+      const newConds = this.parse();
 
       const addedConds: RoleConditionalPolicyDecision<PermissionAction>[] = [];
       const removedConds: RoleConditionalPolicyDecision<PermissionAction>[] =
@@ -173,9 +173,11 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
    */
   parse(): RoleConditionalPolicyDecision<PermissionAction>[] {
     const fileContents = this.getCurrentContents();
-    const data = yaml.loadAll(
-      fileContents,
-    ) as RoleConditionalPolicyDecision<PermissionAction>[];
+    const data = yaml
+      .loadAll(fileContents)
+      .filter(
+        doc => doc !== null,
+      ) as RoleConditionalPolicyDecision<PermissionAction>[];
 
     for (const condition of data) {
       validateRoleCondition(condition);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix issue, when conditional file contains extra yaml delimiters and rbac-backend refuce parsing such file during validation phase.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
