### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/mighty-jeans-sneeze.md
+++ b/workspaces/azure-devops/.changeset/mighty-jeans-sneeze.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Added fetch depth option to the `azure:repository:clone` action.

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.15.1
+
+### Patch Changes
+
+- 93cfa0a: Added fetch depth option to the `azure:repository:clone` action.
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.15.1

### Patch Changes

-   93cfa0a: Added fetch depth option to the `azure:repository:clone` action.
