### PR TITLE
Change check ID display to check name

### DIFF
--- a/workspaces/tech-insights/.changeset/cuddly-flowers-glow.md
+++ b/workspaces/tech-insights/.changeset/cuddly-flowers-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-maturity': patch
+---
+
+Display the check name in the maturity results table instead of the id

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/maturityTableRows.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/maturityTableRows.tsx
@@ -126,7 +126,7 @@ const MaturityCheckTableRow = ({
                   value={{ rank: checkResult.check.metadata.rank }}
                   size={25}
                 />
-                <Typography>{checkResult.check.id}</Typography>
+                <Typography>{checkResult.check.name}</Typography>
               </Stack>
             </Grid>
             <Grid item xs={7.5}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use the check's name since that's intended to be a human-readable value. The id is often a camelCased name which won't word wrap and creates poor UI as in:

<img width="432" height="149" alt="image" src="https://github.com/user-attachments/assets/d0300cbe-92fd-476e-a47c-dad04ab49777" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
