### PR TITLE
docs(adr): add new frontend system documentation

### DIFF
--- a/workspaces/adr/.changeset/twenty-boxes-float.md
+++ b/workspaces/adr/.changeset/twenty-boxes-float.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-adr': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/adr/plugins/adr/README.md
+++ b/workspaces/adr/plugins/adr/README.md
@@ -111,6 +111,32 @@ import { AdrDocument } from '@backstage-community/plugin-adr-common';
 </SearchResult>
 ```
 
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import adrPlugin from '@backstage-community/plugin-adr/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    adrPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `entity-content:adr/entity`
+- `search-result-list-item:adr`
+- `api:adr/adr-api`
+
 ## Custom ADR formats
 
 By default, this plugin will parse ADRs according to the format specified by the [Markdown Architecture Decision Record (MADR) v2.x template](https://github.com/adr/madr/tree/2.1.2) or the [Markdown Any Decision Record (MADR) 3.x template](https://github.com/adr/madr/tree/3.0.0). If your ADRs are written using a different format, you can apply the following customizations to correctly identify and parse your documents:


### PR DESCRIPTION
This PR adds some basic documentation on how to use the ADR plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
