### PR TITLE
Remove `rollbar-backend` legacy backend

### DIFF
--- a/workspaces/rollbar/.changeset/tasty-cooks-do.md
+++ b/workspaces/rollbar/.changeset/tasty-cooks-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rollbar-backend': minor
+---
+
+**BREAKING** Removes `rollbar-backend` legacy backend support. The plugin now uses the [new Backstage backend system](https://backstage.io/docs/plugins/new-backend-system/).

--- a/workspaces/rollbar/plugins/rollbar-backend/README.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/README.md
@@ -6,80 +6,26 @@ Simple plugin that proxies requests to the [Rollbar](https://rollbar.com) API.
 
 1. Install the plugin using:
 
-```bash
-# From your Backstage root directory
-yarn --cwd packages/backend add @backstage-community/plugin-rollbar-backend
-```
+   ```bash
+   # From your Backstage root directory
+   yarn --cwd packages/backend add @backstage-community/plugin-rollbar-backend
+   ```
 
 2. In your `packages/backend/src/index.ts` make the following changes:
 
-```diff
-  import { createBackend } from '@backstage/backend-defaults';
+   ```diff
+     import { createBackend } from '@backstage/backend-defaults';
 
-  const backend = createBackend();
+     const backend = createBackend();
 
-  // ... other feature additions
+     // ... other feature additions
 
-+ backend.add(import('@backstage-community/plugin-rollbar-backend'));
+   + backend.add(import('@backstage-community/plugin-rollbar-backend'));
 
-  // ...
+     // ...
 
-  backend.start();
-```
-
-### Legacy Backend Setup
-
-1. Install the plugin using:
-
-```bash
-# From your Backstage root directory
-yarn --cwd packages/backend add @backstage-community/plugin-rollbar-backend
-```
-
-2. Create a `rollbar.ts` file inside `packages/backend/src/plugins/`:
-
-```typescript
-import { createRouter } from '@backstage-community/plugin-rollbar-backend';
-import { Router } from 'express';
-import { PluginEnvironment } from '../types';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  return await createRouter({
-    logger: env.logger,
-    config: env.config,
-  });
-}
-```
-
-3. Modify your `packages/backend/src/index.ts` to include:
-
-```diff
- ...
-
- import { Config } from '@backstage/config';
- import app from './plugins/app';
-+import rollbar from './plugins/rollbar';
- import scaffolder from './plugins/scaffolder';
-
- ...
-
- async function main() {
-
-   ...
-
-   const authEnv = useHotMemoize(module, () => createEnv('auth'));
-+  const rollbarEnv = useHotMemoize(module, () => createEnv('rollbar'));
-   const proxyEnv = useHotMemoize(module, () => createEnv('proxy'));
-
-   ...
-
-   const apiRouter = Router();
-   apiRouter.use('/catalog', await catalog(catalogEnv));
-+  apiRouter.use('/rollbar', await rollbar(rollbarEnv));
-   apiRouter.use('/scaffolder', await scaffolder(scaffolderEnv));
-```
+     backend.start();
+   ```
 
 The following values are read from the configuration file.
 
@@ -88,8 +34,9 @@ rollbar:
   accountToken: ${ROLLBAR_ACCOUNT_TOKEN}
 ```
 
-_NOTE: The `ROLLBAR_ACCOUNT_TOKEN` environment variable must be set to a read
-access account token._
+> [!NOTE]
+> The `ROLLBAR_ACCOUNT_TOKEN` environment variable must be set to a read
+> access account token.
 
 ## Links
 

--- a/workspaces/rollbar/plugins/rollbar-backend/report.api.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/report.api.md
@@ -4,12 +4,7 @@
 
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { Config } from '@backstage/config';
-import express from 'express';
 import { LoggerService } from '@backstage/backend-plugin-api';
-
-// @public @deprecated (undocumented)
-export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public (undocumented)
 export function getRequestHeaders(token: string): {
@@ -218,14 +213,4 @@ export type RollbarTopActiveItem = {
   };
   counts: number[];
 };
-
-// @public @deprecated (undocumented)
-export interface RouterOptions {
-  // (undocumented)
-  config: Config;
-  // (undocumented)
-  logger: LoggerService;
-  // (undocumented)
-  rollbarApi?: RollbarApi;
-}
 ```

--- a/workspaces/rollbar/plugins/rollbar-backend/src/index.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/index.ts
@@ -21,5 +21,4 @@
  */
 
 export * from './api';
-export * from './service/router';
 export { rollbarPlugin as default } from './plugin';

--- a/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/plugin.ts
@@ -26,7 +26,7 @@ import { createRouter } from './service/router';
  * @public
  */
 export const rollbarPlugin = createBackendPlugin({
-  pluginId: 'azure-devops',
+  pluginId: 'rollbar',
   register(env) {
     env.registerInit({
       deps: {

--- a/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/service/router.ts
@@ -21,20 +21,12 @@ import { RollbarApi } from '../api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 
-/**
- * @deprecated Please migrate to the new backend system as this will be removed in the future.
- *
- * @public */
-export interface RouterOptions {
+interface RouterOptions {
   rollbarApi?: RollbarApi;
   logger: LoggerService;
   config: Config;
 }
 
-/**
- * @deprecated Please migrate to the new backend system as this will be removed in the future.
- *
- * @public */
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Per https://github.com/backstage/community-plugins/pull/4776#pullrequestreview-3059630095, this is a breaking change to remove `rollbar-backend`'s deprecated legacy backend interface, enabling a cleaner approach to upcoming improvements.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
