### PR TITLE
feat(mcp-chat): add baseUrl support for OpenAI compatible endpoints

### DIFF
--- a/workspaces/mcp-chat/.changeset/upset-tigers-run.md
+++ b/workspaces/mcp-chat/.changeset/upset-tigers-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': patch
+---
+
+Add support for optional baseUrl parameter in OpenAI provider for compatible endpoints (e.g., Azure OpenAI)

--- a/workspaces/mcp-chat/README.md
+++ b/workspaces/mcp-chat/README.md
@@ -145,6 +145,10 @@ mcpChat:
   # Supported Providers: OpenAI, Gemini, Claude, and Ollama
   providers:
     - id: openai # OpenAI provider
+      # Optional: Specify a custom baseUrl for OpenAI-compatible endpoints
+      # This is useful when using Azure OpenAI or other OpenAI-compatible services
+      # Example for Azure: baseUrl: 'https://your-resource.openai.azure.com/openai/deployments/your-deployment'
+      # baseUrl: 'https://custom-openai-compatible-url/v1'
       token: ${OPENAI_API_KEY}
       model: gpt-4o-mini # or gpt-4, gpt-3.5-turbo, etc.
     - id: claude # Claude provider

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
@@ -84,7 +84,10 @@ describe('getProviderConfig', () => {
         if (key === 'model') return 'test-model';
         throw new Error(`Unexpected key: ${key}`);
       }),
-      getOptionalString: jest.fn().mockReturnValue('test-key'),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        return 'test-key';
+      }),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -111,7 +114,10 @@ describe('getProviderConfig', () => {
           if (key === 'model') return 'test-model';
           throw new Error(`Unexpected key: ${key}`);
         }),
-        getOptionalString: jest.fn().mockReturnValue('test-key'),
+        getOptionalString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'baseUrl') return undefined;
+          return 'test-key';
+        }),
       } as any;
 
       mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -121,6 +127,41 @@ describe('getProviderConfig', () => {
       expect(result.type).toBe(id);
       expect(result.apiKey).toBe('test-key');
       expect(result.model).toBe('test-model');
+    });
+  });
+
+  it('should configure OpenAI provider with default and custom base URLs', () => {
+    const testCases = [
+      {
+        customBaseUrl: undefined,
+        expectedBaseUrl: 'https://api.openai.com/v1',
+      },
+      {
+        customBaseUrl: 'https://custom-openai.com/v1',
+        expectedBaseUrl: 'https://custom-openai.com/v1',
+      },
+    ];
+
+    testCases.forEach(({ customBaseUrl, expectedBaseUrl }) => {
+      const mockProviderConfig = {
+        getString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'id') return 'openai';
+          if (key === 'model') return 'test-model';
+          throw new Error(`Unexpected key: ${key}`);
+        }),
+        getOptionalString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'token') return 'test-token';
+          if (key === 'baseUrl') return customBaseUrl;
+          return undefined;
+        }),
+      } as any;
+
+      mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+      const result = getProviderConfig(mockConfig);
+      expect(result.baseUrl).toBe(expectedBaseUrl);
+      expect(result.type).toBe('openai');
+      expect(result.apiKey).toBe('test-token');
     });
   });
 
@@ -180,7 +221,10 @@ describe('getProviderConfig', () => {
         if (key === 'model') return 'gpt-4';
         throw new Error(`Unexpected key: ${key}`);
       }),
-      getOptionalString: jest.fn().mockReturnValue('first-key'),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        return 'first-key';
+      }),
     } as any;
 
     const mockProviderConfig2 = {
@@ -189,7 +233,10 @@ describe('getProviderConfig', () => {
         if (key === 'model') return 'claude-3-sonnet-20240229';
         throw new Error(`Unexpected key: ${key}`);
       }),
-      getOptionalString: jest.fn().mockReturnValue('second-key'),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        return 'second-key';
+      }),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([
@@ -214,7 +261,10 @@ describe('getProviderConfig', () => {
         if (key === 'model') return '';
         throw new Error(`Unexpected key: ${key}`);
       }),
-      getOptionalString: jest.fn().mockReturnValue('test-key'),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        return 'test-key';
+      }),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -239,7 +289,10 @@ describe('getProviderInfo', () => {
         if (key === 'model') return 'gpt-4';
         throw new Error(`Unexpected key: ${key}`);
       }),
-      getOptionalString: jest.fn().mockReturnValue('test-key'),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return 'https://api.openai.com/v1';
+        return 'test-key';
+      }),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
@@ -64,7 +64,9 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
     openai: {
       type: 'openai',
       apiKey: token,
-      baseUrl: 'https://api.openai.com/v1',
+      baseUrl:
+        providerConfig.getOptionalString('baseUrl') ||
+        'https://api.openai.com/v1',
       model: model,
     },
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description

This PR adds support for custom `baseUrl` configuration for the OpenAI provider in the MCP Chat plugin.

**Changes:**
- Added support for optional custom `baseUrl` in OpenAI provider configuration, enabling compatibility with OpenAI-compatible endpoints (e.g., Azure OpenAI, custom proxies)
- Updated documentation in README.md with configuration examples for custom baseUrl usage
- Added comprehensive test coverage for both default and custom baseUrl scenarios

**Benefits:**
- Users can now use Azure OpenAI or other OpenAI-compatible services
- Maintains backward compatibility with default OpenAI endpoint
- Follows the same pattern already implemented for Ollama provider

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) - _N/A: backend configuration change_
- [x] All your commits have a `Signed-off-by` line in the message.

---

### Technical Details

**Modified files:**
- `workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts`
  - Modified `getProviderConfig()` to support optional `baseUrl` for OpenAI provider
  - Falls back to default `https://api.openai.com/v1` if not specified
  
- `workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts`
  - Added test cases for OpenAI provider with default and custom baseUrl configurations
  
- `workspaces/mcp-chat/README.md`
  - Added configuration documentation with Azure OpenAI example
  - Documented the optional `baseUrl` parameter

**Example configuration:**
```yaml
mcpChat:
  providers:
    - id: openai
      baseUrl: 'https://your-resource.openai.azure.com/openai/deployments/your-deployment'
      token: ${OPENAI_API_KEY}
      model: gpt-4o-mini
