### PR TITLE
Mend: Migrated Mend Plugin to Material UI 5

### DIFF
--- a/workspaces/mend/.changeset/khaki-jokes-camp.md
+++ b/workspaces/mend/.changeset/khaki-jokes-camp.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mend': minor
+---
+
+Migrated plugin to Material UI 5 and Added More Pagination Option for the Table

--- a/workspaces/mend/plugins/mend/README.md
+++ b/workspaces/mend/plugins/mend/README.md
@@ -4,7 +4,7 @@ This plugin integrates Mend.io functionality seamlessly into your Backstage appl
 
 ### Plugin Compatibility
 
-The plugin has been successfully tested with Backstage v1.28. If you are using a newer version of Backstage, please file an issue, and we will provide guidance on the best integration practices for your specific version.
+The plugin has been successfully tested with Backstage v1.40.0 If you are using a newer version of Backstage, please file an issue, and we will provide guidance on the best integration practices for your specific version.
 
 ### Features
 

--- a/workspaces/mend/plugins/mend/package.json
+++ b/workspaces/mend/plugins/mend/package.json
@@ -39,15 +39,15 @@
     "@backstage/plugin-catalog-react": "^1.20.1",
     "@backstage/theme": "^0.6.8",
     "@material-table/core": "4.3.46",
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.61",
+    "@mui/icons-material": "^5.18.0",
+    "@mui/material": "^5.18.0",
+    "@mui/styles": "^5.18.0",
     "@tanstack/react-query": "^5.51.11",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.25.1"
   },
   "devDependencies": {
@@ -59,8 +59,8 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
     "msw": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.25.1"
   },
   "files": [

--- a/workspaces/mend/plugins/mend/src/components/Card.tsx
+++ b/workspaces/mend/plugins/mend/src/components/Card.tsx
@@ -1,12 +1,11 @@
 import type { ReactNode } from 'react';
-import {
-  Card as Containter,
-  CardContent,
-  CardHeader,
-  CircularProgress,
-  Divider,
-  makeStyles,
-} from '@material-ui/core';
+import Container from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+
+import { makeStyles } from '@mui/styles';
 
 type CardProps = {
   children: ReactNode;
@@ -40,12 +39,12 @@ export const Card = ({ children, loading, title }: CardProps): ReactNode => {
   const classes = useStyles();
 
   return (
-    <Containter className={classes.container}>
+    <Container className={classes.container}>
       <CardHeader className={classes.header} title={title} />
       <Divider />
       <CardContent className={classes.content}>
         {loading ? <CircularProgress /> : children}
       </CardContent>
-    </Containter>
+    </Container>
   );
 };

--- a/workspaces/mend/plugins/mend/src/components/Sidebar.tsx
+++ b/workspaces/mend/plugins/mend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { SvgIcon } from '@material-ui/core';
+import SvgIcon from '@mui/material/SvgIcon';
 import { SidebarItem } from '@backstage/core-components';
 
 /** @public */

--- a/workspaces/mend/plugins/mend/src/components/StatisticsBar/StatisticsBar.tsx
+++ b/workspaces/mend/plugins/mend/src/components/StatisticsBar/StatisticsBar.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useState } from 'react';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@mui/styles';
 import { StatisticsBarScrap } from './internal/StatisticsBarScrap';
 import { StatisticsBarSegment } from './internal/StatisticsBarSegment';
 import { StatisticsBarProps } from './statisticsBar.types';

--- a/workspaces/mend/plugins/mend/src/components/StatisticsBar/internal/StatisticsBarScrap.tsx
+++ b/workspaces/mend/plugins/mend/src/components/StatisticsBar/internal/StatisticsBarScrap.tsx
@@ -1,5 +1,6 @@
 import { ReactElement } from 'react';
-import { makeStyles, Theme } from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { numberToShortText } from '../../../utils';
 import { StatisticsBarScrapProps } from '../statisticsBar.types';
 import { linearGradient } from '../statisticsBar.helpers';

--- a/workspaces/mend/plugins/mend/src/components/StatisticsBar/internal/StatisticsBarSegment.tsx
+++ b/workspaces/mend/plugins/mend/src/components/StatisticsBar/internal/StatisticsBarSegment.tsx
@@ -1,4 +1,6 @@
-import { makeStyles, Tooltip, Theme } from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import Tooltip from '@mui/material/Tooltip';
+import { makeStyles } from '@mui/styles';
 import { StatisticsBarSegmentProps } from '../statisticsBar.types';
 import { linearGradient } from '../statisticsBar.helpers';
 
@@ -12,7 +14,7 @@ const useStyles = makeStyles<
     width: ({ percentage }) => `${percentage}%`,
     backgroundColor: ({ color }) => {
       if (color) return color;
-      return theme.palette.type === 'light'
+      return theme.palette.mode === 'light'
         ? '#F5F6F8'
         : theme.palette.background.default;
     },

--- a/workspaces/mend/plugins/mend/src/components/Tag.tsx
+++ b/workspaces/mend/plugins/mend/src/components/Tag.tsx
@@ -1,5 +1,8 @@
 import { forwardRef } from 'react';
-import { Chip, makeStyles, Theme } from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import Chip from '@mui/material/Chip';
+
+import { makeStyles } from '@mui/styles';
 
 export enum TagColor {
   CRITICAL = 'critical',

--- a/workspaces/mend/plugins/mend/src/components/Tooltip.tsx
+++ b/workspaces/mend/plugins/mend/src/components/Tooltip.tsx
@@ -1,10 +1,8 @@
 import type { ReactElement } from 'react';
 import { useRef, useState, useCallback } from 'react';
-import {
-  makeStyles,
-  Theme,
-  Tooltip as MaterialTooltip,
-} from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import MaterialTooltip from '@mui/material/Tooltip';
+import { makeStyles } from '@mui/styles';
 import { useResize } from '../hooks';
 
 type ExtendedClassesProps = {
@@ -31,16 +29,20 @@ const useStyles = makeStyles<
 >(theme => ({
   tooltip: ({ extendedClasses }) => ({
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? '#232F3E'
         : theme.palette.background.default,
     ...extendedClasses?.tooltip,
+    marginBottom: '0.8rem',
   }),
   arrow: {
     color:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? '#232F3E'
         : theme.palette.background.default,
+    overflow: 'inherit',
+    bottom: 0,
+    marginBottom: '-0.25em',
   },
 }));
 
@@ -90,7 +92,7 @@ export const Tooltip = ({
       disableHoverListener={isDisabled}
       placement="top"
       arrow
-      interactive
+      disableInteractive
     >
       <span className={additionalClasses.contentWrapper} ref={node}>
         {children}

--- a/workspaces/mend/plugins/mend/src/components/Total.tsx
+++ b/workspaces/mend/plugins/mend/src/components/Total.tsx
@@ -1,15 +1,14 @@
-import {
-  Card as MaterialCard,
-  CardActions,
-  CardContent,
-  CardHeader,
-  Divider,
-  Grid,
-  Link,
-  makeStyles,
-  SvgIcon,
-  Typography,
-} from '@material-ui/core';
+import MaterialCard from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import CardHeader from '@mui/material/CardHeader';
+import Divider from '@mui/material/Divider';
+import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
+import SvgIcon from '@mui/material/SvgIcon';
+import Typography from '@mui/material/Typography';
+import type { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { Statistics } from '../models';
 import { numberToShortText } from '../utils';
 import { Card } from './Card';
@@ -23,7 +22,7 @@ type TotalProps = {
   url: string;
 };
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<Theme>(theme => ({
   container: {
     border: '1px solid #dfdfdf',
     boxShadow: '0px 2px 4px 0px #00000026',
@@ -33,7 +32,7 @@ const useStyles = makeStyles(theme => ({
     display: 'flex',
     flexDirection: 'column',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? '#F5F6F8'
         : theme.palette.background.default,
   },
@@ -81,7 +80,16 @@ export const Total = ({
       <CardHeader className={classes.header} title={title} />
       <Divider />
       <CardContent className={classes.content}>
-        <Grid container direction="row" style={{ paddingBottom: '1rem' }}>
+        <Grid
+          container
+          direction="row"
+          sx={{
+            padding: 2,
+            paddingRight: 0,
+            flexWrap: { xs: 'wrap', lg: 'nowrap' },
+          }}
+          gap={2}
+        >
           <Grid item lg={2} md={12}>
             <Card title="Total Findings" loading={dataLoading}>
               <Typography

--- a/workspaces/mend/plugins/mend/src/components/table/ProjectFilterComponent.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/ProjectFilterComponent.tsx
@@ -9,22 +9,22 @@
  * State is owned by the parent; this component receives current selections and
  * a setter via props and renders accordingly.
  */
-import {
-  Box,
-  Checkbox,
-  Chip,
-  FormControl,
-  InputLabel,
-  ListItemText,
-  MenuItem,
-  OutlinedInput,
-  Select,
-  Typography,
-  Tooltip,
-} from '@material-ui/core';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import ListItemText from '@mui/material/ListItemText';
+import MenuItem from '@mui/material/MenuItem';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Select from '@mui/material/Select';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { SelectItem } from '@backstage/core-components';
-import type { MenuProps as MUIMenuProps } from '@material-ui/core/Menu';
-import type { ChangeEvent } from 'react';
+import type { MenuProps as MUIMenuProps } from '@mui/material/Menu';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import Cancel from '@mui/icons-material/Cancel';
+import { useTheme } from '@mui/material/styles';
 /**
  * Props for ProjectFilterComponent.
  *
@@ -52,8 +52,7 @@ const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
 /**
  * MUI Menu props for consistent dropdown placement and max height.
- * Note: getContentAnchorEl is set to null to anchor the menu to the bottom
- * edge of the select input (for MUI v4 behavior).
+ * anchor the menu using anchorOrigin and transformOrigin.
  */
 const selectMenuProps: Partial<MUIMenuProps> = {
   PaperProps: {
@@ -61,8 +60,6 @@ const selectMenuProps: Partial<MUIMenuProps> = {
       maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
     },
   },
-  // Ensure the menu appears anchored to the bottom edge of the select input
-  getContentAnchorEl: null,
   anchorOrigin: {
     vertical: 'bottom',
     horizontal: 'left',
@@ -84,6 +81,7 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
   projectNameOptions,
   ALL_OPTION,
 }) => {
+  const theme = useTheme();
   // If there is no project data or only trivial options (e.g., ALL + placeholder),
   // do not render the filter.
   if (!projectList || projectNameOptions.length <= 2) {
@@ -97,7 +95,7 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
    * - Selecting another value while ALL is active removes ALL.
    * - Clearing all selections reverts to ALL.
    */
-  const handleProjectNameChange = (event: ChangeEvent<{ value: unknown }>) => {
+  const handleProjectNameChange = (event: SelectChangeEvent<string[]>) => {
     // SelectedItems can be string or string[]
     const selected = event.target.value;
     const selectedArray = Array.isArray(selected) ? selected : [selected];
@@ -146,7 +144,7 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
         <Typography
           component="span"
           display="block"
-          style={{
+          sx={{
             textTransform: 'none',
             lineHeight: '16px',
             fontWeight: 'revert',
@@ -161,7 +159,6 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
           e.g. to investigate results of a specific branch.
         </Typography>
       }
-      arrow
       placement="right"
     >
       <FormControl
@@ -185,7 +182,7 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
               label="Filter by Project Name"
             />
           }
-          SelectDisplayProps={{ style: { paddingTop: 10, paddingBottom: 10 } }}
+          SelectDisplayProps={{ style: { paddingTop: 12, paddingBottom: 20 } }}
           renderValue={selected => {
             const values = Array.isArray(selected)
               ? (selected as string[])
@@ -194,18 +191,31 @@ export const ProjectFilterComponent: React.FC<ProjectFilterComponentProps> = ({
               <Box display="flex" flexWrap="wrap">
                 {values.map(value =>
                   value === ALL_OPTION.value ? (
-                    <Chip
-                      key={ALL_OPTION.value}
-                      label={ALL_OPTION.label}
-                      style={{ margin: 2 }}
-                    />
+                    <Chip key={ALL_OPTION.value} label={ALL_OPTION.label} />
                   ) : (
                     <Chip
                       key={value}
                       label={value}
                       onMouseDown={e => e.stopPropagation()}
                       onDelete={() => handleChipDelete(value)}
-                      style={{ margin: 2 }}
+                      deleteIcon={<Cancel sx={{ marginRight: 1 }} />}
+                      sx={{
+                        '& [class*="MuiChip-deleteIcon"]': {
+                          // default icon color
+                          color:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(255, 255, 255, 0.26)'
+                              : 'rgba(0, 0, 0, 0.26)',
+                          transition: 'color 0.3s ease',
+                        },
+                        '&:hover [class*="MuiChip-deleteIcon"]': {
+                          // icon color on chip hover
+                          color:
+                            theme.palette.mode === 'dark'
+                              ? 'rgba(255, 255, 255, 0.40)'
+                              : 'gray',
+                        },
+                      }}
                     />
                   ),
                 )}

--- a/workspaces/mend/plugins/mend/src/components/table/Table.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/Table.tsx
@@ -4,8 +4,10 @@ import {
   Table as TableBackstage,
   SelectItem,
 } from '@backstage/core-components';
+import SvgIcon from '@mui/material/SvgIcon';
 import { ProjectFilterComponent } from './ProjectFilterComponent';
-import { makeStyles, SvgIcon } from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { Project, Finding, Statistics } from '../../models';
 import { TableMessage } from './TableMessage';
 import { TableHeader } from './TableHeader';
@@ -44,9 +46,9 @@ export type TableColumnProps<T> = {
   render: (row: T) => ReactNode;
 };
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<Theme>(theme => ({
   funnelIcon: {
-    color: theme.palette.type === 'light' ? '#232F3E' : 'white',
+    color: theme.palette.mode === 'light' ? '#232F3E' : 'white',
   },
 }));
 
@@ -146,7 +148,7 @@ export const Table = ({
         toolbar: true,
         grouping: true, // NOTE: require to display groupbar component
         pageSize: 50,
-        pageSizeOptions: [50, 100, 200],
+        pageSizeOptions: [10, 30, 50, 100, 200],
         emptyRowsWhenPaging: false,
         rowStyle: {
           borderTop: '1px solid #DFDFDF',

--- a/workspaces/mend/plugins/mend/src/components/table/TableBar.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TableBar.tsx
@@ -1,4 +1,5 @@
-import { Typography, makeStyles } from '@material-ui/core';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from '@mui/styles';
 import { numberToShortText } from '../../utils';
 
 type TableBarProps = {

--- a/workspaces/mend/plugins/mend/src/components/table/TableMessage.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TableMessage.tsx
@@ -1,4 +1,6 @@
-import { makeStyles, Typography, SvgIcon } from '@material-ui/core';
+import Typography from '@mui/material/Typography';
+import SvgIcon from '@mui/material/SvgIcon';
+import { makeStyles } from '@mui/styles';
 import { tableIconMap, TableIcon } from './table.icons';
 
 type TableMessageProps = {

--- a/workspaces/mend/plugins/mend/src/components/table/TablePagination/TablePagination.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TablePagination/TablePagination.tsx
@@ -1,8 +1,7 @@
 import type { MouseEvent, ChangeEventHandler } from 'react';
-import {
-  TablePagination as MaterialTablePagination,
-  makeStyles,
-} from '@material-ui/core';
+import MaterialTablePagination from '@mui/material/TablePagination';
+import type { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { TablePaginationActions } from './TablePaginationActions';
 
 type TablePaginationProps = {
@@ -20,11 +19,11 @@ type TablePaginationProps = {
   >;
 };
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<Theme>(theme => ({
   root: {
-    color: theme.palette.type === 'light' ? '#232F3E' : 'white',
+    color: theme.palette.mode === 'light' ? '#232F3E' : 'white',
     backgroundColor:
-      theme.palette.type === 'light'
+      theme.palette.mode === 'light'
         ? 'white'
         : theme.palette.background.default,
   },
@@ -35,7 +34,7 @@ const useStyles = makeStyles(theme => ({
     flex: 'none',
   },
   selectIcon: {
-    color: theme.palette.type === 'light' ? '#232F3E' : 'white',
+    color: theme.palette.mode === 'light' ? '#232F3E' : 'white',
   },
 }));
 

--- a/workspaces/mend/plugins/mend/src/components/table/TablePagination/TablePaginationActions.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TablePagination/TablePaginationActions.tsx
@@ -1,5 +1,10 @@
 import type { MouseEvent } from 'react';
-import { IconButton, makeStyles, SvgIcon, useTheme } from '@material-ui/core';
+import type { Theme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
+import SvgIcon from '@mui/material/SvgIcon';
+
+import { makeStyles } from '@mui/styles';
 
 type TablePaginationActionsProps = {
   count: number;
@@ -56,7 +61,7 @@ const ArrowRight = () => (
   </SvgIcon>
 );
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles<Theme>(theme => ({
   container: {
     display: 'flex',
     gap: '8px',
@@ -66,7 +71,7 @@ const useStyles = makeStyles(theme => ({
   },
   buttonContainer: {
     padding: '0',
-    color: theme.palette.type === 'light' ? '#073C8C' : 'white',
+    color: theme.palette.mode === 'light' ? '#073C8C' : 'white',
     '&:disabled': {
       color: '#C4C6CB',
     },
@@ -106,6 +111,7 @@ export const TablePaginationActions = ({
         disabled={page === 0}
         aria-label="first page"
         className={classes.buttonContainer}
+        size="large"
       >
         {theme.direction === 'rtl' ? <LastPageIcon /> : <FirstPageIcon />}
       </IconButton>
@@ -114,6 +120,7 @@ export const TablePaginationActions = ({
         disabled={page === 0}
         aria-label="previous page"
         className={classes.buttonContainer}
+        size="large"
       >
         {theme.direction === 'rtl' ? <ArrowRight /> : <ArrowLeft />}
       </IconButton>
@@ -123,6 +130,7 @@ export const TablePaginationActions = ({
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
         aria-label="next page"
         className={classes.buttonContainer}
+        size="large"
       >
         {theme.direction === 'rtl' ? <ArrowLeft /> : <ArrowRight />}
       </IconButton>
@@ -131,6 +139,7 @@ export const TablePaginationActions = ({
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
         aria-label="last page"
         className={classes.buttonContainer}
+        size="large"
       >
         {theme.direction === 'rtl' ? <FirstPageIcon /> : <LastPageIcon />}
       </IconButton>

--- a/workspaces/mend/plugins/mend/src/components/table/TablePaper.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TablePaper.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode, CSSProperties, FC } from 'react';
-import { Grid, Paper } from '@material-ui/core';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
 
 type TablePaperProps = {
   children: ReactNode[];
@@ -8,7 +9,7 @@ type TablePaperProps = {
 
 export const TablePaper: FC<TablePaperProps> = ({ children, style }) => {
   return (
-    <Grid direction="column" xs={12}>
+    <Grid direction="column" xs={12} style={{ width: '100%' }}>
       {[
         children[1],
         <Paper elevation={3} style={{ ...style, marginTop: '50px' }}>

--- a/workspaces/mend/plugins/mend/src/components/table/TableToolbar.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/TableToolbar.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { MTableToolbar } from '@material-table/core';
-import { Grid, Typography } from '@material-ui/core';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
 
 type TableToolbarProps = {
   children: ReactNode;
@@ -16,7 +17,12 @@ export const TableToolbar = ({
   title,
 }: TableToolbarProps) => {
   return (
-    <Grid container alignItems="center" alignContent="center">
+    <Grid
+      container
+      alignItems="center"
+      alignContent="center"
+      sx={{ paddingLeft: 2 }}
+    >
       <Grid item xs={12}>
         {title && <Typography variant="h4">{title}</Typography>}
       </Grid>
@@ -26,6 +32,9 @@ export const TableToolbar = ({
         xs={12}
         alignItems="center"
         justifyContent="space-between"
+        margin={0}
+        paddingBottom={1}
+        paddingTop={1}
       >
         <Grid item xs={9}>
           <ProjectFilterComponent />

--- a/workspaces/mend/plugins/mend/src/components/table/table.icons.tsx
+++ b/workspaces/mend/plugins/mend/src/components/table/table.icons.tsx
@@ -1,21 +1,21 @@
 import type { Ref } from 'react';
 import { forwardRef } from 'react';
-import AddBox from '@material-ui/icons/AddBox';
-import ArrowUpward from '@material-ui/icons/ArrowUpward';
-import Check from '@material-ui/icons/Check';
-import ChevronLeft from '@material-ui/icons/ChevronLeft';
-import ChevronRight from '@material-ui/icons/ChevronRight';
-import Clear from '@material-ui/icons/Clear';
-import DeleteOutline from '@material-ui/icons/DeleteOutline';
-import Edit from '@material-ui/icons/Edit';
-import FilterList from '@material-ui/icons/FilterList';
-import FirstPage from '@material-ui/icons/FirstPage';
-import LastPage from '@material-ui/icons/LastPage';
-import Remove from '@material-ui/icons/Remove';
-import SaveAlt from '@material-ui/icons/SaveAlt';
-import ViewColumn from '@material-ui/icons/ViewColumn';
-import Retry from '@material-ui/icons/Replay';
-import Resize from '@material-ui/icons/Height';
+import AddBox from '@mui/icons-material/AddBox';
+import ArrowUpward from '@mui/icons-material/ArrowUpward';
+import Check from '@mui/icons-material/Check';
+import ChevronLeft from '@mui/icons-material/ChevronLeft';
+import ChevronRight from '@mui/icons-material/ChevronRight';
+import Clear from '@mui/icons-material/Clear';
+import DeleteOutline from '@mui/icons-material/DeleteOutline';
+import Edit from '@mui/icons-material/Edit';
+import FilterList from '@mui/icons-material/FilterList';
+import FirstPage from '@mui/icons-material/FirstPage';
+import LastPage from '@mui/icons-material/LastPage';
+import Remove from '@mui/icons-material/Remove';
+import SaveAlt from '@mui/icons-material/SaveAlt';
+import ViewColumn from '@mui/icons-material/ViewColumn';
+import Retry from '@mui/icons-material/Replay';
+import Resize from '@mui/icons-material/Height';
 
 export const tableBackstageIcons = {
   Add: forwardRef((props, ref: Ref<SVGSVGElement>) => (

--- a/workspaces/mend/plugins/mend/src/pages/overview/components/ProjectTableLanguages.tsx
+++ b/workspaces/mend/plugins/mend/src/pages/overview/components/ProjectTableLanguages.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useCallback } from 'react';
-import { makeStyles, Typography } from '@material-ui/core';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from '@mui/styles';
 import { Tag, Tooltip } from '../../../components';
 import { useResize } from '../../../hooks';
 

--- a/workspaces/mend/plugins/mend/src/pages/overview/components/projectTable.schema.tsx
+++ b/workspaces/mend/plugins/mend/src/pages/overview/components/projectTable.schema.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { styled, Typography } from '@material-ui/core';
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
 import { Tag, TagColor, type TableRowProjectProps } from '../../../components';
 import { dateTimeFormat, getObjValue } from '../../../utils';
 import { ProjectTableLanguages } from './ProjectTableLanguages';
@@ -32,7 +33,7 @@ export const tagColorMap = {
 };
 
 const StyledTypography = styled(Typography)(({ theme }) => ({
-  color: theme?.palette?.type === 'light' ? '#073C8C' : 'white',
+  color: theme?.palette?.mode === 'light' ? '#073C8C' : 'white',
 }));
 
 const classes: Record<string, CSSProperties> = {

--- a/workspaces/mend/plugins/mend/src/pages/tab/components/FindingTableIssueTrackingTooltip.tsx
+++ b/workspaces/mend/plugins/mend/src/pages/tab/components/FindingTableIssueTrackingTooltip.tsx
@@ -1,10 +1,8 @@
-import {
-  Box,
-  Divider,
-  makeStyles,
-  SvgIcon,
-  Typography,
-} from '@material-ui/core';
+import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import SvgIcon from '@mui/material/SvgIcon';
+import Typography from '@mui/material/Typography';
+import { makeStyles } from '@mui/styles';
 import { Tag, TagColor, Tooltip } from '../../../components';
 import { dateTimeFormat } from '../../../utils';
 

--- a/workspaces/mend/plugins/mend/src/pages/tab/components/findingTable.schema.tsx
+++ b/workspaces/mend/plugins/mend/src/pages/tab/components/findingTable.schema.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from 'react';
-import { Typography } from '@material-ui/core';
+import Typography from '@mui/material/Typography';
 import { dateTimeFormat, getObjValue } from '../../../utils';
 import {
   Tag,

--- a/workspaces/mend/yarn.lock
+++ b/workspaces/mend/yarn.lock
@@ -1569,21 +1569,21 @@ __metadata:
     "@backstage/test-utils": "npm:^1.7.11"
     "@backstage/theme": "npm:^0.6.8"
     "@material-table/core": "npm:4.3.46"
-    "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@mui/icons-material": "npm:^5.18.0"
+    "@mui/material": "npm:^5.18.0"
+    "@mui/styles": "npm:^5.18.0"
     "@tanstack/react-query": "npm:^5.51.11"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
     msw: "npm:^1.0.0"
-    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    react: "npm:^17.0.0 || ^18.0.0"
+    react-dom: "npm:^17.0.0 || ^18.0.0"
     react-router-dom: "npm:^6.25.1"
     react-use: "npm:^17.2.4"
   peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.25.1
   languageName: unknown
   linkType: soft
@@ -3108,6 +3108,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/cache@npm:^11.13.5":
+  version: 11.14.0
+  resolution: "@emotion/cache@npm:11.14.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/sheet": "npm:^1.4.0"
+    "@emotion/utils": "npm:^1.4.2"
+    "@emotion/weak-memoize": "npm:^0.4.0"
+    stylis: "npm:4.2.0"
+  checksum: 10/52336b28a27b07dde8fcdfd80851cbd1487672bbd4db1e24cca1440c95d8a6a968c57b0453c2b7c88d9b432b717f99554dbecc05b5cdef27933299827e69fd8e
+  languageName: node
+  linkType: hard
+
 "@emotion/hash@npm:^0.8.0":
   version: 0.8.0
   resolution: "@emotion/hash@npm:0.8.0"
@@ -3115,7 +3128,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/hash@npm:^0.9.2":
+"@emotion/hash@npm:^0.9.1, @emotion/hash@npm:^0.9.2":
   version: 0.9.2
   resolution: "@emotion/hash@npm:0.9.2"
   checksum: 10/379bde2830ccb0328c2617ec009642321c0e009a46aa383dfbe75b679c6aea977ca698c832d225a893901f29d7b3eef0e38cf341f560f6b2b56f1ff23c172387
@@ -3172,6 +3185,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/serialize@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@emotion/serialize@npm:1.3.3"
+  dependencies:
+    "@emotion/hash": "npm:^0.9.2"
+    "@emotion/memoize": "npm:^0.9.0"
+    "@emotion/unitless": "npm:^0.10.0"
+    "@emotion/utils": "npm:^1.4.2"
+    csstype: "npm:^3.0.2"
+  checksum: 10/44a2e06fc52dba177d9cf720f7b2c5d45ee4c0d9c09b78302d9a625e758d728ef3ae26f849237fec6f70e9eeb7d87e45a65028e944dc1f877df97c599f1cdaee
+  languageName: node
+  linkType: hard
+
 "@emotion/sheet@npm:^1.4.0":
   version: 1.4.0
   resolution: "@emotion/sheet@npm:1.4.0"
@@ -3219,6 +3245,13 @@ __metadata:
   version: 1.4.1
   resolution: "@emotion/utils@npm:1.4.1"
   checksum: 10/95e56fc0c9e05cf01a96268f0486ce813f1109a8653d2f575c67df9e8765d9c1b2daf09ad1ada67d933efbb08ca7990228e14b210c713daf90156b4869abe6a7
+  languageName: node
+  linkType: hard
+
+"@emotion/utils@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@emotion/utils@npm:1.4.2"
+  checksum: 10/e5f3b8bca066b3361a7ad9064baeb9d01ed1bf51d98416a67359b62cb3affec6bb0249802c4ed11f4f8030f93cc4b67506909420bdb110adec6983d712897208
   languageName: node
   linkType: hard
 
@@ -4714,6 +4747,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/core-downloads-tracker@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/core-downloads-tracker@npm:5.18.0"
+  checksum: 10/065b46739d2bd84b880ad2f6a0a2062d60e3a296ce18ff380cad22ab5b2cb3de396755f322f4bea3a422ffffe1a9244536fc3c9623056ff3873c996e6664b1b9
+  languageName: node
+  linkType: hard
+
+"@mui/icons-material@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/icons-material@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+  peerDependencies:
+    "@mui/material": ^5.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f55f3da3c375ec3bad5417f5588122587ccf6a02093de286ca723bb6d01692f2cdf81dea413abc396eba87d6f7ab7443cc51e3dd024da8099764e55e12fa4176
+  languageName: node
+  linkType: hard
+
 "@mui/material@npm:^5.12.2":
   version: 5.16.7
   resolution: "@mui/material@npm:5.16.7"
@@ -4747,6 +4803,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/material@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/material@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@mui/core-downloads-tracker": "npm:^5.18.0"
+    "@mui/system": "npm:^5.18.0"
+    "@mui/types": "npm:~7.2.15"
+    "@mui/utils": "npm:^5.17.1"
+    "@popperjs/core": "npm:^2.11.8"
+    "@types/react-transition-group": "npm:^4.4.10"
+    clsx: "npm:^2.1.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+    react-transition-group: "npm:^4.4.5"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/4b72e07c76c7c4b1076db82ef42a06dfab7d73d73f0d272019b2e0b200fc25c27bb295a8672577e1094168054159bed387cf9af74fec30e98aead7d97fad0a57
+  languageName: node
+  linkType: hard
+
 "@mui/private-theming@npm:^5.16.6":
   version: 5.16.6
   resolution: "@mui/private-theming@npm:5.16.6"
@@ -4761,6 +4850,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/3a7ba9fc5c2f0c8311b5ecadd967e5529ce43c1c5682bfc88d4fe37efdac75e986dd33a45cfecea9561370ad5be659dc32e457e1aff31b861ac93ddd1172a720
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^5.17.1":
+  version: 5.17.1
+  resolution: "@mui/private-theming@npm:5.17.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@mui/utils": "npm:^5.17.1"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f8b849f545e8ab29eac959f174f56702e5b72ffda85c3b0621750e294a3f64d15873ebdb792cf478564db1c3cf4b366eabcd4156897d811949f2df079b424c8c
   languageName: node
   linkType: hard
 
@@ -4782,6 +4888,59 @@ __metadata:
     "@emotion/styled":
       optional: true
   checksum: 10/8e241269c2f95038102f4b6b44eda71f5dd5c2e99c5a5902fe41778f609ae83c75ca8c77f94aaf61f07c7275d0d333e53ae9d9ea7a7a402602ec594045c30be3
+  languageName: node
+  linkType: hard
+
+"@mui/styled-engine@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/styled-engine@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@emotion/cache": "npm:^11.13.5"
+    "@emotion/serialize": "npm:^1.3.3"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/8468a82bafb6dba40b7a3add845dd49868bcbcda3e9a0226a08f74b715dcbe2360186944ef94c44b2abe85f79335a470c0634195b9e48ccf6b5439df4bc17a90
+  languageName: node
+  linkType: hard
+
+"@mui/styles@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/styles@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@emotion/hash": "npm:^0.9.1"
+    "@mui/private-theming": "npm:^5.17.1"
+    "@mui/types": "npm:~7.2.15"
+    "@mui/utils": "npm:^5.17.1"
+    clsx: "npm:^2.1.0"
+    csstype: "npm:^3.1.3"
+    hoist-non-react-statics: "npm:^3.3.2"
+    jss: "npm:^10.10.0"
+    jss-plugin-camel-case: "npm:^10.10.0"
+    jss-plugin-default-unit: "npm:^10.10.0"
+    jss-plugin-global: "npm:^10.10.0"
+    jss-plugin-nested: "npm:^10.10.0"
+    jss-plugin-props-sort: "npm:^10.10.0"
+    jss-plugin-rule-value-function: "npm:^10.10.0"
+    jss-plugin-vendor-prefixer: "npm:^10.10.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b02cc02f7c8eafe0bd5b8bc1121ee0cee50bb48e876b652313aad4c61ae466c411423e8e82f603a386ecf569c537ecfa92b6c7dabd0c798d6727e935df7fa1e6
   languageName: node
   linkType: hard
 
@@ -4813,6 +4972,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/system@npm:^5.18.0":
+  version: 5.18.0
+  resolution: "@mui/system@npm:5.18.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@mui/private-theming": "npm:^5.17.1"
+    "@mui/styled-engine": "npm:^5.18.0"
+    "@mui/types": "npm:~7.2.15"
+    "@mui/utils": "npm:^5.17.1"
+    clsx: "npm:^2.1.0"
+    csstype: "npm:^3.1.3"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/4584a4d4f62ddaecc8b047f1a3b24ecde2ea4198963b5db3c006fd8109cd16085099862dbf935fad545ee146a3c06f119e0dd9bdc987cf45f900bab611a4afe7
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:^7.2.15":
   version: 7.2.18
   resolution: "@mui/types@npm:7.2.18"
@@ -4822,6 +5009,18 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/662b0e2858b1675cff54e69082f2265d4f2be247627f97333a9e6afa7199b6d520f57b3f366c8b62ade1593228a95a7618d21ac229102d58dd4906f804fcd7b6
+  languageName: node
+  linkType: hard
+
+"@mui/types@npm:~7.2.15":
+  version: 7.2.24
+  resolution: "@mui/types@npm:7.2.24"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/5ed4f90ec62c7df901e58b53011bf6b377b48e13b07de9eeb15c7a6f3f759310f0682b64685c7762f660fad6edf4c8e05595313c93810fc63c54270b899b4a75
   languageName: node
   linkType: hard
 
@@ -4842,6 +5041,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/214bc3e9fe49579c5aee264477c802e5f5ced3473cafb1ed0aacd63db223e2668a08fb1f7304e70ea0511f68200dd80c3b49cc58050c7b0962228758a003371d
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.17.1":
+  version: 5.17.1
+  resolution: "@mui/utils@npm:5.17.1"
+  dependencies:
+    "@babel/runtime": "npm:^7.23.9"
+    "@mui/types": "npm:~7.2.15"
+    "@types/prop-types": "npm:^15.7.12"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/26efae9a9f84a817b016a93ab3e3c3d08533947f62b19d4a5f8cd67ebf6932b1f68c4e4ae677dc0d3397ecd1bf1cc8cb47ab83a345bcaa9b4f45c401ec9d3926
   languageName: node
   linkType: hard
 
@@ -16095,7 +16314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-camel-case@npm:^10.5.1":
+"jss-plugin-camel-case@npm:^10.10.0, jss-plugin-camel-case@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-camel-case@npm:10.10.0"
   dependencies:
@@ -16106,7 +16325,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-default-unit@npm:^10.5.1":
+"jss-plugin-default-unit@npm:^10.10.0, jss-plugin-default-unit@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-default-unit@npm:10.10.0"
   dependencies:
@@ -16116,7 +16335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-global@npm:^10.5.1":
+"jss-plugin-global@npm:^10.10.0, jss-plugin-global@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-global@npm:10.10.0"
   dependencies:
@@ -16126,7 +16345,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-nested@npm:^10.5.1":
+"jss-plugin-nested@npm:^10.10.0, jss-plugin-nested@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-nested@npm:10.10.0"
   dependencies:
@@ -16137,7 +16356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-props-sort@npm:^10.5.1":
+"jss-plugin-props-sort@npm:^10.10.0, jss-plugin-props-sort@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-props-sort@npm:10.10.0"
   dependencies:
@@ -16147,7 +16366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-rule-value-function@npm:^10.5.1":
+"jss-plugin-rule-value-function@npm:^10.10.0, jss-plugin-rule-value-function@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-rule-value-function@npm:10.10.0"
   dependencies:
@@ -16158,7 +16377,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss-plugin-vendor-prefixer@npm:^10.5.1":
+"jss-plugin-vendor-prefixer@npm:^10.10.0, jss-plugin-vendor-prefixer@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss-plugin-vendor-prefixer@npm:10.10.0"
   dependencies:
@@ -16169,7 +16388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jss@npm:10.10.0, jss@npm:^10.5.1":
+"jss@npm:10.10.0, jss@npm:^10.10.0, jss@npm:^10.5.1":
   version: 10.10.0
   resolution: "jss@npm:10.10.0"
   dependencies:
@@ -20293,7 +20512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^16.13.1 || ^17.0.0 || ^18.0.0":
+"react-dom@npm:^17.0.0 || ^18.0.0":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -20379,6 +20598,13 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.0.0":
+  version: 19.1.1
+  resolution: "react-is@npm:19.1.1"
+  checksum: 10/44e0937da1f0da1d5dbd4f01972870768ef207f8a49717f4491f5022454f34c956cb66be560aee5286387169853b0283a81e1f419b51dc62654c8710dc98065a
   languageName: node
   linkType: hard
 
@@ -20602,7 +20828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^16.13.1 || ^17.0.0 || ^18.0.0":
+"react@npm:^17.0.0 || ^18.0.0":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:

--- a/workspaces/mend/yarn.lock
+++ b/workspaces/mend/yarn.lock
@@ -3095,20 +3095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.11.0, @emotion/cache@npm:^11.13.0":
-  version: 11.13.1
-  resolution: "@emotion/cache@npm:11.13.1"
-  dependencies:
-    "@emotion/memoize": "npm:^0.9.0"
-    "@emotion/sheet": "npm:^1.4.0"
-    "@emotion/utils": "npm:^1.4.0"
-    "@emotion/weak-memoize": "npm:^0.4.0"
-    stylis: "npm:4.2.0"
-  checksum: 10/090c8ad2e5b23f1b3a95e94f1f0554a40ed1dcd844c9d31629a68ff824eff40f32d1362f67aefa440ee0aabd5a8cabcc76870fd6d77144d3ff251bdcdf1420b9
-  languageName: node
-  linkType: hard
-
-"@emotion/cache@npm:^11.13.5":
+"@emotion/cache@npm:^11.13.0, @emotion/cache@npm:^11.13.5":
   version: 11.14.0
   resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
@@ -3172,20 +3159,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.2.0, @emotion/serialize@npm:^1.3.0, @emotion/serialize@npm:^1.3.1":
-  version: 1.3.2
-  resolution: "@emotion/serialize@npm:1.3.2"
-  dependencies:
-    "@emotion/hash": "npm:^0.9.2"
-    "@emotion/memoize": "npm:^0.9.0"
-    "@emotion/unitless": "npm:^0.10.0"
-    "@emotion/utils": "npm:^1.4.1"
-    csstype: "npm:^3.0.2"
-  checksum: 10/ead557c1ff19d917ef8169c02738ef36f0851fbfdf0bf69a543045bddea3b7281dc8252ee466cc5fb44ed27d1e61280ff943bb60a2c04158751fb07b3457cc93
-  languageName: node
-  linkType: hard
-
-"@emotion/serialize@npm:^1.3.3":
+"@emotion/serialize@npm:^1.2.0, @emotion/serialize@npm:^1.3.0, @emotion/serialize@npm:^1.3.1, @emotion/serialize@npm:^1.3.3":
   version: 1.3.3
   resolution: "@emotion/serialize@npm:1.3.3"
   dependencies:
@@ -3241,14 +3215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.4.0, @emotion/utils@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@emotion/utils@npm:1.4.1"
-  checksum: 10/95e56fc0c9e05cf01a96268f0486ce813f1109a8653d2f575c67df9e8765d9c1b2daf09ad1ada67d933efbb08ca7990228e14b210c713daf90156b4869abe6a7
-  languageName: node
-  linkType: hard
-
-"@emotion/utils@npm:^1.4.2":
+"@emotion/utils@npm:^1.4.0, @emotion/utils@npm:^1.4.2":
   version: 1.4.2
   resolution: "@emotion/utils@npm:1.4.2"
   checksum: 10/e5f3b8bca066b3361a7ad9064baeb9d01ed1bf51d98416a67359b62cb3affec6bb0249802c4ed11f4f8030f93cc4b67506909420bdb110adec6983d712897208
@@ -4740,13 +4707,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^5.16.7":
-  version: 5.16.7
-  resolution: "@mui/core-downloads-tracker@npm:5.16.7"
-  checksum: 10/b65c48ba2bf6bba6435ba9f2d6c33db0c8a85b3ff7599136a9682b72205bec76470ab5ed5e6e625d5bd012ed9bcbc641ed677548be80d217c9fb5d0435567062
-  languageName: node
-  linkType: hard
-
 "@mui/core-downloads-tracker@npm:^5.18.0":
   version: 5.18.0
   resolution: "@mui/core-downloads-tracker@npm:5.18.0"
@@ -4770,40 +4730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^5.12.2":
-  version: 5.16.7
-  resolution: "@mui/material@npm:5.16.7"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/core-downloads-tracker": "npm:^5.16.7"
-    "@mui/system": "npm:^5.16.7"
-    "@mui/types": "npm:^7.2.15"
-    "@mui/utils": "npm:^5.16.6"
-    "@popperjs/core": "npm:^2.11.8"
-    "@types/react-transition-group": "npm:^4.4.10"
-    clsx: "npm:^2.1.0"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
-    react-transition-group: "npm:^4.4.5"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10/67f118e5a4bc89553d87b1b5bfe8c37b979ee981415dfda39fba0b27d08636be91fa9f270ea674d19f5a23186f53be67e3eb397f03333a7342170f43db8d0058
-  languageName: node
-  linkType: hard
-
-"@mui/material@npm:^5.18.0":
+"@mui/material@npm:^5.12.2, @mui/material@npm:^5.18.0":
   version: 5.18.0
   resolution: "@mui/material@npm:5.18.0"
   dependencies:
@@ -4836,23 +4763,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/private-theming@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/private-theming@npm:5.16.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/utils": "npm:^5.16.6"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/3a7ba9fc5c2f0c8311b5ecadd967e5529ce43c1c5682bfc88d4fe37efdac75e986dd33a45cfecea9561370ad5be659dc32e457e1aff31b861ac93ddd1172a720
-  languageName: node
-  linkType: hard
-
 "@mui/private-theming@npm:^5.17.1":
   version: 5.17.1
   resolution: "@mui/private-theming@npm:5.17.1"
@@ -4867,27 +4777,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/f8b849f545e8ab29eac959f174f56702e5b72ffda85c3b0621750e294a3f64d15873ebdb792cf478564db1c3cf4b366eabcd4156897d811949f2df079b424c8c
-  languageName: node
-  linkType: hard
-
-"@mui/styled-engine@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/styled-engine@npm:5.16.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@emotion/cache": "npm:^11.11.0"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.4.1
-    "@emotion/styled": ^11.3.0
-    react: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-  checksum: 10/8e241269c2f95038102f4b6b44eda71f5dd5c2e99c5a5902fe41778f609ae83c75ca8c77f94aaf61f07c7275d0d333e53ae9d9ea7a7a402602ec594045c30be3
   languageName: node
   linkType: hard
 
@@ -4944,34 +4833,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^5.16.7":
-  version: 5.16.7
-  resolution: "@mui/system@npm:5.16.7"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/private-theming": "npm:^5.16.6"
-    "@mui/styled-engine": "npm:^5.16.6"
-    "@mui/types": "npm:^7.2.15"
-    "@mui/utils": "npm:^5.16.6"
-    clsx: "npm:^2.1.0"
-    csstype: "npm:^3.1.3"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    "@emotion/react": ^11.5.0
-    "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@emotion/react":
-      optional: true
-    "@emotion/styled":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10/736d8a7e22b6682fa791caad485462914f0f395043e168e4a09067a2d4f3e3320a6b33fa764b85244bd648d016ec7b539a6d5dfab45302e45f377c64d9c342ca
-  languageName: node
-  linkType: hard
-
 "@mui/system@npm:^5.18.0":
   version: 5.18.0
   resolution: "@mui/system@npm:5.18.0"
@@ -5000,18 +4861,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/types@npm:^7.2.15":
-  version: 7.2.18
-  resolution: "@mui/types@npm:7.2.18"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/662b0e2858b1675cff54e69082f2265d4f2be247627f97333a9e6afa7199b6d520f57b3f366c8b62ade1593228a95a7618d21ac229102d58dd4906f804fcd7b6
-  languageName: node
-  linkType: hard
-
 "@mui/types@npm:~7.2.15":
   version: 7.2.24
   resolution: "@mui/types@npm:7.2.24"
@@ -5021,26 +4870,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/5ed4f90ec62c7df901e58b53011bf6b377b48e13b07de9eeb15c7a6f3f759310f0682b64685c7762f660fad6edf4c8e05595313c93810fc63c54270b899b4a75
-  languageName: node
-  linkType: hard
-
-"@mui/utils@npm:^5.16.6":
-  version: 5.16.6
-  resolution: "@mui/utils@npm:5.16.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.23.9"
-    "@mui/types": "npm:^7.2.15"
-    "@types/prop-types": "npm:^15.7.12"
-    clsx: "npm:^2.1.1"
-    prop-types: "npm:^15.8.1"
-    react-is: "npm:^18.3.1"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/214bc3e9fe49579c5aee264477c802e5f5ced3473cafb1ed0aacd63db223e2668a08fb1f7304e70ea0511f68200dd80c3b49cc58050c7b0962228758a003371d
   languageName: node
   linkType: hard
 
@@ -20594,7 +20423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0, react-is@npm:^18.2.0, react-is@npm:^18.3.1":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Migrated Mend Plugin to Material UI 5
- Added More option for item per page for the Tables
- Updated Backstage version in the Document

<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/d3170dd4-ce38-4963-99e9-41def7d3ffb1" />

<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/840a84ec-99e1-44c3-92d1-3a301fd3dea2" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
