### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/popular-cougars-develop.md
+++ b/workspaces/topology/.changeset/popular-cougars-develop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-use `usek8sobjects` hook from k8s-react package

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.4.2
+
+### Patch Changes
+
+- 56b4264: use `usek8sobjects` hook from k8s-react package
+
 ## 2.4.1
 
 ### Patch Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.4.2

### Patch Changes

-   56b4264: use `usek8sobjects` hook from k8s-react package
