### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/gold-rules-burn.md
+++ b/workspaces/github-actions/.changeset/gold-rules-burn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Change default branch to be that of the target repository instead of assuming it is using master.

--- a/workspaces/github-actions/.changeset/strong-days-deliver.md
+++ b/workspaces/github-actions/.changeset/strong-days-deliver.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': patch
----
-
-Resolve visual issue caused by the centering of the Workflow Status was done inside the component instead of controlled by the wrapper object. This led to case where when viewing 'Workflow run details' the status was centered when all other content was left aligned.

--- a/workspaces/github-actions/.changeset/version-bump-1-41-1.md
+++ b/workspaces/github-actions/.changeset/version-bump-1-41-1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-actions': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-github-actions
 
+## 0.13.0
+
+### Minor Changes
+
+- 624c181: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- b41b1f0: Change default branch to be that of the target repository instead of assuming it is using master.
+- 337f19a: Resolve visual issue caused by the centering of the Workflow Status was done inside the component instead of controlled by the wrapper object. This led to case where when viewing 'Workflow run details' the status was centered when all other content was left aligned.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.13.0

### Minor Changes

-   624c181: Backstage version bump to v1.41.1

### Patch Changes

-   b41b1f0: Change default branch to be that of the target repository instead of assuming it is using master.
-   337f19a: Resolve visual issue caused by the centering of the Workflow Status was done inside the component instead of controlled by the wrapper object. This led to case where when viewing 'Workflow run details' the status was centered when all other content was left aligned.
