### PR TITLE
Fixed erroneous repository.url in some manage plugin packages

### DIFF
--- a/workspaces/manage/.changeset/tricky-planes-sparkle.md
+++ b/workspaces/manage/.changeset/tricky-planes-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-manage-module-tech-insights': patch
+'@backstage-community/plugin-manage-react': patch
+'@backstage-community/plugin-manage': patch
+---
+
+Fixed erroneous repository.url in package.json

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -22,7 +22,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",
-    "directory": "plugins/manage-module-tech-insights"
+    "directory": "workspaces/manage/plugins/manage-module-tech-insights"
   },
   "keywords": [
     "backstage",

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/backstage/backstage",
+    "url": "https://github.com/backstage/community-plugins",
     "directory": "plugins/manage-module-tech-insights"
   },
   "keywords": [

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/backstage/backstage",
+    "url": "https://github.com/backstage/community-plugins",
     "directory": "plugins/manage-react"
   },
   "keywords": [

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -25,7 +25,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",
-    "directory": "plugins/manage-react"
+    "directory": "workspaces/manage/plugins/manage-react"
   },
   "keywords": [
     "backstage",

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -25,7 +25,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",
-    "directory": "plugins/manage"
+    "directory": "workspaces/manage/plugins/manage"
   },
   "keywords": [
     "backstage",

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://backstage.io",
   "repository": {
     "type": "git",
-    "url": "https://github.com/backstage/backstage",
+    "url": "https://github.com/backstage/community-plugins",
     "directory": "plugins/manage"
   },
   "keywords": [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixed erroneous `repository.url` which were pointing to `backstage/backstage` instead of `backstage/community-plugins`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
