### PR TITLE
fix(redhat-argocd): show Revisions for multi-source apps

### DIFF
--- a/workspaces/redhat-argocd/.changeset/curvy-houses-vanish.md
+++ b/workspaces/redhat-argocd/.changeset/curvy-houses-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-redhat-argocd': minor
+---
+
+Fix issue where Revision data did not render for multi-source apps

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -133,9 +133,11 @@ const DeploymentSummary = () => {
               latestRevision,
               entity?.metadata?.annotations || {},
             );
+        const latestRevisionLinkText =
+          latestRevision === '' ? '-' : latestRevision?.substring(0, 7);
         return (
           <Link href={commitUrl} target="_blank" rel="noopener">
-            {latestRevision?.substring(0, 7) ?? '-'}
+            {latestRevisionLinkText}
           </Link>
         );
       },

--- a/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/redhat-argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -123,16 +123,19 @@ const DeploymentSummary = () => {
         const repoUrl =
           row?.spec?.sources?.[0]?.repoURL ?? row?.spec?.source?.repoURL ?? '';
 
+        // Depending on how many sources there could be multiple revisions.
+        const latestRevision =
+          latestRev?.revision ?? latestRev?.revisions?.pop() ?? '';
         const commitUrl = isAppHelmChartType(row)
           ? repoUrl
           : getCommitUrl(
               repoUrl,
-              latestRev?.revision ?? '',
+              latestRevision,
               entity?.metadata?.annotations || {},
             );
         return (
           <Link href={commitUrl} target="_blank" rel="noopener">
-            {latestRev?.revision?.substring(0, 7) ?? '-'}
+            {latestRevision?.substring(0, 7) ?? '-'}
           </Link>
         );
       },


### PR DESCRIPTION
Fixes an issue where the data under Revision in the Deployment Summary component did not render.

Should fix #5319 .

**Before:**
<img width="1468" height="406" alt="image" src="https://github.com/user-attachments/assets/a2da4c4e-f764-4554-aaec-2e39c9a3ba8a" />

**After:**
<img width="1468" height="406" alt="image" src="https://github.com/user-attachments/assets/dc3cf01a-5163-4415-9997-0b020320d751" />

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
