### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/giant-lobsters-care.md
+++ b/workspaces/linguist/.changeset/giant-lobsters-care.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-linguist-tags-processor': patch
----
-
-Added note regarding the need to install the Linguist Backend plugin for the Linguist Tags Catalog Processor to work

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-linguist-tags-processor
 
+## 0.12.1
+
+### Patch Changes
+
+- 7d5b162: Added note regarding the need to install the Linguist Backend plugin for the Linguist Tags Catalog Processor to work
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
+++ b/workspaces/linguist/plugins/catalog-backend-module-linguist-tags-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-linguist-tags-processor",
   "description": "The linguist-tags-processor backend module for the catalog plugin.",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-linguist-tags-processor@0.12.1

### Patch Changes

-   7d5b162: Added note regarding the need to install the Linguist Backend plugin for the Linguist Tags Catalog Processor to work
