### PR TITLE
Add index to improve performance of fact deletion

### DIFF
--- a/workspaces/tech-insights/.changeset/beige-tables-lie.md
+++ b/workspaces/tech-insights/.changeset/beige-tables-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+---
+
+add index to improve performance of fact deletion

--- a/workspaces/tech-insights/plugins/tech-insights-backend/migrations/20251021115029_add_facts_id_timestamp_index.js
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/migrations/20251021115029_add_facts_id_timestamp_index.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const indexName = 'fact_id_timestamp_idx';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async knex => {
+  await knex.schema.alterTable('facts', table => {
+    table.index(['id', 'timestamp'], indexName);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async knex => {
+  await knex.schema.alterTable('facts', table => {
+    table.dropIndex(['id', 'timestamp'], indexName);
+  });
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I saw that the highest load on my backstage DB by far was from the following query:
```
delete from "facts" where "id" = $1 and "timestamp" < $2
```

<img width="1566" height="127" alt="image" src="https://github.com/user-attachments/assets/75485c1e-0386-49b7-982a-6113655043fe" />

Which is run as part of the fact generation [here](https://github.com/backstage/community-plugins/blob/main/workspaces/tech-insights/plugins/tech-insights-backend/src/service/persistence/TechInsightsDatabase.ts#L215).

The performance of this query is very slow for a database with a large number of entities or a large history of facts.  We could see somewhat better performance by reducing the number of entities or facts per entity, but adding an index would really help.

There is currently an index on `['id', 'entity', 'timestamp']` but not on `['id',  'timestamp']`.  Adding this index significantly reduces the load on the DB and the overall performance of the tech insights plugin.  Here are my DB metrics from when the index was added:
<img width="429" height="255" alt="image" src="https://github.com/user-attachments/assets/0c372f74-3e4b-48fb-a64b-211cd5703dee" />
<img width="428" height="258" alt="image" src="https://github.com/user-attachments/assets/3efeedee-ada0-4a9e-a591-1609df2e3e49" />
<img width="430" height="250" alt="image" src="https://github.com/user-attachments/assets/2605be21-1dc4-4866-8070-ef4264098ed9" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
