### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/cyan-poets-bow.md
+++ b/workspaces/tekton/.changeset/cyan-poets-bow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': minor
----
-
-Standardize i18n in Tekton plugin

--- a/workspaces/tekton/.changeset/renovate-7e0e881.md
+++ b/workspaces/tekton/.changeset/renovate-7e0e881.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.2`.

--- a/workspaces/tekton/.changeset/thin-ears-wash.md
+++ b/workspaces/tekton/.changeset/thin-ears-wash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Fix broken url in package.json

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 3.29.0
+
+### Minor Changes
+
+- 99b0588: Standardize i18n in Tekton plugin
+
+### Patch Changes
+
+- 9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
+- 773c07a: Fix broken url in package.json
+
 ## 3.28.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.29.0

### Minor Changes

-   99b0588: Standardize i18n in Tekton plugin

### Patch Changes

-   9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
-   773c07a: Fix broken url in package.json
