### PR TITLE
[shortcuts] Add support for opening sites in a new tab

### DIFF
--- a/workspaces/shortcuts/.changeset/nice-terms-work.md
+++ b/workspaces/shortcuts/.changeset/nice-terms-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-shortcuts': patch
+---
+
+Add support for opening external link in a new tab


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a check for external links in shortcuts, and if found, opens a new tab when accessing the shortcut. Closes #4863.

Not sure if we want to introduce a setting to enable this or if default functionality is desired, looking for feedback on this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
