### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/tasty-cooks-do.md
+++ b/workspaces/rollbar/.changeset/tasty-cooks-do.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rollbar-backend': minor
----
-
-**BREAKING** Removes `rollbar-backend` legacy backend support. The plugin now uses the [new Backstage backend system](https://backstage.io/docs/plugins/new-backend-system/).

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.6.0
+
+### Minor Changes
+
+- 56382c8: **BREAKING** Removes `rollbar-backend` legacy backend support. The plugin now uses the [new Backstage backend system](https://backstage.io/docs/plugins/new-backend-system/).
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar-backend@0.6.0

### Minor Changes

-   56382c8: **BREAKING** Removes `rollbar-backend` legacy backend support. The plugin now uses the [new Backstage backend system](https://backstage.io/docs/plugins/new-backend-system/).
