### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/beige-tables-lie.md
+++ b/workspaces/tech-insights/.changeset/beige-tables-lie.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-backend': patch
----
-
-add index to improve performance of fact deletion

--- a/workspaces/tech-insights/.changeset/cuddly-flowers-glow.md
+++ b/workspaces/tech-insights/.changeset/cuddly-flowers-glow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-maturity': patch
----
-
-Display the check name in the maturity results table instead of the id

--- a/workspaces/tech-insights/.changeset/dirty-windows-appear.md
+++ b/workspaces/tech-insights/.changeset/dirty-windows-appear.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-maturity': minor
----
-
-Display Multiple links
-Display errorInfo facts description and value if check result is false and fact type is not boolean
-Update layout of maturity check accordion summary display
-bugfix: Remove local implementation of accordion

--- a/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tech-insights-backend
 
+## 2.4.2
+
+### Patch Changes
+
+- e28273e: add index to improve performance of fact deletion
+
 ## 2.4.1
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-backend",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "tech-insights",

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-tech-insights-maturity
 
+## 0.5.0
+
+### Minor Changes
+
+- 7de2f90: Display Multiple links
+  Display errorInfo facts description and value if check result is false and fact type is not boolean
+  Update layout of maturity check accordion summary display
+  bugfix: Remove local implementation of accordion
+
+### Patch Changes
+
+- 98fb7ac: Display the check name in the maturity results table instead of the id
+
 ## 0.4.1
 
 ### Patch Changes

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-maturity",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-maturity@0.5.0

### Minor Changes

-   7de2f90: Display Multiple links
    Display errorInfo facts description and value if check result is false and fact type is not boolean
    Update layout of maturity check accordion summary display
    bugfix: Remove local implementation of accordion

### Patch Changes

-   98fb7ac: Display the check name in the maturity results table instead of the id

## @backstage-community/plugin-tech-insights-backend@2.4.2

### Patch Changes

-   e28273e: add index to improve performance of fact deletion
