### PR TITLE
Version Packages (grafana)

### DIFF
--- a/workspaces/grafana/.changeset/quick-toys-sell.md
+++ b/workspaces/grafana/.changeset/quick-toys-sell.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': patch
----
-
-Prevent dashboard queries on folderTitle from breaking

--- a/workspaces/grafana/.changeset/version-bump-1-41-1.md
+++ b/workspaces/grafana/.changeset/version-bump-1-41-1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/grafana/plugins/grafana/CHANGELOG.md
+++ b/workspaces/grafana/plugins/grafana/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-grafana
 
+## 0.7.0
+
+### Minor Changes
+
+- e0159d4: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- 4281062: Prevent dashboard queries on folderTitle from breaking
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-grafana",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A Backstage backend plugin that integrates towards Grafana",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-grafana@0.7.0

### Minor Changes

-   e0159d4: Backstage version bump to v1.41.1

### Patch Changes

-   4281062: Prevent dashboard queries on folderTitle from breaking
