### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/tasty-hotels-raise.md
+++ b/workspaces/redhat-argocd/.changeset/tasty-hotels-raise.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-export alpha module in scalprum config

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 1.25.1
+
+### Patch Changes
+
+- 1d422c1: export alpha module in scalprum config
+
 ## 1.25.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@1.25.1

### Patch Changes

-   1d422c1: export alpha module in scalprum config
