### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-950a79f.md
+++ b/workspaces/ocm/.changeset/renovate-950a79f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.25.0`.

--- a/workspaces/ocm/.changeset/version-bump-1-44-2.md
+++ b/workspaces/ocm/.changeset/version-bump-1-44-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.44.2

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 5.11.0
+
+### Minor Changes
+
+- 296d257: Backstage version bump to v1.44.2
+
+### Patch Changes
+
+- 1993915: Updated dependency `@openapitools/openapi-generator-cli` to `2.25.0`.
+- Updated dependencies [296d257]
+  - @backstage-community/plugin-ocm-common@3.14.0
+
 ## 5.10.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.14.0
+
+### Minor Changes
+
+- 296d257: Backstage version bump to v1.44.2
+
 ## 3.13.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 5.10.0
+
+### Minor Changes
+
+- 296d257: Backstage version bump to v1.44.2
+
+### Patch Changes
+
+- Updated dependencies [296d257]
+  - @backstage-community/plugin-ocm-common@3.14.0
+
 ## 5.9.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.10.0

### Minor Changes

-   296d257: Backstage version bump to v1.44.2

### Patch Changes

-   Updated dependencies [296d257]
    -   @backstage-community/plugin-ocm-common@3.14.0

## @backstage-community/plugin-ocm-backend@5.11.0

### Minor Changes

-   296d257: Backstage version bump to v1.44.2

### Patch Changes

-   1993915: Updated dependency `@openapitools/openapi-generator-cli` to `2.25.0`.
-   Updated dependencies [296d257]
    -   @backstage-community/plugin-ocm-common@3.14.0

## @backstage-community/plugin-ocm-common@3.14.0

### Minor Changes

-   296d257: Backstage version bump to v1.44.2
