### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/renovate-1ea9854.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-1ea9854.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.8.0`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-f25e1db.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-f25e1db.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.7.0`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-fe21ae7.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-fe21ae7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.82.4`.

--- a/workspaces/nexus-repository-manager/.changeset/yellow-dryers-eat.md
+++ b/workspaces/nexus-repository-manager/.changeset/yellow-dryers-eat.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Backstage version bump to v1.42.5

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.16.0
+
+### Minor Changes
+
+- 0701a10: Backstage version bump to v1.42.5
+
+### Patch Changes
+
+- 4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
+- 4523634: Updated dependency `@testing-library/jest-dom` to `6.7.0`.
+- af98d48: Updated dependency `@hey-api/openapi-ts` to `0.82.4`.
+
 ## 1.15.1
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.16.0

### Minor Changes

-   0701a10: Backstage version bump to v1.42.5

### Patch Changes

-   4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
-   4523634: Updated dependency `@testing-library/jest-dom` to `6.7.0`.
-   af98d48: Updated dependency `@hey-api/openapi-ts` to `0.82.4`.
