### PR TITLE
fix(tech-insights): handle results correctly when 'only with results' is set to No (#4862)

### DIFF
--- a/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsPage/ScorecardsPage.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/components/ScorecardsPage/ScorecardsPage.tsx
@@ -64,7 +64,11 @@ export const ScorecardsPage = (props: { badge?: boolean; dense?: boolean }) => {
       checks,
       result: filterWithResults
         ? result.filter(response => response.results.length > 0)
-        : result,
+        : result.filter(
+            response =>
+              (response.results?.length ?? 0) === 0 ||
+              response.results.every(r => r.result === false),
+          ),
     };
   }, [api, filterSelectedChecks, filterWithResults]);
 


### PR DESCRIPTION
## Fix: Correct filter behavior for “Only with Results” → No
**Changes**

- Updated filtering logic so that when “Only with Results” is set to No:
- Entities with an empty results array are included.
- Entities where all results.result values are false are also included.

```
result: filterWithResults
        ? result.filter(response => response.results.length > 0)
        : result.filter(
            response =>
              (response.results?.length ?? 0) === 0 ||
              response.results.every(r => r.result === false),
          ),
```

#### Checklist
- [x] Verified logic against sample data.
 - [x] Attached screenshots for UI verification.

<img width="1743" height="958" alt="Screenshot from 2025-08-11 12-55-42" src="https://github.com/user-attachments/assets/7a86189f-cd63-4f84-9508-174a5a71b34b" />
<img width="1743" height="958" alt="Screenshot from 2025-08-11 12-55-36" src="https://github.com/user-attachments/assets/c42636f3-93f4-4ac8-ab4f-71fab56cb6ce" />
