### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/renovate-6172363.md
+++ b/workspaces/jfrog-artifactory/.changeset/renovate-6172363.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.9.1`.

--- a/workspaces/jfrog-artifactory/.changeset/version-bump-1-44-0.md
+++ b/workspaces/jfrog-artifactory/.changeset/version-bump-1-44-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': minor
----
-
-Backstage version bump to v1.44.0

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 1.21.0
+
+### Minor Changes
+
+- b7145e2: Backstage version bump to v1.44.0
+
+### Patch Changes
+
+- 9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
+
 ## 1.20.0
 
 ### Minor Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.21.0

### Minor Changes

-   b7145e2: Backstage version bump to v1.44.0

### Patch Changes

-   9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
