### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/version-bump-1-41-1.md
+++ b/workspaces/quay/.changeset/version-bump-1-41-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.10.0
+
+### Minor Changes
+
+- 78bb7a9: Backstage version bump to v1.41.1
+
 ## 2.9.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.5.0
+
+### Minor Changes
+
+- 78bb7a9: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- Updated dependencies [78bb7a9]
+  - @backstage-community/plugin-quay-common@1.10.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.10.0
+
+### Minor Changes
+
+- 78bb7a9: Backstage version bump to v1.41.1
+
 ## 1.9.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.23.0
+
+### Minor Changes
+
+- 78bb7a9: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- Updated dependencies [78bb7a9]
+  - @backstage-community/plugin-quay-common@1.10.0
+
 ## 1.22.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.23.0

### Minor Changes

-   78bb7a9: Backstage version bump to v1.41.1

### Patch Changes

-   Updated dependencies [78bb7a9]
    -   @backstage-community/plugin-quay-common@1.10.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.10.0

### Minor Changes

-   78bb7a9: Backstage version bump to v1.41.1

## @backstage-community/plugin-quay-backend@1.5.0

### Minor Changes

-   78bb7a9: Backstage version bump to v1.41.1

### Patch Changes

-   Updated dependencies [78bb7a9]
    -   @backstage-community/plugin-quay-common@1.10.0

## @backstage-community/plugin-quay-common@1.10.0

### Minor Changes

-   78bb7a9: Backstage version bump to v1.41.1
