### PR TITLE
chore(tekton): move status & hooks into plugin

### DIFF
--- a/workspaces/tekton/.changeset/full-geckos-wash.md
+++ b/workspaces/tekton/.changeset/full-geckos-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Move Status and hooks into plugin

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunList/PlrStatus.tsx
@@ -16,8 +16,9 @@
 import {
   pipelineRunFilterReducer,
   PipelineRunKind,
-  Status,
 } from '@janus-idp/shared-react';
+
+import { Status } from '../common/Status';
 
 import './PlrStatus.css';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';

--- a/workspaces/tekton/plugins/tekton/src/components/common/CamelCaseWrap.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/common/CamelCaseWrap.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Fragment } from 'react';
+
+const MEMO: { [key: string]: any } = {};
+
+type CamelCaseWrapProps = {
+  value: string;
+  dataTest?: string;
+};
+
+export const CamelCaseWrap = ({ value, dataTest }: CamelCaseWrapProps) => {
+  if (!value) {
+    return '-';
+  }
+
+  if (MEMO[value]) {
+    return MEMO[value];
+  }
+
+  // Add word break points before capital letters (but keep consecutive capital letters together).
+  const words = value.match(/[A-Z]+[^A-Z]*|[^A-Z]+/g);
+  const rendered = (
+    <span data-testid={dataTest}>
+      {words?.map((word, i) => (
+        <Fragment key={word}>
+          {word}
+          {i !== words.length - 1 && <wbr />}
+        </Fragment>
+      ))}
+    </span>
+  );
+  MEMO[value] = rendered;
+  return rendered;
+};
+
+export default CamelCaseWrap;

--- a/workspaces/tekton/plugins/tekton/src/components/common/Status.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/common/Status.tsx
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement, CSSProperties } from 'react';
+import {
+  StatusClassKey,
+  StatusError,
+  StatusOK,
+  StatusPending,
+  StatusRunning,
+  StatusWarning,
+} from '@backstage/core-components';
+
+import { createStyles, makeStyles, Theme } from '@material-ui/core';
+import OffIcon from '@mui/icons-material/DoNotDisturbOnOutlined';
+import UnknownIcon from '@mui/icons-material/HelpOutline';
+import AngleDoubleRightIcon from '@mui/icons-material/KeyboardDoubleArrowRight';
+import BanIcon from '@mui/icons-material/NotInterestedOutlined';
+import PauseIcon from '@mui/icons-material/PauseCircleOutlineOutlined';
+import cx from 'classnames';
+
+import { StatusIconAndText } from './StatusIconAndText';
+
+const useStyles = makeStyles<Theme>(theme =>
+  createStyles({
+    iconStyles: {
+      height: '0.8em',
+      width: '0.8em',
+      top: '0.125em',
+      position: 'relative',
+      flexShrink: 0,
+      marginRight: theme.spacing(0.6),
+    },
+  }),
+);
+
+const DASH = '-';
+
+const useStatusStyles = makeStyles(theme => ({
+  success: {
+    '& svg': {
+      fill: theme.palette.status.ok,
+    },
+  },
+  running: {
+    '& svg': {
+      fill: theme.palette.status.running,
+    },
+  },
+  pending: {
+    '& svg': {
+      fill: theme.palette.status.pending,
+    },
+  },
+  warning: {
+    '& svg': {
+      fill: theme.palette.status.warning,
+    },
+  },
+  error: {
+    '& svg': {
+      fill: theme.palette.status.error,
+    },
+  },
+}));
+
+const StatusIcon = ({
+  statusKey,
+  className,
+}: {
+  statusKey: StatusClassKey;
+  className?: string;
+}) => {
+  const statusStyles = useStatusStyles();
+
+  switch (statusKey) {
+    case 'ok':
+      return (
+        <g className={cx(statusStyles.success, className)}>
+          <StatusOK />{' '}
+        </g>
+      );
+    case 'pending':
+      return (
+        <g className={cx(statusStyles.pending, className)}>
+          <StatusPending />{' '}
+        </g>
+      );
+    case 'running':
+      return (
+        <g className={cx(statusStyles.running, className)}>
+          <StatusRunning />{' '}
+        </g>
+      );
+    case 'warning':
+      return (
+        <g className={cx(statusStyles.warning, className)}>
+          <StatusWarning />{' '}
+        </g>
+      );
+    case 'error':
+      return (
+        <g className={cx(statusStyles.error, className)}>
+          <StatusError />{' '}
+        </g>
+      );
+    default:
+      return null;
+  }
+};
+
+/**
+ * Component for displaying a status message
+ * @param {string} status - type of status to be displayed
+ * @param {boolean} [iconOnly] - (optional) if true, only displays icon
+ * @param {string} [className] - (optional) additional class name for the component
+ * @param {string} [displayStatusText] - (optional) use a different text to display the status
+
+ * @example
+ * ```tsx
+ * <Status status='Warning' />
+ * ```
+ */
+export const Status = ({
+  status,
+  iconOnly,
+  className,
+  displayStatusText,
+  dataTestId,
+  iconStyles,
+  iconClassName,
+}: {
+  status: string | null;
+  displayStatusText?: string;
+  iconOnly?: boolean;
+  className?: string;
+  dataTestId?: string;
+  iconStyles?: CSSProperties;
+  iconClassName?: string;
+}): ReactElement => {
+  const classes = useStyles();
+  const statusProps = {
+    title: displayStatusText || status || '',
+    iconOnly,
+    className,
+    dataTestId,
+  };
+
+  switch (status) {
+    case 'New':
+    case 'Idle':
+    case 'Pending':
+    case 'PipelineNotStarted':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<StatusIcon statusKey="pending" className={iconClassName} />}
+        />
+      );
+
+    case 'In Progress':
+    case 'Progress':
+    case 'Progressing':
+    case 'Installing':
+    case 'InstallReady':
+    case 'Replacing':
+    case 'Running':
+    case 'Updating':
+    case 'Upgrading':
+    case 'PendingInstall':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<StatusIcon statusKey="running" className={iconClassName} />}
+        />
+      );
+
+    case 'Cancelled':
+    case 'Deleting':
+    case 'Expired':
+    case 'Not Ready':
+    case 'Cancelling':
+    case 'Terminating':
+    case 'Superseded':
+    case 'Uninstalling':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<BanIcon className={classes.iconStyles} style={iconStyles} />}
+        />
+      );
+
+    case 'Warning':
+    case 'RequiresApproval':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<StatusIcon statusKey="warning" className={iconClassName} />}
+        />
+      );
+
+    case 'ImagePullBackOff':
+    case 'Error':
+    case 'Failed':
+    case 'Failure':
+    case 'CrashLoopBackOff':
+    case 'ErrImagePull':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<StatusIcon statusKey="error" className={iconClassName} />}
+        />
+      );
+
+    case 'Completed':
+    case 'Succeeded':
+    case 'Synced':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<StatusIcon statusKey="ok" className={iconClassName} />}
+        />
+      );
+
+    case 'Skipped':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={
+            <AngleDoubleRightIcon
+              className={classes.iconStyles}
+              style={iconStyles}
+            />
+          }
+        />
+      );
+    case 'Paused':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<PauseIcon className={classes.iconStyles} style={iconStyles} />}
+        />
+      );
+    case 'Stopped':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={<OffIcon className={classes.iconStyles} style={iconStyles} />}
+        />
+      );
+
+    case 'Unknown':
+      return (
+        <StatusIconAndText
+          {...statusProps}
+          icon={
+            <UnknownIcon className={classes.iconStyles} style={iconStyles} />
+          }
+        />
+      );
+
+    default:
+      return <>{status || DASH}</>;
+  }
+};

