### PR TITLE
Badges: Support `style` and `color` query parameters in obfuscated mode

### DIFF
--- a/workspaces/badges/.changeset/smart-feet-sin.md
+++ b/workspaces/badges/.changeset/smart-feet-sin.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-badges': minor
+'@backstage-community/plugin-badges': patch
 ---
 
 Fixes a bug where badge style and color query parameters were not passed when badge obfuscation was enabled, causing badge style filtering to not work in the UI.

--- a/workspaces/badges/.changeset/smart-feet-sin.md
+++ b/workspaces/badges/.changeset/smart-feet-sin.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-badges': minor
+---
+
+Fixes a bug where badge style and color query parameters were not passed when badge obfuscation was enabled, causing badge style filtering to not work in the UI.

--- a/workspaces/badges/plugins/badges/src/api/BadgesClient.ts
+++ b/workspaces/badges/plugins/badges/src/api/BadgesClient.ts
@@ -57,6 +57,7 @@ export class BadgesClient implements BadgesApi {
       });
       const entityUuidBadgeSpecsUrl = await this.getEntityUuidBadgeSpecsUrl(
         entityUuid,
+        badgeOptions,
       );
 
       const response = await this.fetchApi.fetch(entityUuidBadgeSpecsUrl);
@@ -98,11 +99,20 @@ export class BadgesClient implements BadgesApi {
     return await responseEntityUuid.json();
   }
 
-  private async getEntityUuidBadgeSpecsUrl(entityUuid: {
-    uuid: string;
-  }): Promise<string> {
+  private async getEntityUuidBadgeSpecsUrl(
+    entityUuid: { uuid: string },
+    badgeOptions: BadgeStyleOptions,
+  ): Promise<string> {
     const baseUrl = await this.discoveryApi.getBaseUrl('badges');
-    return `${baseUrl}/entity/${entityUuid}/badge-specs`;
+    const queries: string[] = [];
+    if (badgeOptions.style) {
+      queries.push(`style=${badgeOptions.style}`);
+    }
+    if (badgeOptions.color) {
+      queries.push(`color=${badgeOptions.color}`);
+    }
+    const queryString = queries.length > 0 ? `?${queries.join('&')}` : '';
+    return `${baseUrl}/entity/${entityUuid}/badge-specs${queryString}`;
   }
 
   private async getEntityBadgeSpecsUrl(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When `app.badges.obfuscate: true` is configured, badge style dropdown selections (e.g., "for-the-badge", "flat-square") were ignored because the frontend wasn't passing query parameters in the obfuscated code path.

**Changes:**
- Updated `BadgesClient.getEntityUuidBadgeSpecsUrl()` to accept and process `badgeOptions` parameter
- Added query string construction for `style` and `color` parameters in obfuscated mode
- Ensures consistent behavior between obfuscated and non-obfuscated badge generation


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated documentation (inline code comments)
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message