### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/full-geckos-wash.md
+++ b/workspaces/tekton/.changeset/full-geckos-wash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Move Status and hooks into plugin

--- a/workspaces/tekton/.changeset/renovate-6172363.md
+++ b/workspaces/tekton/.changeset/renovate-6172363.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@testing-library/jest-dom` to `6.9.1`.

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 3.30.2
+
+### Patch Changes
+
+- 6c5b40c: Move Status and hooks into plugin
+- 9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
+
 ## 3.30.1
 
 ### Patch Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.30.1",
+  "version": "3.30.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.30.2

### Patch Changes

-   6c5b40c: Move Status and hooks into plugin
-   9f1486f: Updated dependency `@testing-library/jest-dom` to `6.9.1`.
