### PR TITLE
Improve `rollbar-backend` expired project access token handling

### DIFF
--- a/workspaces/rollbar/.changeset/chilled-turkeys-juggle.md
+++ b/workspaces/rollbar/.changeset/chilled-turkeys-juggle.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-rollbar-backend': minor
+---
+
+**BREAKING** The `RollbarApi` now requires the `CacheService` when being constructed.
+
+Also added feature to expire cached Rollbar project state when using the new backend system.

--- a/workspaces/rollbar/plugins/rollbar-backend/report.api.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/report.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
+import { CacheService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 // @public (undocumented)
@@ -15,7 +16,7 @@ export function getRequestHeaders(token: string): {
 
 // @public (undocumented)
 export class RollbarApi {
-  constructor(accessToken: string, logger: LoggerService);
+  constructor(accessToken: string, logger: LoggerService, cache: CacheService);
   // (undocumented)
   getActivatedCounts(
     projectName: string,
@@ -191,7 +192,7 @@ export type RollbarProjectAccessToken = {
   name: string;
   scopes: RollbarProjectAccessTokenScope[];
   accessToken: string;
-  status: 'enabled' | string;
+  status: 'enabled' | 'expired' | string;
 };
 
 // @public (undocumented)

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
@@ -21,8 +21,25 @@ import {
 } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import { RollbarProjectAccessToken } from './types';
 
 describe('RollbarApi', () => {
+  const server = setupServer();
+  registerMswTestHooks(server);
+
+  const mockBaseUrl = 'https://api.rollbar.com/api/1';
+
+  const mockProjects = [
+    { id: 123, name: 'abc', account_id: 1, status: 'enabled' },
+    {
+      id: 456,
+      name: 'xyz',
+      account_id: 1,
+      status: 'enabled',
+      extra_nested: { nested_value: [{ value_here: 'hello_world' }] },
+    },
+  ];
+
   describe('getRequestHeaders', () => {
     it('should generate headers based on token passed in constructor', () => {
       expect(getRequestHeaders('testtoken')).toEqual({
@@ -34,22 +51,6 @@ describe('RollbarApi', () => {
   });
 
   describe('getAllProjects', () => {
-    const server = setupServer();
-    registerMswTestHooks(server);
-
-    const mockBaseUrl = 'https://api.rollbar.com/api/1';
-
-    const mockProjects = [
-      { id: 123, name: 'abc', account_id: 1, status: 'enabled' },
-      {
-        id: 456,
-        name: 'xyz',
-        account_id: 1,
-        status: 'enabled',
-        extra_nested: { nested_value: [{ value_here: 'hello_world' }] },
-      },
-    ];
-
     const setupHandlers = () => {
       server.use(
         rest.get(`${mockBaseUrl}/projects`, (_, res, ctx) => {
@@ -60,7 +61,11 @@ describe('RollbarApi', () => {
 
     it('should return all projects with a name attribute', async () => {
       setupHandlers();
-      const api = new RollbarApi('my-access-token', mockServices.rootLogger());
+      const api = new RollbarApi(
+        'my-access-token',
+        mockServices.rootLogger(),
+        mockServices.cache.mock(),
+      );
       const projects = await api.getAllProjects();
       expect(projects).toEqual([
         { id: 123, name: 'abc', accountId: 1, status: 'enabled' },
@@ -72,6 +77,72 @@ describe('RollbarApi', () => {
           extraNested: { nestedValue: [{ valueHere: 'hello_world' }] },
         },
       ]);
+    });
+  });
+
+  describe('getProject', () => {
+    const mockProject = mockProjects[0];
+
+    const setupHandlers = () => {
+      server.use(
+        rest.get(`${mockBaseUrl}/projects`, (_, res, ctx) => {
+          return res(ctx.json({ result: mockProjects }));
+        }),
+        rest.get(`${mockBaseUrl}/project/123`, (_, res, ctx) => {
+          return res(ctx.json({ result: mockProject }));
+        }),
+        rest.get(`${mockBaseUrl}/project/123/access_tokens`, (_, res, ctx) => {
+          return res(
+            ctx.json({
+              result: [
+                {
+                  projectId: 123,
+                  name: 'project-token',
+                  scopes: ['read'],
+                  accessToken: 'plugh',
+                  status: 'enabled',
+                },
+              ] satisfies RollbarProjectAccessToken[],
+            }),
+          );
+        }),
+      );
+    };
+
+    it('should use cached project map', async () => {
+      setupHandlers();
+      const cache = mockServices.cache.mock();
+      cache.get.mockResolvedValue({
+        [mockProject.name]: { ...mockProject, accessToken: 'bar' },
+      });
+      const api = new RollbarApi(
+        'my-access-token',
+        mockServices.rootLogger(),
+        cache,
+      );
+      const project = await api.getProject(mockProject.name);
+      expect(project.name).toEqual(mockProject.name);
+    });
+
+    it('should build and cache project map', async () => {
+      setupHandlers();
+      const cache = mockServices.cache.mock();
+      const api = new RollbarApi(
+        'my-access-token',
+        mockServices.rootLogger(),
+        cache,
+      );
+      const project = await api.getProject(mockProject.name);
+      expect(project.name).toEqual(mockProject.name);
+      expect(cache.get).toHaveBeenCalledWith('projectmap');
+      expect(cache.set).toHaveBeenCalledWith(
+        'projectmap',
+        {
+          abc: { id: 123, name: 'abc', accessToken: 'plugh' },
+          xyz: { id: 456, name: 'xyz' },
+        },
+        { ttl: 300 },
+      );
     });
   });
 });

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
@@ -97,6 +97,13 @@ describe('RollbarApi', () => {
               result: [
                 {
                   projectId: 123,
+                  name: 'project-token-expired',
+                  scopes: ['read'],
+                  accessToken: 'xyzzy',
+                  status: 'expired',
+                },
+                {
+                  projectId: 123,
                   name: 'project-token',
                   scopes: ['read'],
                   accessToken: 'plugh',

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
@@ -156,7 +156,9 @@ export class RollbarApi {
 
     if (!project.accessToken) {
       const tokens = await this.getProjectAccessTokens(project.id);
-      const token = tokens.find(t => t.scopes.includes('read'));
+      const token = tokens.find(
+        t => t.scopes.includes('read') && t.status !== 'expired',
+      );
       project.accessToken = token ? token.accessToken : undefined;
 
       // recache to persist mutated item in project map
@@ -166,7 +168,9 @@ export class RollbarApi {
     }
 
     if (!project.accessToken) {
-      throw Error(`Could not find project read access token for '${name}'`);
+      throw Error(
+        `Could not find an active project read access token for '${name}'`,
+      );
     }
 
     return project;

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
@@ -24,7 +24,10 @@ import {
   RollbarTopActiveItem,
 } from './types';
 import fetch from 'node-fetch';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import { CacheService, LoggerService } from '@backstage/backend-plugin-api';
+
+const CACHE_KEY = 'projectmap';
+const CACHE_TTL = 300;
 
 const baseUrl = 'https://api.rollbar.com/api/1';
 
@@ -44,11 +47,10 @@ function camelize<T extends unknown>(val: T): T {
 
 /** @public */
 export class RollbarApi {
-  private projectMap: ProjectMetadataMap | undefined;
-
   constructor(
     private readonly accessToken: string,
     private readonly logger: LoggerService,
+    private readonly cache: CacheService,
   ) {}
 
   async getAllProjects() {
@@ -156,6 +158,11 @@ export class RollbarApi {
       const tokens = await this.getProjectAccessTokens(project.id);
       const token = tokens.find(t => t.scopes.includes('read'));
       project.accessToken = token ? token.accessToken : undefined;
+
+      // recache to persist mutated item in project map
+      if (this.cache) {
+        this.cache.set(CACHE_KEY, projectMap, { ttl: 300 });
+      }
     }
 
     if (!project.accessToken) {
@@ -166,18 +173,18 @@ export class RollbarApi {
   }
 
   private async getProjectMap() {
-    if (this.projectMap) {
-      return this.projectMap;
+    let projectMap: ProjectMetadataMap | undefined = await this.cache.get(
+      CACHE_KEY,
+    );
+    if (!projectMap) {
+      const projects = await this.getAllProjects();
+      projectMap = projects.reduce((accum: ProjectMetadataMap, i) => {
+        accum[i.name] = { id: i.id, name: i.name };
+        return accum;
+      }, {});
+      this.cache.set(CACHE_KEY, projectMap, { ttl: CACHE_TTL });
     }
-
-    const projects = await this.getAllProjects();
-
-    this.projectMap = projects.reduce((accum: ProjectMetadataMap, i) => {
-      accum[i.name] = { id: i.id, name: i.name };
-      return accum;
-    }, {});
-
-    return this.projectMap;
+    return projectMap;
   }
 }
 

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/types.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/types.ts
@@ -80,7 +80,7 @@ export type RollbarProjectAccessToken = {
   name: string;
   scopes: RollbarProjectAccessTokenScope[];
   accessToken: string;
-  status: 'enabled' | string;
+  status: 'enabled' | 'expired' | string;
 };
 
 /** @public */

--- a/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
@@ -30,13 +30,15 @@ export const rollbarPlugin = createBackendPlugin({
   register(env) {
     env.registerInit({
       deps: {
+        cache: coreServices.cache,
         config: coreServices.rootConfig,
         logger: coreServices.logger,
         httpRouter: coreServices.httpRouter,
       },
-      async init({ config, logger, httpRouter }) {
+      async init({ cache, config, logger, httpRouter }) {
         httpRouter.use(
           await createRouter({
+            cache,
             config,
             logger,
           }),

--- a/workspaces/rollbar/plugins/rollbar-backend/src/service/router.test.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/service/router.test.ts
@@ -39,6 +39,7 @@ describe('createRouter', () => {
       rollbarApi,
       logger: mockServices.rootLogger(),
       config: new ConfigReader({ rollbar: { accountToken: 'foo' } }),
+      cache: mockServices.cache.mock(),
     });
     app = express().use(router);
   });

--- a/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
@@ -25,7 +25,7 @@ interface RouterOptions {
   rollbarApi?: RollbarApi;
   logger: LoggerService;
   config: Config;
-  cache?: CacheService;
+  cache: CacheService;
 }
 
 export async function createRouter(

--- a/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
@@ -18,13 +18,14 @@ import express from 'express';
 import Router from 'express-promise-router';
 import { Config } from '@backstage/config';
 import { RollbarApi } from '../api';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import { CacheService, LoggerService } from '@backstage/backend-plugin-api';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
 interface RouterOptions {
   rollbarApi?: RollbarApi;
   logger: LoggerService;
   config: Config;
+  cache?: CacheService;
 }
 
 export async function createRouter(
@@ -40,7 +41,7 @@ export async function createRouter(
 
   if (options.rollbarApi || accessToken) {
     const rollbarApi =
-      options.rollbarApi || new RollbarApi(accessToken, logger);
+      options.rollbarApi || new RollbarApi(accessToken, logger, options.cache);
 
     router.use(express.json());
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently, the Rollbar API class holds project metadata state until the backend restarts. It's possible for developers to modify upstream Rollbar project access tokens (e.g., delete or expire them), which can result in the Rollbar plugin backend service being stuck with invalid access tokens. This change introduces the `CacheService` to handle cached project maps, ensuring that stale Rollbar project data is evicted.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
