### PR TITLE
docs: clarify expectations for unhandled dependency update PRs

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -28,7 +28,9 @@ Plugin ownership is a responsibility often taken on voluntarily and/or in additi
 
 Plugin owners are assumed to have full autonomy over reviewing and merging PRs for their workspace. This includes the merging of Version Packages PRs to trigger a new release.
 
-It is also helpful for workspace owners to review and add approvals to PRs that touch multiple workspaces (such as dependency updates), as these may be landed by `@backstage/community-plugin-maintainers`.
+It is also helpful for workspace owners to review and add approvals to PRs that touch multiple workspaces, as these may be landed by `@backstage/community-plugin-maintainers`.
+
+In the case of PRs for dependency updates, if these are not handled and become stale, `@backstage/community-plugin-maintainers` will take action to merge or close them.
 
 ### Issue Triage
 


### PR DESCRIPTION
As discussed in the Community Plugins SIG. 

While working on this, I realised it might be more effective to tie this process to the existing stale bot. That way, instead of manually tracking timeline, the @backstage/community-plugins-maintainers  team can filter by the **stale** and **dependencies** labels to identify which PRs need action. It also means that if we tweak the staleness timeframes in the bot configuration, this process would automatically stay aligned with those values. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
