### PR TITLE
[Do Not Merge] contribfest - Enable `knipReports`

### DIFF
--- a/workspaces/airbrake/bcp.json
+++ b/workspaces/airbrake/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/allure/bcp.json
+++ b/workspaces/allure/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/apache-airflow/bcp.json
+++ b/workspaces/apache-airflow/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/apollo-explorer/bcp.json
+++ b/workspaces/apollo-explorer/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/badges/bcp.json
+++ b/workspaces/badges/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/bazaar/bcp.json
+++ b/workspaces/bazaar/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/cicd-statistics/bcp.json
+++ b/workspaces/cicd-statistics/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/cloudbuild/bcp.json
+++ b/workspaces/cloudbuild/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/code-climate/bcp.json
+++ b/workspaces/code-climate/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/codescene/bcp.json
+++ b/workspaces/codescene/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/dynatrace/bcp.json
+++ b/workspaces/dynatrace/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/entity-validation/bcp.json
+++ b/workspaces/entity-validation/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/firehydrant/bcp.json
+++ b/workspaces/firehydrant/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/gcalendar/bcp.json
+++ b/workspaces/gcalendar/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/gcp-projects/bcp.json
+++ b/workspaces/gcp-projects/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/github-actions/bcp.json
+++ b/workspaces/github-actions/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/github-deployments/bcp.json
+++ b/workspaces/github-deployments/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/github-issues/bcp.json
+++ b/workspaces/github-issues/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/gitops-profiles/bcp.json
+++ b/workspaces/gitops-profiles/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/gocd/bcp.json
+++ b/workspaces/gocd/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/grafana/bcp.json
+++ b/workspaces/grafana/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/graphiql/bcp.json
+++ b/workspaces/graphiql/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/graphql-voyager/bcp.json
+++ b/workspaces/graphql-voyager/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/ilert/bcp.json
+++ b/workspaces/ilert/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/jaeger/bcp.json
+++ b/workspaces/jaeger/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/jenkins/bcp.json
+++ b/workspaces/jenkins/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/lighthouse/bcp.json
+++ b/workspaces/lighthouse/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/linkerd/bcp.json
+++ b/workspaces/linkerd/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/microsoft-calendar/bcp.json
+++ b/workspaces/microsoft-calendar/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/newrelic/bcp.json
+++ b/workspaces/newrelic/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/nomad/bcp.json
+++ b/workspaces/nomad/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/opencost/bcp.json
+++ b/workspaces/opencost/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/periskop/bcp.json
+++ b/workspaces/periskop/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/puppetdb/bcp.json
+++ b/workspaces/puppetdb/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/sentry/bcp.json
+++ b/workspaces/sentry/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/shortcuts/bcp.json
+++ b/workspaces/shortcuts/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/splunk/bcp.json
+++ b/workspaces/splunk/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/stack-overflow/bcp.json
+++ b/workspaces/stack-overflow/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/stackstorm/bcp.json
+++ b/workspaces/stackstorm/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/tech-radar/bcp.json
+++ b/workspaces/tech-radar/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/todo/bcp.json
+++ b/workspaces/todo/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/vault/bcp.json
+++ b/workspaces/vault/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }

--- a/workspaces/xcmetrics/bcp.json
+++ b/workspaces/xcmetrics/bcp.json
@@ -1,4 +1,4 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR enables the `knipReports` flag for all the Community Maintainer Owned plugins as we will be using this as one way people can contribute during [ContribFest at KubeCon in Atlanta](https://backstage.io/blog/2025/10/15/backstage-contribfest-kubecon-guide).

Please do not merge!

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