--- a/workspaces/tekton/plugins/tekton/src/components/common/StatusIconAndText.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/common/StatusIconAndText.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement, cloneElement } from 'react';
+
+import { makeStyles } from '@material-ui/core/styles';
+import { Typography } from '@material-ui/core';
+import classNames from 'classnames';
+
+import CamelCaseWrap from './CamelCaseWrap';
+
+const DASH = '-';
+
+const useStyles = makeStyles({
+  iconAndText: {
+    display: 'flex',
+    fontWeight: 400,
+    fontSize: '14px',
+  },
+
+  flexChild: {
+    flex: ' 0 0 auto',
+    position: 'relative',
+    top: '0.125em',
+  },
+});
+
+export const StatusIconAndText = ({
+  icon,
+  title,
+  spin,
+  iconOnly,
+  className,
+  dataTestId,
+}: {
+  title: string;
+  iconOnly?: boolean;
+  className?: string;
+  icon: ReactElement;
+  spin?: boolean;
+  dataTestId?: string;
+}): ReactElement => {
+  const styles = useStyles();
+  if (!title) {
+    return <>{DASH}</>;
+  }
+
+  if (iconOnly) {
+    return (
+      <>
+        {cloneElement(icon, {
+          'data-testid': dataTestId ?? `icon-only-${title}`,
+          className: icon.props.className,
+        })}
+      </>
+    );
+  }
+
+  return (
+    <Typography
+      className={classNames(styles.iconAndText, className)}
+      data-testid={dataTestId ?? `icon-with-title-${title}`}
+      title={title}
+    >
+      {cloneElement(icon, {
+        className: classNames(
+          spin && 'fa-spin',
+          icon.props.className,
+          styles.flexChild,
+        ),
+      })}
+      <CamelCaseWrap value={title} dataTest="status-text" />
+    </Typography>
+  );
+};
+
+export default StatusIconAndText;

--- a/workspaces/tekton/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/pipeline-topology/PipelineVisualizationStepList.tsx
@@ -16,8 +16,7 @@
 import { RunStatus } from '@patternfly/react-topology';
 import classNames from 'classnames';
 
