### PR TITLE
core(codeowners): update codeowners for plugins we maintain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ yarn.lock                                                               @backsta
 */yarn.lock                                                             @backstage/community-plugins-maintainers @backstage-service
 .github/archived-plugins.json                                           @backstage/community-plugins-maintainers
 
-/workspaces/3scale                                                      @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr
+/workspaces/3scale                                                      @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
 /workspaces/acr                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
 /workspaces/acs                                                         @backstage/community-plugins-maintainers  @sachaudh @alwayshooin @dvail @maknop
 /workspaces/adr                                                         @backstage/community-plugins-maintainers  @kuangp
@@ -67,7 +67,7 @@ yarn.lock                                                               @backsta
 /workspaces/jenkins                                                     @backstage/community-plugins-maintainers
 /workspaces/jfrog-artifactory                                           @backstage/community-plugins-maintainers  @BethGriggs
 /workspaces/kafka                                                       @backstage/community-plugins-maintainers  @andrewthauer
-/workspaces/keycloak                                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov
+/workspaces/keycloak                                                    @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
 /workspaces/kiali                                                       @backstage/community-plugins-maintainers  @aljesusg @josunect @leandroberetta
 /workspaces/lighthouse                                                  @backstage/community-plugins-maintainers
 /workspaces/linguist                                                    @backstage/community-plugins-maintainers  @awanlin
@@ -83,12 +83,12 @@ yarn.lock                                                               @backsta
 /workspaces/nomad                                                       @backstage/community-plugins-maintainers
 /workspaces/noop                                                        @backstage/community-plugins-maintainers
 /workspaces/npm                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @karthikjeeyar @logonoff
-/workspaces/ocm                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff
+/workspaces/ocm                                                         @backstage/community-plugins-maintainers  @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @logonoff @dzemanov
 /workspaces/octopus-deploy                                              @backstage/community-plugins-maintainers  @jmezach
 /workspaces/odo                                                         @backstage/community-plugins-maintainers
 /workspaces/opencost                                                    @backstage/community-plugins-maintainers
 /workspaces/periskop                                                    @backstage/community-plugins-maintainers
-/workspaces/pingidentity                                                @backstage/community-plugins-maintainers  @jessicajhee
+/workspaces/pingidentity                                                @backstage/community-plugins-maintainers  @jessicajhee @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
 /workspaces/playlist                                                    @backstage/community-plugins-maintainers  @kuangp
 /workspaces/puppetdb                                                    @backstage/community-plugins-maintainers
 /workspaces/quay                                                        @backstage/community-plugins-maintainers  @caugello @cryptorodeo
@@ -97,12 +97,12 @@ yarn.lock                                                               @backsta
 /workspaces/repo-tools                                                  @backstage/community-plugins-maintainers
 /workspaces/report-portal                                               @backstage/community-plugins-maintainers  @yashoswalyo @deshmukhmayur @riginoommen
 /workspaces/rollbar                                                     @backstage/community-plugins-maintainers  @andrewthauer
-/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
-/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
-/workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
-/workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
-/workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
-/workspaces/scaffolder-relation-processor                               @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight
+/workspaces/scaffolder-backend-module-annotator                         @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
+/workspaces/scaffolder-backend-module-kubernetes                        @backstage/community-plugins-maintainers  @debsmita1 @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
+/workspaces/scaffolder-backend-module-regex                             @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
+/workspaces/scaffolder-backend-module-servicenow                        @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
+/workspaces/scaffolder-backend-module-sonarqube                         @backstage/community-plugins-maintainers  @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
+/workspaces/scaffolder-relation-processor                               @backstage/community-plugins-maintainers  @04kash @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
 /workspaces/sentry                                                      @backstage/community-plugins-maintainers
 /workspaces/servicenow                                                  @backstage/community-plugins-maintainers  @AndrienkoAleksandr @ciiay @PatAKnight @christoph-jerolimov
 /workspaces/shortcuts                                                   @backstage/community-plugins-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR:
- Adds @djanickova from our team as code owner
Some contributions:
https://github.com/backstage/community-plugins/pull/4812
https://github.com/backstage/community-plugins/pull/4792
https://github.com/backstage/community-plugins/pull/4783
https://github.com/backstage/community-plugins/pull/5128
https://github.com/backstage/community-plugins/pull/5136
https://github.com/backstage/community-plugins/pull/5269 (in progress)
https://github.com/backstage/community-plugins/pull/5308
https://github.com/backstage/community-plugins/pull/5313

- Adds more people from our team to plugins we maintain, some contributions:
**3scale** (only 2 people currently): https://github.com/backstage/community-plugins/pull/5236
**keycloak** (only 2 people currently): https://github.com/backstage/community-plugins/pull/5128
**pingidentity** (only 1 person currently): https://github.com/backstage/community-plugins/pull/5312, https://github.com/backstage/community-plugins/pull/4740
**ocm** (adding at least 1 person from our team since we also maintain it): https://github.com/backstage/community-plugins/pull/4921, https://github.com/backstage/community-plugins/pull/5313, https://github.com/backstage/community-plugins/pull/4194, https://github.com/backstage/community-plugins/pull/3797



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
