### PR TITLE
Allow creating new announcement category for edit

### DIFF
--- a/workspaces/announcements/.changeset/violet-chairs-talk.md
+++ b/workspaces/announcements/.changeset/violet-chairs-talk.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements-react': patch
+'@backstage-community/plugin-announcements': patch
+---
+
+Allow creating new announcement category for edit

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -250,6 +250,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'createAnnouncementPage.alertMessageWithNewCategory': 'with new category';
     readonly 'editAnnouncementPage.edit': 'Edit';
     readonly 'editAnnouncementPage.updatedMessage': 'Announcement updated.';
+    readonly 'editAnnouncementPage.updatedMessageWithNewCategory': 'with new category';
     readonly 'editAnnouncementPage.notFoundMessage': 'Unable to find announcement';
     readonly 'newAnnouncementBanner.markAsSeen': 'Mark as seen';
     readonly 'newCategoryDialog.title': 'Title';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -139,6 +139,7 @@ export const announcementsTranslationRef = createTranslationRef({
     },
     editAnnouncementPage: {
       updatedMessage: 'Announcement updated.',
+      updatedMessageWithNewCategory: 'with new category',
       notFoundMessage: 'Unable to find announcement',
       edit: 'Edit',
     },

--- a/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
@@ -15,6 +15,7 @@
  */
 import { ReactNode } from 'react';
 import useAsync from 'react-use/esm/useAsync';
+import slugify from 'slugify';
 import { Page, Header, Content, Progress } from '@backstage/core-components';
 import {
   alertApiRef,
@@ -27,6 +28,7 @@ import {
   announcementsApiRef,
   CreateAnnouncementRequest,
   useAnnouncementsTranslation,
+  useCategories,
 } from '@backstage-community/plugin-announcements-react';
 import { Alert } from '@material-ui/lab';
 
@@ -43,18 +45,38 @@ export const EditAnnouncementPage = (props: EditAnnouncementPageProps) => {
   const { value, loading, error } = useAsync(async () =>
     announcementsApi.announcementByID(id),
   );
+  const { categories } = useCategories();
   const { t } = useAnnouncementsTranslation();
 
   let title = props.title;
   let content: ReactNode = <Progress />;
 
   const onSubmit = async (request: CreateAnnouncementRequest) => {
+    const { category } = request;
+
+    const slugs = categories.map(c => c.slug);
+    let updateMsg = t('editAnnouncementPage.updatedMessage') as string;
+
     try {
-      await announcementsApi.updateAnnouncement(id, request);
-      alertApi.post({
-        message: t('editAnnouncementPage.updatedMessage'),
-        severity: 'success',
-      });
+      if (category) {
+        const categorySlug = slugify(category, {
+          lower: true,
+        });
+
+        if (slugs.indexOf(categorySlug) === -1) {
+          updateMsg = updateMsg.replace('.', '');
+          updateMsg = `${updateMsg} ${t(
+            'editAnnouncementPage.updatedMessageWithNewCategory',
+          )} ${category}.`;
+
+          await announcementsApi.createCategory({
+            title: category,
+          });
+        }
+
+        await announcementsApi.updateAnnouncement(id, request);
+        alertApi.post({ message: updateMsg, severity: 'success' });
+      }
     } catch (err) {
       alertApi.post({ message: (err as Error).message, severity: 'error' });
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR supports adding a new announcement category during editing, which is currently broken. The approach in the PR matches the same [approach used during creation](https://github.com/backstage/community-plugins/blob/e121abbd11d87d77c21238f013a67d408d240930/workspaces/announcements/plugins/announcements/src/components/CreateAnnouncementPage/CreateAnnouncementPage.tsx#L55-L69).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
