### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/spicy-socks-clean.md
+++ b/workspaces/kafka/.changeset/spicy-socks-clean.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kafka': minor
----
-
-Backstage version bump to v1.43.2 and migrate the `kafka` plugin to the new frontend system.

--- a/workspaces/kafka/plugins/kafka/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kafka
 
+## 0.9.0
+
+### Minor Changes
+
+- 6c22329: Backstage version bump to v1.43.2 and migrate the `kafka` plugin to the new frontend system.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/kafka/plugins/kafka/package.json
+++ b/workspaces/kafka/plugins/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A Backstage plugin that integrates towards Kafka",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka@0.9.0

### Minor Changes

-   6c22329: Backstage version bump to v1.43.2 and migrate the `kafka` plugin to the new frontend system.
