### PR TITLE
Version Packages (newrelic)

### DIFF
--- a/workspaces/newrelic/.changeset/hot-candles-flow.md
+++ b/workspaces/newrelic/.changeset/hot-candles-flow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-newrelic-dashboard': minor
----
-
-**BREAKING**: Plugin ID was previously incorrect as `newrelic`, so it's been updated to `newrelic-dashboard`. If you were referencing any extension in this plugin before, you'll now need to rename `newrelic` to `newrelic-dashboard`

--- a/workspaces/newrelic/plugins/newrelic-dashboard/CHANGELOG.md
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-newrelic-dashboard
 
+## 0.12.0
+
+### Minor Changes
+
+- 36d6417: **BREAKING**: Plugin ID was previously incorrect as `newrelic`, so it's been updated to `newrelic-dashboard`. If you were referencing any extension in this plugin before, you'll now need to rename `newrelic` to `newrelic-dashboard`
+
 ## 0.11.1
 
 ### Patch Changes

--- a/workspaces/newrelic/plugins/newrelic-dashboard/package.json
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-newrelic-dashboard",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "newrelic-dashboard",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-newrelic-dashboard@0.12.0

### Minor Changes

-   36d6417: **BREAKING**: Plugin ID was previously incorrect as `newrelic`, so it's been updated to `newrelic-dashboard`. If you were referencing any extension in this plugin before, you'll now need to rename `newrelic` to `newrelic-dashboard`
