### PR TITLE
feat(feedback): optional setting for Jira API host

### DIFF
--- a/workspaces/feedback/.changeset/warm-pillows-deny.md
+++ b/workspaces/feedback/.changeset/warm-pillows-deny.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-feedback-backend': patch
+---
+
+Added optional config setting for supplying the Jira API host, to support using scoped API tokens with Jira Cloud.

--- a/workspaces/feedback/plugins/feedback-backend/README.md
+++ b/workspaces/feedback/plugins/feedback-backend/README.md
@@ -79,6 +79,10 @@ feedback:
         # set hostType: CLOUD to make api work
         # default value is SERVER
         hostType: CLOUD
+        # (optional) When using a scoped API token with Jira cloud, provide the API host
+        # in the format https://api.atlassian.com/ex/jira/<cloudId>
+        # Defaults to the value of host if not set.
+        apiHost: ${JIRA_API_HOST_URL}
 
     email:
       ## Email integration uses nodemailer to send emails

--- a/workspaces/feedback/plugins/feedback-backend/config.d.ts
+++ b/workspaces/feedback/plugins/feedback-backend/config.d.ts
@@ -32,6 +32,11 @@ export interface Config {
          */
         host?: string;
         /**
+         * The hostname or URL of the JIRA API for the organization, if different from the value set in host.
+         * @visibility frontend
+         */
+        apiHost?: string;
+        /**
          * The access token for authenticating with JIRA.
          * @visibility secret
          */

--- a/workspaces/feedback/plugins/feedback-backend/src/service/router.ts
+++ b/workspaces/feedback/plugins/feedback-backend/src/service/router.ts
@@ -185,12 +185,13 @@ export async function createRouter(
             return logger.error('Jira integeration not found');
           }
           host = serviceConfig.getString('host');
+          const apiHost = serviceConfig.getOptionalString('apiHost') ?? host;
           const authToken = serviceConfig.getString('token');
           const hostType = serviceConfig.getOptionalString('hostType');
 
           const projectKey = entityRef.metadata.annotations['jira/project-key'];
           const jiraService = new JiraApiService(
-            host,
+            apiHost,
             authToken,
             logger,
             hostType,
@@ -348,10 +349,11 @@ export async function createRouter(
               .find(hostConfig => host === hostConfig.getString('host')) ??
             config.getConfigArray('feedback.integrations.jira')[0];
           host = serviceConfig.getString('host');
+          const apiHost = serviceConfig.getOptionalString('apiHost') ?? host;
           const authToken = serviceConfig.getString('token');
 
           const resp = await new JiraApiService(
-            host,
+            apiHost,
             authToken,
             logger,
           ).getTicketDetails(ticketId);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When integrating with Jira Cloud there are two options for API host.

`https://<yourDomain>.atlassian.net/`
- Same host as the Jira Cloud UI, can be used to created browsable links in the Backstage/Feedback UI.
- Does not support scoped API tokens.

`https://api.atlassian.com/ex/jira/<cloudId>`
- Different host from the Jira Cloud UI. Cannot be used to create browsable links in the Backstage/Feedback UI.
- Supports scoped API tokens.

To support using scoped API tokens with the Feedback plugin, this PR adds an optional setting, `apiHost` that can be populated when the host to use for API requests differs from the host to use for generating links. If the new setting is not populated then use the existing `host` setting for both, as per the previous behaviour.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
