### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/beige-spoons-compete.md
+++ b/workspaces/nexus-repository-manager/.changeset/beige-spoons-compete.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-remove product theme from dev dependencies and dev app

--- a/workspaces/nexus-repository-manager/.changeset/quick-maps-cross.md
+++ b/workspaces/nexus-repository-manager/.changeset/quick-maps-cross.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Aligned `formatDate` utility with `ADR012 using Luxon`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-1ccac76.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-1ccac76.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.6.4`.

--- a/workspaces/nexus-repository-manager/.changeset/version-bump-1-41-1.md
+++ b/workspaces/nexus-repository-manager/.changeset/version-bump-1-41-1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.15.0
+
+### Minor Changes
+
+- d7e6708: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- c6f0aec: remove product theme from dev dependencies and dev app
+- 333e98c: Aligned `formatDate` utility with `ADR012 using Luxon`.
+- 6877ddc: Updated dependency `@testing-library/jest-dom` to `6.6.4`.
+
 ## 1.14.2
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.15.0

### Minor Changes

-   d7e6708: Backstage version bump to v1.41.1

### Patch Changes

-   c6f0aec: remove product theme from dev dependencies and dev app
-   333e98c: Aligned `formatDate` utility with `ADR012 using Luxon`.
-   6877ddc: Updated dependency `@testing-library/jest-dom` to `6.6.4`.
