### PR TITLE
Version Packages (github-discussions)

### DIFF
--- a/workspaces/github-discussions/.changeset/version-bump-1-44-0.md
+++ b/workspaces/github-discussions/.changeset/version-bump-1-44-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-github-discussions': minor
-'@backstage-community/plugin-github-discussions-common': minor
-'@backstage-community/plugin-search-backend-module-github-discussions': minor
----
-
-Backstage version bump to v1.44.0

--- a/workspaces/github-discussions/packages/app/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [6d3602c]
+  - @backstage-community/plugin-github-discussions@0.7.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/app/package.json
+++ b/workspaces/github-discussions/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/github-discussions/packages/backend/CHANGELOG.md
+++ b/workspaces/github-discussions/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [6d3602c]
+  - @backstage-community/plugin-search-backend-module-github-discussions@0.8.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/workspaces/github-discussions/packages/backend/package.json
+++ b/workspaces/github-discussions/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-discussions-common
 
+## 0.8.0
+
+### Minor Changes
+
+- 6d3602c: Backstage version bump to v1.44.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/github-discussions-common/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-github-discussions-common",
   "description": "Common functionalities for the github-discussions plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/github-discussions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-github-discussions
 
+## 0.7.0
+
+### Minor Changes
+
+- 6d3602c: Backstage version bump to v1.44.0
+
+### Patch Changes
+
+- Updated dependencies [6d3602c]
+  - @backstage-community/plugin-github-discussions-common@0.8.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/github-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-discussions",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-search-backend-module-github-discussions
 
+## 0.8.0
+
+### Minor Changes
+
+- 6d3602c: Backstage version bump to v1.44.0
+
+### Patch Changes
+
+- Updated dependencies [6d3602c]
+  - @backstage-community/plugin-github-discussions-common@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
+++ b/workspaces/github-discussions/plugins/search-backend-module-github-discussions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-github-discussions",
   "description": "The github-discussions backend module for the search plugin.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-discussions@0.7.0

### Minor Changes

-   6d3602c: Backstage version bump to v1.44.0

### Patch Changes

-   Updated dependencies [6d3602c]
    -   @backstage-community/plugin-github-discussions-common@0.8.0

## @backstage-community/plugin-github-discussions-common@0.8.0

### Minor Changes

-   6d3602c: Backstage version bump to v1.44.0

## @backstage-community/plugin-search-backend-module-github-discussions@0.8.0

### Minor Changes

-   6d3602c: Backstage version bump to v1.44.0

### Patch Changes

-   Updated dependencies [6d3602c]
    -   @backstage-community/plugin-github-discussions-common@0.8.0

## app@0.0.7

### Patch Changes

-   Updated dependencies [6d3602c]
    -   @backstage-community/plugin-github-discussions@0.7.0

## backend@0.0.7

### Patch Changes

-   Updated dependencies [6d3602c]
    -   @backstage-community/plugin-search-backend-module-github-discussions@0.8.0
