### PR TITLE
docs(cicd-statistics): add new frontend system documentation

### DIFF
--- a/workspaces/cicd-statistics/.changeset/wicked-zebras-lie.md
+++ b/workspaces/cicd-statistics/.changeset/wicked-zebras-lie.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-cicd-statistics': patch
+'@backstage-community/plugin-cicd-statistics-module-github': patch
+'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/README.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/README.md
@@ -40,3 +40,27 @@ import { EntityCicdStatisticsContent } from '@backstage-community/plugin-cicd-st
   <EntityCicdStatisticsContent />
 </EntityLayout.Route>;
 ```
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import cicdStatisticsPluginGithubModule from '@backstage-community/plugin-cicd-statistics-module-github/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    cicdStatisticsPluginGithubModule,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:cicd-statistics/cicd-statistics-github-api`

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/README.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/README.md
@@ -37,3 +37,27 @@ import { EntityCicdStatisticsContent } from '@backstage-community/plugin-cicd-st
   <EntityCicdStatisticsContent />
 </EntityLayout.Route>;
 ```
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import cicdStatisticsPluginGitlabModule from '@backstage-community/plugin-cicd-statistics-module-gitlab/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    cicdStatisticsPluginGitlabModule,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:cicd-statistics/cicd-statistics-gitlab-api`

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/README.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/README.md
@@ -11,3 +11,27 @@ To use this plugin, you need to implement an API `CicdStatisticsApi` and bind it
 First time the UI shows, and each time the user changes filters and clicks `Update` to refresh the data, `fetchBuilds` is invoked with the filter options. The API implementation is the expected to fetch build information from somewhere, format it into a generic and rather simple type `Build` (also defined in `types.ts`). The API can optionally signal completion for a progress bar in the UI.
 
 When this plugin has fetched the builds, it will transpose the list of builds (and build stages) into a tree of build stages. As build pipelines sometimes change, certain stages might end or begin within the date range of the view (when _Normalize time range_ is enabled, which is the default).
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import cicdStatisticsPlugin from '@backstage-community/plugin-cicd-statistics/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    cicdStatisticsPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `entity-content:cicd-statistics/entity`


### PR DESCRIPTION
This PR adds some basic documentation on how to use the cicd-statistics plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
