### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-ac0acff.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-ac0acff.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@types/node-fetch` to `2.6.13`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-fe21ae7.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-fe21ae7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.82.4`.

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 2.8.2
+
+### Patch Changes
+
+- 14b24f1: Updated dependency `@types/node-fetch` to `2.6.13`.
+- af98d48: Updated dependency `@hey-api/openapi-ts` to `0.82.4`.
+
 ## 2.8.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.8.2

### Patch Changes

-   14b24f1: Updated dependency `@types/node-fetch` to `2.6.13`.
-   af98d48: Updated dependency `@hey-api/openapi-ts` to `0.82.4`.
