### PR TITLE
Version Packages (lighthouse)

### DIFF
--- a/workspaces/lighthouse/.changeset/angry-rules-peel.md
+++ b/workspaces/lighthouse/.changeset/angry-rules-peel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse-common': patch
----
-
-Marked `lighthouse.baseUrl` configuration as required.

--- a/workspaces/lighthouse/.changeset/four-jars-hug.md
+++ b/workspaces/lighthouse/.changeset/four-jars-hug.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse': patch
----
-
-Added support for the new frontend system.

--- a/workspaces/lighthouse/.changeset/khaki-comics-shout.md
+++ b/workspaces/lighthouse/.changeset/khaki-comics-shout.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-lighthouse-backend': patch
----
-
-Added development environment for starting the plugin in isolation.

--- a/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-lighthouse-backend
 
+## 0.14.1
+
+### Patch Changes
+
+- a1ec06f: Added development environment for starting the plugin in isolation.
+- Updated dependencies [a1ec06f]
+  - @backstage-community/plugin-lighthouse-common@0.10.1
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/lighthouse/plugins/lighthouse-backend/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-backend",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Backend functionalities for lighthouse",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/lighthouse/plugins/lighthouse-common/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-lighthouse-common
 
+## 0.10.1
+
+### Patch Changes
+
+- a1ec06f: Marked `lighthouse.baseUrl` configuration as required.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/lighthouse/plugins/lighthouse-common/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse-common",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Common functionalities for lighthouse, to be shared between lighthouse and lighthouse-backend plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/lighthouse/plugins/lighthouse/CHANGELOG.md
+++ b/workspaces/lighthouse/plugins/lighthouse/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-lighthouse
 
+## 0.13.1
+
+### Patch Changes
+
+- a1ec06f: Added support for the new frontend system.
+- Updated dependencies [a1ec06f]
+  - @backstage-community/plugin-lighthouse-common@0.10.1
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/lighthouse/plugins/lighthouse/package.json
+++ b/workspaces/lighthouse/plugins/lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-lighthouse",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A Backstage plugin that integrates towards Lighthouse",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-lighthouse@0.13.1

### Patch Changes

-   a1ec06f: Added support for the new frontend system.
-   Updated dependencies [a1ec06f]
    -   @backstage-community/plugin-lighthouse-common@0.10.1

## @backstage-community/plugin-lighthouse-backend@0.14.1

### Patch Changes

-   a1ec06f: Added development environment for starting the plugin in isolation.
-   Updated dependencies [a1ec06f]
    -   @backstage-community/plugin-lighthouse-common@0.10.1

## @backstage-community/plugin-lighthouse-common@0.10.1

### Patch Changes

-   a1ec06f: Marked `lighthouse.baseUrl` configuration as required.
