### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/curly-ducks-march.md
+++ b/workspaces/confluence/.changeset/curly-ducks-march.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-confluence': minor
----
-
-Export `ConfluenceSearchResultListItem` as a search result list item extension. Also update component to accept `limeClamp` and custom `icon` parameters along with minor tweaks to styling to be consistent with other search result list item components.

--- a/workspaces/confluence/.changeset/happy-carpets-travel.md
+++ b/workspaces/confluence/.changeset/happy-carpets-travel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Fallback to document modified by display name if public name is not defined

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-confluence
 
+## 0.10.0
+
+### Minor Changes
+
+- 20ccec6: Export `ConfluenceSearchResultListItem` as a search result list item extension. Also update component to accept `limeClamp` and custom `icon` parameters along with minor tweaks to styling to be consistent with other search result list item components.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.12.2
+
+### Patch Changes
+
+- 20ccec6: Fallback to document modified by display name if public name is not defined
+
 ## 0.12.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.10.0

### Minor Changes

-   20ccec6: Export `ConfluenceSearchResultListItem` as a search result list item extension. Also update component to accept `limeClamp` and custom `icon` parameters along with minor tweaks to styling to be consistent with other search result list item components.

## @backstage-community/plugin-search-backend-module-confluence-collator@0.12.2

### Patch Changes

-   20ccec6: Fallback to document modified by display name if public name is not defined
