### PR TITLE
ci: add maintainer workspaces to PR labeler config

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -409,3 +409,7 @@ workspace/wheel-of-names:
 workspace/xcmetrics:
 - changed-files:
   - any-glob-to-any-file: ['workspaces/xcmetrics/**']
+
+owner/area-maintainers:
+- changed-files:
+  - any-glob-to-any-file: ['workspaces/airbrake/**', 'workspaces/allure/**', 'workspaces/apache-airflow/**', 'workspaces/apollo-explorer/**', 'workspaces/badges/**', 'workspaces/bazaar/**', 'workspaces/cicd-statistics/**', 'workspaces/cloudbuild/**', 'workspaces/code-climate/**', 'workspaces/codescene/**', 'workspaces/dynatrace/**', 'workspaces/entity-validation/**', 'workspaces/firehydrant/**', 'workspaces/gcalendar/**', 'workspaces/gcp-projects/**', 'workspaces/github-actions/**', 'workspaces/github-deployments/**', 'workspaces/github-issues/**', 'workspaces/gitops-profiles/**', 'workspaces/gocd/**', 'workspaces/grafana/**', 'workspaces/graphiql/**', 'workspaces/graphql-voyager/**', 'workspaces/ilert/**', 'workspaces/jaeger/**', 'workspaces/jenkins/**', 'workspaces/lighthouse/**', 'workspaces/linkerd/**', 'workspaces/microsoft-calendar/**', 'workspaces/newrelic/**', 'workspaces/nomad/**', 'workspaces/opencost/**', 'workspaces/periskop/**', 'workspaces/puppetdb/**', 'workspaces/sentry/**', 'workspaces/shortcuts/**', 'workspaces/splunk/**', 'workspaces/stack-overflow/**', 'workspaces/stackstorm/**', 'workspaces/tech-radar/**', 'workspaces/todo/**', 'workspaces/vault/**', 'workspaces/xcmetrics/**']

--- a/scripts/list-maintainer-workspaces.js
+++ b/scripts/list-maintainer-workspaces.js
@@ -23,7 +23,7 @@ import { listWorkspaces } from './list-workspaces.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 
-async function main() {
+async function main(args) {
   const rootPath = resolve(__dirname, '..');
 
   // Get `CODEOWNERS` entries
@@ -53,6 +53,13 @@ async function main() {
     }
   }
 
+  // Check if --json flag is provided
+  if (args.includes('--json')) {
+    console.log(JSON.stringify(maintainerWorkspaces));
+    return;
+  }
+
+  // Default behavior - detailed output
   // How many workspaces do we own?
   console.log(`Workspace count: ${maintainerWorkspaces.length} \n`);
 

--- a/scripts/update-issue-labeler-config.js
+++ b/scripts/update-issue-labeler-config.js
@@ -17,15 +17,32 @@
 import fs from 'fs-extra';
 import { resolve } from 'path';
 import * as url from 'url';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import { listWorkspaces } from './list-workspaces.js';
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+const execAsync = promisify(exec);
+
+async function getMaintainerWorkspaces() {
+  try {
+    const { stdout } = await execAsync(
+      'node scripts/list-maintainer-workspaces.js --json',
+    );
+    return JSON.parse(stdout.trim());
+  } catch (error) {
+    console.error('Error running list-maintainer-workspaces.js:', error);
+    return [];
+  }
+}
 
 async function main() {
   const rootPath = resolve(__dirname, '..');
   const githubIssueLabelerConfigPath = resolve(rootPath, '.github/labeler.yml');
   const githubPrLabelerConfigPath = resolve(rootPath, '.github/pr-labeler.yml');
   const workspaces = await listWorkspaces();
+  const maintainerWorkspaces = await getMaintainerWorkspaces();
 
   // Generate issue labeler configuration (based on issue template selection)
   const issueLabelMappings = [
@@ -34,12 +51,17 @@ async function main() {
   ].join('\n\n');
 
   // Generate PR labeler configuration (based on file changes)
-  const prLabelMappings = workspaces
-    .map(
+  const prLabelMappings = [
+    // Workspace labels for all workspaces
+    ...workspaces.map(
       w =>
         `workspace/${w}:\n- changed-files:\n  - any-glob-to-any-file: ['workspaces/${w}/**']`,
-    )
-    .join('\n\n');
+    ),
+    // Owner/area-maintainers label for maintainer workspaces only
+    `owner/area-maintainers:\n- changed-files:\n  - any-glob-to-any-file: [${maintainerWorkspaces
+      .map(w => `'workspaces/${w}/**'`)
+      .join(', ')}]`,
+  ].join('\n\n');
 
   await fs.writeFile(githubIssueLabelerConfigPath, issueLabelMappings);
   await fs.writeFile(githubPrLabelerConfigPath, prLabelMappings);
@@ -49,6 +71,9 @@ async function main() {
   );
   console.log(
     `Generated PR labeler configuration for ${workspaces.length} workspaces`,
+  );
+  console.log(
+    `Added owner/area-maintainers label for ${maintainerWorkspaces.length} maintainer workspaces`,
   );
 }
 


### PR DESCRIPTION
Implements a new `owner/area-maintainers` label. To achieve this, extend `list-maintainer-workspaces` with a `--json` flag, and update `update-issue-labeler-config` to generate the extra PR label mappings automatically.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
