### PR TITLE
fix(ocm): fix invalid example resource entity

### DIFF
--- a/workspaces/ocm/examples/entities.yaml
+++ b/workspaces/ocm/examples/entities.yaml
@@ -14,6 +14,7 @@ metadata:
   name: qux
 spec:
   type: kubernetes-cluster
+  owner: guests
 ---
 # https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
 apiVersion: backstage.io/v1alpha1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes:
```
catalog warn Processor BuiltinKindsEntityProcessor threw an error while validating the entity resource:default/qux; caused by TypeError: /spec must have required property 'owner' - missingProperty: owner entity="resource:default/qux" location="file:/Users/dzemanov/Documents/Projects/community-plugins/workspaces/ocm/examples/entities.yaml"
```


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
