### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/upset-tigers-run.md
+++ b/workspaces/mcp-chat/.changeset/upset-tigers-run.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': patch
----
-
-Add support for optional baseUrl parameter in OpenAI provider for compatible endpoints (e.g., Azure OpenAI)

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.1.1
+
+### Patch Changes
+
+- 95d31eb: Add support for optional baseUrl parameter in OpenAI provider for compatible endpoints (e.g., Azure OpenAI)
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat-backend@0.1.1

### Patch Changes

-   95d31eb: Add support for optional baseUrl parameter in OpenAI provider for compatible endpoints (e.g., Azure OpenAI)
