### PR TITLE
docs(copilot): add new frontend system documentation

### DIFF
--- a/workspaces/copilot/.changeset/honest-taxis-warn.md
+++ b/workspaces/copilot/.changeset/honest-taxis-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/copilot/plugins/copilot/README.md
+++ b/workspaces/copilot/plugins/copilot/README.md
@@ -73,3 +73,29 @@ To start using the GitHub Copilot Plugin, follow these steps:
      </SidebarPage>
    );
    ```
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import copilotPlugin from '@backstage-community/plugin-copilot/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    copilotPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:copilot`
+- `page:copilot`
+- `nav-item:copilot`


### PR DESCRIPTION
This PR adds some basic documentation on how to use the GitHub Copilot plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
