### PR TITLE
Remove extraneous semi-colon from <Route />

### DIFF
--- a/workspaces/copilot/.changeset/sweet-maps-talk.md
+++ b/workspaces/copilot/.changeset/sweet-maps-talk.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+Update README.md with better installation instructions to prevent silly copy/paste errors that are exposed by the new frontend system

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -42,7 +42,12 @@ To start using the GitHub Copilot Plugin, follow these steps:
    import { CopilotIndexPage } from '@backstage-community/plugin-copilot';
 
    // Add the routes
-   <Route path="/copilot" element={<CopilotIndexPage />} />
+   const routes = (
+     <FlatRoutes>
+       // ...
+       <Route path="/copilot" element={<CopilotIndexPage />} />
+     </FlatRoutes>
+   );
    ```
 
    **Root.tsx**:

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -54,8 +54,20 @@ To start using the GitHub Copilot Plugin, follow these steps:
 
    ```tsx
    import { CopilotSidebar } from '@backstage-community/plugin-copilot';
-   // Add the copilot sidebar
-   <SidebarScrollWrapper>
-     <CopilotSidebar />
-   </SidebarScrollWrapper>;
+
+   // Add the CopilotSidebar component somewhere inside your SidebarPage
+   export const Root = ({ children }: PropsWithChildren<{}>) => (
+     <SidebarPage>
+       <Sidebar>
+         {/* ... */}
+         <SidebarGroup label="Menu" icon={<MenuIcon />}>
+            {/* ... */}
+           <SidebarScrollWrapper>
+            <CopilotSidebar />
+           </SidebarScrollWrapper>
+            {/* ... */}
+        </SidebarGroup>
+        {/* ... */}
+     </SidebarPage>
+   );
    ```

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -42,7 +42,7 @@ To start using the GitHub Copilot Plugin, follow these steps:
    import { CopilotIndexPage } from '@backstage-community/plugin-copilot';
 
    // Add the routes
-   <Route path="/copilot" element={<CopilotIndexPage />} />;
+   <Route path="/copilot" element={<CopilotIndexPage />} />
    ```
 
    **Root.tsx**:


### PR DESCRIPTION

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
When the semi-colon shown with this tag is included when nested inside another react tag (i.e. `<FlatRoutes>...</FlatRoutes>`) it creates a text node containing `;` which is not allowed when using the new frontend system.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
