### PR TITLE
Version Packages (github-pull-requests-board)

### DIFF
--- a/workspaces/github-pull-requests-board/.changeset/fresh-games-crash.md
+++ b/workspaces/github-pull-requests-board/.changeset/fresh-games-crash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': patch
----
-
-Decouple entities from the board logic for reuse the board on other places

--- a/workspaces/github-pull-requests-board/.changeset/version-bump-1-42-3.md
+++ b/workspaces/github-pull-requests-board/.changeset/version-bump-1-42-3.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': minor
----
-
-Backstage version bump to v1.42.3

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-github-pull-requests-board
 
+## 0.9.0
+
+### Minor Changes
+
+- 2cea0d0: Backstage version bump to v1.42.3
+
+### Patch Changes
+
+- c2b33a1: Decouple entities from the board logic for reuse the board on other places
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-pull-requests-board",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-pull-requests-board@0.9.0

### Minor Changes

-   2cea0d0: Backstage version bump to v1.42.3

### Patch Changes

-   c2b33a1: Decouple entities from the board logic for reuse the board on other places
