### PR TITLE
explore: slow group diagram rendering

### DIFF
--- a/workspaces/explore/.changeset/heavy-singers-grin.md
+++ b/workspaces/explore/.changeset/heavy-singers-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore': patch
+---
+
+Fixed slow rendering of group diagram for bigger organisations

--- a/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
+++ b/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.tsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles(
   theme => ({
     graph: {
       minHeight: '100%',
+      maxHeight: '1200px',
       flex: 1,
     },
     graphWrapper: {


### PR DESCRIPTION
Set a max height so fix the slow rendering of the group diagram

####  Small group diagram:
<img width="2325" height="1262" alt="small-org" src="https://github.com/user-attachments/assets/6881eed2-ebf1-4ad1-a280-c6358a7413ea" />

#### Bigger group diagram:
much faster loading..  🚀 
![explore-group-fix](https://github.com/user-attachments/assets/01e08a26-42d3-47a8-b129-670c5bcc8f04)

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
