### PR TITLE
topology: remove product theme from dev dependencies

### DIFF
--- a/workspaces/topology/.changeset/two-bees-fetch.md
+++ b/workspaces/topology/.changeset/two-bees-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+remove product theme from dev dependencies and dev app

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -71,7 +71,6 @@
     "@backstage/core-app-api": "^1.18.0",
     "@backstage/dev-utils": "^1.1.12",
     "@backstage/test-utils": "^1.7.10",
-    "@redhat-developer/red-hat-developer-hub-theme": "0.5.1",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",

--- a/workspaces/topology/yarn.lock
+++ b/workspaces/topology/yarn.lock
@@ -2811,7 +2811,6 @@ __metadata:
     "@patternfly/react-styles": "npm:^6.1.0"
     "@patternfly/react-tokens": "npm:^6.1.0"
     "@patternfly/react-topology": "npm:^6.1.0"
-    "@redhat-developer/red-hat-developer-hub-theme": "npm:0.5.1"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
@@ -10305,21 +10304,6 @@ __metadata:
     js-cookie:
       optional: true
   checksum: 10/6a841c648edbc54b11fd90de9bb61c3059255598fc4a714c508c269a03c4ca9bbf32cf017d3bd2b3a1bf7cd1d9bf4bb56028f64ad455f796079632f4a7cd4f00
-  languageName: node
-  linkType: hard
-
-"@redhat-developer/red-hat-developer-hub-theme@npm:0.5.1":
-  version: 0.5.1
-  resolution: "@redhat-developer/red-hat-developer-hub-theme@npm:0.5.1"
-  peerDependencies:
-    "@backstage/theme": ^0.5.2
-    "@emotion/react": ^11.11.1
-    "@emotion/styled": ^11.11.0
-    "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.11.3
-    "@mui/icons-material": ^5.14.19
-    "@mui/material": ^5.14.20
-  checksum: 10/11b5edca383f3b350e7c7474d7005c34477a04c8cafadadb33695b04c66b245fdeb2bfeeef8ce4cbee4c613758e1b37cc9783cf1d3006290dcf7f50cb9b791b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow up on #4795 and 3556 and it does the same as #4804 because the product theme was restored by accident with #4701

This will replace #4885

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
