### PR TITLE
scripts - Detailed maintainer owned report

### DIFF
--- a/scripts/list-maintainer-workspaces.js
+++ b/scripts/list-maintainer-workspaces.js
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { resolve } from 'path';
+import fs from 'fs';
+import { resolve, join } from 'path';
 import * as url from 'url';
 import * as codeowners from 'codeowners-utils';
 import { listWorkspaces } from './list-workspaces.js';
@@ -61,6 +62,60 @@ async function main() {
     const chunk = maintainerWorkspaces.slice(i, i + chunkSize);
     console.log(`${JSON.stringify(chunk)}\n`);
   }
+
+  const maintainerWorkspacesReport = [];
+  for (const workspace of maintainerWorkspaces) {
+    const workspacePath = resolve(rootPath, 'workspaces');
+    const currentWorkspacePath = resolve(workspacePath, workspace);
+
+    // version
+    const backstageFile = join(currentWorkspacePath, 'backstage.json');
+    let version = '';
+    if (fs.existsSync(backstageFile)) {
+      const file = fs.readFileSync(backstageFile);
+      const json = JSON.parse(file);
+      version = json.version;
+    }
+
+    // auto bump
+    const bumpFile = join(currentWorkspacePath, '.auto-version-bump');
+    const usesAutoVersionBump = fs.existsSync(bumpFile);
+
+    // yarn plugin
+    const yarnPluginFile = join(
+      currentWorkspacePath,
+      '.yarn/plugins/@yarnpkg/plugin-backstage.cjs',
+    );
+    const usesYarnPlugin = fs.existsSync(yarnPluginFile);
+
+    // bcp.json
+    const bcpFile = join(currentWorkspacePath, 'bcp.json');
+    const usesBcp = fs.existsSync(bcpFile);
+    let usesBcpKnipReports = false;
+    let usesBcpAutoVersionBump = false;
+    let usedBcpListDeprecations = false;
+    if (usesBcp) {
+      const file = fs.readFileSync(bcpFile);
+      const json = JSON.parse(file);
+      usesBcpKnipReports = json.knip - reports;
+      usesBcpAutoVersionBump = json.auto - version - bump;
+      usedBcpListDeprecations = json.list - deprecations;
+    }
+
+    const report = {
+      workspace,
+      version,
+      usesAutoVersionBump,
+      usesYarnPlugin,
+      usesBcp,
+      usesBcpKnipReports,
+      usesBcpAutoVersionBump,
+      usedBcpListDeprecations,
+    };
+    maintainerWorkspacesReport.push(report);
+  }
+
+  console.table(maintainerWorkspacesReport);
 }
 
 main(process.argv.slice(2)).catch(error => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a detailed report for all the maintainer owned workspaces to the existing `list-maintainer-workspaces.js` script. This allows us to get a view on the state of various aspects of the repo. Here's the results:

<img width="1503" height="878" alt="image" src="https://github.com/user-attachments/assets/b76d505e-2c04-4d47-88ca-097c21a8a4d6" />


**Note:** the last two columns isn't something we have in place yet but are looking to add or migrate to so it made sense to add them in now to help get visibility into that work.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
