### PR TITLE
fix(sonarqube): maximum update depth exceeded in SonarqubeRelatedEntitiesOverview

### DIFF
--- a/workspaces/sonarqube/.changeset/sweet-jobs-care.md
+++ b/workspaces/sonarqube/.changeset/sweet-jobs-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': patch
+---
+
+Fix maximum update depth exceeded in SonarqubeRelatedEntitiesOverview

--- a/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeRelatedEntitiesOverview/SonarQubeRelatedEntitiesOverview.tsx
+++ b/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeRelatedEntitiesOverview/SonarQubeRelatedEntitiesOverview.tsx
@@ -39,7 +39,7 @@ export const SonarQubeRelatedEntitiesOverview = (props: SonarOverviewProps) => {
   const sonarQubeApi = useApi(sonarQubeApiRef);
   const { entity: parentEntity } = useEntity();
   const {
-    entities = [],
+    entities,
     loading: loadingEntities,
     error: errorEntities,
   } = useRelatedEntities(parentEntity, {
@@ -54,7 +54,7 @@ export const SonarQubeRelatedEntitiesOverview = (props: SonarOverviewProps) => {
 
   const entityNameToProjectKey: { [key: string]: string } = {};
 
-  for (const entity of entities) {
+  for (const entity of entities || []) {
     const { projectKey, projectInstance } = getProjectInfo(entity);
     if (projectKey) {
       entityNameToProjectKey[entity.metadata.name] = projectKey;
@@ -78,7 +78,7 @@ export const SonarQubeRelatedEntitiesOverview = (props: SonarOverviewProps) => {
     return <ResponseErrorPanel error={error} />;
   }
 
-  const tableContent: any[] = entities.map(entity => {
+  const tableContent: any[] | undefined = entities?.map(entity => {
     const projectKey = entityNameToProjectKey[entity.metadata.name];
     return {
       id: projectKey || entity.metadata.name,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Mea culpa, by fixing another issue (#4622) if have mistakenly introduce another bug.

The problem is, that the reference of the entities is reassigned each call. This causes an infinite loop of updates. 
The solution is to not assign a default value (`[]`) for the hook.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
