### PR TITLE
feat(bookmarks): allow different links for view and new tab

### DIFF
--- a/workspaces/bookmarks/.changeset/quiet-coins-grow.md
+++ b/workspaces/bookmarks/.changeset/quiet-coins-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-bookmarks': minor
+---
+
+Allow links to be added to bookmarks that have different embed and "Open in new tab" URLs

--- a/workspaces/bookmarks/app-config.yaml
+++ b/workspaces/bookmarks/app-config.yaml
@@ -1,3 +1,9 @@
+bookmarks:
+  customProtocols:
+    gdoc:
+      iframeBaseUrl: https://docs.google.com/document/d/%s/mobilebasic
+      linkBaseUrl: https://docs.google.com/document/d/%s/edit
+
 app:
   title: Scaffolded Backstage App
   baseUrl: http://localhost:3000

--- a/workspaces/bookmarks/plugins/bookmarks/README.md
+++ b/workspaces/bookmarks/plugins/bookmarks/README.md
@@ -47,6 +47,31 @@ metadata:
 
 4. Done! Enjoy your bookmarks by visiting the updated entity page in Backstage through your company catalog.
 
+## Configuration
+
+You can configure custom protocols for bookmarks in your `app-config.yaml` file. This allows you to define how certain types of links should be handled, including their iframe and link URLs.
+
+The `%s` placeholder in the URLs will be replaced with the content of the URL after the protocol. For example, if you have a bookmark with the URL `gdoc:12345?usp=sharing#!SECTION`, the `%s` will be replaced with `12345?usp=sharing#!SECTION`.
+
+For example, to add support for Google Docs, you can add the following configuration:
+
+```yaml
+bookmarks:
+  customProtocols:
+    gdoc:
+      iframeBaseUrl: https://docs.google.com/document/d/%s/mobilebasic
+      linkBaseUrl: https://docs.google.com/document/d/%s/edit
+```
+
+Once this configuration is added, you can create bookmarks using the `gdoc:` protocol, and they will be displayed correctly in the Bookmarks plugin:
+
+```yaml
+# omitted...
+metadata:
+  bookmarks:
+    'My life story': gdoc:1qaLicIa3FZKyup4JXo9ivNgWDmkbX6-XBaQNfKeKjpw
+```
+
 ## Usage
 
 Once installed, you can view bookmarks by navigating to the "Bookmarks" tab in the entity page of your Backstage application.

--- a/workspaces/bookmarks/plugins/bookmarks/config.d.ts
+++ b/workspaces/bookmarks/plugins/bookmarks/config.d.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CustomProtocolConfig } from './src/hooks/useCustomProtocol';
+
+export interface Config {
+  /**
+   * Configuration for the Bookmarks plugin
+   *
+   * @visibility frontend
+   */
+  bookmarks?: {
+    /**
+     * Configuration for custom protocols, which can be used to embed
+     * or link to URLs with non-standard protocols.
+     *
+     * @deepVisibility frontend
+     */
+    customProtocols?: CustomProtocolConfig;
+  };
+}

