### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/famous-shoes-clap.md
+++ b/workspaces/npm/.changeset/famous-shoes-clap.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-npm-backend': patch
-'@backstage-community/plugin-npm-common': patch
-'@backstage-community/plugin-npm': patch
----
-
-Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies

--- a/workspaces/npm/.changeset/spotty-pillows-call.md
+++ b/workspaces/npm/.changeset/spotty-pillows-call.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': patch
----
-
-Export `npmTranslationRef` and `npmTranslations` also in the stable/'old' frontend system build.

--- a/workspaces/npm/plugins/npm-backend/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-npm-backend
 
+## 1.10.1
+
+### Patch Changes
+
+- bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
+- Updated dependencies [bff3611]
+  - @backstage-community/plugin-npm-common@1.10.1
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-backend/package.json
+++ b/workspaces/npm/plugins/npm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-npm-backend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm-common/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm-common
 
+## 1.10.1
+
+### Patch Changes
+
+- bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-common/package.json
+++ b/workspaces/npm/plugins/npm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm-common",
   "description": "Common functionalities for the npm plugin",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-npm
 
+## 1.10.1
+
+### Patch Changes
+
+- bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
+- 4d64513: Export `npmTranslationRef` and `npmTranslations` also in the stable/'old' frontend system build.
+- Updated dependencies [bff3611]
+  - @backstage-community/plugin-npm-common@1.10.1
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.10.1

### Patch Changes

-   bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
-   4d64513: Export `npmTranslationRef` and `npmTranslations` also in the stable/'old' frontend system build.
-   Updated dependencies [bff3611]
    -   @backstage-community/plugin-npm-common@1.10.1

## @backstage-community/plugin-npm-backend@1.10.1

### Patch Changes

-   bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
-   Updated dependencies [bff3611]
    -   @backstage-community/plugin-npm-common@1.10.1

## @backstage-community/plugin-npm-common@1.10.1

### Patch Changes

-   bff3611: Remove unused @backstage/catalog-client dependency from the backend and other test devDependencies
