### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/tough-weeks-attend.md
+++ b/workspaces/announcements/.changeset/tough-weeks-attend.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-announcements-react': patch
-'@backstage-community/plugin-announcements': patch
----
-
-Fixes an issue where an empty list of userOwnershipRefs causes excessive api calls to the catalog when creating a new announcement.

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.9.1
+
+### Patch Changes
+
+- 7ad0cd0: Fixes an issue where an empty list of userOwnershipRefs causes excessive api calls to the catalog when creating a new announcement.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements
 
+## 0.10.2
+
+### Patch Changes
+
+- 7ad0cd0: Fixes an issue where an empty list of userOwnershipRefs causes excessive api calls to the catalog when creating a new announcement.
+- Updated dependencies [7ad0cd0]
+  - @backstage-community/plugin-announcements-react@0.9.1
+
 ## 0.10.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.10.2

### Patch Changes

-   7ad0cd0: Fixes an issue where an empty list of userOwnershipRefs causes excessive api calls to the catalog when creating a new announcement.
-   Updated dependencies [7ad0cd0]
    -   @backstage-community/plugin-announcements-react@0.9.1

## @backstage-community/plugin-announcements-react@0.9.1

### Patch Changes

-   7ad0cd0: Fixes an issue where an empty list of userOwnershipRefs causes excessive api calls to the catalog when creating a new announcement.
