### PR TITLE
fix(announcements): Resolve route conflicts

### DIFF
--- a/workspaces/announcements/.changeset/ninety-poets-hug.md
+++ b/workspaces/announcements/.changeset/ninety-poets-hug.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Fixed routing issue where some links were incorrectly redirecting to `/announcements/admin` instead of `/announcements`. Changed `<AnnouncementsAdminPortal />` from a routable extension to a component extension to resolve the mount point conflict with the main `<AnnouncementsPage />`.

--- a/workspaces/announcements/plugins/announcements/src/plugin.ts
+++ b/workspaces/announcements/plugins/announcements/src/plugin.ts
@@ -78,10 +78,11 @@ export const AnnouncementsPage = announcementsPlugin.provide(
  * @public
  */
 export const AnnouncementsAdminPortal = announcementsPlugin.provide(
-  createRoutableExtension({
+  createComponentExtension({
     name: 'AnnouncementsAdminPortal',
-    component: () => import('./components/Admin').then(m => m.AdminPortal),
-    mountPoint: rootRouteRef,
+    component: {
+      lazy: () => import('./components/Admin').then(m => m.AdminPortal),
+    },
   }),
 );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I hadn’t noticed this issue before because I was using admin permissions. Some users with default permissions reported that when they click "See all announcements", they’re redirected to an admin page, which leads to a 404 error.


| Current route | Fixed route |
|---------------|-------------|
| <img src="https://github.com/user-attachments/assets/3e5c78b2-4962-4a9f-a882-02f06b1c5b53" width="250" /> | <img src="https://github.com/user-attachments/assets/49a4b539-850b-4311-8611-0f8eddb36519" width="250" /> |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
