### PR TITLE
fix: handle null until_date in announcements to prevent 500 errors

### DIFF
--- a/workspaces/announcements/.changeset/nine-olives-sit.md
+++ b/workspaces/announcements/.changeset/nine-olives-sit.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-announcements-backend': patch
+'@backstage-community/plugin-announcements-common': patch
+'@backstage-community/plugin-announcements': patch
+---
+
+Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -48,7 +48,7 @@ interface AnnouncementRequest {
   body: string;
   active: boolean;
   start_at: string;
-  until_date: string;
+  until_date?: string;
   sendNotification: boolean;
   on_behalf_of?: string;
   tags?: string[];
@@ -201,9 +201,11 @@ export async function createRouter(
       }
 
       const startAt = DateTime.fromISO(req.body.start_at);
-      const untilDate = DateTime.fromISO(req.body.until_date);
+      const untilDate = req.body.until_date
+        ? DateTime.fromISO(req.body.until_date)
+        : undefined;
 
-      if (untilDate < startAt) {
+      if (untilDate && untilDate < startAt) {
         return res
           .status(400)
           .json({ error: 'until_date cannot be before start_at' });
@@ -221,7 +223,7 @@ export async function createRouter(
           id: uuid(),
           created_at: DateTime.now(),
           start_at: DateTime.fromISO(req.body.start_at),
-          until_date: DateTime.fromISO(req.body.until_date),
+          until_date: untilDate,
           tags: validatedTags,
         });
 
@@ -269,7 +271,7 @@ export async function createRouter(
         },
       } = req;
 
-      if (until_date < start_at) {
+      if (until_date && until_date < start_at) {
         return res
           .status(400)
           .json({ error: 'until_date cannot be before start_at' });
@@ -298,7 +300,7 @@ export async function createRouter(
             category,
             active,
             start_at: DateTime.fromISO(start_at),
-            until_date: DateTime.fromISO(until_date),
+            until_date: until_date ? DateTime.fromISO(until_date) : undefined,
             on_behalf_of,
             tags: validatedTags,
           },

--- a/workspaces/announcements/plugins/announcements-backend/src/service/model.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/model.ts
@@ -27,5 +27,5 @@ export type AnnouncementModel = Omit<
 > & {
   created_at: DateTime;
   start_at: DateTime;
-  until_date: DateTime;
+  until_date?: DateTime | null;
 };

--- a/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -55,6 +55,37 @@ describe('AnnouncementsDatabase', () => {
     });
   });
 
+  it('should handle an announcement without until_date (open-ended)', async () => {
+    await store.insertAnnouncement({
+      id: 'open-ended',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      active: true,
+      start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+      // no until_date provided
+      on_behalf_of: 'group:default/team-a',
+    });
+
+    const announcement = await store.announcementByID('open-ended');
+    expect(announcement).toEqual({
+      id: 'open-ended',
+      publisher: 'publisher',
+      title: 'title',
+      excerpt: 'excerpt',
+      body: 'body',
+      category: undefined,
+      tags: [],
+      created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+      active: 1,
+      start_at: timestampToDateTime('2025-01-18T13:00:00.708Z'),
+      until_date: null,
+      on_behalf_of: 'group:default/team-a',
+    });
+  });
+
   it('should return an announcement by id', async () => {
     await store.insertAnnouncement({
       id: 'id',

--- a/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -35,7 +35,7 @@ type AnnouncementUpsert = Omit<
   tags?: string[];
   created_at: DateTime;
   start_at: DateTime;
-  until_date: DateTime;
+  until_date?: DateTime;
 };
 
 /**
@@ -48,7 +48,7 @@ type DbAnnouncement = Omit<
   category?: string;
   tags?: string | string[];
   start_at: string;
-  until_date: string;
+  until_date: string | null;
 };
 
 /**
@@ -68,17 +68,16 @@ type AnnouncementModelsList = {
 };
 
 export const timestampToDateTime = (input: Date | string): DateTime => {
-  if (typeof input === 'object') {
+  if (input instanceof Date) {
     return DateTime.fromJSDate(input).toUTC();
   }
-
-  const result = input.includes(' ')
-    ? DateTime.fromSQL(input, { zone: 'utc' })
-    : DateTime.fromISO(input, { zone: 'utc' });
+  const trimmed = input.trim();
+  const result = trimmed.includes(' ')
+    ? DateTime.fromSQL(trimmed, { zone: 'utc' })
+    : DateTime.fromISO(trimmed, { zone: 'utc' });
   if (!result.isValid) {
     throw new TypeError('Not valid');
   }
-
   return result;
 };
 
@@ -127,7 +126,9 @@ const announcementUpsertToDB = (
     created_at: announcement.created_at.toSQL()!,
     active: announcement.active,
     start_at: announcement.start_at.toSQL()!,
-    until_date: announcement.until_date.toSQL()!,
+    until_date: announcement.until_date
+      ? announcement.until_date.toSQL()!
+      : null,
     on_behalf_of: announcement.on_behalf_of,
     tags:
       announcement.tags && announcement.tags.length > 0
@@ -164,7 +165,9 @@ const DBToAnnouncementWithCategory = (
     created_at: timestampToDateTime(announcementDb.created_at),
     active: announcementDb.active,
     start_at: timestampToDateTime(announcementDb.start_at),
-    until_date: timestampToDateTime(announcementDb.until_date),
+    until_date: announcementDb.until_date
+      ? timestampToDateTime(announcementDb.until_date)
+      : null,
     on_behalf_of: announcementDb.on_behalf_of,
   };
 };

--- a/workspaces/announcements/plugins/announcements-backend/src/service/signal.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/signal.ts
@@ -48,7 +48,9 @@ export const signalAnnouncement = async (
         ...announcement,
         created_at: announcement.created_at.toString(),
         start_at: announcement.start_at.toString(),
-        until_date: announcement.until_date.toString(),
+        until_date: announcement.until_date
+          ? announcement.until_date.toString()
+          : null,
       },
     },
   });

--- a/workspaces/announcements/plugins/announcements-common/report.api.md
+++ b/workspaces/announcements/plugins/announcements-common/report.api.md
@@ -16,7 +16,7 @@ export type Announcement = {
   created_at: string;
   active: boolean;
   start_at: string;
-  until_date: string;
+  until_date?: string | null;
   on_behalf_of?: string;
   tags?: Tag[];
   sendNotification?: boolean;

--- a/workspaces/announcements/plugins/announcements-common/src/types.ts
+++ b/workspaces/announcements/plugins/announcements-common/src/types.ts
@@ -62,8 +62,8 @@ export type Announcement = {
   active: boolean;
   /** Date indicating when the announcement starts (is visible to end users) */
   start_at: string;
-  /** Date indicating when the announcement should show until, using current filters */
-  until_date: string;
+  /** Date indicating when the announcement should show until, using current filters. If omitted, the announcement is open-ended. */
+  until_date?: string | null;
   /** The team on whose behalf the announcement was published */
   on_behalf_of?: string;
   /** Array of tags associated with the announcement */

--- a/workspaces/announcements/plugins/announcements/src/components/Admin/AnnouncementsContent/AnnouncementsContent.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/Admin/AnnouncementsContent/AnnouncementsContent.tsx
@@ -268,7 +268,9 @@ export const AnnouncementsContent = () => {
       field: 'until_date',
       type: 'date',
       render: rowData =>
-        DateTime.fromISO(rowData.until_date).toFormat('M/d/yyyy'),
+        rowData?.until_date
+          ? DateTime.fromISO(rowData.until_date).toFormat('M/d/yyyy')
+          : '-',
     },
     {
       title: (


### PR DESCRIPTION
Signed-off-by: gaelgoth <gothuey.gael@gmail.com>

~Fallback to `start_date` when `until_date` is `null`. This is a temp fix for #5322~.

Edit: `until_date` is now considered `nullable` which the case for existing announcements before the `until_date`
 intrdocution

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
