### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/curvy-days-drop.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/curvy-days-drop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': minor
----
-
-Add notifications support for scaffolder relation processor to send notifications when template versions are updated. The plugin uses Backstage's notification system to alert users when scaffolder templates have new versions available. This helps teams stay informed about template updates and ensures they can take advantage of the latest improvements and fixes. The notification feature is disabled by default and can be enabled via config.

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 2.7.0
+
+### Minor Changes
+
+- a271cd6: Add notifications support for scaffolder relation processor to send notifications when template versions are updated. The plugin uses Backstage's notification system to alert users when scaffolder templates have new versions available. This helps teams stay informed about template updates and ensures they can take advantage of the latest improvements and fixes. The notification feature is disabled by default and can be enabled via config.
+
 ## 2.6.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@2.7.0

### Minor Changes

-   a271cd6: Add notifications support for scaffolder relation processor to send notifications when template versions are updated. The plugin uses Backstage's notification system to alert users when scaffolder templates have new versions available. This helps teams stay informed about template updates and ensures they can take advantage of the latest improvements and fixes. The notification feature is disabled by default and can be enabled via config.
