### PR TITLE
multi-source-security-viewer: remove product theme from dev dependencies and dev app

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/tall-laws-itch.md
+++ b/workspaces/multi-source-security-viewer/.changeset/tall-laws-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-multi-source-security-viewer': patch
+---
+
+remove product theme from dev dependencies and dev app

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/dev/index.tsx
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/dev/index.tsx
@@ -22,7 +22,6 @@ import { Header, Page, TabbedLayout } from '@backstage/core-components';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { MockPermissionApi, TestApiProvider } from '@backstage/test-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
-import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
 import { mockEntity } from '../src/__fixtures__/entity';
 import { mssvJenkinsApiRef } from '../src/api/jenkins';
 import { mockPipelineRuns } from '../src/__fixtures__/pipelineruns';
@@ -109,7 +108,6 @@ class MockMssvAzureDevopsClient implements MssvApi {
 }
 
 createDevApp()
-  .addThemes(getAllThemes())
   .addPage({
     element: (
       <TestApiProvider

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
@@ -74,7 +74,6 @@
     "@backstage/core-app-api": "^1.17.0",
     "@backstage/dev-utils": "^1.1.10",
     "@backstage/test-utils": "^1.7.8",
-    "@redhat-developer/red-hat-developer-hub-theme": "^0.4.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",

--- a/workspaces/multi-source-security-viewer/yarn.lock
+++ b/workspaces/multi-source-security-viewer/yarn.lock
@@ -2986,7 +2986,6 @@ __metadata:
     "@patternfly/patternfly": "npm:^6.0.0"
     "@patternfly/react-core": "npm:^6.0.0"
     "@patternfly/react-tokens": "npm:^6.0.0"
-    "@redhat-developer/red-hat-developer-hub-theme": "npm:^0.4.0"
     "@tanstack/react-query": "npm:^5.62.7"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
@@ -10410,21 +10409,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10/ecd6c410d0277649c6a6dc19156a06cc7beb92ac79eb798ee18d30ca9bdf92ccf63ad7794b384471059f03d3dc8c612b26ca6aec42769d01e2a43d07919fd02b
-  languageName: node
-  linkType: hard
-
-"@redhat-developer/red-hat-developer-hub-theme@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0"
-  peerDependencies:
-    "@backstage/theme": ^0.5.2
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.14.19
-    "@mui/material": ^5.14.20
-  checksum: 10/ea8ffb4eac6841b0d7992655d44321abe3476279a58a4d2371b3f72dfef53e426e03d1ffc95adb014f6371cd8e02a8aa4f7657f98721d440a7ff4f2c98c2629b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes the product specific theme. See https://github.com/backstage/community-plugins/issues/4795 and https://github.com/backstage/community-plugins/pull/3556

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
