### PR TITLE
feat(announcements): add search extensions for new frontend system

### DIFF
--- a/workspaces/announcements/.changeset/four-onions-dream.md
+++ b/workspaces/announcements/.changeset/four-onions-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Added search extensions for new frontend system

--- a/workspaces/announcements/plugins/announcements/src/alpha.ts
+++ b/workspaces/announcements/plugins/announcements/src/alpha.ts
@@ -22,6 +22,10 @@ import { announcementsApiExtension } from './alpha/apis';
 import { entityAnnouncementsCard } from './alpha/entityCards';
 import { announcementsNavItem } from './alpha/navItems';
 import { announcementsPage } from './alpha/pages';
+import {
+  announcementsSearchResultListItem,
+  announcementsSearchFilterResultType,
+} from './alpha/search';
 import { rootRouteRef } from './routes';
 
 /**
@@ -37,5 +41,7 @@ export default createFrontendPlugin({
     entityAnnouncementsCard,
     announcementsPage,
     announcementsNavItem,
+    announcementsSearchResultListItem,
+    announcementsSearchFilterResultType,
   ],
 }) as FrontendPlugin;

--- a/workspaces/announcements/plugins/announcements/src/alpha/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/alpha/index.ts
@@ -17,3 +17,4 @@ export * from './apis';
 export * from './entityCards';
 export * from './navItems';
 export * from './pages';
+export * from './search';

--- a/workspaces/announcements/plugins/announcements/src/alpha/search.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/search.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  SearchFilterResultTypeBlueprint,
+  SearchResultListItemBlueprint,
+} from '@backstage/plugin-search-react/alpha';
+import NewReleasesIcon from '@material-ui/icons/NewReleases';
+
+export const announcementsSearchResultListItem =
+  SearchResultListItemBlueprint.make({
+    params: {
+      component: () =>
+        import('../components/AnnouncementSearchResultListItem').then(
+          m => m.AnnouncementSearchResultListItem,
+        ),
+      predicate: result => result.type === 'announcements',
+    },
+  });
+
+export const announcementsSearchFilterResultType =
+  SearchFilterResultTypeBlueprint.make({
+    params: {
+      name: 'Announcements',
+      value: 'announcements',
+      icon: <NewReleasesIcon />,
+    },
+  });


### PR DESCRIPTION
This PR adds search extensions to improve support for the new frontend system. More specifically, an extensions for a `SearchResultListItem` and a `SearcFilterResultType` were added, allowing the announcements to be searched.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
