### PR TITLE
ci: attempt to fix deprecate script with registry config and validation

### DIFF
--- a/.github/workflows/deprecate-archived-plugins.yml
+++ b/.github/workflows/deprecate-archived-plugins.yml
@@ -6,6 +6,8 @@ on:
       - '.github/archived-plugins.json'
     branches:
       - main
+  # Temporary for testing
+  workflow_dispatch:
 
 jobs:
   deprecate:
@@ -17,3 +19,4 @@ jobs:
         run: ./scripts/ci/deprecate-archived-plugins.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org

--- a/scripts/ci/deprecate-archived-plugins.sh
+++ b/scripts/ci/deprecate-archived-plugins.sh
@@ -43,6 +43,14 @@ jq -r '
         echo "    Message: $message"
     else
         echo "Deprecating: $package_name"
+
+        # Validate package exists and is accessible before deprecating
+        if ! npm view "$package_name" version &>/dev/null; then
+            echo "Error: Cannot view package $package_name"
+            continue
+        fi
+
+        echo "Running: npm deprecate $package_name \"$message\""
         npm deprecate "$package_name" "$message"
         echo "Done: $package_name"
     fi


### PR DESCRIPTION
Set npm registry explicitly via `NPM_CONFIG_REGISTRY` environment variable, add `workflow_dispatch` trigger for manual testing. Also adds validation before deprecation attempt.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
