### PR TITLE
ci: add setup-node action to fix workflow, remove workflow_dispatch

### DIFF
--- a/.github/workflows/deprecate-archived-plugins.yml
+++ b/.github/workflows/deprecate-archived-plugins.yml
@@ -6,14 +6,18 @@ on:
       - '.github/archived-plugins.json'
     branches:
       - main
-  # Temporary for testing
-  workflow_dispatch:
 
 jobs:
   deprecate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Deprecate packages
         run: ./scripts/ci/deprecate-archived-plugins.sh


### PR DESCRIPTION
Confirmed working in https://github.com/backstage/community-plugins/actions/runs/17768183004:
<img width="1547" height="345" alt="image" src="https://github.com/user-attachments/assets/6d1060f7-1342-4894-812f-6b6d89717e3d" />


#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
