### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/gorgeous-donkeys-wave.md
+++ b/workspaces/nexus-repository-manager/.changeset/gorgeous-donkeys-wave.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Migrate the `nexus-repository-manager` plugin to the new frontend system.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-02f70fe.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-02f70fe.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.86.11`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-6172363.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-6172363.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.9.1`.

--- a/workspaces/nexus-repository-manager/.changeset/version-bump-1-44-2.md
+++ b/workspaces/nexus-repository-manager/.changeset/version-bump-1-44-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Backstage version bump to v1.44.2

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.18.0
+
+### Minor Changes
+
+- 893d1d6: Backstage version bump to v1.44.2
+
+### Patch Changes
+
+- 47d8095: Migrate the `nexus-repository-manager` plugin to the new frontend system.
+- 80b07a8: Updated dependency `@hey-api/openapi-ts` to `0.86.11`.
+- 9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.18.0

### Minor Changes

-   893d1d6: Backstage version bump to v1.44.2

### Patch Changes

-   47d8095: Migrate the `nexus-repository-manager` plugin to the new frontend system.
-   80b07a8: Updated dependency `@hey-api/openapi-ts` to `0.86.11`.
-   9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
