### PR TITLE
fix: type error in scaffolder-backend-module-regex/v1.41.1

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.4.1",
     "@backstage/plugin-scaffolder-node": "^0.10.0",
-    "yaml": "^2.3.3",
-    "zod": "^3.22.4"
+    "yaml": "^2.3.3"
   },
   "devDependencies": {
     "@backstage/cli": "^0.33.1",

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/report.api.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/report.api.md
@@ -18,7 +18,9 @@ pattern: string;
 replacement: string;
 flags?: ("i" | "g" | "m" | "y" | "u" | "s" | "d")[] | undefined;
 }[];
-}, any, "v1">;
+}, {
+[x: string]: any;
+}, "v2">;
 
 // @public (undocumented)
 const scaffolderModuleRegexActions: BackendFeature;

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/src/actions/regex/replace.ts
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/src/actions/regex/replace.ts
@@ -74,7 +74,7 @@ export const createReplaceAction = () => {
       'Replaces strings that match a regular expression pattern with a specified replacement string',
     examples,
     schema: {
-      input: schemaInput,
+      input: _zImpl => schemaInput,
     },
 
     async handler(ctx) {

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/src/actions/regex/replace.ts
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/src/actions/regex/replace.ts
@@ -15,52 +15,7 @@
  */
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 
-import { z } from 'zod';
-
 import { examples } from './replace.example';
-
-const schemaInput = z.object({
-  regExps: z.array(
-    z.object({
-      pattern: z
-        .string()
-        .refine(
-          // You should not parse a regex (regular language) with a regex (regular language),
-          // you actually need a context free grammar to parse a regex (regular language).
-          // Hence, we are using a string comparison here.
-          value => !value.startsWith('/') && !value.endsWith('/'),
-          {
-            message:
-              'The RegExp constructor cannot take a string pattern with a leading and trailing forward slash.',
-          },
-        )
-        .describe(
-          'The regex pattern to match the value like in String.prototype.replace()',
-        ),
-      flags: z
-        .array(
-          // Prefer array over set here because input values are normally defined in YAML which doesn't support Sets.
-          z.enum(['g', 'm', 'i', 'y', 'u', 's', 'd'], {
-            invalid_type_error:
-              'Invalid flag, possible values are: g, m, i, y, u, s, d',
-          }),
-        )
-        .optional()
-        .describe('The flags for the regex'),
-      replacement: z
-        .string()
-        .describe(
-          'The replacement value for the regex like in String.prototype.replace()',
-        ),
-      values: z.array(
-        z.object({
-          key: z.string().describe('The key to access the regex value'),
-          value: z.string().describe('The input value of the regex'),
-        }),
-      ),
-    }),
-  ),
-});
 
 const id = 'regex:replace';
 
@@ -74,7 +29,49 @@ export const createReplaceAction = () => {
       'Replaces strings that match a regular expression pattern with a specified replacement string',
     examples,
     schema: {
-      input: _zImpl => schemaInput,
+      input: {
+        regExps: z =>
+          z.array(
+            z.object({
+              pattern: z
+                .string()
+                .refine(
+                  // You should not parse a regex (regular language) with a regex (regular language),
+                  // you actually need a context free grammar to parse a regex (regular language).
+                  // Hence, we are using a string comparison here.
+                  value => !value.startsWith('/') && !value.endsWith('/'),
+                  {
+                    message:
+                      'The RegExp constructor cannot take a string pattern with a leading and trailing forward slash.',
+                  },
+                )
+                .describe(
+                  'The regex pattern to match the value like in String.prototype.replace()',
+                ),
+              flags: z
+                .array(
+                  // Prefer array over set here because input values are normally defined in YAML which doesn't support Sets.
+                  z.enum(['g', 'm', 'i', 'y', 'u', 's', 'd'], {
+                    invalid_type_error:
+                      'Invalid flag, possible values are: g, m, i, y, u, s, d',
+                  }),
+                )
+                .optional()
+                .describe('The flags for the regex'),
+              replacement: z
+                .string()
+                .describe(
+                  'The replacement value for the regex like in String.prototype.replace()',
+                ),
+              values: z.array(
+                z.object({
+                  key: z.string().describe('The key to access the regex value'),
+                  value: z.string().describe('The input value of the regex'),
+                }),
+              ),
+            }),
+          ),
+      },
     },
 
     async handler(ctx) {

--- a/workspaces/scaffolder-backend-module-regex/yarn.lock
+++ b/workspaces/scaffolder-backend-module-regex/yarn.lock
@@ -2535,7 +2535,6 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "npm:^0.10.0"
     "@backstage/plugin-scaffolder-node-test-utils": "npm:^0.3.1"
     yaml: "npm:^2.3.3"
-    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A minor fix of a type error occuring in the PR for upgrading scaffolder-backend-module-regex to v1.41.1.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
