### PR TITLE
fix(newrelic): fix incorrect pluginId for newrelic-dashboard in nfe

### DIFF
--- a/workspaces/newrelic/.changeset/hot-candles-flow.md
+++ b/workspaces/newrelic/.changeset/hot-candles-flow.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-newrelic-dashboard': minor
 ---
 
-fix incorrect pluginId for NFE
+**BREAKING**: Plugin ID was previously incorrect as `newrelic`, so it's been updated to `newrelic-dashboard`. If you were referencing any extension in this plugin before, you'll now need to rename `newrelic` to `newrelic-dashboard`

--- a/workspaces/newrelic/.changeset/hot-candles-flow.md
+++ b/workspaces/newrelic/.changeset/hot-candles-flow.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-newrelic-dashboard': patch
+'@backstage-community/plugin-newrelic-dashboard': minor
 ---
 
 fix incorrect pluginId for NFE

--- a/workspaces/newrelic/.changeset/hot-candles-flow.md
+++ b/workspaces/newrelic/.changeset/hot-candles-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-newrelic-dashboard': patch
+---
+
+fix incorrect pluginId for NFE

--- a/workspaces/newrelic/plugins/newrelic-dashboard/report-alpha.api.md
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/report-alpha.api.md
@@ -21,7 +21,7 @@ const _default: FrontendPlugin<
   {},
   {},
   {
-    'api:newrelic': ExtensionDefinition<{
+    'api:newrelic-dashboard': ExtensionDefinition<{
       kind: 'api';
       name: undefined;
       config: {};
@@ -36,7 +36,7 @@ const _default: FrontendPlugin<
         factory: AnyApiFactory;
       };
     }>;
-    'entity-card:newrelic/EntityNewRelicDashboardCard': ExtensionDefinition<{
+    'entity-card:newrelic-dashboard/EntityNewRelicDashboardCard': ExtensionDefinition<{
       kind: 'entity-card';
       name: 'EntityNewRelicDashboardCard';
       config: {
@@ -77,7 +77,7 @@ const _default: FrontendPlugin<
         type?: EntityCardType | undefined;
       };
     }>;
-    'entity-content:newrelic/EntityNewRelicDashboardContent': ExtensionDefinition<{
+    'entity-content:newrelic-dashboard/EntityNewRelicDashboardContent': ExtensionDefinition<{
       kind: 'entity-content';
       name: 'EntityNewRelicDashboardContent';
       config: {

--- a/workspaces/newrelic/plugins/newrelic-dashboard/src/alpha/plugin.tsx
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/src/alpha/plugin.tsx
@@ -66,7 +66,7 @@ export const newRelicDashboardCard = EntityCardBlueprint.make({
 
 /** @alpha */
 export default createFrontendPlugin({
-  pluginId: 'newrelic',
+  pluginId: 'newrelic-dashboard',
   extensions: [
     newRelicApi,
     newRelicDashboardEntityContent,

--- a/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.test.ts
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.test.ts
@@ -15,7 +15,7 @@
  */
 import { newRelicDashboardPlugin } from './plugin';
 
-describe('new-relic-dashboard', () => {
+describe('newrelic-dashboard', () => {
   it('should export plugin', () => {
     expect(newRelicDashboardPlugin).toBeDefined();
   });

--- a/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.ts
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.ts
@@ -27,7 +27,7 @@ import { rootRouteRef } from './routes';
 
 /** @public */
 export const newRelicDashboardPlugin = createPlugin({
-  id: 'new-relic-dashboard',
+  id: 'new-relicdashboard',
   routes: {
     root: rootRouteRef,
   },

--- a/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.ts
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/src/plugin.ts
@@ -27,7 +27,7 @@ import { rootRouteRef } from './routes';
 
 /** @public */
 export const newRelicDashboardPlugin = createPlugin({
-  id: 'new-relicdashboard',
+  id: 'newrelic-dashboard',
   routes: {
     root: rootRouteRef,
   },

--- a/workspaces/newrelic/plugins/newrelic-dashboard/src/routes.ts
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/src/routes.ts
@@ -16,5 +16,5 @@
 import { createRouteRef } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({
-  id: 'new-relic-dashboard',
+  id: 'newrelic-dashboard',
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The pluginId for NFE conflicts between the two New Relic plugins. This PR changes the newrelic-dashboard plugin to have the correct pluginId.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
