### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/shiny-buses-rush.md
+++ b/workspaces/topology/.changeset/shiny-buses-rush.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Fix rendering of markdown on the missing permission page

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 2.6.1
+
+### Patch Changes
+
+- 1defa96: Fix rendering of markdown on the missing permission page
+
 ## 2.6.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.6.1

### Patch Changes

-   1defa96: Fix rendering of markdown on the missing permission page
