### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/late-pens-walk.md
+++ b/workspaces/kiali/.changeset/late-pens-walk.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-kiali-react': patch
-'@backstage-community/plugin-kiali': patch
----
-
-Fix for graph loading issue – it was not rendering when the page was first displayed, only after a refresh.
-Added detail pages as a drawer that opens when clicking on each workload, service, or application link.

--- a/workspaces/kiali/.changeset/major-pillows-attack.md
+++ b/workspaces/kiali/.changeset/major-pillows-attack.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
-'@backstage-community/plugin-kiali-common': minor
-'@backstage-community/plugin-kiali-react': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Upgrade backstage 1.42.5

--- a/workspaces/kiali/.changeset/renovate-7e0e881.md
+++ b/workspaces/kiali/.changeset/renovate-7e0e881.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.2`.

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.25.0
+
+### Minor Changes
+
+- d0926d5: Upgrade backstage 1.42.5
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-common
 
+## 0.4.0
+
+### Minor Changes
+
+- d0926d5: Upgrade backstage 1.42.5
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-kiali-react
 
+## 0.3.0
+
+### Minor Changes
+
+- d0926d5: Upgrade backstage 1.42.5
+
+### Patch Changes
+
+- 396515d: Fix for graph loading issue – it was not rendering when the page was first displayed, only after a refresh.
+  Added detail pages as a drawer that opens when clicking on each workload, service, or application link.
+- Updated dependencies [d0926d5]
+  - @backstage-community/plugin-kiali-common@0.4.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,21 @@
 ### Dependencies
 
+## 1.42.0
+
+### Minor Changes
+
+- d0926d5: Upgrade backstage 1.42.5
+
+### Patch Changes
+
+- 396515d: Fix for graph loading issue – it was not rendering when the page was first displayed, only after a refresh.
+  Added detail pages as a drawer that opens when clicking on each workload, service, or application link.
+- 9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
+- Updated dependencies [396515d]
+- Updated dependencies [d0926d5]
+  - @backstage-community/plugin-kiali-react@0.3.0
+  - @backstage-community/plugin-kiali-common@0.4.0
+
 ## 1.41.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.42.0

### Minor Changes

-   d0926d5: Upgrade backstage 1.42.5

### Patch Changes

-   396515d: Fix for graph loading issue – it was not rendering when the page was first displayed, only after a refresh.
    Added detail pages as a drawer that opens when clicking on each workload, service, or application link.
-   9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
-   Updated dependencies [396515d]
-   Updated dependencies [d0926d5]
    -   @backstage-community/plugin-kiali-react@0.3.0
    -   @backstage-community/plugin-kiali-common@0.4.0

## @backstage-community/plugin-kiali-backend@1.25.0

### Minor Changes

-   d0926d5: Upgrade backstage 1.42.5

## @backstage-community/plugin-kiali-common@0.4.0

### Minor Changes

-   d0926d5: Upgrade backstage 1.42.5

## @backstage-community/plugin-kiali-react@0.3.0

### Minor Changes

-   d0926d5: Upgrade backstage 1.42.5

### Patch Changes

-   396515d: Fix for graph loading issue – it was not rendering when the page was first displayed, only after a refresh.
    Added detail pages as a drawer that opens when clicking on each workload, service, or application link.
-   Updated dependencies [d0926d5]
    -   @backstage-community/plugin-kiali-common@0.4.0
