### PR TITLE
support multiple Confluences 

### DIFF
--- a/workspaces/confluence/.changeset/bright-parrots-doubt.md
+++ b/workspaces/confluence/.changeset/bright-parrots-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': major
+---
+
+Add support for indexing and searching multiple confluence in the search backend module.

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/README.md
@@ -146,6 +146,67 @@ search:
           seconds: 3
 ```
 
+## Multiple Confluence Instance Support
+
+This plugin supports indexing and searching documentation from multiple Confluence instances.
+
+### Configuration Example
+
+Add each Confluence instance under the `confluence` key in your `app-config.yaml`, using a unique name for each (e.g., `default`, `secondary`):
+
+```yaml
+confluence:
+  default:
+    baseUrl: 'https://api.atlassian.com/ex/confluence/<instance1-id>/wiki'
+    auth:
+      type: 'basic'
+      token: '<TOKEN_FOR_INSTANCE_1>'
+      email: '<EMAIL_FOR_INSTANCE_1>'
+  secondary:
+    baseUrl: 'https://api.atlassian.com/ex/confluence/<instance2-id>/wiki'
+    auth:
+      type: 'basic'
+      token: '<TOKEN_FOR_INSTANCE_2>'
+      email: '<EMAIL_FOR_INSTANCE_2>'
+```
+
+### Configure a collator for each instance under search.collators:
+
+```yaml
+search:
+  collators:
+    confluence:
+      instanceKey: default
+      schedule:
+        frequency: { minutes: 30 }
+        timeout: { minutes: 10 }
+    confluenceSecondary:
+      instanceKey: secondary
+      schedule:
+        frequency: { minutes: 30 }
+        timeout: { minutes: 10 }
+```
+
+### UI Integration
+
+In your search UI, ensure both types are available and selected by default:
+
+```
+<SearchType.Accordion
+  name="Result Type"
+  defaultValue={['confluence', 'confluenceSecondary']}
+  types={[
+    { value: 'confluence', name: 'Confluence one' },
+    { value: 'confluenceSecondary', name: 'Confluence two' },
+    // ...other types
+  ]}
+/>
+```
+
+## Result
+
+With this configuration, your Backstage instance will index and display search results from all configured Confluence instances.
+
 ## Special thanks & Disclaimer
 
 Thanks to K-Phoen for creating the confluence plugin found [here](https://github.com/K-Phoen/backstage-plugin-confluence). As an outcome

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/config.d.ts
@@ -30,70 +30,72 @@ export interface Config {
     };
   };
   confluence?: {
-    /**
-     * The base URL for accessing the Confluence API
-     * Typically: https://{org-name}.atlassian.net/wiki
-     */
-    baseUrl: string;
-    /**
-     * Confluence API credentials
-     */
-    auth: {
+    [instanceKey: string]: {
       /**
-       * Authentication method - basic, bearer, or userpass
+       * The base URL for accessing the Confluence API
+       * Typically: https://{org-name}.atlassian.net/wiki
        */
-      type: 'basic' | 'bearer' | 'userpass';
+      baseUrl: string;
       /**
-       * Confluence bearer authentication token with `Read` permissions, only required if type is set to 'basic' or 'bearer'.
-       * Reference the Confluence documentation to generate an API token:
-       * https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
-       * @visibility secret
+       * Confluence API credentials
        */
-      token?: string;
+      auth: {
+        /**
+         * Authentication method - basic, bearer, or userpass
+         */
+        type: 'basic' | 'bearer' | 'userpass';
+        /**
+         * Confluence bearer authentication token with `Read` permissions, only required if type is set to 'basic' or 'bearer'.
+         * Reference the Confluence documentation to generate an API token:
+         * https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+         * @visibility secret
+         */
+        token?: string;
+        /**
+         * Email associated with the token, only required if type is set to 'basic'.
+         * @visibility secret
+         */
+        email?: string;
+        /**
+         * Confluence basic authentication username, only required if type is set to 'userpass'.
+         * While Confluence supports BASIC authentication, using an API token is preferred.
+         * See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+         */
+        username?: string;
+        /**
+         * Confluence basic authentication password, only required if type is set to 'userpass'.
+         * While Confluence supports BASIC authentication, using an API token is preferred.
+         * See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+         * @visibility secret
+         */
+        password?: string;
+      };
       /**
-       * Email associated with the token, only required if type is set to 'basic'.
-       * @visibility secret
+       * Array of Confluence spaces to index. If omitted, all spaces will be indexed.
+       * See: https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/
        */
-      email?: string;
+      spaces?: string[];
       /**
-       * Confluence basic authentication username, only required if type is set to 'userpass'.
-       * While Confluence supports BASIC authentication, using an API token is preferred.
-       * See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+       * CQL query to select the pages to index. It is combined via 'AND' with spaces parameter above when finding documents.
+       * Reference the Confluence documentation for information about CQL syntax:
+       * https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/
        */
-      username?: string;
+      query?: string;
       /**
-       * Confluence basic authentication password, only required if type is set to 'userpass'.
-       * While Confluence supports BASIC authentication, using an API token is preferred.
-       * See: https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
-       * @visibility secret
+       * An abstract value that controls the concurrency level of the
+       * collation process. Increasing this value will both increase the
+       * number of entities fetched at a time from the catalog, as well as how
+       * many things are being processed concurrently.
+       *
+       * Defaults to `15`.
+       * @deprecated Use `maxRequestsPerSecond` instead.
        */
-      password?: string;
+      parallelismLimit?: number;
+      /**
+       * The maximum number of requests per second to make to the Confluence API.
+       * @visibility backend
+       */
+      maxRequestsPerSecond?: number;
     };
-    /**
-     * Array of Confluence spaces to index. If omitted, all spaces will be indexed.
-     * See: https://support.atlassian.com/confluence-cloud/docs/use-spaces-to-organize-your-work/
-     */
-    spaces?: string[];
-    /**
-     * CQL query to select the pages to index. It is combined via 'AND' with spaces parameter above when finding documents.
-     * Reference the Confluence documentation for information about CQL syntax:
-     * https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/
-     */
-    query?: string;
-    /**
-     * An abstract value that controls the concurrency level of the
-     * collation process. Increasing this value will both increase the
-     * number of entities fetched at a time from the catalog, as well as how
-     * many things are being processed concurrently.
-     *
-     * Defaults to `15`.
-     * @deprecated Use `maxRequestsPerSecond` instead.
-     */
-    parallelismLimit?: number;
-    /**
-     * The maximum number of requests per second to make to the Confluence API.
-     * @visibility backend
-     */
-    maxRequestsPerSecond?: number;
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!
What’s Changed

Added support for multiple Confluence instances in the search backend module.
Updated ConfluenceCollatorFactory and backend module to dynamically register collators for each configured Confluence instance.
Updated documentation with configuration examples for multiple Confluence instances and UI integration.
Provided example UI code to ensure both Confluence sources are available and selected by default in the search page.

How to Use

Configure multiple Confluence instances in your app-config.yaml under the confluence key, each with a unique name (e.g., default, secondary).
Register a collator for each instance under search.collators, using the instanceKey property to point to the correct config.
Update your search UI to include both types (e.g., confluence, confluenceSecondary) so results from all sources are visible.
See the updated README for detailed configuration and UI examples.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
<img width="1466" height="590" alt="multiple-confluence" src="https://github.com/user-attachments/assets/778bc045-4ba1-4fd2-8ec0-29debb9eb51e" />
 