--- a/workspaces/bookmarks/plugins/bookmarks/dev/PluginTestPage/PluginTestPage.tsx
+++ b/workspaces/bookmarks/plugins/bookmarks/dev/PluginTestPage/PluginTestPage.tsx
@@ -22,8 +22,7 @@ import { EntityBookmarksContent } from '../../src/components/EntityBookmarksCont
 import { Entity } from '@backstage/catalog-model';
 
 const testData: UrlTree = {
-  'Life story':
-    'https://docs.google.com/document/d/1qaLicIa3FZKyup4JXo9ivNgWDmkbX6-XBaQNfKeKjpw/mobilebasic',
+  'Life story': 'gdoc:1qaLicIa3FZKyup4JXo9ivNgWDmkbX6-XBaQNfKeKjpw', // gdoc defined in app-config.yaml
   'My cool gadgets and gizmos': {
     'fortune cowsay lolcat': 'https://logonoff.co/projects/fcl/index.html',
     'XP tour': 'https://logonoff.co/projects/windowsxptour/index.html',

--- a/workspaces/bookmarks/plugins/bookmarks/package.json
+++ b/workspaces/bookmarks/plugins/bookmarks/package.json
@@ -55,8 +55,10 @@
     "react-router-dom": "~6.27.0"
   },
   "files": [
+    "config.d.ts",
     "dist"
   ],
+  "configSchema": "config.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",

--- a/workspaces/bookmarks/plugins/bookmarks/src/components/BookmarksViewer/BookmarksViewer.tsx
+++ b/workspaces/bookmarks/plugins/bookmarks/src/components/BookmarksViewer/BookmarksViewer.tsx
@@ -27,6 +27,7 @@ import { BookmarkMobileView } from './helpers/BookmarkMobileView';
 import { BookmarkViewerFrame } from './helpers/BookmarkViewerFrame';
 import { NavButton } from './helpers/NavButton';
 import { TableOfContents } from './helpers/TableOfContents';
+import { useCustomProtocol } from '../../hooks/useCustomProtocol';
 
 /** Props for layout components */
 export type BookmarkViewerLayoutProps = {
@@ -43,6 +44,8 @@ export const BookmarksViewer = memo(({ tree }: { tree: UrlTree }) => {
     flattenedTree[0],
   );
   const { t } = useTranslation();
+
+  const { src, href } = useCustomProtocol(currentNode.value);
 
   const isDesktop = useIsDesktop();
   const View = isDesktop ? BookmarkDesktopView : BookmarkMobileView;
@@ -79,7 +82,7 @@ export const BookmarksViewer = memo(({ tree }: { tree: UrlTree }) => {
     ) : null;
   }, [flattenedTree, setCurrentNode, currentFlattenedIndex]);
 
-  const viewer = <BookmarkViewerFrame src={currentNode.value} />;
+  const viewer = <BookmarkViewerFrame src={src} />;
 
   const toc = (
     <TableOfContents
@@ -91,7 +94,7 @@ export const BookmarksViewer = memo(({ tree }: { tree: UrlTree }) => {
 
   const openInNewTab = (
     <Button
-      href={currentNode.value}
+      href={href}
       target="_blank"
       rel="noopener"
       sx={{ mb: 2 }}

--- a/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.test.tsx
+++ b/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useCustomProtocol } from './useCustomProtocol';
+import { mockApis, TestApiProvider } from '@backstage/test-utils';
+import { configApiRef } from '@backstage/core-plugin-api';
+
+/** Produce an AppConfig wrapper for some given config */
+const getMockAppConfig =
+  (config: object) =>
+  ({ children }: { children: React.ReactNode }) => {
+    const mockConfig = mockApis.config({ data: config });
+    return (
+      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+        {children}
+      </TestApiProvider>
+    );
+  };
+
+describe('useCustomProtocol', () => {
+  it('should export hook', () => {
+    expect(useCustomProtocol).toBeDefined();
+  });
+
+  it('should return original URL if no custom protocols are configured', () => {
+    const { result } = renderHook(
+      () => useCustomProtocol('https://example.com'),
+      {
+        wrapper: getMockAppConfig({}),
+      },
+    );
+    expect(result.current).toEqual({
+      src: 'https://example.com',
+      href: 'https://example.com',
+    });
+  });
+
+  it('should throw an error when the app-config is malformed', () => {
+    const invalidAppConfigs = [
+      { bookmarks: { customProtocols: 'invalid' } },
+      { bookmarks: { customProtocols: { gdoc: 'invalid' } } },
+      { bookmarks: { customProtocols: { gdoc: { iframeBaseUrl: 123 } } } },
+      { bookmarks: { customProtocols: { gdoc: { linkBaseUrl: null } } } },
+    ];
+
+    // suppress console.error for this test to avoid noise
+    for (const config of invalidAppConfigs) {
+      /* eslint-disable no-console */
+      const originalError = console.error;
+      console.error = jest.fn();
+
+      expect(() =>
+        renderHook(() => useCustomProtocol('foo:bar'), {
+          wrapper: getMockAppConfig(config),
+        }),
+      ).toThrow('Invalid bookmarks.customProtocols configuration!');
+
+      expect(console.error).toHaveBeenCalled();
+
+      console.error = originalError;
+      /* eslint-enable no-console */
+    }
+  });
+
+  it('should return transformed URLs for supported protocols', () => {
+    const wrapper = getMockAppConfig({
+      bookmarks: {
+        customProtocols: {
+          gdoc: {
+            iframeBaseUrl: 'https://docs.google.com/document/d/%s/mobilebasic',
+            linkBaseUrl: 'https://docs.google.com/document/d/%s/edit',
+          },
+          foo: {
+            iframeBaseUrl: 'https://foo.example.com/view?doc=%s',
+            linkBaseUrl: 'https://foo.example.com/edit?doc=%s',
+          },
+        },
+      },
+    });
+
+    const { result: result1 } = renderHook(
+      () => useCustomProtocol('gdoc:12345'),
+      {
+        wrapper,
+      },
+    );
+    expect(result1.current).toEqual({
+      src: 'https://docs.google.com/document/d/12345/mobilebasic',
+      href: 'https://docs.google.com/document/d/12345/edit',
+    });
+
+    const { result: result2 } = renderHook(
+      () => useCustomProtocol('foo:abcde'),
+      {
+        wrapper,
+      },
+    );
+    expect(result2.current).toEqual({
+      src: 'https://foo.example.com/view?doc=abcde',
+      href: 'https://foo.example.com/edit?doc=abcde',
+    });
+
+    // not in the config, should return original URL
+    const { result: result3 } = renderHook(
+      () => useCustomProtocol('https://example.com'),
+      {
+        wrapper,
+      },
+    );
+    expect(result3.current).toEqual({
+      src: 'https://example.com',
+      href: 'https://example.com',
+    });
+  });
+});

--- a/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.ts
+++ b/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
+
+export type UseCustomProtocolResult = {
+  /** The URL to be used in an iframe src attribute */
+  src: string;
+  /** The URL to be used in an anchor href attribute */
+  href: string;
+};
+
+/** The schema of `bookmarks.customProtocols` config */
+export type CustomProtocolConfig = {
+  /** The custom protocol to match, e.g. "myapp" for "myapp://some/path" */
+  [protocol: string]: {
+    /**
+     * The base URL to use for iframe src with %s replaced by the encoded original URL,
+     * e.g. "https://myapp-iframe-host.com/iframe?url=%s"
+     */
+    iframeBaseUrl: string;
+    /**
+     * The base URL to use for anchor href with %s replaced by the encoded original URL,
+     * e.g. "https://myapp-web-host.com/open?url=%s"
+     */
+    linkBaseUrl: string;
+  };
+};
+
+/** Validates if the given config matches the CustomProtocolConfig schema */
+const validateCustomProtocolConfig = (
+  config: unknown,
+): config is CustomProtocolConfig => {
+  if (typeof config !== 'object' || config === null) {
+    return false;
+  }
+
+  for (const [protocol, urls] of Object.entries(config)) {
+    if (
+      typeof protocol !== 'string' ||
+      typeof urls !== 'object' ||
+      urls === null
+    ) {
+      return false;
+    }
+    if (
+      typeof urls?.iframeBaseUrl !== 'string' ||
+      typeof urls?.linkBaseUrl !== 'string'
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * A hook that transforms a custom protocol URL to a safe URL for iframe and anchor usage.
+ */
+export const useCustomProtocol = (url: string): UseCustomProtocolResult => {
+  const customProtocols = useApi(
+    configApiRef,
+  ).getOptional<CustomProtocolConfig>('bookmarks.customProtocols');
+
+  if (!customProtocols) {
+    return { src: url, href: url };
+  } else if (!validateCustomProtocolConfig(customProtocols)) {
+    throw new Error('Invalid bookmarks.customProtocols configuration!');
+  }
+
+  const protocol = new URL(url).protocol.replace(':', '');
+  const urlContent = url.slice(protocol.length + 1);
+
+  if (Object.keys(customProtocols).includes(protocol)) {
+    const { iframeBaseUrl, linkBaseUrl } = customProtocols[protocol];
+
+    const encodedUrl = encodeURIComponent(urlContent);
+    return {
+      src: iframeBaseUrl.replace('%s', encodedUrl),
+      href: linkBaseUrl.replace('%s', encodedUrl),
+    };
+  }
+
+  // Fallback to the original URL if no custom protocol is matched
+  return { src: url, href: url };
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

You can configure custom protocols for bookmarks in your `app-config.yaml` file. This allows you to define how certain types of links should be handled, including their iframe and link URLs.

For example, to add support for Google Docs, you can add the following configuration:

```yaml
bookmarks:
  customProtocols:
    gdoc:
      iframeBaseUrl: https://docs.google.com/document/d/%s/mobilebasic
      linkBaseUrl: https://docs.google.com/document/d/%s/edit
```

<img width="1594" height="1011" alt="image" src="https://github.com/user-attachments/assets/9b139525-592e-4c77-aedf-988c79ed6dcd" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
