### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/version-bump-1-42-3.md
+++ b/workspaces/linguist/.changeset/version-bump-1-42-3.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': minor
-'@backstage-community/plugin-linguist': minor
-'@backstage-community/plugin-linguist-backend': minor
-'@backstage-community/plugin-linguist-common': minor
----
-
-Backstage version bump to v1.42.3

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.12.0
+
+### Minor Changes
+
+- ca3c813: Backstage version bump to v1.42.3
+
+### Patch Changes
+
+- Updated dependencies [ca3c813]
+  - @backstage-community/plugin-linguist-common@0.11.0
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.18.0
+
+### Minor Changes
+
+- ca3c813: Backstage version bump to v1.42.3
+
+### Patch Changes
+
+- Updated dependencies [ca3c813]
+  - @backstage-community/plugin-linguist-common@0.11.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",

--- a/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-common
 
+## 0.11.0
+
+### Minor Changes
+
+- ca3c813: Backstage version bump to v1.42.3
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-common/package.json
+++ b/workspaces/linguist/plugins/linguist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-common",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Common functionalities for the linguist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-linguist
 
+## 0.11.0
+
+### Minor Changes
+
+- ca3c813: Backstage version bump to v1.42.3
+
+### Patch Changes
+
+- Updated dependencies [ca3c813]
+  - @backstage-community/plugin-linguist-common@0.11.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.12.0

### Minor Changes

-   ca3c813: Backstage version bump to v1.42.3

### Patch Changes

-   Updated dependencies [ca3c813]
    -   @backstage-community/plugin-linguist-common@0.11.0

## @backstage-community/plugin-linguist@0.11.0

### Minor Changes

-   ca3c813: Backstage version bump to v1.42.3

### Patch Changes

-   Updated dependencies [ca3c813]
    -   @backstage-community/plugin-linguist-common@0.11.0

## @backstage-community/plugin-linguist-backend@0.18.0

### Minor Changes

-   ca3c813: Backstage version bump to v1.42.3

### Patch Changes

-   Updated dependencies [ca3c813]
    -   @backstage-community/plugin-linguist-common@0.11.0

## @backstage-community/plugin-linguist-common@0.11.0

### Minor Changes

-   ca3c813: Backstage version bump to v1.42.3
