### PR TITLE
docs(graphiql): add new frontend system documentation

### DIFF
--- a/workspaces/graphiql/.changeset/many-taxis-rest.md
+++ b/workspaces/graphiql/.changeset/many-taxis-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-graphiql': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/graphiql/plugins/graphiql/README.md
+++ b/workspaces/graphiql/plugins/graphiql/README.md
@@ -70,3 +70,30 @@ If all you need is a static list of endpoints, the plugin exports a `GraphQLEndp
 +       ]),
 +   }),
 ```
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import graphiqlPlugin from '@backstage-community/plugin-graphiql/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    graphiqlPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `page:graphiql`
+- `nav-item:graphiql`
+- `api:graphiql`
+- `graphiql-endpoint:graphiql/gitlab`


### PR DESCRIPTION
This PR adds some basic documentation on how to use the GraphiQL plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
