### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/renovate-1ea9854.md
+++ b/workspaces/jfrog-artifactory/.changeset/renovate-1ea9854.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.8.0`.

--- a/workspaces/jfrog-artifactory/.changeset/version-bump-1-43-2.md
+++ b/workspaces/jfrog-artifactory/.changeset/version-bump-1-43-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': minor
----
-
-Backstage version bump to v1.43.2

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 1.20.0
+
+### Minor Changes
+
+- f7c4334: Backstage version bump to v1.43.2
+
+### Patch Changes
+
+- 4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
+
 ## 1.19.0
 
 ### Minor Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.20.0

### Minor Changes

-   f7c4334: Backstage version bump to v1.43.2

### Patch Changes

-   4819a06: Updated dependency `@testing-library/jest-dom` to `6.8.0`.
