### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/hot-lobsters-clean.md
+++ b/workspaces/rbac/.changeset/hot-lobsters-clean.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Added missing configSchema into package.json

--- a/workspaces/rbac/.changeset/renovate-d0025d1.md
+++ b/workspaces/rbac/.changeset/renovate-d0025d1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@mui/icons-material` to `5.18.0`.
-Updated dependency `@mui/material` to `5.18.0`.
-Updated dependency `@mui/styles` to `5.18.0`.
-Updated dependency `@mui/lab` to `5.0.0-alpha.177`.

--- a/workspaces/rbac/.changeset/renovate-d1192b1.md
+++ b/workspaces/rbac/.changeset/renovate-d1192b1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.13`.

--- a/workspaces/rbac/.changeset/version-bump-1-41-1.md
+++ b/workspaces/rbac/.changeset/version-bump-1-41-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': minor
-'@backstage-community/plugin-rbac-common': minor
-'@backstage-community/plugin-rbac-node': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Dependencies
 
+## 7.2.0
+
+### Minor Changes
+
+- 2f4d9ff: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- e843699: Added missing configSchema into package.json
+- Updated dependencies [2f4d9ff]
+  - @backstage-community/plugin-rbac-common@1.19.0
+  - @backstage-community/plugin-rbac-node@1.13.0
+
 ## 7.1.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.19.0
+
+### Minor Changes
+
+- 2f4d9ff: Backstage version bump to v1.41.1
+
 ## 1.18.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.13.0
+
+### Minor Changes
+
+- 2f4d9ff: Backstage version bump to v1.41.1
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,21 @@
 ### Dependencies
 
+## 1.43.0
+
+### Minor Changes
+
+- 2f4d9ff: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- 34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
+  Updated dependency `@mui/material` to `5.18.0`.
+  Updated dependency `@mui/styles` to `5.18.0`.
+  Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
+- 4b2569f: Updated dependency `start-server-and-test` to `2.0.13`.
+- Updated dependencies [2f4d9ff]
+  - @backstage-community/plugin-rbac-common@1.19.0
+
 ## 1.42.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.42.2",
+  "version": "1.43.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.43.0

### Minor Changes

-   2f4d9ff: Backstage version bump to v1.41.1

### Patch Changes

-   34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
    Updated dependency `@mui/material` to `5.18.0`.
    Updated dependency `@mui/styles` to `5.18.0`.
    Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
-   4b2569f: Updated dependency `start-server-and-test` to `2.0.13`.
-   Updated dependencies [2f4d9ff]
    -   @backstage-community/plugin-rbac-common@1.19.0

## @backstage-community/plugin-rbac-backend@7.2.0

### Minor Changes

-   2f4d9ff: Backstage version bump to v1.41.1

### Patch Changes

-   e843699: Added missing configSchema into package.json
-   Updated dependencies [2f4d9ff]
    -   @backstage-community/plugin-rbac-common@1.19.0
    -   @backstage-community/plugin-rbac-node@1.13.0

## @backstage-community/plugin-rbac-common@1.19.0

### Minor Changes

-   2f4d9ff: Backstage version bump to v1.41.1

## @backstage-community/plugin-rbac-node@1.13.0

### Minor Changes

-   2f4d9ff: Backstage version bump to v1.41.1
