### PR TITLE
Repo Actions - Skip version bump when release version matches workspace version

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -78,6 +78,13 @@ jobs:
       - name: 'Set release name'
         id: set_release_name
         run: node scripts/ci/set-release-name.js ${{ matrix.workspace }} ${{ inputs.release_line || 'main' }}
+      - name: 'Check current and release versions'
+        id: check
+        run: |
+          if [[ "${{ steps.set_release_name.outputs.release_version }}" == "${{ steps.set_release_name.outputs.current_version }}" ]]; then
+            echo "Backstage release version and current workspace version are the same, skipping version bump"
+            exit 1 # Non-zero exit code fails the step and job
+          fi
       - name: 'Configure git'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -97,7 +104,7 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: Run dedupe
         working-directory: ./workspaces/${{ matrix.workspace }}
-        run: yarn dedupe   
+        run: yarn dedupe
       - name: 'Check for changes'
         id: check_for_changes
         run: |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Skip version bump when release version matches workspace version, this avoids extra PR's being created in cases where the workspace has already been updated to the latest version.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