-import { Status } from '@janus-idp/shared-react';
-
+import { Status } from '../common/Status';
 import { StepStatus } from '../../types/taskRun';
 
 import './PipelineVisualizationStepList.css';

--- a/workspaces/tekton/plugins/tekton/src/hooks/useAllWatchResources.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useAllWatchResources.ts
@@ -17,8 +17,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { KubernetesObjects } from '@backstage/plugin-kubernetes-react';
 
-import { useDeepCompareMemoize } from '@janus-idp/shared-react';
-
+import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { TektonResponseData } from '../types/types';
 import { getTektonResources } from '../utils/tekton-utils';
 

--- a/workspaces/tekton/plugins/tekton/src/hooks/useDebounceCallback.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useDebounceCallback.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useMemo } from 'react';
+
+import { debounce } from 'lodash';
+
+import { useDeepCompareMemoize } from './useDeepCompareMemoize';
+
+interface Cancelable {
+  cancel(): void;
+  flush(): void;
+}
+
+export const useDebounceCallback = <T extends (...args: any[]) => any>(
+  callback: T,
+  timeout: number = 500,
+  debounceParams: {
+    leading?: boolean;
+    trailing?: boolean;
+    maxWait?: number;
+  } = {
+    leading: false,
+    trailing: true,
+  },
+): ((...args: any) => any) & Cancelable => {
+  const memDebounceParams = useDeepCompareMemoize(debounceParams);
+  const callbackRef = useRef<T>();
+  callbackRef.current = callback;
+
+  return useMemo(() => {
+    return debounce(
+      (...args) => callbackRef.current?.(...args),
+      timeout,
+      memDebounceParams,
+    );
+  }, [memDebounceParams, timeout]);
+};

--- a/workspaces/tekton/plugins/tekton/src/hooks/useDeepCompareMemoize.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useDeepCompareMemoize.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef } from 'react';
+
+import { isEqual } from 'lodash';
+
+export const useDeepCompareMemoize = <T = any>(
+  value: T,
+  stringify?: boolean,
+): T => {
+  const ref = useRef<T>();
+
+  if (
+    stringify
+      ? JSON.stringify(value) !== JSON.stringify(ref.current)
+      : !isEqual(value, ref.current)
+  ) {
+    ref.current = value;
+  }
+
+  return ref.current as T;
+};

--- a/workspaces/tekton/plugins/tekton/src/hooks/useResourcesClusters.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useResourcesClusters.ts
@@ -17,8 +17,7 @@ import { useEffect, useState } from 'react';
 
 import { KubernetesObjects } from '@backstage/plugin-kubernetes-react';
 
-import { useDeepCompareMemoize } from '@janus-idp/shared-react';
-
+import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 import { ClusterErrors } from '../types/types';
 import { getClusters } from '../utils/tekton-utils';
 

--- a/workspaces/tekton/plugins/tekton/src/hooks/useTektonObjectResponse.test.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useTektonObjectResponse.test.ts
@@ -28,7 +28,13 @@ const watchedResources = [ModelsPlural.pipelineruns, ModelsPlural.taskruns];
 
 jest.mock('@backstage/plugin-kubernetes-react', () => ({
   useKubernetesObjects: jest.fn(),
+}));
+
+jest.mock('./useDeepCompareMemoize', () => ({
   useDeepCompareMemoize: (val: any) => val,
+}));
+
+jest.mock('./useDebounceCallback', () => ({
   useDebounceCallback: (val: any) => jest.fn(val),
 }));
 

--- a/workspaces/tekton/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
+++ b/workspaces/tekton/plugins/tekton/src/hooks/useTektonObjectsResponse.ts
@@ -19,16 +19,14 @@ import { useEntity } from '@backstage/plugin-catalog-react';
 
 import { isEqual } from 'lodash';
 
-import {
-  ComputedStatus,
-  useDebounceCallback,
-  useDeepCompareMemoize,
-} from '@janus-idp/shared-react';
+import { ComputedStatus } from '@janus-idp/shared-react';
 
 import { useKubernetesObjects } from '@backstage/plugin-kubernetes-react';
 import { TektonResourcesContextData, TektonResponseData } from '../types/types';
 import { useAllWatchResources } from './useAllWatchResources';
 import { useResourcesClusters } from './useResourcesClusters';
+import { useDebounceCallback } from './useDebounceCallback';
+import { useDeepCompareMemoize } from './useDeepCompareMemoize';
 
 export const useTektonObjectsResponse = (
   watchedResource: string[],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Resolves

- Moved Status and StatusIconAndText components into Tekton plugin
- Migrated useDeepCompareMemoize and useDebounceCallback hooks locally.
- Updated imports and references accordingly.
- Verified UI consistency and functional behavior.

## Screenshots
<img width="2958" height="1814" alt="image" src="https://github.com/user-attachments/assets/3a509084-66d0-4430-936e-84232575090a" />

<img width="2968" height="1832" alt="image" src="https://github.com/user-attachments/assets/a1fd6004-6881-4df6-8186-92be8bf14f4b" />


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
