### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/renovate-7e0e881.md
+++ b/workspaces/quay/.changeset/renovate-7e0e881.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.2`.

--- a/workspaces/quay/.changeset/version-bump-1-43-2.md
+++ b/workspaces/quay/.changeset/version-bump-1-43-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.43.2

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.12.0
+
+### Minor Changes
+
+- 5c7023b: Backstage version bump to v1.43.2
+
 ## 2.11.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.7.0
+
+### Minor Changes
+
+- 5c7023b: Backstage version bump to v1.43.2
+
+### Patch Changes
+
+- Updated dependencies [5c7023b]
+  - @backstage-community/plugin-quay-common@1.12.0
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.12.0
+
+### Minor Changes
+
+- 5c7023b: Backstage version bump to v1.43.2
+
 ## 1.11.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.25.0
+
+### Minor Changes
+
+- 5c7023b: Backstage version bump to v1.43.2
+
+### Patch Changes
+
+- 9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
+- Updated dependencies [5c7023b]
+  - @backstage-community/plugin-quay-common@1.12.0
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.25.0

### Minor Changes

-   5c7023b: Backstage version bump to v1.43.2

### Patch Changes

-   9ffcad1: Updated dependency `start-server-and-test` to `2.1.2`.
-   Updated dependencies [5c7023b]
    -   @backstage-community/plugin-quay-common@1.12.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.12.0

### Minor Changes

-   5c7023b: Backstage version bump to v1.43.2

## @backstage-community/plugin-quay-backend@1.7.0

### Minor Changes

-   5c7023b: Backstage version bump to v1.43.2

### Patch Changes

-   Updated dependencies [5c7023b]
    -   @backstage-community/plugin-quay-common@1.12.0

## @backstage-community/plugin-quay-common@1.12.0

### Minor Changes

-   5c7023b: Backstage version bump to v1.43.2
