### PR TITLE
Fix deprecation warnings for createFrontendPlugin function

### DIFF
--- a/workspaces/acr/.changeset/beige-readers-camp.md
+++ b/workspaces/acr/.changeset/beige-readers-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-acr': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/acr/plugins/acr/src/alpha.tsx
+++ b/workspaces/acr/plugins/acr/src/alpha.tsx
@@ -78,6 +78,6 @@ export const acrImagesEntityContent: any = EntityContentBlueprint.make({
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'acr',
+  pluginId: 'acr',
   extensions: [acrApi, acrImagesEntityContent],
 });

--- a/workspaces/cicd-statistics/.changeset/seven-parents-glow.md
+++ b/workspaces/cicd-statistics/.changeset/seven-parents-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cicd-statistics': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/src/alpha.ts
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/src/alpha.ts
@@ -22,7 +22,7 @@ import { rootCatalogCicdStatsRouteRef } from './plugin';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'cicd-statistics',
+  pluginId: 'cicd-statistics',
   routes: convertLegacyRouteRefs({
     entityContent: rootCatalogCicdStatsRouteRef,
   }),

--- a/workspaces/confluence/.changeset/proud-rings-pull.md
+++ b/workspaces/confluence/.changeset/proud-rings-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-confluence': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/confluence/plugins/confluence/src/alpha.ts
+++ b/workspaces/confluence/plugins/confluence/src/alpha.ts
@@ -51,7 +51,7 @@ const confluenceSearchFilterResultType = SearchFilterResultTypeBlueprint.make({
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'confluence',
+  pluginId: 'confluence',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/github-deployments/.changeset/moody-dots-flash.md
+++ b/workspaces/github-deployments/.changeset/moody-dots-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-deployments': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/github-deployments/plugins/github-deployments/src/alpha.ts
+++ b/workspaces/github-deployments/plugins/github-deployments/src/alpha.ts
@@ -25,7 +25,7 @@ import { rootRouteRef } from './routes';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'github-deployments',
+  pluginId: 'github-deployments',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/github-issues/.changeset/fuzzy-horses-exercise.md
+++ b/workspaces/github-issues/.changeset/fuzzy-horses-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-issues': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/github-issues/plugins/github-issues/src/alpha.ts
+++ b/workspaces/github-issues/plugins/github-issues/src/alpha.ts
@@ -26,7 +26,7 @@ import { rootRouteRef } from './routes';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'github-issues',
+  pluginId: 'github-issues',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/github-pull-requests-board/.changeset/short-tomatoes-sleep.md
+++ b/workspaces/github-pull-requests-board/.changeset/short-tomatoes-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-pull-requests-board': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/alpha.ts
+++ b/workspaces/github-pull-requests-board/plugins/github-pull-requests-board/src/alpha.ts
@@ -25,7 +25,7 @@ import { rootRouteRef } from './routes';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'github-pull-requests-board',
+  pluginId: 'github-pull-requests-board',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/grafana/.changeset/fresh-cups-care.md
+++ b/workspaces/grafana/.changeset/fresh-cups-care.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/grafana/plugins/grafana/src/alpha.ts
+++ b/workspaces/grafana/plugins/grafana/src/alpha.ts
@@ -27,7 +27,7 @@ import {
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'grafana',
+  pluginId: 'grafana',
   extensions: [
     grafanaApiExtension,
     entityGrafanaAlertsCard,

--- a/workspaces/jenkins/.changeset/gorgeous-waves-sneeze.md
+++ b/workspaces/jenkins/.changeset/gorgeous-waves-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/jenkins/plugins/jenkins/src/alpha.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/alpha.ts
@@ -26,7 +26,7 @@ import { rootRouteRef } from './plugin';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'jenkins',
+  pluginId: 'jenkins',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/sentry/.changeset/spicy-cameras-explode.md
+++ b/workspaces/sentry/.changeset/spicy-cameras-explode.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sentry': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/sentry/plugins/sentry/src/alpha.ts
+++ b/workspaces/sentry/plugins/sentry/src/alpha.ts
@@ -26,7 +26,7 @@ import { rootRouteRef } from './plugin';
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'sentry',
+  pluginId: 'sentry',
   routes: convertLegacyRouteRefs({
     entityContent: rootRouteRef,
   }),

--- a/workspaces/stack-overflow/.changeset/heavy-keys-check.md
+++ b/workspaces/stack-overflow/.changeset/heavy-keys-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-stack-overflow': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/stack-overflow/plugins/stack-overflow/src/alpha.tsx
+++ b/workspaces/stack-overflow/plugins/stack-overflow/src/alpha.tsx
@@ -46,7 +46,7 @@ const stackOverflowSearchResultListItem = SearchResultListItemBlueprint.make({
 
 /** @alpha */
 export default createFrontendPlugin({
-  id: 'stack-overflow',
+  pluginId: 'stack-overflow',
   // TODO: Migrate homepage cards when the declarative homepage plugin supports them
   extensions: [stackOverflowApi, stackOverflowSearchResultListItem],
 });

--- a/workspaces/vault/.changeset/stupid-eagles-hang.md
+++ b/workspaces/vault/.changeset/stupid-eagles-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-vault': patch
+---
+
+Fixed deprecation warning for createFrontendPlugin

--- a/workspaces/vault/plugins/vault/src/alpha.tsx
+++ b/workspaces/vault/plugins/vault/src/alpha.tsx
@@ -74,6 +74,6 @@ export const vaultEntityContent: any = EntityContentBlueprint.make({
  * @alpha
  */
 export default createFrontendPlugin({
-  id: 'vault',
+  pluginId: 'vault',
   extensions: [vaultApi, vaultEntityContent],
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates 'id' to 'pluginId' in `createFrontendPlugin` function to fix deprecation warning in various plugins that have been migrated to NFS.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
