### PR TITLE
docs(grafana): add new frontend system documentation

### DIFF
--- a/workspaces/grafana/.changeset/nice-bees-dress.md
+++ b/workspaces/grafana/.changeset/nice-bees-dress.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/grafana/plugins/grafana/README.md
+++ b/workspaces/grafana/plugins/grafana/README.md
@@ -21,6 +21,33 @@ Entity dashboards card:
 
 ![Dashboards card](./docs/dashboards_card.png)
 
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import grafanaPlugin from '@backstage-community/plugin-grafana/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    grafanaPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:grafana`
+- `entity-card:grafana/dashboards`
+- `entity-card:grafana/alerts`
+- `entity-card:grafana/overview-dashboard`
+
 ## Special thanks & Disclaimer
 
 Thanks to K-Phoen for creating the grafana plugin found [here](https://github.com/K-Phoen/backstage-plugin-grafana). As an outcome


### PR DESCRIPTION
This PR adds some basic documentation on how to use the Grafana plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
