### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/two-coats-shake.md
+++ b/workspaces/analytics/.changeset/two-coats-shake.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
----
-
-Adding a sessionReplay config block to the plugin options, allowing users to enable/disable session replay and set options like sampling rate, error sampling rate, masking selectors, and block selectors.

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.10.0
+
+### Minor Changes
+
+- 7eb926b: Adding a sessionReplay config block to the plugin options, allowing users to enable/disable session replay and set options like sampling rate, error sampling rate, masking selectors, and block selectors.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-newrelic-browser@0.10.0

### Minor Changes

-   7eb926b: Adding a sessionReplay config block to the plugin options, allowing users to enable/disable session replay and set options like sampling rate, error sampling rate, masking selectors, and block selectors.
