### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/itchy-bees-vanish.md
+++ b/workspaces/confluence/.changeset/itchy-bees-vanish.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Option to cache Confluence documents to reduce API calls.
-
-The cache uses document version information, so you can safely set long cache durations (if your cache memory allows it!). You can enable caching with `documentCacheEnabled: true` and adjust the cache duration with `documentCacheTtl` (default to 24h). Since indexing will be faster, you may want to reduce your indexing schedule interval.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.12.1
+
+### Patch Changes
+
+- 076d975: Option to cache Confluence documents to reduce API calls.
+
+  The cache uses document version information, so you can safely set long cache durations (if your cache memory allows it!). You can enable caching with `documentCacheEnabled: true` and adjust the cache duration with `documentCacheTtl` (default to 24h). Since indexing will be faster, you may want to reduce your indexing schedule interval.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-search-backend-module-confluence-collator@0.12.1

### Patch Changes

-   076d975: Option to cache Confluence documents to reduce API calls.

    The cache uses document version information, so you can safely set long cache durations (if your cache memory allows it!). You can enable caching with `documentCacheEnabled: true` and adjust the cache duration with `documentCacheTtl` (default to 24h). Since indexing will be faster, you may want to reduce your indexing schedule interval.
