### PR TITLE
docs(explore): add new frontend system documentation

### DIFF
--- a/workspaces/explore/.changeset/spicy-dancers-warn.md
+++ b/workspaces/explore/.changeset/spicy-dancers-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/explore/plugins/explore/README.md
+++ b/workspaces/explore/plugins/explore/README.md
@@ -97,6 +97,33 @@ const SearchPage = () => {
 ...
 ```
 
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import explorePlugin from '@backstage-community/plugin-explore/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    explorePlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:explore`
+- `page:explore`
+- `nav-item:explore`
+- `search-result-list-item:explore`
+
 ## Customization
 
 Create a custom explore page in


### PR DESCRIPTION
This PR adds some basic documentation on how to use the explore plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
