### PR TITLE
announcements: Fix table rendering when using md-editor

### DIFF
--- a/workspaces/announcements/.changeset/pink-spoons-sit.md
+++ b/workspaces/announcements/.changeset/pink-spoons-sit.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+- Fixed table rendering in `<AnnouncementsPage markdownRenderer="md-editor" />`. Table styling was not correctly applied when using the Backstage Light theme.
+- Updated `@uiw/react-md-editor` dependency to `^4.0.8`.

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -70,7 +70,7 @@
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@types/react": "^17.0.0 || ^18.0.0",
-    "@uiw/react-md-editor": "^4.0.7",
+    "@uiw/react-md-editor": "^4.0.8",
     "add": "^2.0.6",
     "luxon": "^3.2.0",
     "react-use": "^17.2.4",

--- a/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -53,6 +53,33 @@ const useStyles = makeStyles(theme => ({
       paddingLeft: theme.spacing(1),
       color: theme.palette.text.secondary,
     },
+    '& table': {
+      '& thead th': {
+        color: theme.palette.text.primary,
+        backgroundColor:
+          theme.palette.type === 'dark'
+            ? theme.palette.background.default
+            : theme.palette.background.paper,
+      },
+      '& th, & td': {
+        border: 0,
+      },
+      '& tbody tr:nth-of-type(odd)': {
+        backgroundColor:
+          theme.palette.type === 'dark'
+            ? theme.palette.action.selected
+            : theme.palette.action.hover,
+      },
+      '& tbody tr:nth-of-type(even)': {
+        backgroundColor:
+          theme.palette.type === 'dark'
+            ? theme.palette.background.paper
+            : theme.palette.background.paper,
+      },
+      '& tbody td': {
+        borderTop: `1px solid ${theme.palette.divider}`,
+      },
+    },
   },
 }));
 

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -1756,7 +1756,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14.5.1"
     "@types/luxon": "npm:^3.3.3"
     "@types/react": "npm:^17.0.0 || ^18.0.0"
-    "@uiw/react-md-editor": "npm:^4.0.7"
+    "@uiw/react-md-editor": "npm:^4.0.8"
     add: "npm:^2.0.6"
     cross-fetch: "npm:^3.1.8"
     luxon: "npm:^3.2.0"
@@ -11186,9 +11186,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uiw/react-md-editor@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "@uiw/react-md-editor@npm:4.0.7"
+"@uiw/react-md-editor@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@uiw/react-md-editor@npm:4.0.8"
   dependencies:
     "@babel/runtime": "npm:^7.14.6"
     "@uiw/react-markdown-preview": "npm:^5.0.6"
@@ -11197,7 +11197,7 @@ __metadata:
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: 10/554fb1efb85ab82870d14924c103d0e21af2a56fcc0dd9b32d40fd9a2e529401600568945ead1177ed6080f826aa886f68c7e1bd560a9145f12b0bd0e880b77f
+  checksum: 10/c6a2d7c2c3d843cc7e1dc1e26f01067937a2c7d82073353650ddb125dd05623d1121866d294c3270f48cad05c47fc17c8ccc15303c656104f2814ddb950e4af9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

If announcements are rendered with `md-editor` the table doesn't follow white theme styling:

<img width="796" height="400" alt="image" src="https://github.com/user-attachments/assets/418c4a30-17a6-407b-b3ad-03c383e62b06" />

After this fix:

<img width="796" height="400" alt="image" src="https://github.com/user-attachments/assets/cef55b22-fb72-4ed9-94cf-c46320ee5dc8" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
