### PR TITLE
Fix bug in edit announcement page

### DIFF
--- a/workspaces/announcements/.changeset/quiet-pears-move.md
+++ b/workspaces/announcements/.changeset/quiet-pears-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Fix bug in edit announcement page

--- a/workspaces/announcements/.changeset/quiet-pears-move.md
+++ b/workspaces/announcements/.changeset/quiet-pears-move.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-announcements': patch
 ---
 
-Fix bug in edit announcement page
+Fix a bug in the Edit announcement page where the page does not update the announcement if the announcement is missing a category

--- a/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.test.tsx
@@ -1,0 +1,422 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Route } from 'react-router-dom';
+
+import { FlatRoutes } from '@backstage/core-app-api';
+import { alertApiRef } from '@backstage/core-plugin-api';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import {
+  TestApiProvider,
+  mockApis,
+  renderInTestApp,
+} from '@backstage/test-utils';
+import {
+  AnnouncementsApi,
+  announcementsApiRef,
+  CreateAnnouncementRequest,
+} from '@backstage-community/plugin-announcements-react';
+import * as AnnouncementsReact from '@backstage-community/plugin-announcements-react';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import * as AnnouncementForm from '../AnnouncementForm';
+import { rootRouteRef } from '../../routes';
+
+import { EditAnnouncementPage } from './EditAnnouncementPage';
+
+jest.mock('../AnnouncementForm');
+
+jest.mock('@backstage-community/plugin-announcements-react', () => ({
+  ...jest.requireActual('@backstage-community/plugin-announcements-react'),
+  useAnnouncementsTranslation: () => ({ t: (key: string) => key }),
+  useCategories: jest.fn().mockReturnValue({ categories: [] }),
+}));
+
+const announcementsApiMock: jest.Mocked<
+  Pick<
+    AnnouncementsApi,
+    'announcementByID' | 'createCategory' | 'updateAnnouncement'
+  >
+> = {
+  announcementByID: jest.fn(),
+  createCategory: jest.fn(),
+  updateAnnouncement: jest.fn(),
+};
+
+const alertApiMock = { post: jest.fn() };
+
+const renderEditAnnouncementPage = async () => {
+  return renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [announcementsApiRef, announcementsApiMock],
+        [alertApiRef, alertApiMock],
+        [permissionApiRef, mockApis.permission()],
+      ]}
+    >
+      <FlatRoutes>
+        <Route
+          path="/announcements/edit/:id"
+          element={
+            <EditAnnouncementPage themeId="home" title="Announcements" />
+          }
+        />
+      </FlatRoutes>
+    </TestApiProvider>,
+    {
+      mountedRoutes: {
+        '/announcements': rootRouteRef,
+        '/catalog/:namespace/:kind/:name': entityRouteRef,
+      },
+      routeEntries: ['/announcements/edit/1'],
+    },
+  );
+};
+
+describe('EditAnnouncementPage', () => {
+  const announcement = {
+    id: '1',
+    publisher: 'default:user/user',
+    title: 'Announcement title',
+    excerpt: 'Announcement excerpt',
+    body: 'Announcement body',
+    created_at: '2025-01-10T00:00:00.000Z',
+    active: true,
+    start_at: '2025-01-10T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('renders loading state', async () => {
+    jest.useFakeTimers();
+
+    announcementsApiMock.announcementByID.mockImplementationOnce(() => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(announcement);
+        }, 1000);
+      });
+    });
+
+    await renderEditAnnouncementPage();
+
+    expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+    await screen.findByRole('progressbar');
+
+    jest.runAllTimers();
+
+    await waitForElementToBeRemoved(screen.queryByRole('progressbar'));
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'editAnnouncementPage.edit "Announcement title" – Announcements',
+      }),
+    ).toBeVisible();
+  });
+
+  it('renders error state', async () => {
+    announcementsApiMock.announcementByID.mockRejectedValue(
+      new Error('Failed'),
+    );
+
+    await renderEditAnnouncementPage();
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toBeVisible();
+
+    expect(within(alert).getByText(/failed/i)).toBeVisible();
+  });
+
+  it('renders not found message', async () => {
+    announcementsApiMock.announcementByID.mockResolvedValueOnce(
+      undefined as any,
+    );
+
+    await renderEditAnnouncementPage();
+
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toBeVisible();
+
+    expect(
+      within(alert).getByText('editAnnouncementPage.notFoundMessage'),
+    ).toBeVisible();
+  });
+
+  it('renders form when announcement is loaded', async () => {
+    jest
+      .spyOn(AnnouncementForm, 'AnnouncementForm')
+      .mockImplementationOnce(() => <div data-testid="announcement-form" />);
+    announcementsApiMock.announcementByID.mockResolvedValueOnce(announcement);
+
+    await renderEditAnnouncementPage();
+
+    expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+    expect(screen.getByTestId('announcement-form')).toBeVisible();
+  });
+
+  describe('when updating announcement', () => {
+    describe('with no category', () => {
+      it('submits update successfully without creating a category', async () => {
+        jest
+          .spyOn(AnnouncementForm, 'AnnouncementForm')
+          .mockImplementationOnce(
+            ({
+              onSubmit,
+            }: {
+              onSubmit: (data: CreateAnnouncementRequest) => Promise<void>;
+            }) => (
+              <div data-testid="announcement-form">
+                (
+                <button
+                  onClick={() =>
+                    onSubmit({
+                      ...announcement,
+                      title: 'Updated title',
+                    })
+                  }
+                >
+                  Submit
+                </button>
+                )
+              </div>
+            ),
+          );
+
+        announcementsApiMock.announcementByID.mockResolvedValue(announcement);
+
+        await renderEditAnnouncementPage();
+
+        expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+        expect(screen.getByTestId('announcement-form')).toBeVisible();
+
+        const submitButton = screen.getByRole('button', { name: /submit/i });
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(announcementsApiMock.updateAnnouncement).toHaveBeenCalledWith(
+            '1',
+            expect.objectContaining({
+              title: 'Updated title',
+            }),
+          );
+        });
+
+        expect(announcementsApiMock.createCategory).not.toHaveBeenCalled();
+
+        expect(alertApiMock.post).toHaveBeenCalledWith({
+          message: 'editAnnouncementPage.updatedMessage',
+          severity: 'success',
+        });
+      });
+    });
+
+    describe('with existing category', () => {
+      it('submits update successfully without creating a category', async () => {
+        jest.spyOn(AnnouncementsReact, 'useCategories').mockReturnValue({
+          categories: [{ slug: 'existing-cat', title: 'Existing Category' }],
+          loading: false,
+          error: undefined,
+          retry: jest.fn(),
+        });
+
+        jest
+          .spyOn(AnnouncementForm, 'AnnouncementForm')
+          .mockImplementationOnce(
+            ({
+              onSubmit,
+            }: {
+              onSubmit: (data: CreateAnnouncementRequest) => Promise<void>;
+            }) => (
+              <div data-testid="announcement-form">
+                (
+                <button
+                  onClick={() =>
+                    onSubmit({
+                      ...announcement,
+                      category: 'existing-cat',
+                      title: 'Updated title',
+                    })
+                  }
+                >
+                  Submit
+                </button>
+                )
+              </div>
+            ),
+          );
+
+        announcementsApiMock.announcementByID.mockResolvedValue(announcement);
+
+        await renderEditAnnouncementPage();
+
+        expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+        expect(screen.getByTestId('announcement-form')).toBeVisible();
+
+        const submitButton = screen.getByRole('button', { name: /submit/i });
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(announcementsApiMock.updateAnnouncement).toHaveBeenCalledWith(
+            '1',
+            expect.objectContaining({
+              title: 'Updated title',
+            }),
+          );
+        });
+
+        expect(announcementsApiMock.createCategory).not.toHaveBeenCalled();
+
+        expect(alertApiMock.post).toHaveBeenCalledWith({
+          message: 'editAnnouncementPage.updatedMessage',
+          severity: 'success',
+        });
+      });
+    });
+
+    describe('with new category', () => {
+      it('creates category and submits update successfully', async () => {
+        jest
+          .spyOn(AnnouncementForm, 'AnnouncementForm')
+          .mockImplementationOnce(
+            ({
+              onSubmit,
+            }: {
+              onSubmit: (data: CreateAnnouncementRequest) => Promise<void>;
+            }) => (
+              <div data-testid="announcement-form">
+                (
+                <button
+                  onClick={() =>
+                    onSubmit({
+                      ...announcement,
+                      category: 'updated-category',
+                      title: 'Updated title',
+                    })
+                  }
+                >
+                  Submit
+                </button>
+                )
+              </div>
+            ),
+          );
+
+        announcementsApiMock.announcementByID.mockResolvedValue(announcement);
+
+        await renderEditAnnouncementPage();
+
+        expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+        expect(screen.getByTestId('announcement-form')).toBeVisible();
+
+        const submitButton = screen.getByRole('button', { name: /submit/i });
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(announcementsApiMock.updateAnnouncement).toHaveBeenCalledWith(
+            '1',
+            expect.objectContaining({
+              title: 'Updated title',
+            }),
+          );
+        });
+
+        expect(announcementsApiMock.createCategory).toHaveBeenCalledWith({
+          title: 'updated-category',
+        });
+
+        expect(alertApiMock.post).toHaveBeenCalledWith({
+          message:
+            'editAnnouncementPageupdatedMessage editAnnouncementPage.updatedMessageWithNewCategory updated-category.',
+          severity: 'success',
+        });
+      });
+    });
+
+    describe('fails', () => {
+      it('posts error', async () => {
+        jest
+          .spyOn(AnnouncementForm, 'AnnouncementForm')
+          .mockImplementationOnce(
+            ({
+              onSubmit,
+            }: {
+              onSubmit: (data: CreateAnnouncementRequest) => Promise<void>;
+            }) => (
+              <div data-testid="announcement-form">
+                (
+                <button
+                  onClick={() =>
+                    onSubmit({
+                      ...announcement,
+                      title: 'Updated title',
+                    })
+                  }
+                >
+                  Submit
+                </button>
+                )
+              </div>
+            ),
+          );
+
+        announcementsApiMock.announcementByID.mockResolvedValue(announcement);
+
+        announcementsApiMock.updateAnnouncement.mockRejectedValue(
+          new Error('Update failed'),
+        );
+
+        await renderEditAnnouncementPage();
+
+        expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
+
+        expect(screen.getByTestId('announcement-form')).toBeVisible();
+
+        const submitButton = screen.getByRole('button', { name: /submit/i });
+
+        await userEvent.click(submitButton);
+
+        await waitFor(() => {
+          expect(alertApiMock.post).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: 'Update failed',
+              severity: 'error',
+            }),
+          );
+        });
+      });
+    });
+  });
+});

--- a/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/EditAnnouncementPage/EditAnnouncementPage.tsx
@@ -73,10 +73,10 @@ export const EditAnnouncementPage = (props: EditAnnouncementPageProps) => {
             title: category,
           });
         }
-
-        await announcementsApi.updateAnnouncement(id, request);
-        alertApi.post({ message: updateMsg, severity: 'success' });
       }
+
+      await announcementsApi.updateAnnouncement(id, request);
+      alertApi.post({ message: updateMsg, severity: 'success' });
     } catch (err) {
       alertApi.post({ message: (err as Error).message, severity: 'error' });
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes a bug that was introduced in #5130 where the Edit announcement page does not update the announcement if the announcement is missing a category.

Thanks to @matdtr for [reporting](https://github.com/backstage/community-plugins/pull/5130#issuecomment-3253833754) the bug.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
