### PR TITLE
fix(): RBAC missing configSchema

### DIFF
--- a/workspaces/rbac/.changeset/hot-lobsters-clean.md
+++ b/workspaces/rbac/.changeset/hot-lobsters-clean.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Added missing configSchema into package.json

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -79,6 +79,7 @@
     "config.d.ts",
     "migrations"
   ],
+  "configSchema": "config.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When we used `yarn backstage-cli config:check --strict --lax` with this plugin enabled it failed with the following error:

```
Loaded config from app-config.yaml

Error: Configuration does not match schema

  Config must NOT have additional properties { additionalProperty=rbac } at /permission
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
