### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/seven-rules-sell.md
+++ b/workspaces/redhat-argocd/.changeset/seven-rules-sell.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Add i18n support

--- a/workspaces/redhat-argocd/.changeset/shaggy-suits-brush.md
+++ b/workspaces/redhat-argocd/.changeset/shaggy-suits-brush.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Revert back to using custom K8s API ref to prevent duplicate factory issue

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.25.0
+
+### Minor Changes
+
+- bb1fa55: Add i18n support
+- 9de3869: Revert back to using custom K8s API ref to prevent duplicate factory issue
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.25.0

### Minor Changes

-   bb1fa55: Add i18n support
-   9de3869: Revert back to using custom K8s API ref to prevent duplicate factory issue
