### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/renovate-d0025d1.md
+++ b/workspaces/topology/.changeset/renovate-d0025d1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Updated dependency `@mui/icons-material` to `5.18.0`.
-Updated dependency `@mui/material` to `5.18.0`.
-Updated dependency `@mui/styles` to `5.18.0`.
-Updated dependency `@mui/lab` to `5.0.0-alpha.177`.

--- a/workspaces/topology/.changeset/two-bees-fetch.md
+++ b/workspaces/topology/.changeset/two-bees-fetch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-remove product theme from dev dependencies and dev app

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 2.4.1
+
+### Patch Changes
+
+- 34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
+  Updated dependency `@mui/material` to `5.18.0`.
+  Updated dependency `@mui/styles` to `5.18.0`.
+  Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
+- f25b944: remove product theme from dev dependencies and dev app
+
 ## 2.4.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.4.1

### Patch Changes

-   34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
    Updated dependency `@mui/material` to `5.18.0`.
    Updated dependency `@mui/styles` to `5.18.0`.
    Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
-   f25b944: remove product theme from dev dependencies and dev app
