### PR TITLE
feat(analytics): add support for version tracking in segment analytics

### DIFF
--- a/workspaces/analytics/.changeset/rare-kids-heal.md
+++ b/workspaces/analytics/.changeset/rare-kids-heal.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-analytics-provider-segment': minor
+---
+
+- Added support for App version and Backstage version tracking in analytics events
+- New configuration options: `appVersion` and `backstageVersion` for enhanced analytics segmentation

--- a/workspaces/analytics/plugins/analytics-provider-segment/README.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/README.md
@@ -58,6 +58,26 @@ app:
       # highlight-end
 ```
 
+### Version Tracking
+
+To include version information in your analytics events (helpful for version-based filtering in dashboards), you can configure:
+
+```yaml title="app-config.yaml"
+app:
+  analytics:
+    segment:
+      writeKey: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      appVersion: '1.2.3' # Your Backstage app version
+      backstageVersion: '1.17.0' # Backstage framework version
+```
+
+When configured, these version fields will be included in all analytics events sent to Segment, allowing you to:
+
+- Filter analytics dashboards by app version
+- Track feature adoption across different versions
+- Monitor user behavior changes between versions
+- Create version-specific analytics reports
+
 ## Debugging and Testing
 
 In pre-production environments, you may wish to set additional configurations

--- a/workspaces/analytics/plugins/analytics-provider-segment/app-config.backstage-community.yaml
+++ b/workspaces/analytics/plugins/analytics-provider-segment/app-config.backstage-community.yaml
@@ -4,3 +4,5 @@ app:
       writeKey: ${SEGMENT_WRITE_KEY}
       maskIP: true # prevents IP addresses from being sent if true
       testMode: false # prevents data from being sent if true
+      appVersion: '1.2.3' # Your Backstage app version
+      backstageVersion: '1.17.0' # Backstage framework version

--- a/workspaces/analytics/plugins/analytics-provider-segment/config.d.ts
+++ b/workspaces/analytics/plugins/analytics-provider-segment/config.d.ts
@@ -40,6 +40,20 @@ export interface Config {
              * @visibility frontend
              */
             maskIP?: boolean;
+
+            /**
+             * The version of the Backstage application. This will be included in all
+             * analytics events to help with version-based filtering of analytics dashboards.
+             * @visibility frontend
+             */
+            appVersion?: string;
+
+            /**
+             * The version of Backstage framework being used. This will be included in all
+             * analytics events to help with framework version tracking.
+             * @visibility frontend
+             */
+            backstageVersion?: string;
           }
         | {
             /**
@@ -60,6 +74,20 @@ export interface Config {
              * @visibility frontend
              */
             maskIP?: boolean;
+
+            /**
+             * The version of the Backstage application. This will be included in all
+             * analytics events to help with version-based filtering of analytics dashboards.
+             * @visibility frontend
+             */
+            appVersion?: string;
+
+            /**
+             * The version of Backstage framework being used. This will be included in all
+             * analytics events to help with framework version tracking.
+             * @visibility frontend
+             */
+            backstageVersion?: string;
           };
     };
   };

--- a/workspaces/analytics/plugins/analytics-provider-segment/src/apis/implementations/AnalyticsApi/Segment.test.ts
+++ b/workspaces/analytics/plugins/analytics-provider-segment/src/apis/implementations/AnalyticsApi/Segment.test.ts
@@ -181,6 +181,64 @@ describe('SegmentAnalytics', () => {
     });
   });
 
+  describe('version tracking', () => {
+    const configWithVersions = new ConfigReader({
+      app: {
+        analytics: {
+          segment: {
+            writeKey,
+            testMode: false,
+            maskIP: false,
+            appVersion: '1.2.3',
+            backstageVersion: '1.17.0',
+          },
+        },
+      },
+    });
+
+    it('includes versions in events when configured', async () => {
+      const api = SegmentAnalytics.fromConfig(configWithVersions);
+      await api.captureEvent({
+        action: 'click',
+        subject: 'button',
+        context,
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        'click',
+        {
+          subject: 'button',
+          context: {
+            ...context,
+            appVersion: '1.2.3',
+            backstageVersion: '1.17.0',
+          },
+          attributes: undefined,
+        },
+        {},
+      );
+    });
+
+    it('does not include version properties when not configured', async () => {
+      const api = SegmentAnalytics.fromConfig(basicValidConfig);
+      await api.captureEvent({
+        action: 'click',
+        subject: 'button',
+        context,
+      });
+
+      expect(mockTrack).toHaveBeenCalledWith(
+        'click',
+        {
+          subject: 'button',
+          context: context,
+          attributes: undefined,
+        },
+        {},
+      );
+    });
+  });
+
   describe('identityApi', () => {
     const identityApi = {
       getBackstageIdentity: jest.fn().mockResolvedValue({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### What's Changed

Added App version and Backstage version tracking to the Segment analytics provider plugin.

### New Features

- **App Version Tracking**: New `appVersion` config option
- **Backstage Version Tracking**: New `backstageVersion` config option  
- **Enhanced Analytics**: Version info included in all events for better segmentation

### Configuration

```yaml
app:
  analytics:
    segment:
      writeKey: ${SEGMENT_WRITE_KEY}
      appVersion: '1.7.0'           # Your app version
      backstageVersion: '1.39.1'    # Backstage framework version
```

### Benefits

- Filter analytics by app version
- Track feature adoption across versions
- Monitor user behavior changes between versions

### Backward Compatibility

✅ Fully backward compatible - existing configs work without changes. Version fields are optional.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
