### PR TITLE
feat(announcements): Add analytics tracking for announcements interactions

### DIFF
--- a/workspaces/announcements/.changeset/grumpy-roses-do.md
+++ b/workspaces/announcements/.changeset/grumpy-roses-do.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Added analytics event tracking for announcement link clicks. When users click on an announcement with a `link` property, an analytics event is now captured using the [Plugin Analytics](https://backstage.io/docs/plugins/analytics/#capturing-events). This applies to the following components: `AnnouncementsCard`, `AnnouncementPage`,`NewAnnouncementBanner`.

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.test.tsx
@@ -20,10 +20,16 @@ import {
   announcementsApiRef,
 } from '@backstage-community/plugin-announcements-react';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
-import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import {
+  mockApis,
+  TestApiProvider,
+  renderInTestApp,
+} from '@backstage/test-utils';
 import { Route } from 'react-router-dom';
 import { FlatRoutes } from '@backstage/core-app-api';
 import { DateTime } from 'luxon';
+import { analyticsApiRef } from '@backstage/core-plugin-api';
+import { waitFor } from '@testing-library/react';
 
 const announcementsApiMock: jest.Mocked<
   Pick<
@@ -36,9 +42,18 @@ const announcementsApiMock: jest.Mocked<
   markLastSeenDate: jest.fn(),
 };
 
