### PR TITLE
docs(newrelic): add new frontend system documentation

### DIFF
--- a/workspaces/newrelic/.changeset/rare-turkeys-destroy.md
+++ b/workspaces/newrelic/.changeset/rare-turkeys-destroy.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-newrelic': patch
+'@backstage-community/plugin-newrelic-dashboard': patch
+---
+
+Added documentation for the New Frontend System

--- a/workspaces/newrelic/plugins/newrelic-dashboard/README.md
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/README.md
@@ -77,3 +77,29 @@ spec:
 ```
 
 All set , you will be able to see the plugin in action!
+
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import newrelicDashboardPlugin from '@backstage-community/plugin-newrelic-dashboard/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    newrelicDashboardPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:newrelic-dashboard`
+- `entity-content:newrelic-dashboard/EntityNewRelicDashboardContent`
+- `entity-card:newrelic-dashboard/EntityNewRelicDashboardCard`

--- a/workspaces/newrelic/plugins/newrelic/README.md
+++ b/workspaces/newrelic/plugins/newrelic/README.md
@@ -98,6 +98,32 @@ APIs.
 
 - Currently only supports New Relic APM data
 
+## New Frontend System
+
+### Setup
+
+If you're using [feature discovery](https://backstage.io/docs/frontend-system/architecture/app/#feature-discovery), the plugin should be automatically discovered and enabled. Otherwise, you can manually enable the plugin by adding it to your app:
+
+```tsx
+// packages/app/src/App.tsx
+import newrelicPlugin from '@backstage-community/plugin-newrelic/alpha';
+
+const app = createApp({
+  features: [
+    // ...
+    newrelicPlugin,
+  ],
+});
+```
+
+### Extensions
+
+The following extensions are available in the plugin:
+
+- `api:newrelic`
+- `page:newrelic`
+- `nav-item:newrelic`
+
 ---
 
 You can also serve the plugin in isolation by running `yarn start` in the plugin directory.


### PR DESCRIPTION
This PR adds some basic documentation on how to use the New Relic plugin with the New Frontend System, based on [issue #31294 in the `backstage` repository](https://github.com/backstage/backstage/issues/31294).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
