### PR TITLE
announcements - New Frontend System NavItem Icon Switch

### DIFF
--- a/workspaces/announcements/.changeset/big-comics-drum.md
+++ b/workspaces/announcements/.changeset/big-comics-drum.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Updated the New Frontend System NavItem to use the `RecordVoiceOverIcon` instead of the `NotificationsIcon` to avoid confusion with the Backstage Notifications NavItem

--- a/workspaces/announcements/plugins/announcements/src/alpha/navItems.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/navItems.tsx
@@ -16,7 +16,7 @@
 import { NavItemBlueprint } from '@backstage/frontend-plugin-api/';
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 import { rootRouteRef } from '../routes';
-import NotificationsIcon from '@material-ui/icons/Notifications';
+import RecordVoiceOverIcon from '@material-ui/icons/RecordVoiceOver';
 
 /**
  * @alpha
@@ -25,7 +25,7 @@ export const announcementsNavItem = NavItemBlueprint.make({
   params: {
     title: 'Announcements',
     routeRef: convertLegacyRouteRef(rootRouteRef),
-    icon: NotificationsIcon,
+    icon: RecordVoiceOverIcon,
   },
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Backstage Notifications uses the `NotificationsIcon` and seen [here in code](https://github.com/backstage/backstage/blob/65cd0fbc6b3ab6dbf36e4df2e886099461c6e563/plugins/notifications/src/components/NotificationsSideBarItem/NotificationsSideBarItem.tsx#L99) and [here in the Demo Site](https://demo.backstage.io/notifications). 

The Announcements plugin uses the same icon in its NavItem for the New Frontend System. I propose we switch this for `RecordVoiceOverIcon`. We use this already for the Announcements [search results](https://github.com/backstage/community-plugins/tree/main/workspaces/announcements#announcements-search). Here is what this looks like:

| Before    | After |
| -------- | ------- |
|  <img width="226" height="520" alt="Screenshot 2025-08-03 at 1 33 28 PM" src="https://github.com/user-attachments/assets/9f8d75e0-b202-4c2d-965f-0d685bea0c22" /> |   <img width="224" height="532" alt="Screenshot 2025-08-03 at 1 34 13 PM" src="https://github.com/user-attachments/assets/ef758181-dc67-4821-8fe0-eaa461c42de2" />  |



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
