### PR TITLE
ci: fix deprecation token name

### DIFF
--- a/.github/workflows/deprecate-archived-plugins.yml
+++ b/.github/workflows/deprecate-archived-plugins.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Deprecate packages
         run: ./scripts/ci/deprecate-archived-plugins.sh
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The [action run](https://github.com/backstage/community-plugins/actions/runs/17330961676) failed, I believe it is because the incorrect token name was used.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
