### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/forty-showers-type.md
+++ b/workspaces/servicenow/.changeset/forty-showers-type.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': patch
-'@backstage-community/plugin-servicenow-common': patch
-'@backstage-community/plugin-servicenow': patch
----
-
-Create and export new catalog entity filter function isServicenowAvailable

--- a/workspaces/servicenow/.changeset/slow-cobras-guess.md
+++ b/workspaces/servicenow/.changeset/slow-cobras-guess.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
----
-
-Added support for the new frontend system.
-
-The plugin automatically adds a "ServiceNow" tab to a software catalog entity if the entity has an `servicenow.com/entity-id` annotation.
-
-It does not add the "My ServiceNow Tickets" tab to the user entity for now.

--- a/workspaces/servicenow/.changeset/twenty-stars-pick.md
+++ b/workspaces/servicenow/.changeset/twenty-stars-pick.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
-'@backstage-community/plugin-servicenow': minor
----
-
-Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.
-
-The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.2.0
+
+### Minor Changes
+
+- 6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.
+
+  The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.
+
+### Patch Changes
+
+- 6be0265: Create and export new catalog entity filter function isServicenowAvailable
+- Updated dependencies [6be0265]
+- Updated dependencies [6be0265]
+  - @backstage-community/plugin-servicenow-common@1.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-servicenow-common
 
+## 1.2.0
+
+### Minor Changes
+
+- 6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.
+
+  The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.
+
+### Patch Changes
+
+- 6be0265: Create and export new catalog entity filter function isServicenowAvailable
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-common/package.json
+++ b/workspaces/servicenow/plugins/servicenow-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-common",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the servicenow plugin",
   "main": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,26 @@
 # @backstage-community/plugin-servicenow
 
+## 1.2.0
+
+### Minor Changes
+
+- 0d3e031: Added support for the new frontend system.
+
+  The plugin automatically adds a "ServiceNow" tab to a software catalog entity if the entity has an `servicenow.com/entity-id` annotation.
+
+  It does not add the "My ServiceNow Tickets" tab to the user entity for now.
+
+- 6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.
+
+  The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.
+
+### Patch Changes
+
+- 6be0265: Create and export new catalog entity filter function isServicenowAvailable
+- Updated dependencies [6be0265]
+- Updated dependencies [6be0265]
+  - @backstage-community/plugin-servicenow-common@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.2.0

### Minor Changes

-   0d3e031: Added support for the new frontend system.

    The plugin automatically adds a "ServiceNow" tab to a software catalog entity if the entity has an `servicenow.com/entity-id` annotation.

    It does not add the "My ServiceNow Tickets" tab to the user entity for now.

-   6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.

    The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.

### Patch Changes

-   6be0265: Create and export new catalog entity filter function isServicenowAvailable
-   Updated dependencies [6be0265]
-   Updated dependencies [6be0265]
    -   @backstage-community/plugin-servicenow-common@1.2.0

## @backstage-community/plugin-servicenow-backend@1.2.0

### Minor Changes

-   6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.

    The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.

### Patch Changes

-   6be0265: Create and export new catalog entity filter function isServicenowAvailable
-   Updated dependencies [6be0265]
-   Updated dependencies [6be0265]
    -   @backstage-community/plugin-servicenow-common@1.2.0

## @backstage-community/plugin-servicenow-common@1.2.0

### Minor Changes

-   6be0265: Export the catalog entity tab content as `EntityServicenowContent` instead of `ServicenowPage` to align it with the Backstage naming conventions.

    The `ServicenowPage` is still exported for now, but marked as **deprecated**. It might be removed or replaced in a future release.

### Patch Changes

-   6be0265: Create and export new catalog entity filter function isServicenowAvailable
