### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/spicy-tables-wave.md
+++ b/workspaces/redhat-argocd/.changeset/spicy-tables-wave.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': patch
----
-
-Re-enable the Rollouts feature by adding the Rollouts component back to the Lifecycle Drawer.

--- a/workspaces/redhat-argocd/.changeset/version-bump-1-44-2.md
+++ b/workspaces/redhat-argocd/.changeset/version-bump-1-44-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd-common': minor
----
-
-Backstage version bump to v1.44.2

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.11.0
+
+### Minor Changes
+
+- d49c2a6: Backstage version bump to v1.44.2
+
+### Patch Changes
+
+- Updated dependencies [d49c2a6]
+  - @backstage-community/plugin-redhat-argocd-common@1.9.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.9.0
+
+### Minor Changes
+
+- d49c2a6: Backstage version bump to v1.44.2
+
 ## 1.8.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 2.1.0
+
+### Minor Changes
+
+- d49c2a6: Backstage version bump to v1.44.2
+
+### Patch Changes
+
+- c00e4d6: Re-enable the Rollouts feature by adding the Rollouts component back to the Lifecycle Drawer.
+- Updated dependencies [d49c2a6]
+  - @backstage-community/plugin-redhat-argocd-common@1.9.0
+
 ## 2.0.0
 
 ### Major Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@2.1.0

### Minor Changes

-   d49c2a6: Backstage version bump to v1.44.2

### Patch Changes

-   c00e4d6: Re-enable the Rollouts feature by adding the Rollouts component back to the Lifecycle Drawer.
-   Updated dependencies [d49c2a6]
    -   @backstage-community/plugin-redhat-argocd-common@1.9.0

## @backstage-community/plugin-redhat-argocd-backend@0.11.0

### Minor Changes

-   d49c2a6: Backstage version bump to v1.44.2

### Patch Changes

-   Updated dependencies [d49c2a6]
    -   @backstage-community/plugin-redhat-argocd-common@1.9.0

## @backstage-community/plugin-redhat-argocd-common@1.9.0

### Minor Changes

-   d49c2a6: Backstage version bump to v1.44.2
