### PR TITLE
feat(mssv): add isMultiCIAvailableAndEnabled

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/slimy-pillows-vanish.md
+++ b/workspaces/multi-source-security-viewer/.changeset/slimy-pillows-vanish.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-multi-source-security-viewer-common': minor
+'@backstage-community/plugin-multi-source-security-viewer': minor
+---
+
+Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.

--- a/workspaces/multi-source-security-viewer/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/multi-source-security-viewer/packages/app/src/components/catalog/EntityPage.tsx
@@ -73,7 +73,7 @@ import {
   isKubernetesAvailable,
 } from '@backstage/plugin-kubernetes';
 import {
-  isMultiCIAvailable,
+  isMultiCIAvailableAndEnabled,
   EntityMultiCIPipelinesContent,
 } from '@backstage-community/plugin-multi-source-security-viewer';
 
@@ -132,7 +132,7 @@ const cicdContent = (
 
 const securityContent = (
   <EntitySwitch>
-    <EntitySwitch.Case if={isMultiCIAvailable}>
+    <EntitySwitch.Case if={isMultiCIAvailableAndEnabled}>
       <EntityMultiCIPipelinesContent />
     </EntitySwitch.Case>
 

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/report.api.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/report.api.md
@@ -6,6 +6,9 @@
 import { BasicPermission } from '@backstage/plugin-permission-common';
 
 // @public
+export const MSSV_ENABLED_ANNOTATION = 'mssv/enabled';
+
+// @public
 export const mssvPermissions: BasicPermission[];
 
 // @public

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/src/annotations.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/src/annotations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {
-  multiSourceSecurityViewerPlugin,
-  EntityMultiCIPipelinesContent,
-  isMultiCIAvailable,
-  isMultiCIAvailableAndEnabled,
-} from './plugin';
+
+/**
+ * Annotation to enable the plugin
+ *
+ * @public
+ */
+export const MSSV_ENABLED_ANNOTATION = 'mssv/enabled';

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/src/index.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/src/index.ts
@@ -20,3 +20,4 @@
  * @packageDocumentation
  */
 export * from './permissions';
+export * from './annotations';

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
@@ -50,6 +50,38 @@ To enable the PipelineRun list in the Security tab on the entity view page, add 
 +);
 ```
 
+The plugin will be displayed when the annotations of the CI provider will be present. This can also be additionally controlled by setting the following annotation on the component.
+
+```
+mssv/enabled: 'true'
+```
+
+If you choose to display the plugin when the annotation is present along with the CI provider annotations, use `isMultiCIAvailableAndEnabled` instead.
+
+```diff
++import {
++  isMultiCIAvailableAndEnabled,
++  EntityMultiCIPipelinesContent,
++} from '@backstage-community/plugin-multi-source-security-viewer';
++
++import { EntityJenkinsContent } from '@backstage-community/plugin-jenkins';
++import { EntityGithubActionsContent } from '@backstage-community/plugin-github-actions';
++
++const securityContent = (
++  <EntitySwitch>
++    <EntitySwitch.Case if={isMultiCIAvailableAndEnabled}>
++      <EntityMultiCIPipelinesContent />
++    </EntitySwitch.Case>
++  </EntitySwitch>
++);
++
++const entityServicePage = (
++  <EntityLayout.Route path="/security" title="Security">
++    {securityContent}
++  </EntityLayout.Route>
++);
+```
+
 ## For users
 
 ### Using the plugin in Backstage

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/report.api.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/report.api.md
@@ -11,8 +11,11 @@ import { RouteRef } from '@backstage/core-plugin-api';
 // @public (undocumented)
 export const EntityMultiCIPipelinesContent: () => JSX_2.Element;
 
-// @public (undocumented)
+// @public
 export const isMultiCIAvailable: (entity: Entity) => boolean;
+
+// @public
+export const isMultiCIAvailableAndEnabled: (entity: Entity) => boolean;
 
 // @public (undocumented)
 export const multiSourceSecurityViewerPlugin: BackstagePlugin<

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/__fixtures__/entity.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/__fixtures__/entity.ts
@@ -25,6 +25,7 @@ export const mockEntity: Entity = {
       'jenkins.io/job-full-name': 'calculator-app-pipeline',
       'github.com/project-slug': 'test-project',
       'gitlab.com/project-id': '112757',
+      'mssv/enabled': 'true',
       'dev.azure.com/project': 'some-project',
       'dev.azure.com/build-definition': 'some-build',
       'dev.azure.com/host-org': 'dev.azure.com/test-project',

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.test.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.test.ts
@@ -13,10 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { multiSourceSecurityViewerPlugin } from './plugin';
+import { Entity } from '@backstage/catalog-model';
+import {
+  isMultiCIAvailableAndEnabled,
+  multiSourceSecurityViewerPlugin,
+} from './plugin';
+import { MSSV_ENABLED_ANNOTATION } from '@backstage-community/plugin-multi-source-security-viewer-common';
 
 describe('multi-source-security-viewer', () => {
   it('should export plugin', () => {
     expect(multiSourceSecurityViewerPlugin).toBeDefined();
+  });
+
+  it('should display when the annotation is set to "true"', () => {
+    let entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        namespace: 'default',
+        name: 'sample',
+        annotations: {
+          [MSSV_ENABLED_ANNOTATION]: 'false',
+        },
+      },
+    };
+    expect(isMultiCIAvailableAndEnabled(entity)).toBe(false);
+    entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        namespace: 'default',
+        name: 'sample',
+        annotations: {
+          [MSSV_ENABLED_ANNOTATION]: 'true',
+          'github.com/project-slug': 'fake/repo',
+        },
+      },
+    };
+    expect(isMultiCIAvailableAndEnabled(entity)).toBe(true);
   });
 });

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/src/plugin.ts
@@ -51,6 +51,7 @@ import {
   isAzurePipelinesAvailable,
 } from '@backstage-community/plugin-azure-devops';
 import { MssvAzureDevopsClient, mssvAzureDevopsApiRef } from './api/azure';
+import { MSSV_ENABLED_ANNOTATION } from '@backstage-community/plugin-multi-source-security-viewer-common';
 
 /** @public */
 export const multiSourceSecurityViewerPlugin = createPlugin({
@@ -127,12 +128,25 @@ export const multiSourceSecurityViewerPlugin = createPlugin({
   },
 });
 
-/** @public */
+/**
+ * @public
+ * Returns true if the CI provider annotations are set on component.
+ */
 export const isMultiCIAvailable = (entity: Entity): boolean =>
   isJenkinsAvailable(entity) ||
   isGitlabAvailable(entity) ||
   isGithubActionsAvailable(entity) ||
   isAzurePipelinesAvailable(entity);
+
+/**
+ * @public
+ * Returns true if CI provider and mssv annotations are set on component.
+ */
+export const isMultiCIAvailableAndEnabled = (entity: Entity): boolean =>
+  Boolean(
+    entity.metadata.annotations?.[MSSV_ENABLED_ANNOTATION] === 'true' &&
+      isMultiCIAvailable(entity),
+  );
 
 /** @public */
 export const EntityMultiCIPipelinesContent =


### PR DESCRIPTION
This new flag ensures that the plugin is shown only when the CI provider is explicitly specified and marked as enabled through annotations.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
