### PR TITLE
fix(copilot): Improve metrics ingestion performance

### DIFF
--- a/workspaces/copilot/.changeset/sixty-numbers-count.md
+++ b/workspaces/copilot/.changeset/sixty-numbers-count.md
@@ -2,4 +2,8 @@
 '@backstage-community/plugin-copilot-backend': minor
 ---
 
-Only gather metrics from teams that have 5 or more members
+Various performance improvements for larger organizations
+
+- Only gather metrics from teams that have 5 or more members
+- To improve performance and reduce the API calls made on large orgs,
+  we only need to retrieve the org and enterprise seats once per task.

--- a/workspaces/copilot/.changeset/sixty-numbers-count.md
+++ b/workspaces/copilot/.changeset/sixty-numbers-count.md
@@ -4,6 +4,8 @@
 
 Various performance improvements for larger organizations
 
-- Only gather metrics from teams that have 5 or more members
+- Only gather metrics from teams that have 5 or more members, teams
+  with less members will not have any metrics provided by the api as
+  documented here https://docs.github.com/en/rest/copilot/copilot-metrics?apiVersion=2022-11-28
 - To improve performance and reduce the API calls made on large orgs,
   we only need to retrieve the org and enterprise seats once per task.

--- a/workspaces/copilot/.changeset/sixty-numbers-count.md
+++ b/workspaces/copilot/.changeset/sixty-numbers-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+---
+
+Only gather metrics from teams that have 5 or more members

