### PR TITLE
feat(redhat-argocd): add option for fullDeploymentHistory

### DIFF
--- a/workspaces/redhat-argocd/.changeset/smart-jokes-exist.md
+++ b/workspaces/redhat-argocd/.changeset/smart-jokes-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-redhat-argocd': minor
+---
+
+add new config showFullDeploymentHistory that allows for duplicate revisions to get shown

--- a/workspaces/redhat-argocd/plugins/argocd/README.md
+++ b/workspaces/redhat-argocd/plugins/argocd/README.md
@@ -60,7 +60,17 @@ You can use the following code to grant the ClusterRole for custom resources:
 
 > Tip: You can use the [prepared manifest for a read-only ClusterRole](https://raw.githubusercontent.com/backstage/community-plugins/main/workspaces/redhat-argocd/plugins/argocd/manifests/clusterrole.yaml), which provides access for both Kubernetes plugin and Argo CD plugin.
 
-##### Annotations
+### Frontend-specific Configurations
+
+By default this plugin removes duplicate entries being shown in the "Deployment history" section.
+To view the full deployment history you set the following:
+
+```yaml
+argocd:
+  fullDeploymentHistory: true # false by default
+```
+
+### Annotations
 
 - The following annotation is added to the entity's `catalog-info.yaml` file to identify whether an entity contains the Kubernetes resources:
 
@@ -89,7 +99,7 @@ You can use the following code to grant the ClusterRole for custom resources:
     backstage.io/kubernetes-label-selector: 'app=my-app,component=front-end'
   ```
 
-##### Labels
+### Labels
 
 - The following label is added to the resources so that the Kubernetes plugin gets the Kubernetes resources from the requested entity:
 

--- a/workspaces/redhat-argocd/plugins/argocd/config.d.ts
+++ b/workspaces/redhat-argocd/plugins/argocd/config.d.ts
@@ -37,6 +37,11 @@ export interface Config {
      */
     refreshInterval?: number;
     /**
+     * Support for showing full deployment history (duplicates not removed)
+     * @visibility frontend
+     */
+    fullDeploymentHistory?: boolean;
+    /**
      * The base url of the ArgoCD instance.
      * @visibility frontend
      */

--- a/workspaces/redhat-argocd/plugins/argocd/dev/__data__/revision.ts
+++ b/workspaces/redhat-argocd/plugins/argocd/dev/__data__/revision.ts
@@ -19,6 +19,7 @@ export const mockRevision: RevisionInfo = {
   author: 'author-name',
   date: new Date('2023-10-10T05:28:38Z'),
   message: 'First release',
+  revisionID: '90f9758b7033a4bbb7c33a35ee474d61091644bc',
 };
 
 export const mockRevisionTwo = {

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/Common/AppCommitLink.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/Common/AppCommitLink.tsx
@@ -34,7 +34,7 @@ import { Entity } from '@backstage/catalog-model';
 interface CommitLinkProps {
   entity: Entity;
   application: Application;
-  revisionsMap: { [key: string]: RevisionInfo };
+  revisions: RevisionInfo[];
   latestRevision: History;
   showAuthor?: boolean;
 }
@@ -53,7 +53,7 @@ const useCommitStyles = makeStyles<Theme>(theme => ({
 const AppCommitLink: FC<CommitLinkProps> = ({
   entity,
   application,
-  revisionsMap,
+  revisions,
   latestRevision,
   showAuthor = false,
 }) => {
@@ -65,7 +65,7 @@ const AppCommitLink: FC<CommitLinkProps> = ({
     latestRevision?.revisions?.[0] ?? latestRevision?.revision ?? '';
 
   const revisionInfo = latestRevisionSha
-    ? revisionsMap?.[latestRevisionSha]
+    ? revisions?.find(r => r?.revisionID === latestRevisionSha)
     : undefined;
 
   const repoUrl =
@@ -91,7 +91,7 @@ const AppCommitLink: FC<CommitLinkProps> = ({
     );
   };
 
-  return revisionsMap && latestRevision ? (
+  return revisions && latestRevision ? (
     <div className={classes.commitContainer}>
       <Chip
         data-testid={`${latestRevisionSha.slice(0, 5)}-commit-link`}

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/Common/__tests__/AppCommitLink.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/Common/__tests__/AppCommitLink.test.tsx
@@ -31,7 +31,7 @@ describe('AppCommitLink', () => {
       <AppCommitLink
         application={mockApplication}
         entity={mockEntity}
-        revisionsMap={{}}
+        revisions={[]}
         latestRevision={mockApplication.status.history?.[1] as History}
       />,
     );
@@ -46,10 +46,7 @@ describe('AppCommitLink', () => {
       <AppCommitLink
         application={mockApplication}
         entity={mockEntity}
-        revisionsMap={{
-          '90f9758b7033a4bbb7c33a35ee474d61091644bc':
-            mockRevision as unknown as RevisionInfo,
-        }}
+        revisions={[mockRevision as unknown as RevisionInfo]}
         latestRevision={mockApplication.status.history?.[1] as History}
       />,
     );
@@ -80,10 +77,7 @@ describe('AppCommitLink', () => {
           },
         }}
         entity={{ ...mockEntity, metadata: { name: 'entity' } }}
-        revisionsMap={{
-          '90f9758b7033a4bbb7c33a35ee474d61091644bc':
-            mockRevision as unknown as RevisionInfo,
-        }}
+        revisions={[mockRevision as unknown as RevisionInfo]}
         latestRevision={mockApplication.status.history?.[1] as History}
       />,
     );
@@ -99,10 +93,7 @@ describe('AppCommitLink', () => {
       <AppCommitLink
         application={mockApplication}
         entity={mockEntity}
-        revisionsMap={{
-          '90f9758b7033a4bbb7c33a35ee474d61091644bc':
-            mockRevision as unknown as RevisionInfo,
-        }}
+        revisions={[mockRevision as unknown as RevisionInfo]}
         latestRevision={mockApplication.status.history?.[1] as History}
       />,
     );
@@ -115,10 +106,7 @@ describe('AppCommitLink', () => {
       <AppCommitLink
         application={mockApplication}
         entity={mockEntity}
-        revisionsMap={{
-          '90f9758b7033a4bbb7c33a35ee474d61091644bc':
-            mockRevision as unknown as RevisionInfo,
-        }}
+        revisions={[mockRevision as unknown as RevisionInfo]}
         latestRevision={mockApplication.status.history?.[1] as History}
         showAuthor
       />,

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -40,7 +40,6 @@ import DeploymentLifecycleCard from './DeploymentLifecycleCard';
 import DeploymentLifecycleDrawer from './DeploymentLifecycleDrawer';
 import { ArgoResourcesProvider } from './sidebar/rollouts/RolloutContext';
 import { DrawerProvider } from './DrawerContext';
-import { ConstructionOutlined } from '@mui/icons-material';
 
 const useDrawerStyles = makeStyles<Theme>(theme =>
   createStyles({

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycle.tsx
@@ -16,11 +16,10 @@
 import { useState, useRef, useMemo, useEffect } from 'react';
 
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 
 import { createStyles, makeStyles, Theme, Typography } from '@material-ui/core';
-
 import { argoCDApiRef } from '../../api';
 import { useApplications } from '../../hooks/useApplications';
 import { useArgocdConfig } from '../../hooks/useArgocdConfig';
@@ -33,7 +32,7 @@ import {
   getArgoCdAppConfig,
   getInstanceName,
   getUniqueRevisions,
-  mapRevisions,
+  removeDuplicateRevisions,
 } from '../../utils/utils';
 
 import PermissionAlert from '../Common/PermissionAlert';
@@ -41,6 +40,7 @@ import DeploymentLifecycleCard from './DeploymentLifecycleCard';
 import DeploymentLifecycleDrawer from './DeploymentLifecycleDrawer';
 import { ArgoResourcesProvider } from './sidebar/rollouts/RolloutContext';
 import { DrawerProvider } from './DrawerContext';
+import { ConstructionOutlined } from '@mui/icons-material';
 
 const useDrawerStyles = makeStyles<Theme>(theme =>
   createStyles({
@@ -65,6 +65,7 @@ const DeploymentLifecycle = () => {
   const classes = useDrawerStyles();
 
   const api = useApi(argoCDApiRef);
+  const configApi = useApi(configApiRef);
 
   const { instances, intervalMs } = useArgocdConfig();
   const instanceName = getInstanceName(entity) || instances?.[0]?.name;
@@ -84,18 +85,24 @@ const DeploymentLifecycle = () => {
 
   const [open, setOpen] = useState(false);
   const [activeItem, setActiveItem] = useState<string>();
-  const [, setRevisions] = useState<{
-    [key: string]: RevisionInfo;
-  }>();
-  const revisionCache = useRef<{ [key: string]: RevisionInfo }>({});
+  const [, setRevisions] = useState<RevisionInfo[]>();
+  const revisionCache = useRef<RevisionInfo[]>([]);
+  const keepDuplicateRevisions = configApi.getOptionalBoolean(
+    'argocd.fullDeploymentHistory',
+  );
 
   const uniqRevisions: string[] = useMemo(
     () => getUniqueRevisions(apps),
     [apps],
   );
 
+  // Even if we allow duplicates revisions in the data because of multiple deployments
+  // we need to check if the number of unique revisions have changed
+  const uniqCachedRevisions = removeDuplicateRevisions(
+    revisionCache.current,
+  ).map(r => r.revisionID);
   useEffect(() => {
-    if (uniqRevisions.length !== Object.keys(revisionCache.current).length) {
+    if (uniqRevisions.length !== uniqCachedRevisions.length) {
       api
         .getRevisionDetailsList({
           apps: apps,
@@ -103,7 +110,11 @@ const DeploymentLifecycle = () => {
           revisionIDs: uniqRevisions,
         })
         .then(data => {
-          revisionCache.current = mapRevisions(uniqRevisions, data);
+          // By default, the data returned can contain copies of the same revision, depending on
+          // the amount of deployments.
+          revisionCache.current = keepDuplicateRevisions
+            ? data
+            : removeDuplicateRevisions(data);
           setRevisions(revisionCache.current);
         })
         .catch(e => {
@@ -111,7 +122,15 @@ const DeploymentLifecycle = () => {
           console.warn(e);
         });
     }
-  }, [api, apps, entity, instanceName, uniqRevisions]);
+  }, [
+    api,
+    apps,
+    entity,
+    instanceName,
+    uniqRevisions,
+    keepDuplicateRevisions,
+    uniqCachedRevisions,
+  ]);
 
   const toggleDrawer = () => setOpen(e => !e);
 
@@ -150,7 +169,7 @@ const DeploymentLifecycle = () => {
           <DeploymentLifecycleCard
             app={app}
             key={app.metadata.uid ?? idx}
-            revisionsMap={revisionCache.current}
+            revisions={revisionCache.current}
             onclick={() => {
               toggleDrawer();
               setActiveItem(app.metadata.name);
@@ -160,7 +179,7 @@ const DeploymentLifecycle = () => {
       </div>
       <DrawerProvider
         application={activeApp as Application}
-        revisionsMap={revisionCache.current}
+        revisions={revisionCache.current}
       >
         <ArgoResourcesProvider application={activeApp}>
           <DeploymentLifecycleDrawer

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -53,14 +53,14 @@ const useCardStyles = makeStyles<Theme>(theme =>
 
 interface DeploymentLifecycleCardProps {
   app: Application;
-  revisionsMap: { [key: string]: RevisionInfo };
+  revisions: RevisionInfo[];
   onclick?: () => void;
 }
 
 const DeploymentLifecycleCard: FC<DeploymentLifecycleCardProps> = ({
   app,
   onclick,
-  revisionsMap,
+  revisions,
 }) => {
   const appName = app?.metadata?.instance?.name ?? 'default';
   const appHistory = app?.status?.history ?? [];
@@ -110,7 +110,7 @@ const DeploymentLifecycleCard: FC<DeploymentLifecycleCardProps> = ({
               <AppCommitLink
                 application={app}
                 entity={entity}
-                revisionsMap={revisionsMap}
+                revisions={revisions}
                 latestRevision={latestRevision}
               />
             </MetadataItemWithTooltip>

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleDrawer.tsx
@@ -73,7 +73,7 @@ const DeploymentLifecycleDrawer: FC<DeploymentLifecycleDrawerProps> = ({
 }) => {
   const {
     application: app,
-    revisionsMap,
+    revisions,
     appHistory,
     latestRevision,
   } = useDrawerContext();
@@ -138,7 +138,7 @@ const DeploymentLifecycleDrawer: FC<DeploymentLifecycleDrawerProps> = ({
                   <AppCommitLink
                     application={app}
                     entity={entity}
-                    revisionsMap={revisionsMap}
+                    revisions={revisions}
                     latestRevision={latestRevision}
                     showAuthor
                   />

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DrawerContext.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/DrawerContext.tsx
@@ -24,14 +24,14 @@ import {
 
 interface DrawerContextValue {
   application: Application;
-  revisionsMap: { [key: string]: RevisionInfo };
+  revisions: RevisionInfo[];
   latestRevision: History;
   appHistory: History[];
 }
 
 interface DrawerContextProps {
   application: Application;
-  revisionsMap: { [key: string]: RevisionInfo };
+  revisions: RevisionInfo[];
   children: ReactNode;
 }
 
@@ -41,7 +41,7 @@ export const DrawerContext = createContext<DrawerContextValue>(
 
 export const DrawerProvider: FC<DrawerContextProps> = ({
   application,
-  revisionsMap,
+  revisions,
   children,
 }) => {
   const appHistory = application?.status?.history ?? [];
@@ -53,7 +53,7 @@ export const DrawerProvider: FC<DrawerContextProps> = ({
         application,
         appHistory,
         latestRevision,
-        revisionsMap,
+        revisions,
       }}
     >
       {children}

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycle.test.tsx
@@ -15,7 +15,7 @@
  */
 import { PropsWithChildren } from 'react';
 
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { usePermission } from '@backstage/plugin-permission-react';
 
 import { createTheme, ThemeProvider } from '@material-ui/core';
@@ -25,6 +25,7 @@ import { mockApplication, mockEntity } from '../../../../dev/__data__';
 import { useArgocdConfig } from '../../../hooks/useArgocdConfig';
 import DeploymentLifecycle from '../DeploymentLifecycle';
 import { useArgoResources } from '../sidebar/rollouts/RolloutContext';
+import { argoCDApiRef } from '../../../api';
 
 jest.mock('../../../hooks/useArgocdConfig', () => ({
   useArgocdConfig: jest.fn(),
@@ -60,6 +61,47 @@ jest.mock('@backstage/core-components', () => ({
   ),
 }));
 
+// Mock for configApiRef
+const mockConfigApi = {
+  getOptionalBoolean: jest.fn().mockReturnValue(false),
+};
+
+// Mock for ArgoCDApiRef
+const mockArgoCDAPI = {
+  listApps: jest.fn().mockResolvedValue({ items: [mockApplication] }),
+  getRevisionDetailsList: jest.fn().mockResolvedValue({
+    commit: 'commit message',
+    author: 'test-user',
+    date: new Date(),
+  }),
+};
+
+/**
+ * Replaces useApi's implementation with a version that:
+ *   - returns mockConfigApi when called with configApiRef
+ *   - returns an Argo API mock when called with argoCDApiRef
+ *   - returns {} for anything else
+ *
+ * You can override Argo methods per test by passing functions in `argoImpl`
+ */
+function setUseApi(argoImpl: {
+  listApps?: jest.Mock | (() => Promise<any>);
+  getRevisionDetailsList?: jest.Mock | (() => Promise<any>);
+}) {
+  (useApi as jest.Mock).mockImplementation((ref: any) => {
+    if (ref === configApiRef) return mockConfigApi;
+    if (ref === argoCDApiRef) {
+      return {
+        listApps: argoImpl.listApps ?? mockArgoCDAPI.listApps,
+        getRevisionDetailsList:
+          argoImpl.getRevisionDetailsList ??
+          mockArgoCDAPI.getRevisionDetailsList,
+      };
+    }
+    return {};
+  });
+}
+
 describe('DeploymentLifecycle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -74,19 +116,8 @@ describe('DeploymentLifecycle', () => {
       instanceName: 'main',
     });
 
-    (useApi as any).mockReturnValue({
-      listApps: async () => {
-        return Promise.resolve({ items: [mockApplication] });
-      },
-      getRevisionDetailsList: async () => {
-        return Promise.resolve({
-          commit: 'commit message',
-          author: 'test-user',
-          date: new Date(),
-        });
-      },
-    });
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Setup useAPI implementation mock with defaults
+    setUseApi({});
   });
 
   it('should render Permission alert if the user does not have view permission', () => {
@@ -140,13 +171,10 @@ describe('DeploymentLifecycle', () => {
   });
 
   test('should catch the error while fetching revision details', async () => {
-    (useApi as any).mockReturnValue({
-      listApps: async () => {
-        return Promise.resolve({ items: [mockApplication] });
-      },
-      getRevisionDetailsList: async () => {
-        return Promise.reject(new Error('500: Internal server error'));
-      },
+    setUseApi({
+      getRevisionDetailsList: jest
+        .fn()
+        .mockRejectedValue(new Error('500: Internal server error')),
     });
 
     render(<DeploymentLifecycle />);
@@ -160,18 +188,12 @@ describe('DeploymentLifecycle', () => {
   });
 
   test('should catch the error while fetching applications', async () => {
-    (useApi as any).mockReturnValue({
-      listApps: async () => {
-        return Promise.reject(new Error('500: Internal server error'));
-      },
-      getRevisionDetailsList: async () => {
-        return Promise.resolve({
-          commit: 'commit message',
-          author: 'test-user',
-          date: new Date(),
-        });
-      },
+    setUseApi({
+      listApps: jest
+        .fn()
+        .mockRejectedValue(new Error('500: Internal server error')),
     });
+
     render(<DeploymentLifecycle />);
 
     await waitFor(() => {
@@ -181,14 +203,11 @@ describe('DeploymentLifecycle', () => {
   });
 
   test('should not render the component if there are no applications matching the selector', async () => {
-    (useApi as any).mockReturnValue({
-      listApps: async () => {
-        return Promise.resolve({ items: [] });
-      },
-      getRevisionDetailsList: async () => {
-        return Promise.resolve({});
-      },
+    setUseApi({
+      listApps: jest.fn().mockResolvedValue({ items: [] }),
+      getRevisionDetailsList: jest.fn().mockResolvedValue({}),
     });
+
     render(<DeploymentLifecycle />);
 
     await waitFor(() => {

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleCard.test.tsx
@@ -56,7 +56,7 @@ describe('DeploymentLifecylceCard', () => {
     render(
       <DeploymentLifecycleCard
         app={null as unknown as Application}
-        revisionsMap={{}}
+        revisions={[]}
       />,
     );
 
@@ -65,12 +65,12 @@ describe('DeploymentLifecylceCard', () => {
     ).not.toBeInTheDocument();
   });
   test('should render if the application card', () => {
-    render(<DeploymentLifecycleCard app={mockApplication} revisionsMap={{}} />);
+    render(<DeploymentLifecycleCard app={mockApplication} revisions={[]} />);
     expect(screen.getByTestId('quarkus-app-dev-card')).toBeInTheDocument();
   });
 
   test('application header should link to external link', () => {
-    render(<DeploymentLifecycleCard app={mockApplication} revisionsMap={{}} />);
+    render(<DeploymentLifecycleCard app={mockApplication} revisions={[]} />);
     const link = screen.getByTestId('quarkus-app-dev-link');
     fireEvent.click(link);
 
@@ -81,7 +81,7 @@ describe('DeploymentLifecylceCard', () => {
   });
 
   test('should render incluster tooltip', () => {
-    render(<DeploymentLifecycleCard app={mockApplication} revisionsMap={{}} />);
+    render(<DeploymentLifecycleCard app={mockApplication} revisions={[]} />);
 
     fireEvent.mouseDown(screen.getByText('(in-cluster)'));
     expect(screen.getByTestId('local-cluster-tooltip')).toBeInTheDocument();
@@ -98,9 +98,7 @@ describe('DeploymentLifecylceCard', () => {
         },
       },
     };
-    render(
-      <DeploymentLifecycleCard app={remoteApplication} revisionsMap={{}} />,
-    );
+    render(<DeploymentLifecycleCard app={remoteApplication} revisions={[]} />);
 
     expect(screen.queryByText('(in-cluster)')).not.toBeInTheDocument();
     expect(
@@ -120,9 +118,7 @@ describe('DeploymentLifecylceCard', () => {
     };
     global.open = jest.fn();
 
-    render(
-      <DeploymentLifecycleCard app={remoteApplication} revisionsMap={{}} />,
-    );
+    render(<DeploymentLifecycleCard app={remoteApplication} revisions={[]} />);
     const commitLink = screen.getByTestId('90f97-commit-link');
     fireEvent.click(commitLink);
 
@@ -142,13 +138,14 @@ describe('DeploymentLifecylceCard', () => {
     render(
       <DeploymentLifecycleCard
         app={mockApplication}
-        revisionsMap={{
-          '90f9758b7033a4bbb7c33a35ee474d61091644bc': {
+        revisions={[
+          {
+            revisionID: '90f9758b7033a4bbb7c33a35ee474d61091644bc',
             author: 'test user',
             message: 'commit message',
             date: new Date(),
           },
-        }}
+        ]}
       />,
     );
 
@@ -180,7 +177,7 @@ test('application card should not contain commit section for helm based applicat
     },
   };
 
-  render(<DeploymentLifecycleCard app={helmApplication} revisionsMap={{}} />);
+  render(<DeploymentLifecycleCard app={helmApplication} revisions={[]} />);
 
   const commitLink = screen.queryByText('Commit');
   expect(commitLink).not.toBeInTheDocument();

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleDrawer.test.tsx
@@ -55,7 +55,7 @@ describe('DeploymentLifecycleDrawer', () => {
     (useArgoResources as jest.Mock).mockReturnValue({ rollouts: [] });
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: mockApplication,
-      revisionsMap: {},
+      revisions: [],
       appHistory: mockApplication?.status?.history,
       latestRevision: mockApplication?.status?.history?.[1],
     });
@@ -96,7 +96,7 @@ describe('DeploymentLifecycleDrawer', () => {
   test('should not render the application drawer component', () => {
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: null as unknown as Application,
-      revisionsMap: {},
+      revisions: [{}],
     });
 
     render(<DeploymentLifecycleDrawer isOpen onClose={() => jest.fn()} />);
@@ -124,7 +124,7 @@ describe('DeploymentLifecycleDrawer', () => {
     };
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: helmApplication,
-      revisionsMap: {},
+      revisions: [{}],
     });
 
     render(<DeploymentLifecycleDrawer isOpen onClose={() => jest.fn()} />, {
@@ -140,13 +140,13 @@ describe('DeploymentLifecycleDrawer', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: mockApplication,
-      revisionsMap: {
-        '90f9758b7033a4bbb7c33a35ee474d61091644bc': {
+      revisions: [
+        {
           author: 'test user',
           message: 'commit message',
           date: new Date(),
         },
-      },
+      ],
       appHistory: mockApplication.status.history,
       latestRevision: mockApplication.status.history?.[1],
     });
@@ -176,7 +176,7 @@ describe('DeploymentLifecycleDrawer', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: remoteApplication,
-      revisionsMap: {},
+      revisions: [{}],
       appHistory: mockApplication.status.history,
       latestRevision: mockApplication.status.history?.[1],
     });
@@ -204,7 +204,7 @@ describe('DeploymentLifecycleDrawer', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: remoteApplication,
-      revisionsMap: {},
+      revisions: [{}],
     });
 
     render(<DeploymentLifecycleDrawer isOpen onClose={jest.fn()} />, {

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DrawerContext.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DrawerContext.test.tsx
@@ -39,7 +39,7 @@ describe('DrawerContext', () => {
     const { container } = render(
       <DrawerProvider
         application={null as unknown as Application}
-        revisionsMap={{}}
+        revisions={[]}
       >
         <MockComponent />
       </DrawerProvider>,
@@ -50,7 +50,7 @@ describe('DrawerContext', () => {
 
   it('should render the mock element with correct data', () => {
     render(
-      <DrawerProvider application={mockApplication} revisionsMap={{}}>
+      <DrawerProvider application={mockApplication} revisions={[]}>
         <MockComponent />
       </DrawerProvider>,
     );

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/DeploymentHistoryCommit.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/DeploymentHistoryCommit.tsx
@@ -47,6 +47,7 @@ export const DeploymentHistoryCommit: FC<DeploymentHistoryCommitProps> = ({
         width: '50rem',
         marginBottom: '5px',
       }}
+      data-testid={`commit-sha-${revisionSha}`}
     >
       <CardContent>
         <Typography

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/DeploymentMetadata.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/DeploymentMetadata.tsx
@@ -18,6 +18,7 @@ import { useDrawerContext } from '../../../DrawerContext';
 import { Resource } from '@backstage-community/plugin-redhat-argocd-common';
 import { isAppHelmChartType } from '../../../../../utils/utils';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import Metadata from '../../../../Common/Metadata';
 import MetadataItem from '../../../../Common/MetadataItem';
 import MetadataItemWithTooltip from '../../../../Common/MetadataItemWithTooltip';
@@ -52,10 +53,14 @@ const useDeploymentInfoStyles = makeStyles((theme: Theme) => ({
 
 const DeploymentMetadata = ({ resource }: { resource: Resource }) => {
   const { entity } = useEntity();
-  const { application, latestRevision, revisionsMap, appHistory } =
+  const configApi = useApi(configApiRef);
+  const showFullDeploymentHistory = configApi.getOptionalBoolean(
+    'argocd.fullDeploymentHistory',
+  );
+
+  const { application, latestRevision, revisions, appHistory } =
     useDrawerContext();
   const classes = useDeploymentInfoStyles();
-
   const ImageLinks = () => {
     const images = application?.status?.summary?.images;
     return images.map(image => {
@@ -88,7 +93,7 @@ const DeploymentMetadata = ({ resource }: { resource: Resource }) => {
               application={application}
               entity={entity}
               latestRevision={latestRevision}
-              revisionsMap={revisionsMap}
+              revisions={revisions}
             />
           </MetadataItem>
         ) : (
@@ -98,10 +103,11 @@ const DeploymentMetadata = ({ resource }: { resource: Resource }) => {
       {appHistory.length > 0 && (
         <DeploymentHistory
           application={application}
-          revisionsMap={revisionsMap}
+          revisions={revisions}
           appHistory={appHistory}
           styleClasses={classes}
           annotations={entity?.metadata?.annotations}
+          showFullDeploymentHistory={showFullDeploymentHistory}
         />
       )}
     </>

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/__tests__/DeploymentMetadata.test.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/resource/__tests__/DeploymentMetadata.test.tsx
@@ -23,6 +23,9 @@ import {
 import { useDrawerContext } from '../../../../DrawerContext';
 import { mockApplication, mockEntity } from '../../../../../../../dev/__data__';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { TestApiProvider } from '@backstage/test-utils';
+import { configApiRef, ApiRef } from '@backstage/core-plugin-api';
+import { Config } from '@backstage/config';
 
 const resource: Resource = {
   group: 'apps',
@@ -45,27 +48,87 @@ jest.mock('../../../../DrawerContext', () => ({
   useDrawerContext: jest.fn(),
 }));
 
+const mockConfigApi = {
+  // argocd.fullDeploymentHistory
+  getOptionalBoolean: jest.fn().mockReturnValue(false),
+};
+
+const defaultApis: readonly [readonly [ApiRef<Config>, Partial<Config>]] = [
+  [configApiRef, mockConfigApi],
+];
+
+const renderWithApis = (
+  component: React.ReactElement,
+  apis?: readonly [readonly [ApiRef<Config>, Partial<Config>]] | undefined,
+) => {
+  return render(
+    <TestApiProvider apis={apis ?? defaultApis}>{component}</TestApiProvider>,
+  );
+};
+
 describe('DeploymentMetadata', () => {
   it('should render Deployment Metadata', () => {
     (useEntity as jest.Mock).mockReturnValue({ entity: mockEntity });
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: mockApplication,
-      revisionsMap: {
-        '90f9758b7033a4bbb7c33a35ee474d61091644bc': {
+      revisions: [
+        {
           author: 'test user',
           message: 'commit message',
           date: new Date(),
         },
-      },
+      ],
       appHistory: mockApplication.status.history,
       latestRevision: mockApplication.status.history?.[1],
     });
 
-    render(<DeploymentMetadata resource={resource} />);
+    renderWithApis(<DeploymentMetadata resource={resource} />);
 
     expect(screen.getByText('Deployment history')).toBeInTheDocument();
     expect(screen.getByTestId('90f97-commit-link')).toBeInTheDocument();
+  });
+
+  it('should render Deployment Metadata with duplicate revisions if allowed', () => {
+    (useEntity as jest.Mock).mockReturnValue({ entity: mockEntity });
+
+    const mockConfigApiTrue = {
+      getOptionalBoolean: jest.fn().mockReturnValue(true),
+    };
+
+    (useDrawerContext as jest.Mock).mockReturnValue({
+      application: mockApplication,
+      revisions: [
+        {
+          author: 'test user',
+          message: 'commit message',
+          date: new Date(),
+          revisionID: '90f9758b7033a4bbb7c33a35ee474d61091644bc',
+        },
+        {
+          author: 'test user',
+          message: 'commit message',
+          date: new Date(),
+          revisionID: '90f9758b7033a4bbb7c33a35ee474d61091644bc',
+        },
+      ],
+      appHistory: mockApplication.status.history,
+      latestRevision: mockApplication.status.history?.[1],
+    });
+
+    const apis: readonly [readonly [ApiRef<Config>, Partial<Config>]] = [
+      [configApiRef, mockConfigApiTrue],
+    ];
+    renderWithApis(<DeploymentMetadata resource={resource} />, apis);
+
+    expect(screen.getByText('Deployment history')).toBeInTheDocument();
+    expect(screen.getByTestId('90f97-commit-link')).toBeInTheDocument();
+    // We should see two of the same revisions shown in the child components
+    expect(
+      screen.getAllByTestId(
+        'commit-sha-90f9758b7033a4bbb7c33a35ee474d61091644bc',
+      ).length,
+    ).toBe(2);
   });
 
   it('should not render application history', () => {
@@ -73,12 +136,12 @@ describe('DeploymentMetadata', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: mockApplication,
-      revisionsMap: {},
+      revisions: [{}],
       appHistory: [],
       latestRevision: mockApplication.status.history?.[1],
     });
 
-    render(<DeploymentMetadata resource={resource} />);
+    renderWithApis(<DeploymentMetadata resource={resource} />);
 
     expect(screen.queryByText('Deployment history')).not.toBeInTheDocument();
   });
@@ -95,12 +158,12 @@ describe('DeploymentMetadata', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: remoteApplication,
-      revisionsMap: {},
+      revisions: [{}],
       appHistory: remoteApplication.status.history,
       latestRevision: remoteApplication.status.history?.[1],
     });
 
-    render(<DeploymentMetadata resource={resource} />);
+    renderWithApis(<DeploymentMetadata resource={resource} />);
 
     expect(screen.queryByText('quarkus-app:latest')).toBeInTheDocument();
   });
@@ -121,12 +184,12 @@ describe('DeploymentMetadata', () => {
 
     (useDrawerContext as jest.Mock).mockReturnValue({
       application: remoteApplication,
-      revisionsMap: {},
+      revisions: [{}],
       appHistory: remoteApplication.status.history,
       latestRevision: remoteApplication.status.history?.[1],
     });
 
-    render(<DeploymentMetadata resource={resource} />);
+    renderWithApis(<DeploymentMetadata resource={resource} />);
 
     expect(screen.queryByText('commit message')).not.toBeInTheDocument();
   });

--- a/workspaces/redhat-argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
+++ b/workspaces/redhat-argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
@@ -32,7 +32,6 @@ import {
   getResourceCreateTimestamp,
   sortValues,
   removeDuplicateRevisions,
-  mapRevisions,
 } from '../utils';
 
 describe('Utils', () => {
@@ -468,21 +467,25 @@ describe('Utils', () => {
           author: 'user-a',
           date: date,
           message: 'commit sent to repo',
+          revisionID: 'abc123',
         },
         {
           author: 'user-a',
           date: date,
           message: 'commit sent to repo',
+          revisionID: 'abc123',
         },
         {
           author: 'user-a',
           date: date,
           message: 'commit sent to repo',
+          revisionID: 'abc123',
         },
         {
           author: 'user-b',
           date: date,
           message: 'fixes bug issue',
+          revisionID: 'def456',
         },
       ];
 
@@ -491,110 +494,15 @@ describe('Utils', () => {
           author: 'user-a',
           date: date,
           message: 'commit sent to repo',
+          revisionID: 'abc123',
         },
         {
           author: 'user-b',
           date: date,
           message: 'fixes bug issue',
-        },
-      ]);
-    });
-  });
-
-  describe('mapRevisions', () => {
-    const date =
-      'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)';
-    const mockRevisions = ['abc123', 'def456', 'ghi789'];
-    const mockRevisionData = [
-      {
-        revisionID: 'abc123',
-        author: 'user a',
-        message: 'submitted fix',
-        date,
-      },
-      {
-        revisionID: 'abc123',
-        author: 'user a',
-        message: 'submitted fix',
-        date,
-      },
-      {
-        revisionID: 'abc123',
-        author: 'user a',
-        message: 'submitted fix',
-        date,
-      },
-      {
-        revisionID: 'def456',
-        author: 'user a',
-        message: 'adds new feature',
-        date,
-      },
-      {
-        revisionID: 'def456',
-        author: 'user a',
-        message: 'adds new feature',
-        date,
-      },
-      {
-        revisionID: 'ghi789',
-        author: 'user b',
-        message: 'fixes bug',
-        date,
-      },
-    ];
-
-    it('should map revisions by revisionID if available', () => {
-      expect(mapRevisions(mockRevisions, mockRevisionData as any)).toEqual({
-        abc123: {
-          author: 'user a',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'submitted fix',
-          revisionID: 'abc123',
-        },
-        def456: {
-          author: 'user a',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'adds new feature',
           revisionID: 'def456',
         },
-        ghi789: {
-          author: 'user b',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'fixes bug',
-          revisionID: 'ghi789',
-        },
-      });
-    });
-
-    it('should map revisions by index if revisionID is not available', () => {
-      const mockRevisionDataWithoutRevisionID = mockRevisionData.map(r => {
-        return {
-          author: r.author,
-          message: r.message,
-          date: r.date,
-        };
-      });
-
-      expect(
-        mapRevisions(mockRevisions, mockRevisionDataWithoutRevisionID as any),
-      ).toEqual({
-        abc123: {
-          author: 'user a',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'submitted fix',
-        },
-        def456: {
-          author: 'user a',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'adds new feature',
-        },
-        ghi789: {
-          author: 'user b',
-          date: 'Fri Feb 28 2025 21:11:22 GMT+0000 (Coordinated Universal Time)',
-          message: 'fixes bug',
-        },
-      });
+      ]);
     });
   });
 });

--- a/workspaces/redhat-argocd/plugins/argocd/src/utils/utils.ts
+++ b/workspaces/redhat-argocd/plugins/argocd/src/utils/utils.ts
@@ -24,7 +24,6 @@ import {
   RevisionInfo,
 } from '@backstage-community/plugin-redhat-argocd-common';
 import { ArgoResources } from '../types/resources';
-import { ConstructionOutlined } from '@mui/icons-material';
 
 export const enum ArgoCdLabels {
   appSelector = 'argocd/app-selector',

--- a/workspaces/redhat-argocd/plugins/argocd/src/utils/utils.ts
+++ b/workspaces/redhat-argocd/plugins/argocd/src/utils/utils.ts
@@ -24,6 +24,7 @@ import {
   RevisionInfo,
 } from '@backstage-community/plugin-redhat-argocd-common';
 import { ArgoResources } from '../types/resources';
+import { ConstructionOutlined } from '@mui/icons-material';
 
 export const enum ArgoCdLabels {
   appSelector = 'argocd/app-selector',
@@ -254,7 +255,9 @@ export const sortValues = (
 /**
  * Removes duplicate commits based on their author, message and date.
  */
-export const removeDuplicateRevisions = (revisions: RevisionInfo[]) => {
+export const removeDuplicateRevisions = (
+  revisions: RevisionInfo[],
+): RevisionInfo[] => {
   const uniqueMap = new Map<string, RevisionInfo>();
 
   revisions.forEach(revision => {
@@ -265,23 +268,4 @@ export const removeDuplicateRevisions = (revisions: RevisionInfo[]) => {
   });
 
   return Array.from(uniqueMap.values());
-};
-
-/**
- * Maps revisions to unique commits using revisionID when available.
- * Falls back to mapping by index if the attribute revisionID is not provided.
- */
-export const mapRevisions = (
-  revisions: string[],
-  data: RevisionInfo[],
-): Record<string, RevisionInfo> => {
-  const uniqRevisionInfo = removeDuplicateRevisions(data);
-  // Create a map for quick lookup by revisionID
-  const revisionMap = new Map(uniqRevisionInfo.map(r => [r.revisionID, r]));
-
-  return revisions.reduce((acc, rev, i) => {
-    acc[rev] =
-      revisionMap.get(rev) ?? uniqRevisionInfo[i] ?? ({} as RevisionInfo);
-    return acc;
-  }, {} as Record<string, RevisionInfo>);
 };


### PR DESCRIPTION
Adds the ability to view the full deployment history with duplicate revisions kept.

This should fix #5213 

`fullDeploymentHistory: true`:

https://github.com/user-attachments/assets/86997cb9-a066-4e24-90bc-70d490168179

Duplicate revisions get shown, matching number of deployments.

`fullDeploymentHistory: false` (default behavior, even if annotation is not used):

https://github.com/user-attachments/assets/17e30fbd-844d-4356-9ebe-e3ea39c26147

Duplicate revisions get filtered out

By default the revision duplicates get filtered out, so the default behavior is kept.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
