### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/curvy-houses-vanish.md
+++ b/workspaces/redhat-argocd/.changeset/curvy-houses-vanish.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Fix issue where Revision data did not render for multi-source apps

--- a/workspaces/redhat-argocd/.changeset/renovate-1ea9854.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-1ea9854.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.8.0`.

--- a/workspaces/redhat-argocd/.changeset/smart-jokes-exist.md
+++ b/workspaces/redhat-argocd/.changeset/smart-jokes-exist.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-add new config showFullDeploymentHistory that allows for duplicate revisions to get shown

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.24.0
+
+### Minor Changes
+
+- d13d63f: Fix issue where Revision data did not render for multi-source apps
+- 1f13ecc: add new config showFullDeploymentHistory that allows for duplicate revisions to get shown
+
+### Patch Changes
+
+- 4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
+
 ## 1.23.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.24.0

### Minor Changes

-   d13d63f: Fix issue where Revision data did not render for multi-source apps
-   1f13ecc: add new config showFullDeploymentHistory that allows for duplicate revisions to get shown

### Patch Changes

-   4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
