### PR TITLE
Update version bump workflow to push new version bump to old PR if applicable

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,14 +23,11 @@ on:
           - 'major'
           - 'minor'
           - 'patch'
-      enable-pr-reuse:
+      enable_pr_reuse:
         description: 'Enable PR reuse and branch renaming (experimental)'
         required: true
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -97,7 +94,7 @@ jobs:
           fi
       - name: 'Check for existing version bump PR'
         id: check_existing_pr
-        if: ${{ inputs.enable_pr_reuse == 'true' }}
+        if: ${{ inputs.enable_pr_reuse }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           github-token: ${{secrets.GH_SERVICE_ACCOUNT_TOKEN}}
@@ -210,7 +207,7 @@ jobs:
             const workspace = '${{ matrix.workspace }}';
             const releaseVersion = '${{ steps.set_release_name.outputs.release_version }}';
             const currentVersion = '${{ steps.set_release_name.outputs.current_version }}';
-            const enablePRReuse = '${{ inputs.enable_pr_reuse }}' === 'true';
+            const enablePRReuse = ${{ inputs.enable_pr_reuse }};
             
             let branchName, hasExistingPR;
             if (enablePRReuse) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change checks for an existing version bump PR and pushes a new version bump commit to this PR, as opposed to opening a new PR. This reduces noise as it avoids multiple open version bump PRs for a single workspace.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
