### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/chilled-turkeys-juggle.md
+++ b/workspaces/rollbar/.changeset/chilled-turkeys-juggle.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-rollbar-backend': minor
----
-
-**BREAKING** The `RollbarApi` now requires the `CacheService` when being constructed.
-
-Also added feature to expire cached Rollbar project state when using the new backend system.

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- b6879b9: **BREAKING** The `RollbarApi` now requires the `CacheService` when being constructed.
+
+  Also added feature to expire cached Rollbar project state when using the new backend system.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar-backend@0.7.0

### Minor Changes

-   b6879b9: **BREAKING** The `RollbarApi` now requires the `CacheService` when being constructed.

    Also added feature to expire cached Rollbar project state when using the new backend system.
