### PR TITLE
Fix incorrect rollbar-backend plugin id

### DIFF
--- a/workspaces/rollbar/.changeset/early-pets-mate.md
+++ b/workspaces/rollbar/.changeset/early-pets-mate.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-rollbar-backend': patch
+---
+
+Use the same plugin id for rollbar frontend and backend plugins
+

--- a/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
@@ -26,7 +26,7 @@ import { createRouter } from './service/router';
  * @public
  */
 export const rollbarPlugin = createBackendPlugin({
-  pluginId: 'azure-devops',
+  pluginId: 'rollbar',
   register(env) {
     env.registerInit({
       deps: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The rollbar backend plugin did not have the id expected by the frontend plugin and all rollbar to backend requests
failed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
