### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-e7447df.md
+++ b/workspaces/ocm/.changeset/renovate-e7447df.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.24.0`.

--- a/workspaces/ocm/.changeset/version-bump-1-43-2.md
+++ b/workspaces/ocm/.changeset/version-bump-1-43-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.43.2

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 5.10.0
+
+### Minor Changes
+
+- 36f2716: Backstage version bump to v1.43.2
+
+### Patch Changes
+
+- 7b478dd: Updated dependency `@openapitools/openapi-generator-cli` to `2.24.0`.
+- Updated dependencies [36f2716]
+  - @backstage-community/plugin-ocm-common@3.13.0
+
 ## 5.9.1
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.13.0
+
+### Minor Changes
+
+- 36f2716: Backstage version bump to v1.43.2
+
 ## 3.12.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 5.9.0
+
+### Minor Changes
+
+- 36f2716: Backstage version bump to v1.43.2
+
+### Patch Changes
+
+- Updated dependencies [36f2716]
+  - @backstage-community/plugin-ocm-common@3.13.0
+
 ## 5.8.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.9.0

### Minor Changes

-   36f2716: Backstage version bump to v1.43.2

### Patch Changes

-   Updated dependencies [36f2716]
    -   @backstage-community/plugin-ocm-common@3.13.0

## @backstage-community/plugin-ocm-backend@5.10.0

### Minor Changes

-   36f2716: Backstage version bump to v1.43.2

### Patch Changes

-   7b478dd: Updated dependency `@openapitools/openapi-generator-cli` to `2.24.0`.
-   Updated dependencies [36f2716]
    -   @backstage-community/plugin-ocm-common@3.13.0

## @backstage-community/plugin-ocm-common@3.13.0

### Minor Changes

-   36f2716: Backstage version bump to v1.43.2