-const renderAnnouncementPage = () => {
+type AnalyticsMock = ReturnType<typeof mockApis.analytics.mock>;
+
+const renderAnnouncementPage = (analyticsApi?: AnalyticsMock) => {
+  const analytics = analyticsApi ?? mockApis.analytics.mock();
+
   return renderInTestApp(
-    <TestApiProvider apis={[[announcementsApiRef, announcementsApiMock]]}>
+    <TestApiProvider
+      apis={[
+        [announcementsApiRef, announcementsApiMock],
+        [analyticsApiRef, analytics],
+      ]}
+    >
       <FlatRoutes>
         <Route
           path="/announcements/view/:id"
@@ -53,7 +68,7 @@ const renderAnnouncementPage = () => {
       },
       routeEntries: ['/announcements/view/1'],
     },
-  );
+  ).then(result => ({ renderResult: result, analytics }));
 };
 
 describe('AnnouncementPage', () => {
@@ -77,10 +92,10 @@ describe('AnnouncementPage', () => {
   it('should render announcement', async () => {
     announcementsApiMock.announcementByID.mockResolvedValue(announcement);
 
-    const { getByText } = await renderAnnouncementPage();
+    const { renderResult } = await renderAnnouncementPage();
 
     expect(announcementsApiMock.announcementByID).toHaveBeenCalledWith('1');
-    expect(getByText('Announcement title')).toBeInTheDocument();
+    expect(renderResult.getByText('Announcement title')).toBeInTheDocument();
   });
 
   it('should update the last seen date if the announcement is newer than previously displayed announcements', async () => {
@@ -114,8 +129,32 @@ describe('AnnouncementPage', () => {
       new Error('Announcement not found'),
     );
 
-    const { getByText } = await renderAnnouncementPage();
+    const { renderResult } = await renderAnnouncementPage();
 
-    expect(getByText('Announcement not found')).toBeInTheDocument();
+    expect(
+      renderResult.getByText('Announcement not found'),
+    ).toBeInTheDocument();
+  });
+
+  it('captures analytics view event for announcements', async () => {
+    const analyticsApi = mockApis.analytics.mock();
+    announcementsApiMock.announcementByID.mockResolvedValue(announcement);
+
+    const { analytics } = await renderAnnouncementPage(analyticsApi);
+
+    await waitFor(() => {
+      expect(analytics.captureEvent).toHaveBeenCalledTimes(1);
+    });
+
+    expect(analytics.captureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'view',
+        subject: 'Announcement title',
+        attributes: {
+          announcementId: '1',
+          location: 'AnnouncementPage',
+        },
+      }),
+    );
   });
 });

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementPage/AnnouncementPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 import { DateTime } from 'luxon';
 import {
@@ -27,6 +27,7 @@ import {
   useApi,
   useRouteRef,
   useRouteRefParams,
+  useAnalytics,
 } from '@backstage/core-plugin-api';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import { announcementViewRouteRef, rootRouteRef } from '../../routes';
@@ -100,6 +101,7 @@ type AnnouncementPageProps = {
 export const AnnouncementPage = (props: AnnouncementPageProps) => {
   const announcementsApi = useApi(announcementsApiRef);
   const { id } = useRouteRefParams(announcementViewRouteRef);
+  const analytics = useAnalytics();
   const { value, loading, error } = useAsync(
     async () => announcementsApi.announcementByID(id),
     [id],
@@ -129,6 +131,19 @@ export const AnnouncementPage = (props: AnnouncementPageProps) => {
       announcementsApi.markLastSeenDate(announcementCreatedAt);
     }
   }
+
+  useEffect(() => {
+    if (!value) {
+      return;
+    }
+
+    analytics.captureEvent('view', value.title, {
+      attributes: {
+        announcementId: value.id,
+        location: 'AnnouncementPage',
+      },
+    });
+  }, [analytics, value]);
 
   return (
     <Page themeId={props.themeId}>

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -21,7 +21,7 @@ import {
   Link,
   Progress,
 } from '@backstage/core-components';
-import { useApi, useRouteRef } from '@backstage/core-plugin-api';
+import { useApi, useRouteRef, useAnalytics } from '@backstage/core-plugin-api';
 import { announcementEntityPermissions } from '@backstage-community/plugin-announcements-common';
 import {
   announcementCreateRouteRef,
@@ -86,6 +86,7 @@ export const AnnouncementsCard = ({
   const viewAnnouncementLink = useRouteRef(announcementViewRouteRef);
   const createAnnouncementLink = useRouteRef(announcementCreateRouteRef);
   const lastSeen = announcementsApi.lastSeenDate();
+  const analytics = useAnalytics();
   const { t } = useAnnouncementsTranslation();
 
   const { announcements, loading, error } = useAnnouncements({
@@ -139,6 +140,14 @@ export const AnnouncementsCard = ({
                 <Link
                   to={viewAnnouncementLink({ id: announcement.id })}
                   variant="inherit"
+                  onClick={() =>
+                    analytics.captureEvent('click', announcement.title, {
+                      attributes: {
+                        announcementId: announcement.id,
+                        location: 'AnnouncementsCard',
+                      },
+                    })
+                  }
                 >
                   {announcement.title}
                 </Link>

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.test.tsx
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import {
+  mockApis,
+  TestApiProvider,
+  renderInTestApp,
+} from '@backstage/test-utils';
 import { announcementsApiRef } from '@backstage-community/plugin-announcements-react';
 import { AnnouncementsList } from '@backstage-community/plugin-announcements-common';
 import { DateTime } from 'luxon';
 import { NewAnnouncementBanner } from './NewAnnouncementBanner';
 import { rootRouteRef } from '../../routes';
+import { analyticsApiRef } from '@backstage/core-plugin-api';
 
 const mockAnnouncementsApi = (announcements: AnnouncementsList) => ({
   announcements: jest.fn().mockResolvedValue(announcements),
@@ -27,9 +32,21 @@ const mockAnnouncementsApi = (announcements: AnnouncementsList) => ({
   markLastSeenDate: jest.fn(),
 });
 
-const renderNewAnnouncementBanner = async (mockApi: any) => {
-  return await renderInTestApp(
-    <TestApiProvider apis={[[announcementsApiRef, mockApi]]}>
+type AnalyticsMock = ReturnType<typeof mockApis.analytics.mock>;
+
+const renderNewAnnouncementBanner = async (
+  mockApi: any,
+  analyticsApi?: AnalyticsMock,
+) => {
+  const analytics = analyticsApi ?? mockApis.analytics.mock();
+
+  await renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [announcementsApiRef, mockApi],
+        [analyticsApiRef, analytics],
+      ]}
+    >
       <NewAnnouncementBanner />
     </TestApiProvider>,
     {
@@ -38,6 +55,8 @@ const renderNewAnnouncementBanner = async (mockApi: any) => {
       },
     },
   );
+
+  return { analytics };
 };
 
 describe('NewAnnouncementBanner', () => {
@@ -110,5 +129,94 @@ describe('NewAnnouncementBanner', () => {
     await renderNewAnnouncementBanner(mockApi);
 
     expect(screen.queryByText(/new announcement/i)).not.toBeInTheDocument();
+  });
+
+  it('captures analytics view events when banner displays', async () => {
+    const analyticsApi = mockApis.analytics.mock();
+    const announcementsList: AnnouncementsList = {
+      count: 1,
+      results: [
+        {
+          id: '1',
+          title: 'Viewed Announcement',
+          excerpt: 'Look at me',
+          body: 'Body',
+          publisher: 'Publisher 1',
+          created_at: DateTime.now().toISO(),
+          updated_at: DateTime.now().toISO(),
+          active: true,
+          start_at: DateTime.now().toISO(),
+          until_date: DateTime.now().plus({ days: 7 }).toISO(),
+        },
+      ],
+    };
+
+    await renderNewAnnouncementBanner(
+      mockAnnouncementsApi(announcementsList),
+      analyticsApi,
+    );
+
+    await waitFor(() => {
+      expect(analyticsApi.captureEvent).toHaveBeenCalledTimes(1);
+    });
+
+    expect(analyticsApi.captureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'view',
+        subject: 'Viewed Announcement',
+        attributes: {
+          announcementId: '1',
+          location: 'NewAnnouncementBanner',
+        },
+      }),
+    );
+  });
+
+  it('captures analytics click events when banner link selected', async () => {
+    const analyticsApi = mockApis.analytics.mock();
+    const announcementsList: AnnouncementsList = {
+      count: 1,
+      results: [
+        {
+          id: '1',
+          title: 'Clickable Banner Announcement',
+          excerpt: 'Click me',
+          body: 'Body',
+          publisher: 'Publisher 1',
+          created_at: DateTime.now().toISO(),
+          updated_at: DateTime.now().toISO(),
+          active: true,
+          start_at: DateTime.now().toISO(),
+          until_date: DateTime.now().plus({ days: 7 }).toISO(),
+        },
+      ],
+    };
+
+    await renderNewAnnouncementBanner(
+      mockAnnouncementsApi(announcementsList),
+      analyticsApi,
+    );
+
+    const link = await screen.findByText('Clickable Banner Announcement');
+    fireEvent.click(link);
+
+    await waitFor(() => {
+      expect(analyticsApi.captureEvent).toHaveBeenCalled();
+    });
+
+    const events = analyticsApi.captureEvent.mock.calls.map(([event]) => event);
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: 'view',
+          subject: 'Clickable Banner Announcement',
+          attributes: {
+            announcementId: '1',
+            location: 'NewAnnouncementBanner',
+          },
+        }),
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds analytics event tracking to capture when users click/view announcements.

It's a start for #2423 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
