### PR TITLE
chore(scaffolder-backend-module-annotator,scaffolder-backend-module-kubernetes): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,8 +96,8 @@ yarn.lock                                                               @backsta
 /workspaces/repo-tools                                                  @backstage/community-plugins-maintainers
 /workspaces/report-portal                                               @backstage/community-plugins-maintainers  @yashoswalyo @deshmukhmayur @riginoommen
 /workspaces/rollbar                                                     @backstage/community-plugins-maintainers  @andrewthauer
-/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1
-/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1
+/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
+/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
 /workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
 /workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
 /workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds CODEOWNERS for `scaffolder-backend-module-annotator` and `scaffolder-backend-module-kubernetes` from our team since we are the ones responsible for maintaining them.

Some PRs we have reviewed / contributed to:
- https://github.com/backstage/community-plugins/pull/4738
- https://github.com/backstage/community-plugins/pull/4192
- https://github.com/backstage/community-plugins/pull/3117
- https://github.com/backstage/community-plugins/pull/3820
- https://github.com/backstage/community-plugins/pull/4744
- https://github.com/backstage/community-plugins/pull/3791

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
