### PR TITLE
Version Packages (todo)

### DIFF
--- a/workspaces/todo/.changeset/lazy-rabbits-burn.md
+++ b/workspaces/todo/.changeset/lazy-rabbits-burn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-todo': patch
----
-
-Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.

--- a/workspaces/todo/plugins/todo/CHANGELOG.md
+++ b/workspaces/todo/plugins/todo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-todo
 
+## 0.11.1
+
+### Patch Changes
+
+- 1790453: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/todo/plugins/todo/package.json
+++ b/workspaces/todo/plugins/todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-todo",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A Backstage plugin that lets you browse TODO comments in your source code",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-todo@0.11.1

### Patch Changes

-   1790453: Adds support for Backstage's new frontend system, available via the `/alpha` sub-path export.
