### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/sharp-ducks-applaud.md
+++ b/workspaces/cost-insights/.changeset/sharp-ducks-applaud.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': minor
----
-
-**ALPHA BREAKING** The New Frontend System `CostInsightsProjectGrowthInstructionsPage` and `CostInsightsLabelDataflowInstructionsPage` have been removed and the new frontend system support refactored to work in the same way as the current implementation.

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.19.0
+
+### Minor Changes
+
+- ceeadd1: **ALPHA BREAKING** The New Frontend System `CostInsightsProjectGrowthInstructionsPage` and `CostInsightsLabelDataflowInstructionsPage` have been removed and the new frontend system support refactored to work in the same way as the current implementation.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.19.0

### Minor Changes

-   ceeadd1: **ALPHA BREAKING** The New Frontend System `CostInsightsProjectGrowthInstructionsPage` and `CostInsightsLabelDataflowInstructionsPage` have been removed and the new frontend system support refactored to work in the same way as the current implementation.
