### PR TITLE
docs(cost-insights): add new frontend system documentation

### DIFF
--- a/workspaces/cost-insights/.changeset/hungry-apricots-vanish.md
+++ b/workspaces/cost-insights/.changeset/hungry-apricots-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cost-insights': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/cost-insights/plugins/cost-insights/README.md
+++ b/workspaces/cost-insights/plugins/cost-insights/README.md
@@ -118,6 +118,32 @@ To expose the plugin to your users, you can integrate the `cost-insights` route 
 );
 ```
 
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import costInsightsPlugin from '@backstage-community/plugin-cost-insights/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    costInsightsPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:cost-insights`
+- `page:cost-insights`
+- `nav-item:cost-insights`
+
 ## Configuration
 
 Cost Insights has only one required configuration field: `engineerCost` - the average yearly cost of an engineer including benefits.


### PR DESCRIPTION
This PR adds some basic documentation on how to use the Cost Insights plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
