### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/version-bump-1-41-1.md
+++ b/workspaces/cost-insights/.changeset/version-bump-1-41-1.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': minor
-'@backstage-community/plugin-cost-insights-common': minor
----
-
-Backstage version bump to v1.41.1

--- a/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights-common
 
+## 0.6.0
+
+### Minor Changes
+
+- ae26878: Backstage version bump to v1.41.1
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/cost-insights/plugins/cost-insights-common/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights-common",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Common functionalities for the cost-insights plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.18.0
+
+### Minor Changes
+
+- ae26878: Backstage version bump to v1.41.1
+
+### Patch Changes
+
+- Updated dependencies [ae26878]
+  - @backstage-community/plugin-cost-insights-common@0.6.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.18.0

### Minor Changes

-   ae26878: Backstage version bump to v1.41.1

### Patch Changes

-   Updated dependencies [ae26878]
    -   @backstage-community/plugin-cost-insights-common@0.6.0

## @backstage-community/plugin-cost-insights-common@0.6.0

### Minor Changes

-   ae26878: Backstage version bump to v1.41.1
