### PR TITLE
ci(auto-version-bump): run yarn install, move time

### DIFF
--- a/.github/workflows/auto-version-bump-scheduler.yml
+++ b/.github/workflows/auto-version-bump-scheduler.yml
@@ -2,8 +2,8 @@ name: Auto Version Bump Scheduler
 
 on:
   schedule:
-    # Run on Tuesdays at 12:00 UTC to check for Backstage releases
-    - cron: '0 12 * * 2'
+    # Run on Tuesdays at 13:00 UTC to check for Backstage releases
+    - cron: '0 13 * * 2'
 
 concurrency:
   group: auto-version-bump-scheduler
@@ -27,6 +27,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
+
+      - name: yarn install
+        run: yarn install --immutable
 
       - name: Check for Backstage minor releases
         id: check-releases


### PR DESCRIPTION
Sorry for the noise, the job wasn't running `yarn install`.  Bumped time +1 hour again for testing. Once tested/working we can we'll set it back to a quiet/non-disruptive time again.

For reference, last action run where this failed: https://github.com/backstage/community-plugins/actions/runs/16443945931/job/46471031493

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
