### PR TITLE
analytics - Add NFS support for Segment

### DIFF
--- a/workspaces/analytics/.changeset/segment-nu-da.md
+++ b/workspaces/analytics/.changeset/segment-nu-da.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-analytics-provider-segment': patch
+---
+
+Added support for Backstage's New Frontend System.
+
+If you're migrating to the new frontend system, you no longer need to wire up an API implementation in `apis.ts`, it's enough to install this package as a dependency of your app.

--- a/workspaces/analytics/plugins/analytics-provider-segment/README.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/README.md
@@ -43,6 +43,9 @@ This plugin contains no other functionality.
    ];
    ```
 
+   Note: if you are using Backstage's new frontend system, you can skip this
+   step. Installing the package in your app is enough: no API wiring necessary.
+
 2. Configure the plugin in your `app-config.yaml`:
 
 The following is the minimum configuration required to start sending analytics

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -35,6 +35,7 @@
     "@backstage/config": "backstage:^",
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
+    "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/theme": "backstage:^",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.11.3",

--- a/workspaces/analytics/plugins/analytics-provider-segment/report.api.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/report.api.md
@@ -4,20 +4,55 @@
 
 ```ts
 import { AnalyticsApi } from '@backstage/core-plugin-api';
-import { AnalyticsEvent } from '@backstage/core-plugin-api';
+import { AnalyticsEvent } from '@backstage/frontend-plugin-api';
+import { AnalyticsEvent as AnalyticsEvent_2 } from '@backstage/core-plugin-api';
+import { AnalyticsImplementation } from '@backstage/frontend-plugin-api';
+import { AnalyticsImplementationFactory } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/core-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Config } from '@backstage/config';
 import { ConfigApi } from '@backstage/core-plugin-api';
+import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
+import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
+import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 
 // @public
 export const analyticsModuleSegment: BackstagePlugin<{}, {}, {}>;
 
+// @public (undocumented)
+const analyticsProviderSegmentPlugin: OverridableFrontendPlugin<
+  {},
+  {},
+  {
+    'analytics:analytics-provider-segment': ExtensionDefinition<{
+      kind: 'analytics';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        AnalyticsImplementationFactory<{}>,
+        'core.analytics.factory',
+        {}
+      >;
+      inputs: {};
+      params: <
+        TDeps extends {
+          [x: string]: unknown;
+        },
+      >(
+        params: AnalyticsImplementationFactory<TDeps>,
+      ) => ExtensionBlueprintParams<AnalyticsImplementationFactory<{}>>;
+    }>;
+  }
+>;
+export default analyticsProviderSegmentPlugin;
+
 // @public
-export class SegmentAnalytics implements AnalyticsApi {
+export class SegmentAnalytics implements AnalyticsApi, AnalyticsImplementation {
   // (undocumented)
-  captureEvent(event: AnalyticsEvent): Promise<void>;
+  captureEvent(event: AnalyticsEvent | AnalyticsEvent_2): Promise<void>;
   static fromConfig(
     config: ConfigApi,
     options?: {

--- a/workspaces/analytics/plugins/analytics-provider-segment/src/apis/implementations/AnalyticsApi/Segment.ts
+++ b/workspaces/analytics/plugins/analytics-provider-segment/src/apis/implementations/AnalyticsApi/Segment.ts
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 import {
-  AnalyticsApi,
-  AnalyticsEvent,
+  AnalyticsApi as LegacyAnalyticsApi,
+  AnalyticsEvent as LegacyAnalyticsEvent,
   ConfigApi,
   IdentityApi,
 } from '@backstage/core-plugin-api';
+import {
+  AnalyticsEvent,
+  AnalyticsImplementation,
+} from '@backstage/frontend-plugin-api';
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 /**
  * Segment provider for the Backstage Analytics API.
  * @public
  */
-export class SegmentAnalytics implements AnalyticsApi {
+export class SegmentAnalytics
+  implements LegacyAnalyticsApi, AnalyticsImplementation
+{
   private readonly analytics: AnalyticsBrowser;
   private readonly testMode: boolean;
   private readonly maskIP: boolean;
@@ -99,7 +105,7 @@ export class SegmentAnalytics implements AnalyticsApi {
     );
   }
 
-  async captureEvent(event: AnalyticsEvent) {
+  async captureEvent(event: AnalyticsEvent | LegacyAnalyticsEvent) {
     // Don't capture events in test mode.
     if (this.testMode) {
       return;

--- a/workspaces/analytics/plugins/analytics-provider-segment/src/index.ts
+++ b/workspaces/analytics/plugins/analytics-provider-segment/src/index.ts
@@ -21,7 +21,10 @@ import {
 } from '@backstage/core-plugin-api';
 import { SegmentAnalytics } from './apis/implementations/AnalyticsApi';
 
-export { analyticsModuleSegment } from './plugin';
+export {
+  analyticsModuleSegment,
+  analyticsProviderSegmentPlugin as default,
+} from './plugin';
 export * from './apis/implementations/AnalyticsApi';
 /**
  * @public

--- a/workspaces/analytics/plugins/analytics-provider-segment/src/plugin.ts
+++ b/workspaces/analytics/plugins/analytics-provider-segment/src/plugin.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 import { createPlugin } from '@backstage/core-plugin-api';
+import {
+  AnalyticsImplementationBlueprint,
+  configApiRef,
+  createFrontendPlugin,
+  identityApiRef,
+} from '@backstage/frontend-plugin-api';
+import { SegmentAnalytics } from './apis/implementations/AnalyticsApi';
 
 /**
  *
@@ -21,4 +28,21 @@ import { createPlugin } from '@backstage/core-plugin-api';
  */
 export const analyticsModuleSegment = createPlugin({
   id: 'analytics-provider-segment',
+});
+
+const segmentImplementation = AnalyticsImplementationBlueprint.make({
+  params: defineParams =>
+    defineParams({
+      deps: { configApi: configApiRef, identityApi: identityApiRef },
+      factory: ({ configApi, identityApi }) =>
+        SegmentAnalytics.fromConfig(configApi, { identityApi }),
+    }),
+});
+
+/**
+ * @public
+ */
+export const analyticsProviderSegmentPlugin = createFrontendPlugin({
+  pluginId: 'analytics-provider-segment',
+  extensions: [segmentImplementation],
 });

--- a/workspaces/analytics/yarn.lock
+++ b/workspaces/analytics/yarn.lock
@@ -771,6 +771,7 @@ __metadata:
     "@backstage/core-components": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"
+    "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@backstage/theme": "backstage:^"
     "@material-ui/core": "npm:^4.9.13"


### PR DESCRIPTION
## What / Why

In the New Frontend System, we're moving away from an analytics utility API, instead using an `AnalyticsImplementationBlueprint` (https://github.com/backstage/backstage/pull/30677). This allows multiple analytics implementations to be installed and used in a Backstage app simultaneously with no extra code or config.

This PR adds an NFS Analytics Implementation to the Segment Analytics provider.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
