### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/big-comics-drum.md
+++ b/workspaces/announcements/.changeset/big-comics-drum.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Updated the New Frontend System NavItem to use the `RecordVoiceOverIcon` instead of the `NotificationsIcon` to avoid confusion with the Backstage Notifications NavItem

--- a/workspaces/announcements/.changeset/wise-jobs-hope.md
+++ b/workspaces/announcements/.changeset/wise-jobs-hope.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed an issue where your would get a "Routing context not available" error when using the New Frontend System

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements
 
+## 0.10.1
+
+### Patch Changes
+
+- 0ab4439: Updated the New Frontend System NavItem to use the `RecordVoiceOverIcon` instead of the `NotificationsIcon` to avoid confusion with the Backstage Notifications NavItem
+- 1a08ba6: Fixed an issue where your would get a "Routing context not available" error when using the New Frontend System
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.10.1

### Patch Changes

-   0ab4439: Updated the New Frontend System NavItem to use the `RecordVoiceOverIcon` instead of the `NotificationsIcon` to avoid confusion with the Backstage Notifications NavItem
-   1a08ba6: Fixed an issue where your would get a "Routing context not available" error when using the New Frontend System
