### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/all-webs-design.md
+++ b/workspaces/tekton/.changeset/all-webs-design.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-use `usek8sobjects` hook from k8s-react package

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 3.27.5
+
+### Patch Changes
+
+- 56b4264: use `usek8sobjects` hook from k8s-react package
+
 ## 3.27.4
 
 ### Patch Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.27.4",
+  "version": "3.27.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.27.5

### Patch Changes

-   56b4264: use `usek8sobjects` hook from k8s-react package
