### PR TITLE
feat: add filename context to AdrContentDecorator

### DIFF
--- a/workspaces/adr/.changeset/add-filename-context-to-adr-content-decorator.md
+++ b/workspaces/adr/.changeset/add-filename-context-to-adr-content-decorator.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-adr': minor
+---
+
+feat: add filename context to AdrContentDecorator
+
+Enhanced the `AdrContentDecorator` interface to include an optional `filename` parameter, enabling decorators to access the ADR filename for more content transformations.
+
+**Breaking Changes**: None - the `filename` parameter is optional and maintains full backward compatibility.

--- a/workspaces/adr/plugins/adr/README.md
+++ b/workspaces/adr/plugins/adr/README.md
@@ -145,7 +145,12 @@ import {
 
 ...
 
-const myCustomDecorator: AdrContentDecorator = ({ content }) => {
+const myCustomDecorator: AdrContentDecorator = ({ content, filename }) => {
+  if (filename?.includes('security')) {
+    // Apply security-specific formatting
+    return { content: applySecurityFormatting(content) };
+  }
+
   return { content: applyCustomContentTransformation(content) };
 };
 

--- a/workspaces/adr/plugins/adr/report.api.md
+++ b/workspaces/adr/plugins/adr/report.api.md
@@ -47,6 +47,7 @@ export interface AdrClientOptions {
 export type AdrContentDecorator = (adrInfo: {
   baseUrl: string;
   content: string;
+  filename?: string;
 }) => {
   content: string;
 };

--- a/workspaces/adr/plugins/adr/src/components/AdrReader/AdrReader.tsx
+++ b/workspaces/adr/plugins/adr/src/components/AdrReader/AdrReader.tsx
@@ -71,10 +71,10 @@ export const AdrReader = (props: {
 
     return adrDecorators.reduce(
       (content, decorator) =>
-        decorator({ baseUrl: adrLocationUrl, content }).content,
+        decorator({ baseUrl: adrLocationUrl, content, filename: adr }).content,
       value.data,
     );
-  }, [adrLocationUrl, decorators, value]);
+  }, [adrLocationUrl, decorators, value, adr]);
 
   return (
     <CookieAuthRefreshProvider pluginId="adr">

--- a/workspaces/adr/plugins/adr/src/components/AdrReader/types.ts
+++ b/workspaces/adr/plugins/adr/src/components/AdrReader/types.ts
@@ -22,4 +22,5 @@
 export type AdrContentDecorator = (adrInfo: {
   baseUrl: string;
   content: string;
+  filename?: string;
 }) => { content: string };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR enhances the ADR plugin by adding `filename` context to the `AdrContentDecorator` interface, enabling decorators to access the ADR filename for more content transformations.

Closes https://github.com/backstage/community-plugins/issues/5484

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] ~~Tests for new functionality and regression tests for bug fixes~~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
