### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/nine-olives-sit.md
+++ b/workspaces/announcements/.changeset/nine-olives-sit.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': patch
-'@backstage-community/plugin-announcements-common': patch
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.

--- a/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements-backend
 
+## 0.11.1
+
+### Patch Changes
+
+- 2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.
+- Updated dependencies [2007a96]
+  - @backstage-community/plugin-announcements-common@0.9.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements-backend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-common
 
+## 0.9.1
+
+### Patch Changes
+
+- 2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-common/package.json
+++ b/workspaces/announcements/plugins/announcements-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-common",
   "description": "Common functionalities for the announcements plugin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements-node
 
+## 0.8.2
+
+### Patch Changes
+
+- Updated dependencies [2007a96]
+  - @backstage-community/plugin-announcements-common@0.9.1
+
 ## 0.8.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-node/package.json
+++ b/workspaces/announcements/plugins/announcements-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-node",
   "description": "Node.js library for the announcements plugin",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.11.1
+
+### Patch Changes
+
+- Updated dependencies [2007a96]
+  - @backstage-community/plugin-announcements-common@0.9.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-announcements
 
+## 0.12.1
+
+### Patch Changes
+
+- 2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.
+- Updated dependencies [2007a96]
+  - @backstage-community/plugin-announcements-common@0.9.1
+  - @backstage-community/plugin-announcements-react@0.11.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
+## 0.7.2
+
+### Patch Changes
+
+- Updated dependencies [2007a96]
+  - @backstage-community/plugin-announcements-common@0.9.1
+  - @backstage-community/plugin-announcements-node@0.8.2
+
 ## 0.7.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/search-backend-module-announcements/package.json
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-announcements",
   "description": "The announcements backend module for the search plugin.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.12.1

### Patch Changes

-   2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.
-   Updated dependencies [2007a96]
    -   @backstage-community/plugin-announcements-common@0.9.1
    -   @backstage-community/plugin-announcements-react@0.11.1

## @backstage-community/plugin-announcements-backend@0.11.1

### Patch Changes

-   2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.
-   Updated dependencies [2007a96]
    -   @backstage-community/plugin-announcements-common@0.9.1

## @backstage-community/plugin-announcements-common@0.9.1

### Patch Changes

-   2007a96: Fixed #5322 that caused `500` errors when fetching existing announcements with null `until_date`.

## @backstage-community/plugin-announcements-node@0.8.2

### Patch Changes

-   Updated dependencies [2007a96]
    -   @backstage-community/plugin-announcements-common@0.9.1

## @backstage-community/plugin-announcements-react@0.11.1

### Patch Changes

-   Updated dependencies [2007a96]
    -   @backstage-community/plugin-announcements-common@0.9.1

## @backstage-community/plugin-search-backend-module-announcements@0.7.2

### Patch Changes

-   Updated dependencies [2007a96]
    -   @backstage-community/plugin-announcements-common@0.9.1
    -   @backstage-community/plugin-announcements-node@0.8.2
