### PR TITLE
announcements: integration with notifications #4378

### DIFF
--- a/workspaces/announcements/.changeset/giant-plums-leave.md
+++ b/workspaces/announcements/.changeset/giant-plums-leave.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-announcements-backend': minor
+'@backstage-community/plugin-announcements-common': minor
+'@backstage-community/plugin-announcements': minor
+---
+
+With these changes, notifications can be enabled whenever new announcement is created. Announcement notifications are disabled by-default. For details, about notification, please refer [`Notifications`](https://backstage.io/docs/notifications/) docs.
+
+announcements: integration with notifications #4378

--- a/workspaces/announcements/plugins/announcements-backend/README.md
+++ b/workspaces/announcements/plugins/announcements-backend/README.md
@@ -7,6 +7,7 @@ The backend for the Announcements plugin. This plugin provides:
 - Integration with the [`@backstage/plugin-permission-backend`](https://github.com/backstage/backstage/tree/master/plugins/permission-backend) plugin
 - Integration with the [`@backstage/plugin-events-backend`](https://github.com/backstage/backstage/tree/master/plugins/events-backend) plugin
 - Integration with the [`@backstage/plugin-signals-backend`](https://github.com/backstage/backstage/tree/master/plugins/signals-backend) plugin
+- Integration with the [`@backstage/notifications-backend`](https://github.com/backstage/backstage/tree/master/plugins/notifications-backend) plugin
 
 ## Installation
 
@@ -103,3 +104,12 @@ const response = await fetch(
 const data = await response.json();
 return data;
 ```
+
+### Notifications for Announcements
+
+Backstage’s Notification System empowers plugins and services to deliver alerts to users and is directly visible in the UI or via external channels. Visit the [docs](https://backstage.io/docs/notifications/) on notifications for more information.
+
+The Notification plugin delivers real-time alerting, with backend/frontend components to send and display notifications - including push signals.
+To trigger alerts when a new announcement appears, you can combine these systems: send a notification via the Notifications backend whenever an announcement is created.
+
+Announcement notifications are disabled by-default. Notifications can be sent if "sendNotification" option in the UI is enabled.

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -49,6 +49,7 @@
     "@backstage/plugin-auth-node": "^0.6.6",
     "@backstage/plugin-events-backend": "^0.5.5",
     "@backstage/plugin-events-node": "^0.4.14",
+    "@backstage/plugin-notifications-node": "^0.2.18",
     "@backstage/plugin-permission-common": "^0.9.1",
     "@backstage/plugin-permission-node": "^0.10.3",
     "@backstage/plugin-search-backend-node": "^1.3.14",

--- a/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/plugin.ts
@@ -22,6 +22,7 @@ import { signalsServiceRef } from '@backstage/plugin-signals-node';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { buildAnnouncementsContext } from './service';
 import { announcementEntityPermissions } from '@backstage-community/plugin-announcements-common';
+import { notificationService } from '@backstage/plugin-notifications-node';
 
 /**
  * A backend for the announcements plugin.
@@ -41,6 +42,7 @@ export const announcementsPlugin = createBackendPlugin({
         permissions: coreServices.permissions,
         permissionsRegistry: coreServices.permissionsRegistry,
         signals: signalsServiceRef,
+        notifications: notificationService,
       },
       async init({
         config,
@@ -52,6 +54,7 @@ export const announcementsPlugin = createBackendPlugin({
         permissions,
         permissionsRegistry,
         signals,
+        notifications,
       }) {
         const context = await buildAnnouncementsContext({
           config,
@@ -62,6 +65,7 @@ export const announcementsPlugin = createBackendPlugin({
           permissions,
           permissionsRegistry,
           signals,
+          notifications,
         });
 
         permissionsRegistry.addPermissions(

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -59,6 +59,10 @@ describe('createRouter', () => {
     issueUserCookie: jest.fn(),
   };
 
+  const mockNotificationService = {
+    send: jest.fn().mockImplementation(async () => {}),
+  };
+
   afterEach(() => {
     jest.resetAllMocks();
   });
@@ -71,10 +75,12 @@ describe('createRouter', () => {
       permissions: mockPermissions,
       permissionsRegistry: mockServices.permissionsRegistry.mock(),
       httpAuth: mockHttpAuth,
+      notifications: mockNotificationService,
     };
 
     const router = await createRouter(announcementsContext);
     app = express().use(router);
+    mockNotificationService.send.mockClear();
   });
 
   beforeEach(() => {

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -38,6 +38,7 @@ import {
 } from '@backstage-community/plugin-announcements-common';
 import { signalAnnouncement } from './service/signal';
 import { AnnouncementsContext } from './service';
+import { sendAnnouncementNotification } from './service/announcementNotification';
 
 interface AnnouncementRequest {
   publisher: string;
@@ -47,6 +48,7 @@ interface AnnouncementRequest {
   body: string;
   active: boolean;
   start_at: string;
+  sendNotification: boolean;
   on_behalf_of?: string;
   tags?: string[];
 }
@@ -76,6 +78,7 @@ export async function createRouter(
     persistenceContext,
     permissions,
     signals,
+    notifications,
   } = context;
 
   const {
@@ -219,6 +222,11 @@ export async function createRouter(
         });
 
         await signalAnnouncement(announcement, signals);
+        const announcementNotificationsEnabled =
+          req.body?.sendNotification === true;
+        if (announcementNotificationsEnabled) {
+          await sendAnnouncementNotification(announcement, notifications);
+        }
       }
 
       return res.status(201).json(announcement);

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NotificationService } from '@backstage/plugin-notifications-node';
+import { AnnouncementModel } from './model';
+
+export const sendAnnouncementNotification = async (
+  announcement: AnnouncementModel,
+  notifications?: NotificationService,
+) => {
+  if (!notifications) {
+    return;
+  }
+
+  await notifications.send({
+    recipients: {
+      type: 'broadcast',
+    },
+    payload: {
+      title: `New Announcement "${announcement.title}"`,
+      description: announcement.excerpt,
+      link: `/announcements/view/${announcement.id}`,
+    },
+  });
+};

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.test.ts
@@ -36,6 +36,10 @@ describe('buildAnnouncementsContext', () => {
       publish: jest.fn(),
     };
 
+    const mockNotificationService = {
+      send: jest.fn().mockImplementation(async () => {}),
+    };
+    const notifications = mockNotificationService;
     const context = await buildAnnouncementsContext({
       config,
       database,
@@ -45,6 +49,7 @@ describe('buildAnnouncementsContext', () => {
       permissions,
       permissionsRegistry,
       signals,
+      notifications,
     });
 
     const persistenceContext = await initializePersistenceContext(database);
@@ -58,6 +63,7 @@ describe('buildAnnouncementsContext', () => {
       permissionsRegistry,
       persistenceContext,
       signals,
+      notifications,
     });
   });
 });

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementsContextBuilder.ts
@@ -27,6 +27,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { EventsService } from '@backstage/plugin-events-node';
 import { SignalsService } from '@backstage/plugin-signals-node';
+import { NotificationService } from '@backstage/plugin-notifications-node';
 
 /**
  * Context for the announcements plugin.
@@ -42,6 +43,7 @@ export type AnnouncementsContext = {
   permissionsRegistry: PermissionsRegistryService;
   persistenceContext: PersistenceContext;
   signals?: SignalsService;
+  notifications?: NotificationService;
 };
 
 /**
@@ -70,6 +72,7 @@ export const buildAnnouncementsContext = async ({
   permissions,
   permissionsRegistry,
   signals,
+  notifications,
 }: AnnouncementsContextOptions): Promise<AnnouncementsContext> => {
   return {
     config,
@@ -80,5 +83,6 @@ export const buildAnnouncementsContext = async ({
     permissionsRegistry,
     persistenceContext: await initializePersistenceContext(database),
     signals,
+    notifications,
   };
 };

--- a/workspaces/announcements/plugins/announcements-common/report.api.md
+++ b/workspaces/announcements/plugins/announcements-common/report.api.md
@@ -18,6 +18,7 @@ export type Announcement = {
   start_at: string;
   on_behalf_of?: string;
   tags?: Tag[];
+  sendNotification?: boolean;
 };
 
 // @public
@@ -43,6 +44,7 @@ export type AnnouncementsFilters = {
   active?: boolean;
   sortBy?: 'created_at' | 'start_at';
   order?: 'asc' | 'desc';
+  sendNotification?: boolean;
 };
 
 // @public

--- a/workspaces/announcements/plugins/announcements-common/src/types.ts
+++ b/workspaces/announcements/plugins/announcements-common/src/types.ts
@@ -66,6 +66,8 @@ export type Announcement = {
   on_behalf_of?: string;
   /** Array of tags associated with the announcement */
   tags?: Tag[];
+  /** Whether the notification is enabled */
+  sendNotification?: boolean;
 };
 
 /**
@@ -102,6 +104,8 @@ export type AnnouncementsFilters = {
   sortBy?: 'created_at' | 'start_at';
   /** Sorting order: "asc" for ascending or "desc" for descending */
   order?: 'asc' | 'desc';
+  /** Whether the notification is enabled */
+  sendNotification?: boolean;
 };
 
 /**

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/AnnouncementForm.tsx
@@ -65,6 +65,7 @@ export const AnnouncementForm = ({
     category: initialData.category?.slug,
     start_at: formattedStartAt || '',
     tags: initialData.tags?.map(tag => tag.slug) || undefined,
+    sendNotification: initialData.sendNotification ?? false,
   });
   const [loading, setLoading] = useState(false);
   const [onBehalfOfSelectedTeam, setOnBehalfOfSelectedTeam] = useState(
@@ -239,6 +240,17 @@ export const AnnouncementForm = ({
                     />
                   }
                   label={t('announcementForm.active')}
+                />
+                <FormControlLabel
+                  control={
+                    <Switch
+                      name="sendNotification"
+                      checked={form.sendNotification}
+                      onChange={handleChangeActive}
+                      color="primary"
+                    />
+                  }
+                  label="Send Notification"
                 />
                 <Button
                   variant="contained"

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/CategoryInput.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/CategoryInput.test.tsx
@@ -50,6 +50,7 @@ describe('CategoryInput', () => {
       active: boolean;
       start_at: string;
       tags: string[] | undefined;
+      sendNotification: boolean;
     }>,
   ) => void = jest.fn();
 
@@ -64,6 +65,7 @@ describe('CategoryInput', () => {
     active: true,
     start_at: 'start_at',
     tags: ['kubernetes', 'go'],
+    sendNotification: false,
   };
 
   const announcementsApiMock = { categories: jest.fn() };

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementForm/CategoryInput.tsx
@@ -36,6 +36,7 @@ type CategoryInputProps = {
       created_at: string;
       active: boolean;
       start_at: string;
+      sendNotification: boolean;
     }>,
   ) => void;
   form: {
@@ -49,6 +50,7 @@ type CategoryInputProps = {
     created_at: string;
     active: boolean;
     start_at: string;
+    sendNotification: boolean;
   };
   initialValue: string;
 };

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -1649,6 +1649,7 @@ __metadata:
     "@backstage/plugin-catalog-node": "npm:^1.18.0"
     "@backstage/plugin-events-backend": "npm:^0.5.5"
     "@backstage/plugin-events-node": "npm:^0.4.14"
+    "@backstage/plugin-notifications-node": "npm:^0.2.18"
     "@backstage/plugin-permission-backend": "npm:^0.7.3"
     "@backstage/plugin-permission-backend-module-allow-all-policy": "npm:^0.2.11"
     "@backstage/plugin-permission-common": "npm:^0.9.1"
@@ -3063,6 +3064,32 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/e92a1154bc7612c8cf4f620550b05f33a2f1ec8f5ed933e372b2f17158932a05d8b0f2d71c23bc0f619d4c50ba48c2d8ec5111ab90d7f00bc80d0bb441a8ea71
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-common@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@backstage/plugin-notifications-common@npm:0.1.0"
+  dependencies:
+    "@backstage/config": "npm:^1.3.3"
+    "@backstage/types": "npm:^1.2.1"
+    "@material-ui/icons": "npm:^4.9.1"
+  checksum: 10/ea9601f791d2621d34b77f27dd842fea262c030ccb80a5677ef0b112d915c8491fa2d9eec600990e4fc1019e92f0a8c773d7f94f6a0dd483719d85fcd90f2976
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-node@npm:^0.2.18":
+  version: 0.2.18
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.18"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.4.2"
+    "@backstage/catalog-client": "npm:^1.11.0"
+    "@backstage/catalog-model": "npm:^1.7.5"
+    "@backstage/plugin-notifications-common": "npm:^0.1.0"
+    "@backstage/plugin-signals-node": "npm:^0.1.23"
+    knex: "npm:^3.0.0"
+    uuid: "npm:^11.0.0"
+  checksum: 10/b381921a5363ae1ad76a0529ebd9bd003d682ff5e87f97823697fe45134e4a6ec5fefb33cd84048123cc97df98d15b16375a5ab021593e86dd0b7d9bf6667006
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
