### PR TITLE
chore(analytics): update codeowners for the workspace and segment provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,10 +17,10 @@ yarn.lock                                                               @backsta
 /workspaces/airbrake                                                    @backstage/community-plugins-maintainers
 /workspaces/allure                                                      @backstage/community-plugins-maintainers
 /workspaces/amplication                                                 @backstage/community-plugins-maintainers  @itainathaniel
-/workspaces/analytics                                                   @backstage/community-plugins-maintainers
+/workspaces/analytics                                                   @backstage/community-plugins-maintainers  @deshmukhmayur @yashoswalyo @riginoommen @jmezach @AndrienkoAleksandr @PatAKnight @dzemanov @christoph-jerolimov @karthikjeeyar @rohitkrai03
 /workspaces/analytics/plugins/analytics-module-matomo                   @backstage/community-plugins-maintainers  @deshmukhmayur @yashoswalyo @riginoommen
 /workspaces/analytics/plugins/analytics-module-newrelic-browser         @backstage/community-plugins-maintainers  @jmezach
-/workspaces/analytics/plugins/analytics-provider-segment                @backstage/community-plugins-maintainers  @AndrienkoAleksandr @PatAKnight @dzemanov
+/workspaces/analytics/plugins/analytics-provider-segment                @backstage/community-plugins-maintainers  @AndrienkoAleksandr @PatAKnight @dzemanov @christoph-jerolimov @karthikjeeyar @rohitkrai03
 /workspaces/announcements                                               @backstage/community-plugins-maintainers  @kurtaking @gaelgoth
 /workspaces/apache-airflow                                              @backstage/community-plugins-maintainers
 /workspaces/apollo-explorer                                             @backstage/community-plugins-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. This PR adds 3 new codeowners for the **Segment Analytics plugin** from our team that have recently worked on that plugin (@rohitkrai03 @karthikjeeyar and myself)
2. As discussed in today Backstage Community Plugins SIG call I've added **also _all_ owners from the plugins in that workspace also to the workspace**
   * this is now a long list, let see how this works
   * we decided to keep the per plugins list to understand why these people are there and which analytics plugin these people are responsible for

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
