### PR TITLE
tekton: remove product theme from dev dependencies and dev app

### DIFF
--- a/workspaces/tekton/.changeset/orange-dodos-lick.md
+++ b/workspaces/tekton/.changeset/orange-dodos-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+remove product theme from dev dependencies and dev app

--- a/workspaces/tekton/plugins/tekton/dev/index.tsx
+++ b/workspaces/tekton/plugins/tekton/dev/index.tsx
@@ -24,8 +24,6 @@ import {
 import { permissionApiRef } from '@backstage/plugin-permission-react';
 import { mockApis, TestApiProvider } from '@backstage/test-utils';
 
-import { getAllThemes } from '@redhat-developer/red-hat-developer-hub-theme';
-
 import { mockKubernetesPlrResponse } from '../src/__fixtures__/1-pipelinesData';
 import {
   acsDeploymentCheck,
@@ -204,7 +202,6 @@ const mockKubernetesAuthProviderApiRef = {
 };
 
 createDevApp()
-  .addThemes(getAllThemes())
   .addPage({
     element: (
       <TestApiProvider

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -73,7 +73,6 @@
     "@backstage/dev-utils": "^1.1.12",
     "@backstage/test-utils": "^1.7.10",
     "@playwright/test": "^1.52.0",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "14.3.1",
     "@testing-library/react-hooks": "8.0.1",

--- a/workspaces/tekton/yarn.lock
+++ b/workspaces/tekton/yarn.lock
@@ -2807,7 +2807,6 @@ __metadata:
     "@patternfly/react-tokens": "npm:^6.0.0"
     "@patternfly/react-topology": "npm:^6.0.0"
     "@playwright/test": "npm:^1.52.0"
-    "@redhat-developer/red-hat-developer-hub-theme": "npm:0.4.0"
     "@tanstack/react-query": "npm:^5.62.7"
     "@testing-library/jest-dom": "npm:6.6.3"
     "@testing-library/react": "npm:14.3.1"
@@ -10100,21 +10099,6 @@ __metadata:
     js-cookie:
       optional: true
   checksum: 10/6a841c648edbc54b11fd90de9bb61c3059255598fc4a714c508c269a03c4ca9bbf32cf017d3bd2b3a1bf7cd1d9bf4bb56028f64ad455f796079632f4a7cd4f00
-  languageName: node
-  linkType: hard
-
-"@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0":
-  version: 0.4.0
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.4.0"
-  peerDependencies:
-    "@backstage/theme": ^0.5.2
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.14.19
-    "@mui/material": ^5.14.20
-  checksum: 10/ea8ffb4eac6841b0d7992655d44321abe3476279a58a4d2371b3f72dfef53e426e03d1ffc95adb014f6371cd8e02a8aa4f7657f98721d440a7ff4f2c98c2629b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes the product specific theme. See https://github.com/backstage/community-plugins/issues/4795 and https://github.com/backstage/community-plugins/pull/3556

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
