### PR TITLE
test(scaffolder-relation-processor): enhance unit tests

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/thirty-toes-suffer.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/thirty-toes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
+---
+
+Updated unit tests to catch type issues and certain edge cases.

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/ScaffolderRelationEntityProcessor.test.ts
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/src/ScaffolderRelationEntityProcessor.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2025 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,6 +264,80 @@ describe('ScaffolderRelationEntityProcessor', () => {
           version: '2.0.0',
         },
       );
+    });
+
+    it('should not change the cached version if the event service fails', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'backstage.io/template-version': '2.0.0',
+          },
+        },
+      };
+
+      const cachedData = { version: '1.0.0' };
+      (mockCache.get as jest.Mock).mockResolvedValue(cachedData);
+
+      // Mock event service to throw an error
+      (mockEventsService.publish as jest.Mock).mockRejectedValue(
+        new Error('Event service unavailable'),
+      );
+
+      await expect(
+        processor.preProcessEntity(entity, location, emit, location, mockCache),
+      ).rejects.toThrow('Event service unavailable');
+
+      expect(mockEventsService.publish).toHaveBeenCalledWith({
+        topic: 'relationProcessor.template:version_updated',
+        eventPayload: {
+          entityRef: 'template:default/test-template',
+          previousVersion: '1.0.0',
+          currentVersion: '2.0.0',
+        },
+      });
+
+      // Cache.set should not be called - otherwise the owner would never be notified
+      expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger event for version downgrade (2.0.0 → 1.0.0)', async () => {
+      const entity: Entity = {
+        apiVersion: 'scaffolder.backstage.io/v1beta3',
+        kind: 'Template',
+        metadata: {
+          name: 'test-template',
+          annotations: {
+            'backstage.io/template-version': '1.0.0',
+          },
+        },
+      };
+
+      const cachedData = { version: '2.0.0' };
+      (mockCache.get as jest.Mock).mockResolvedValue(cachedData);
+
+      const result = await processor.preProcessEntity(
+        entity,
+        location,
+        emit,
+        location,
+        mockCache,
+      );
+
+      expect(result).toBe(entity);
+      expect(mockCache.get).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+      );
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'template-version-template:default/test-template',
+        {
+          version: '1.0.0',
+        },
+      );
+
+      expect(mockEventsService.publish).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the unit tests for scaffolder-relation-processor to avoid the "as any" type casting and to cover some edge cases as well.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