--- a/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/client/GithubClient.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GithubClient } from './GithubClient';
+import { mockServices } from '@backstage/backend-test-utils';
+import { Octokit } from '@octokit/rest';
+
+// Mock Octokit
+jest.mock('@octokit/rest');
+
+const MockedOctokit = Octokit as jest.MockedClass<typeof Octokit>;
+
+describe('GithubClient', () => {
+  let githubClient: GithubClient;
+  let mockOctokit: jest.Mocked<Octokit>;
+  let mockConfig: any;
+
+  const mockCopilotConfig = {
+    host: 'github.com',
+    apiBaseUrl: 'https://api.github.com',
+    organization: 'test-org',
+    enterprise: 'test-enterprise',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConfig = mockServices.rootConfig({
+      data: {
+        copilot: mockCopilotConfig,
+        integrations: {
+          github: [
+            {
+              host: 'github.com',
+              token: 'test-token',
+            },
+          ],
+        },
+      },
+    });
+
+    mockOctokit = {
+      graphql: jest.fn(),
+      request: jest.fn(),
+      paginate: jest.fn(),
+      copilot: {
+        listCopilotSeats: jest.fn(),
+      },
+    } as any;
+
+    MockedOctokit.mockImplementation(() => mockOctokit);
+
+    githubClient = new GithubClient(mockCopilotConfig, mockConfig);
+  });
+
+  describe('fetchOrganizationTeams', () => {
+    it('should filter out teams with less than 5 members', async () => {
+      const mockGraphQLResponse = {
+        organization: {
+          teams: {
+            pageInfo: {
+              hasNextPage: false,
+              endCursor: null,
+            },
+            nodes: [
+              {
+                id: 'team1-graphql-id',
+                databaseId: 1,
+                slug: 'team-1',
+                name: 'Team 1',
+                members: {
+                  totalCount: 1,
+                },
+              },
+              {
+                id: 'team2-graphql-id',
+                databaseId: 2,
+                slug: 'team-2',
+                name: 'Team 2',
+                members: {
+                  totalCount: 4,
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      mockOctokit.graphql.mockResolvedValueOnce(mockGraphQLResponse);
+
+      const result = await githubClient.fetchOrganizationTeams();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchEnterpriseTeams', () => {
+    it('should fetch enterprise teams with 5 or more members using GraphQL', async () => {
+      const mockGraphQLResponse = {
+        enterprise: {
+          organizations: {
+            nodes: [
+              {
+                teams: {
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                  nodes: [
+                    {
+                      id: 'team1-graphql-id',
+                      databaseId: 1,
+                      slug: 'enterprise-team-1',
+                      name: 'Enterprise Team 1',
+                      members: {
+                        totalCount: 7,
+                      },
+                    },
+                    {
+                      id: 'team2-graphql-id',
+                      databaseId: 2,
+                      slug: 'enterprise-team-2',
+                      name: 'Enterprise Team 2',
+                      members: {
+                        totalCount: 2, // Should be filtered out
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      mockOctokit.graphql.mockResolvedValueOnce(mockGraphQLResponse);
+
+      const result = await githubClient.fetchEnterpriseTeams();
+
+      expect(result).toEqual([
+        {
+          id: 1,
+          slug: 'enterprise-team-1',
+          name: 'Enterprise Team 1',
+        },
+      ]);
+    });
+  });
+});

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
@@ -54,6 +54,12 @@ export async function discoverEnterpriseTeamMetrics({
       `[discoverEnterpriseTeamMetrics] Fetched ${teams.length} teams`,
     );
 
+    // Fetch seat analysis
+    const seats = await api.fetchEnterpriseSeats();
+    logger.info(
+      `[discoverEnterpriseTeamMetrics] Fetched ${seats.length} seats from enterprise`,
+    );
+
     for (const team of teams) {
       try {
         logger.info(
@@ -160,8 +166,6 @@ export async function discoverEnterpriseTeamMetrics({
             await db.batchInsertIdeChatEditorModels(chunk);
           });
 
-          // Fetch seat analysis
-          const seats = await api.fetchEnterpriseSeats();
           const seatsToInsert = convertToTeamSeatAnalysis(
             seats,
             type,

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
@@ -55,6 +55,12 @@ export async function discoverOrganizationTeamMetrics({
       `[discoverOrganizationTeamMetrics] Fetched ${teams.length} teams`,
     );
 
+    // Fetch seat analysis
+    const seats = await api.fetchOrganizationSeats();
+    logger.info(
+      `[discoverOrganizationTeamMetrics] Fetched ${seats.seats.length} seats from organization`,
+    );
+
     for (const team of teams) {
       try {
         logger.info(
@@ -161,8 +167,6 @@ export async function discoverOrganizationTeamMetrics({
             await db.batchInsertIdeChatEditorModels(chunk);
           });
 
-          // Fetch seat analysis
-          const seats = await api.fetchOrganizationSeats();
           const seatsToInsert = convertToTeamSeatAnalysis(
             seats,
             type,

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -15,6 +15,8 @@ The GitHub Copilot Plugin enhances your Backstage experience by providing featur
 - **Enterprise and Organization Integration**: Seamlessly integrate functionalities for GitHub Enterprise and GitHub Organizations.
 - **Team Metrics Comparison**: Select a team and compare its metrics with the overall data, offering more insights into individual team performance.
 
+_GitHub APIs will only show metrics for teams of 5 or more active users per day_
+
 ## Setup
 
 The following sections will help you get the GitHub Copilot Plugin setup and running.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aims to improve the performance of the co-pilot back-end task by limiting the number of teams that it is actively trying to get the metrics from. 

GitHub does not provide metrics for teams with less than five members, therefore we should not query the API for any team that has less than five members.

<img width="564" height="199" alt="CleanShot 2025-07-28 at 16 30 47" src="https://github.com/user-attachments/assets/6380b484-e5c3-4e3e-bd89-49e4042c422a" />

reference - https://docs.github.com/en/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-metrics-for-a-team

We can't easily verify if a user in the team has a copilot license, so we simply filter out any team with less than five members.

---

I also found a bug where we are loading the entire org/enterprise copilot seat list for each team in the org/enterprise, in pages of 100 memers. This may work well for small orgs with a few hundred members. But larger orgs with 1000s or members and teams will quickly run into performance issues and run our of API rate limit.

Taking my org as an example we have 3500 teams and 7000 users. So thats 70 API calls to list all the org users for each of the teams. 
List teams = 35 calls
Gather Metrics for each team 3500 calls
Query seats for each team =  (70 * 3500) = 248,500 calls.. 

lets say > 250k API calls.

With these changes we reduce the number of active teams to about 1500 (teams over 5 members) and only make the calls for seats once.

35+70+3500 = <4k calls..

HUGE difference in performance and API use.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Related to https://github.com/backstage/community-plugins/issues/4367