### PR TITLE
Version Packages (multi-source-security-viewer)

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/slimy-pillows-vanish.md
+++ b/workspaces/multi-source-security-viewer/.changeset/slimy-pillows-vanish.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-multi-source-security-viewer-common': minor
-'@backstage-community/plugin-multi-source-security-viewer': minor
----
-
-Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/CHANGELOG.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-multi-source-security-viewer-common
 
+## 0.4.0
+
+### Minor Changes
+
+- 237d0ce: Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/package.json
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-multi-source-security-viewer-common",
   "description": "Common functionalities for the multi-source-security-viewer plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-multi-source-security-viewer
 
+## 0.6.0
+
+### Minor Changes
+
+- 237d0ce: Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.
+
+### Patch Changes
+
+- Updated dependencies [237d0ce]
+  - @backstage-community/plugin-multi-source-security-viewer-common@0.4.0
+
 ## 0.5.5
 
 ### Patch Changes

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-multi-source-security-viewer",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-multi-source-security-viewer@0.6.0

### Minor Changes

-   237d0ce: Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.

### Patch Changes

-   Updated dependencies [237d0ce]
    -   @backstage-community/plugin-multi-source-security-viewer-common@0.4.0

## @backstage-community/plugin-multi-source-security-viewer-common@0.4.0

### Minor Changes

-   237d0ce: Add isMultiCIAvaibleAndEnabled to display the plugin when the CI provider is defined and set as enabled in the annotation.
