### PR TITLE
Version Packages (bitbucket-pull-requests)

### DIFF
--- a/workspaces/bitbucket-pull-requests/.changeset/loose-mirrors-visit.md
+++ b/workspaces/bitbucket-pull-requests/.changeset/loose-mirrors-visit.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bitbucket-pull-requests': minor
----
-
-Add a new bitbucket homepage component

--- a/workspaces/bitbucket-pull-requests/.changeset/shaky-olives-begin.md
+++ b/workspaces/bitbucket-pull-requests/.changeset/shaky-olives-begin.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bitbucket-pull-requests': major
----
-
-move plugin to the community-plugins backstage repo

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @backstage-community/plugin-bitbucket-pull-requests
+
+## 3.0.0
+
+### Major Changes
+
+- fbd92a7: move plugin to the community-plugins backstage repo
+
+### Minor Changes
+
+- d778269: Add a new bitbucket homepage component

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bitbucket-pull-requests",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-bitbucket-pull-requests@3.0.0

### Major Changes

-   fbd92a7: move plugin to the community-plugins backstage repo

### Minor Changes

-   d778269: Add a new bitbucket homepage component
