### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/quiet-pears-move.md
+++ b/workspaces/announcements/.changeset/quiet-pears-move.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fix a bug in the Edit announcement page where the page does not update the announcement if the announcement is missing a category

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements
 
+## 0.11.1
+
+### Patch Changes
+
+- 92b9e8c: Fix a bug in the Edit announcement page where the page does not update the announcement if the announcement is missing a category
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.11.1

### Patch Changes

-   92b9e8c: Fix a bug in the Edit announcement page where the page does not update the announcement if the announcement is missing a category
