### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/renovate-1ccac76.md
+++ b/workspaces/tekton/.changeset/renovate-1ccac76.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.6.4`.

--- a/workspaces/tekton/.changeset/renovate-d0025d1.md
+++ b/workspaces/tekton/.changeset/renovate-d0025d1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@mui/icons-material` to `5.18.0`.
-Updated dependency `@mui/material` to `5.18.0`.
-Updated dependency `@mui/styles` to `5.18.0`.
-Updated dependency `@mui/lab` to `5.0.0-alpha.177`.

--- a/workspaces/tekton/.changeset/renovate-d1192b1.md
+++ b/workspaces/tekton/.changeset/renovate-d1192b1.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `start-server-and-test` to `2.0.13`.

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 3.27.3
+
+### Patch Changes
+
+- 6877ddc: Updated dependency `@testing-library/jest-dom` to `6.6.4`.
+- 34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
+  Updated dependency `@mui/material` to `5.18.0`.
+  Updated dependency `@mui/styles` to `5.18.0`.
+  Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
+- 4b2569f: Updated dependency `start-server-and-test` to `2.0.13`.
+
 ## 3.27.2
 
 ### Patch Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.27.2",
+  "version": "3.27.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.27.3

### Patch Changes

-   6877ddc: Updated dependency `@testing-library/jest-dom` to `6.6.4`.
-   34aa972: Updated dependency `@mui/icons-material` to `5.18.0`.
    Updated dependency `@mui/material` to `5.18.0`.
    Updated dependency `@mui/styles` to `5.18.0`.
    Updated dependency `@mui/lab` to `5.0.0-alpha.177`.
-   4b2569f: Updated dependency `start-server-and-test` to `2.0.13`.
