### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/curvy-coins-exercise.md
+++ b/workspaces/announcements/.changeset/curvy-coins-exercise.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed the typings for the Announcements new frontend system plugin, which previously prevented correct overriding.

--- a/workspaces/announcements/.changeset/pink-spoons-sit.md
+++ b/workspaces/announcements/.changeset/pink-spoons-sit.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-- Fixed table rendering in `<AnnouncementsPage markdownRenderer="md-editor" />`. Table styling was not correctly applied when using the Backstage Light theme.
-- Updated `@uiw/react-md-editor` dependency to `^4.0.8`.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements
 
+## 0.13.1
+
+### Patch Changes
+
+- 93bb787: Fixed the typings for the Announcements new frontend system plugin, which previously prevented correct overriding.
+- 6efe1a3: - Fixed table rendering in `<AnnouncementsPage markdownRenderer="md-editor" />`. Table styling was not correctly applied when using the Backstage Light theme.
+  - Updated `@uiw/react-md-editor` dependency to `^4.0.8`.
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.13.1

### Patch Changes

-   93bb787: Fixed the typings for the Announcements new frontend system plugin, which previously prevented correct overriding.
-   6efe1a3: - Fixed table rendering in `<AnnouncementsPage markdownRenderer="md-editor" />`. Table styling was not correctly applied when using the Backstage Light theme.
    -   Updated `@uiw/react-md-editor` dependency to `^4.0.8`.
