### PR TITLE
feat(Feedback) - Allow feedback types to be disabled

### DIFF
--- a/workspaces/feedback/.changeset/tiny-cycles-doubt.md
+++ b/workspaces/feedback/.changeset/tiny-cycles-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-feedback': patch
+---
+
+Added functionality to disable a feedback type by providing an empty list of values in the app config.

--- a/workspaces/feedback/plugins/feedback/README.md
+++ b/workspaces/feedback/plugins/feedback/README.md
@@ -79,6 +79,7 @@ It is dedicated to simplifying the process of gathering and managing user feedba
          confirmationSubTitle: 'Each time a friend submits a experience, it creates a task for our developer team to resolve it with priority.'
          confirmationEventMessage: 'Submitted the feedback'
 
+       # Provide an empty list to disable a type (experience or error). At least one must be enabled.
        # List of experiences to show in feedback form, (note: jira is not created for "excellent" and "good" feedbacks)
        experienceList:
          - Excellent

--- a/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.test.tsx
+++ b/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.test.tsx
@@ -19,7 +19,7 @@ import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { fireEvent } from '@testing-library/react';
 
 import { FeedbackAPI, feedbackApiRef } from '../../api';
-import { mockErrorList, mockExperienceList } from '../../mocks';
+import { mockErrorList, mockExperienceList, mockEmptyList } from '../../mocks';
 import { CreateFeedbackModal } from './CreateFeedbackModal';
 
 describe('Create Feedback Modal', () => {
@@ -142,6 +142,163 @@ describe('Create Feedback Modal', () => {
     ).toBeInTheDocument();
     expect(
       rendered.getByRole('button', { name: 'Send Feedback' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Create Feedback Modal - Bugs Disabled', () => {
+  const feedbackApi: Partial<FeedbackAPI> = {
+    createFeedback: jest.fn(),
+    getErrorList: jest.fn().mockReturnValue(mockEmptyList),
+    getExperienceList: jest.fn().mockReturnValue(mockExperienceList),
+  };
+
+  const PROJECT_ID = 'component:default/example-website';
+  const handleModalClose = jest.fn().mockReturnValue(true);
+
+  const render = async () =>
+    await renderInTestApp(
+      <TestApiProvider apis={[[feedbackApiRef, feedbackApi]]}>
+        <CreateFeedbackModal
+          handleModalCloseFn={handleModalClose}
+          projectEntity={PROJECT_ID}
+          open
+        />
+      </TestApiProvider>,
+    );
+
+  it('should render', async () => {
+    const rendered = await render();
+    expect(rendered).toBeDefined();
+  });
+
+  test('should not render type selector', async () => {
+    const rendered = await render();
+    const tags = rendered.queryAllByRole('radio');
+    expect(rendered.queryByText(`Select type`)).not.toBeInTheDocument();
+    expect(tags).toHaveLength(0);
+  });
+
+  it('should render the modal title for feedback', async () => {
+    const rendered = await render();
+
+    expect(
+      rendered.getByText(`Feedback for ${PROJECT_ID.split('/').pop()}`),
+    ).toBeInTheDocument();
+  });
+
+  it('should render all tags for feedback', async () => {
+    const rendered = await render();
+    expect(
+      rendered.getByRole('button', { name: 'Excellent' }),
+    ).toBeInTheDocument();
+    expect(rendered.getByRole('button', { name: 'Good' })).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'Needs Improvement' }),
+    ).toBeInTheDocument();
+    expect(rendered.getByRole('button', { name: 'Other' })).toBeInTheDocument();
+  });
+
+  it('should have correct feedback labels', async () => {
+    const rendered = await render();
+
+    expect(
+      rendered.getByRole('textbox', { name: 'Summary' }),
+    ).toBeInTheDocument();
+
+    expect(
+      rendered.getByRole('textbox', { name: 'Description' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render submit buttons for feedback', async () => {
+    const rendered = await render();
+
+    expect(
+      rendered.getByRole('button', { name: 'Cancel' }),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'Send Feedback' }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('Create Feedback Modal - Experiences Disabled', () => {
+  const feedbackApi: Partial<FeedbackAPI> = {
+    createFeedback: jest.fn(),
+    getErrorList: jest.fn().mockReturnValue(mockErrorList),
+    getExperienceList: jest.fn().mockReturnValue(mockEmptyList),
+  };
+
+  const PROJECT_ID = 'component:default/example-website';
+  const handleModalClose = jest.fn().mockReturnValue(true);
+
+  const render = async () =>
+    await renderInTestApp(
+      <TestApiProvider apis={[[feedbackApiRef, feedbackApi]]}>
+        <CreateFeedbackModal
+          handleModalCloseFn={handleModalClose}
+          projectEntity={PROJECT_ID}
+          open
+        />
+      </TestApiProvider>,
+    );
+
+  it('should render', async () => {
+    const rendered = await render();
+    expect(rendered).toBeDefined();
+  });
+
+  test('should not render type selector', async () => {
+    const rendered = await render();
+    const tags = rendered.queryAllByRole('radio');
+    expect(rendered.queryByText(`Select type`)).not.toBeInTheDocument();
+    expect(tags).toHaveLength(0);
+  });
+
+  it('should render the modal title for bugs', async () => {
+    const rendered = await render();
+    expect(
+      rendered.getByText(`Feedback for ${PROJECT_ID.split('/').pop()}`),
+    ).toBeInTheDocument();
+  });
+
+  it('should render all tags for bug', async () => {
+    const rendered = await render();
+    expect(
+      rendered.getByRole('button', { name: 'Slow Loading' }),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'Not Responsive' }),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'Navigation' }),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'UI Issues' }),
+    ).toBeInTheDocument();
+    expect(rendered.getByRole('button', { name: 'Other' })).toBeInTheDocument();
+  });
+
+  it('should have correct bug labels', async () => {
+    const rendered = await render();
+
+    expect(
+      rendered.getByRole('textbox', { name: 'Summary' }),
+    ).toBeInTheDocument();
+
+    expect(
+      rendered.getByRole('textbox', { name: 'Description' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render submit buttons for bugs', async () => {
+    const rendered = await render();
+    expect(
+      rendered.getByRole('button', { name: 'Cancel' }),
+    ).toBeInTheDocument();
+    expect(
+      rendered.getByRole('button', { name: 'Report Bug' }),
     ).toBeInTheDocument();
   });
 });

--- a/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
+++ b/workspaces/feedback/plugins/feedback/src/components/CreateFeedbackModal/CreateFeedbackModal.tsx
@@ -97,9 +97,13 @@ export const CreateFeedbackModal = (props: {
   const issueTags = feedbackApi.getErrorList();
   const feedbackTags = feedbackApi.getExperienceList();
   const analytics = useAnalytics();
-  const [feedbackType, setFeedbackType] = useState('BUG');
+  const bugsEnabled = issueTags.length === 0 ? false : true;
+  const feedbackEnabled = feedbackTags.length === 0 ? false : true;
+  const defaultType = bugsEnabled ? 'BUG' : 'FEEDBACK';
+  const defaultTag = bugsEnabled ? issueTags[0] : feedbackTags[0];
+  const [feedbackType, setFeedbackType] = useState(defaultType);
   const [submitClicked, setSubmitClicked] = useState(false);
-  const [selectedTag, setSelectedTag] = useState(issueTags[0]);
+  const [selectedTag, setSelectedTag] = useState(defaultTag);
   const app = useApi(configApiRef);
   const summaryLimit = app.getOptionalNumber('feedback.summaryLimit') ?? 240;
 
@@ -135,8 +139,8 @@ export const CreateFeedbackModal = (props: {
     setSummary(s => ({ ...s, value: '', error: false }));
     setDescription(d => ({ ...d, value: '', error: false }));
     setSubmitClicked(false);
-    setFeedbackType('BUG');
-    setSelectedTag(issueTags[0]);
+    setFeedbackType(defaultType);
+    setSelectedTag(defaultTag);
   }
 
   async function handleSubmitClick() {
@@ -244,36 +248,38 @@ export const CreateFeedbackModal = (props: {
                 </Alert>
               </Grid>
             ) : null}
-            <Grid item xs={4}>
-              <Typography variant="h6">Select type</Typography>
-              <RadioGroup className={classes.radioGroup} row>
-                <FormControlLabel
-                  value="BUG"
-                  checked={feedbackType === 'BUG'}
-                  onChange={handleCategoryClick}
-                  label="Bug"
-                  control={
-                    <Radio
-                      icon={<BugReportOutlined />}
-                      checkedIcon={<BugReportTwoToneIcon />}
-                      color="error"
-                    />
-                  }
-                />
-                <FormControlLabel
-                  value="FEEDBACK"
-                  onChange={handleCategoryClick}
-                  label="Feedback"
-                  control={
-                    <Radio
-                      icon={<SmsOutlined />}
-                      checkedIcon={<SmsTwoTone />}
-                      color="primary"
-                    />
-                  }
-                />
-              </RadioGroup>
-            </Grid>
+            {bugsEnabled && feedbackEnabled ? (
+              <Grid item xs={4}>
+                <Typography variant="h6">Select type</Typography>
+                <RadioGroup className={classes.radioGroup} row>
+                  <FormControlLabel
+                    value="BUG"
+                    checked={feedbackType === 'BUG'}
+                    onChange={handleCategoryClick}
+                    label="Bug"
+                    control={
+                      <Radio
+                        icon={<BugReportOutlined />}
+                        checkedIcon={<BugReportTwoToneIcon />}
+                        color="error"
+                      />
+                    }
+                  />
+                  <FormControlLabel
+                    value="FEEDBACK"
+                    onChange={handleCategoryClick}
+                    label="Feedback"
+                    control={
+                      <Radio
+                        icon={<SmsOutlined />}
+                        checkedIcon={<SmsTwoTone />}
+                        color="primary"
+                      />
+                    }
+                  />
+                </RadioGroup>
+              </Grid>
+            ) : null}
             <Grid item xs={12}>
               <Typography variant="h6">
                 Select {feedbackType === 'FEEDBACK' ? 'Feedback' : 'Bug'}

--- a/workspaces/feedback/plugins/feedback/src/mocks/feedback.ts
+++ b/workspaces/feedback/plugins/feedback/src/mocks/feedback.ts
@@ -43,3 +43,4 @@ export const mockExperienceList = [
   'Needs Improvement',
   'Other',
 ];
+export const mockEmptyList = [];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Feedback plugins allow for two types of feedback to be recorded, Bugs and Feedback (referred to under various synonyms in the code). Each type has a default list of values, or can have custom values if provided in the app config.

This PR adds the ability to disable a type (at least one must be enabled) by providing an empty list of values in the app config. When an empty list is provided the type selector UI elements are removed from the create feedback modal and the modal's configuration is defaulted to the remaining type.

**Nothing disabled (default and current behaviour):**

<img width="913" height="785" alt="image" src="https://github.com/user-attachments/assets/888fe0d3-e43d-4f59-be39-5fd21dfdd0b9" />

**Bugs disabled:**

<img width="928" height="625" alt="image" src="https://github.com/user-attachments/assets/3933126b-15c6-4dd1-b506-1c58aee4ea9c" />

**Feedback disabled:**

<img width="911" height="674" alt="image" src="https://github.com/user-attachments/assets/2999737c-e920-4bdf-b80c-411674efff47" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
