### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/vast-goats-trade.md
+++ b/workspaces/jfrog-artifactory/.changeset/vast-goats-trade.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Aligned `formatDate` utility with `ADR012 using Luxon`.

--- a/workspaces/jfrog-artifactory/.changeset/version-bump-1-41-1.md
+++ b/workspaces/jfrog-artifactory/.changeset/version-bump-1-41-1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 1.18.0
+
+### Minor Changes
+
+- 7731edd: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- 4252a3f: Aligned `formatDate` utility with `ADR012 using Luxon`.
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.18.0

### Minor Changes

-   7731edd: Backstage version bump to v1.41.1

### Patch Changes

-   4252a3f: Aligned `formatDate` utility with `ADR012 using Luxon`.
