### PR TITLE
Allow `rollbar` custom environment name

### DIFF
--- a/workspaces/rollbar/.changeset/calm-zebras-turn.md
+++ b/workspaces/rollbar/.changeset/calm-zebras-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rollbar': patch
+---
+
+Allow custom project environment name

--- a/workspaces/rollbar/plugins/rollbar/README.md
+++ b/workspaces/rollbar/plugins/rollbar/README.md
@@ -47,6 +47,8 @@ metadata:
     rollbar.com/project-slug: organization-name/project-name
     # -- or just ---
     rollbar.com/project-slug: project-name
+    # -- optional (default: production) ---
+    rollbar.com/environment: environment-name
 ```
 
 6. Run app with `yarn start` and navigate to `/rollbar` or a catalog entity

--- a/workspaces/rollbar/plugins/rollbar/package.json
+++ b/workspaces/rollbar/plugins/rollbar/package.json
@@ -61,6 +61,7 @@
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
+    "@testing-library/react-hooks": "8.0.1",
     "@types/lodash": "^4.14.151",
     "@types/react-dom": "^18.2.19",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/rollbar/plugins/rollbar/report.api.md
+++ b/workspaces/rollbar/plugins/rollbar/report.api.md
@@ -37,6 +37,7 @@ export interface RollbarApi {
   getTopActiveItems(
     project: string,
     hours?: number,
+    environment?: string,
   ): Promise<RollbarTopActiveItem[]>;
 }
 

--- a/workspaces/rollbar/plugins/rollbar/src/api/RollbarApi.ts
+++ b/workspaces/rollbar/plugins/rollbar/src/api/RollbarApi.ts
@@ -33,6 +33,7 @@ export interface RollbarApi {
   getTopActiveItems(
     project: string,
     hours?: number,
+    environment?: string,
   ): Promise<RollbarTopActiveItem[]>;
   getProjectItems(project: string): Promise<RollbarItemsResponse>;
 }

--- a/workspaces/rollbar/plugins/rollbar/src/constants.ts
+++ b/workspaces/rollbar/plugins/rollbar/src/constants.ts
@@ -16,3 +16,4 @@
 
 /** @public */
 export const ROLLBAR_ANNOTATION = 'rollbar.com/project-slug';
+export const ROLLBAR_ENVIRONMENT_ANNOTATION = 'rollbar.com/environment';

--- a/workspaces/rollbar/plugins/rollbar/src/hooks/useProject.ts
+++ b/workspaces/rollbar/plugins/rollbar/src/hooks/useProject.ts
@@ -15,7 +15,10 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { ROLLBAR_ANNOTATION } from '../constants';
+import {
+  ROLLBAR_ANNOTATION,
+  ROLLBAR_ENVIRONMENT_ANNOTATION,
+} from '../constants';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 
 export function useProjectSlugFromEntity(entity: Entity) {
@@ -33,5 +36,6 @@ export function useProjectSlugFromEntity(entity: Entity) {
       organization ??
       configApi.getOptionalString('rollbar.organization') ??
       configApi.getString('organization.name'),
+    environment: entity?.metadata.annotations?.[ROLLBAR_ENVIRONMENT_ANNOTATION],
   };
 }

--- a/workspaces/rollbar/plugins/rollbar/src/hooks/useTopActiveItems.test.tsx
+++ b/workspaces/rollbar/plugins/rollbar/src/hooks/useTopActiveItems.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { default as React } from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { useTopActiveItems } from './useTopActiveItems';
+import { rollbarApiRef } from '../api';
+import { TestApiProvider } from '@backstage/test-utils';
+import { Entity } from '@backstage/catalog-model';
+import { configApiRef } from '@backstage/core-plugin-api';
+
+describe('useTopActiveItems', () => {
+  const mockApi = {
+    getTopActiveItems: jest.fn(),
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'test-service',
+      annotations: {
+        'rollbar.com/project-slug': 'foo/bar',
+        'rollbar.com/environment': 'qa',
+      },
+    },
+    spec: {},
+  };
+
+  it('should use the environment annotation', async () => {
+    mockApi.getTopActiveItems.mockResolvedValueOnce([
+      { item: { occurrences: 2 } },
+      { item: { occurrences: 5 } },
+    ]);
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestApiProvider
+        apis={[
+          [rollbarApiRef, mockApi],
+          [configApiRef, {}],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+    const { result, waitForNextUpdate } = renderHook(
+      () => useTopActiveItems(entity),
+      { wrapper },
+    );
+    await waitForNextUpdate();
+    expect(mockApi.getTopActiveItems).toHaveBeenCalledWith('bar', 168, 'qa');
+    expect(result.current.items[0].item.occurrences).toBe(5);
+    expect(result.current.items[1].item.occurrences).toBe(2);
+  });
+});

--- a/workspaces/rollbar/plugins/rollbar/src/hooks/useTopActiveItems.ts
+++ b/workspaces/rollbar/plugins/rollbar/src/hooks/useTopActiveItems.ts
@@ -23,14 +23,15 @@ import { useApi } from '@backstage/core-plugin-api';
 
 export function useTopActiveItems(entity: Entity) {
   const api = useApi(rollbarApiRef);
-  const { organization, project } = useProjectSlugFromEntity(entity);
+  const { organization, project, environment } =
+    useProjectSlugFromEntity(entity);
   const { value, loading, error } = useAsync(() => {
     if (!project) {
       return Promise.resolve([]);
     }
 
     return api
-      .getTopActiveItems(project, 168)
+      .getTopActiveItems(project, 168, environment)
       .then(data =>
         data.sort((a, b) => b.item.occurrences - a.item.occurrences),
       );

--- a/workspaces/rollbar/yarn.lock
+++ b/workspaces/rollbar/yarn.lock
@@ -2629,6 +2629,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
+    "@testing-library/react-hooks": "npm:8.0.1"
     "@types/lodash": "npm:^4.14.151"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     "@types/react-dom": "npm:^18.2.19"
@@ -8292,6 +8293,28 @@ __metadata:
     vitest:
       optional: true
   checksum: 10/7ee1e51caffad032734a4a43a00bf72d49080cf1bbf53021b443e91c7fa3762a66f55ce68f1c6643590fe66fbc4df92142659b8cf17c92166a3fb22691987e0d
+  languageName: node
+  linkType: hard
+
+"@testing-library/react-hooks@npm:8.0.1":
+  version: 8.0.1
+  resolution: "@testing-library/react-hooks@npm:8.0.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+    react-error-boundary: "npm:^3.1.0"
+  peerDependencies:
+    "@types/react": ^16.9.0 || ^17.0.0
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+    react-test-renderer: ^16.9.0 || ^17.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react-dom:
+      optional: true
+    react-test-renderer:
+      optional: true
+  checksum: 10/f7b69373feebe99bc7d60595822cc5c00a1a5a4801bc4f99b597256a5c1d23c45a51f359051dd8a7bdffcc23b26f324c582e9433c25804934fd351a886812790
   languageName: node
   linkType: hard
 
@@ -21764,6 +21787,17 @@ __metadata:
   peerDependencies:
     react: ">= 0.14.7"
   checksum: 10/c12f9b51795b6281ed191a1eeadf3e5ab4f109af70c25bee159e0169169b5f31c8bc5706420672c232fb0c0eb665e2e4f9bea8cb086415a7bd19ec98528d024c
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^3.1.0":
+  version: 3.1.4
+  resolution: "react-error-boundary@npm:3.1.4"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 10/7418637bf352b88f35ff3798e6faa094ee046df9d422fc08f54c017892c3c0738dac661ba3d64d97209464e7a60e7fbbeffdbeaee5edc38f3aaf5f1f4a8bf610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It's common for our organization to "burn-in" new services in a QA or testing environment before full production release. At present, the catalog page for these experimental services can only display Rollbar items from a production environment.

The Rollbar API client and backend already support custom environment parameters. This change adds an optional, per-component, annotation that allows component owners to define this environment.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
