### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/afraid-pillows-explain.md
+++ b/workspaces/azure-devops/.changeset/afraid-pillows-explain.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Add new action (azure:pipeline:permit) to Authorize the necessary pipeline resources (e.g., Service Connections, repositories) by executing azure:pipeline:permit; this step ensures that the pipeline has all the required permissions to automatically access the protected resources.

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.11.1
+
+### Patch Changes
+
+- 1fc5b4b: Add new action (azure:pipeline:permit) to Authorize the necessary pipeline resources (e.g., Service Connections, repositories) by executing azure:pipeline:permit; this step ensures that the pipeline has all the required permissions to automatically access the protected resources.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.11.1

### Patch Changes

-   1fc5b4b: Add new action (azure:pipeline:permit) to Authorize the necessary pipeline resources (e.g., Service Connections, repositories) by executing azure:pipeline:permit; this step ensures that the pipeline has all the required permissions to automatically access the protected resources.
