### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/fast-comics-join.md
+++ b/workspaces/kiali/.changeset/fast-comics-join.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali': minor
-'@backstage-community/plugin-kiali-common': minor
----
-
-Improved namespace selector usability, update certs API call to the backend

--- a/workspaces/kiali/.changeset/renovate-22e892d.md
+++ b/workspaces/kiali/.changeset/renovate-22e892d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `cytoscape` to `3.33.1`.

--- a/workspaces/kiali/.changeset/wicked-donuts-call.md
+++ b/workspaces/kiali/.changeset/wicked-donuts-call.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': minor
----
-
-The provider doesn't need to match the cluster

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-common
 
+## 0.7.0
+
+### Minor Changes
+
+- 2312f93: Improved namespace selector usability, update certs API call to the backend
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kiali-react
 
+## 0.5.1
+
+### Patch Changes
+
+- Updated dependencies [2312f93]
+  - @backstage-community/plugin-kiali-common@0.7.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,19 @@
 ### Dependencies
 
+## 1.45.0
+
+### Minor Changes
+
+- 2312f93: Improved namespace selector usability, update certs API call to the backend
+- b9ac9d9: The provider doesn't need to match the cluster
+
+### Patch Changes
+
+- e6bd3fc: Updated dependency `cytoscape` to `3.33.1`.
+- Updated dependencies [2312f93]
+  - @backstage-community/plugin-kiali-common@0.7.0
+  - @backstage-community/plugin-kiali-react@0.5.1
+
 ## 1.44.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.45.0

### Minor Changes

-   2312f93: Improved namespace selector usability, update certs API call to the backend
-   b9ac9d9: The provider doesn't need to match the cluster

### Patch Changes

-   e6bd3fc: Updated dependency `cytoscape` to `3.33.1`.
-   Updated dependencies [2312f93]
    -   @backstage-community/plugin-kiali-common@0.7.0
    -   @backstage-community/plugin-kiali-react@0.5.1

## @backstage-community/plugin-kiali-common@0.7.0

### Minor Changes

-   2312f93: Improved namespace selector usability, update certs API call to the backend

## @backstage-community/plugin-kiali-react@0.5.1

### Patch Changes

-   Updated dependencies [2312f93]
    -   @backstage-community/plugin-kiali-common@0.7.0
