### PR TITLE
redhat-argocd: remove product theme from dev dependencies and dev app

### DIFF
--- a/workspaces/redhat-argocd/.changeset/five-dogs-allow.md
+++ b/workspaces/redhat-argocd/.changeset/five-dogs-allow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-redhat-argocd': patch
+---
+
+remove product theme from dev dependencies and dev app

--- a/workspaces/redhat-argocd/packages/app/package.json
+++ b/workspaces/redhat-argocd/packages/app/package.json
@@ -50,7 +50,6 @@
     "@mui/icons-material": "^5.15.16",
     "@mui/material": "^5.15.16",
     "@mui/styles": "^5.15.16",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router": "^6.23.0",

--- a/workspaces/redhat-argocd/packages/app/src/App.tsx
+++ b/workspaces/redhat-argocd/packages/app/src/App.tsx
@@ -49,8 +49,6 @@ import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import { TechDocsAddons } from '@backstage/plugin-techdocs-react';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
 
-import { getThemes } from '@redhat-developer/red-hat-developer-hub-theme';
-
 import { apis } from './apis';
 import { entityPage } from './components/catalog/EntityPage';
 import { Root } from './components/Root';
@@ -92,7 +90,6 @@ const app = createApp({
       />
     ),
   },
-  themes: getThemes(),
 });
 
 const routes = (

--- a/workspaces/redhat-argocd/plugins/argocd/dev/index.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/dev/index.tsx
@@ -24,7 +24,6 @@ import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { mockApis, TestApiProvider } from '@backstage/test-utils';
 
 import { Box } from '@material-ui/core';
-import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
 
 import {
   ArgoCDApi,
@@ -185,7 +184,6 @@ class MockKubernetesClient implements KubernetesApi {
 
 createDevApp()
   .registerPlugin(argocdPlugin)
-  .addThemes(getAllThemes())
   .addPage({
     element: (
       <TestApiProvider

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -65,7 +65,6 @@
     "@backstage/dev-utils": "^1.1.12",
     "@backstage/test-utils": "^1.7.10",
     "@playwright/test": "^1.52.0",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.6.1",

--- a/workspaces/redhat-argocd/yarn.lock
+++ b/workspaces/redhat-argocd/yarn.lock
@@ -2814,7 +2814,6 @@ __metadata:
     "@patternfly/react-core": "npm:^6.0.0"
     "@patternfly/react-icons": "npm:^6.0.0"
     "@playwright/test": "npm:^1.52.0"
-    "@redhat-developer/red-hat-developer-hub-theme": "npm:0.4.0"
     "@testing-library/jest-dom": "npm:6.6.3"
     "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.6.1"
@@ -10264,21 +10263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0"
-  peerDependencies:
-    "@backstage/theme": ^0.5.2
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.14.19
-    "@mui/material": ^5.14.20
-  checksum: 10/ea8ffb4eac6841b0d7992655d44321abe3476279a58a4d2371b3f72dfef53e426e03d1ffc95adb014f6371cd8e02a8aa4f7657f98721d440a7ff4f2c98c2629b
-  languageName: node
-  linkType: hard
-
 "@redis/bloom@npm:1.2.0":
   version: 1.2.0
   resolution: "@redis/bloom@npm:1.2.0"
@@ -14715,7 +14699,6 @@ __metadata:
     "@mui/icons-material": "npm:^5.15.16"
     "@mui/material": "npm:^5.15.16"
     "@mui/styles": "npm:^5.15.16"
-    "@redhat-developer/red-hat-developer-hub-theme": "npm:0.4.0"
     "@testing-library/jest-dom": "npm:6.6.3"
     "@testing-library/react": "npm:14.3.1"
     "@types/node": "npm:22.15.29"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes the product specific theme. See https://github.com/backstage/community-plugins/issues/4795 and https://github.com/backstage/community-plugins/pull/3556

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
