### PR TITLE
refactor(copilot): Normalized logs date format

### DIFF
--- a/workspaces/copilot/.changeset/old-jobs-work.md
+++ b/workspaces/copilot/.changeset/old-jobs-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+Normalized date format in task logs. Dates now display in ISO 8601 UTC format (`2025-11-03T00:00:00.000Z`) instead of locale-specific format (`Mon Nov 03 2025 01:00:00 GMT+0100 (Central European Standard Time)`).

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -51,7 +51,7 @@
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^3.0.0",
-    "luxon": "^3.5.0",
+    "luxon": "^3.7.2",
     "node-fetch": "^2.6.7",
     "winston": "^3.2.1",
     "yn": "^4.0.0",

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTask.ts
@@ -18,6 +18,7 @@ import {
   MetricsType,
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
+import { formatDate } from '../utils/dateUtils';
 import {
   convertToSeatAnalysis,
   filterBaseMetrics,
@@ -55,7 +56,9 @@ export async function discoverEnterpriseMetrics({
     );
 
     const lastDay = await db.getMostRecentDayFromMetricsV2(type);
-    logger.info(`[discoverEnterpriseMetrics] Found last day: ${lastDay}`);
+    logger.info(
+      `[discoverEnterpriseMetrics] Found last day: ${formatDate(lastDay)}`,
+    );
 
     const newMetrics: CopilotMetrics[] = filterNewMetricsV2(
       copilotMetrics,

--- a/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/EnterpriseTeamTask.ts
@@ -18,6 +18,7 @@ import {
   MetricsType,
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
+import { formatDate } from '../utils/dateUtils';
 import {
   convertToTeamSeatAnalysis,
   filterBaseMetrics,
@@ -72,7 +73,9 @@ export async function discoverEnterpriseTeamMetrics({
 
         const lastDay = await db.getMostRecentDayFromMetricsV2(type, team.slug);
         logger.info(
-          `[discoverEnterpriseTeamMetrics] Found last day: ${lastDay}`,
+          `[discoverEnterpriseTeamMetrics] Found last day: ${formatDate(
+            lastDay,
+          )}`,
         );
 
         const newMetrics: CopilotMetrics[] = filterNewMetricsV2(

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTask.ts
@@ -18,6 +18,7 @@ import {
   CopilotMetrics,
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
+import { formatDate } from '../utils/dateUtils';
 import {
   filterBaseMetrics,
   filterNewMetricsV2,
@@ -55,7 +56,9 @@ export async function discoverOrganizationMetrics({
     );
 
     const lastDay = await db.getMostRecentDayFromMetricsV2(type);
-    logger.info(`[discoverOrganizationMetrics] Found last day: ${lastDay}`);
+    logger.info(
+      `[discoverOrganizationMetrics] Found last day: ${formatDate(lastDay)}`,
+    );
 
     const newMetrics: CopilotMetrics[] = filterNewMetricsV2(
       copilotMetrics,

--- a/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/OrganizationTeamTask.ts
@@ -19,6 +19,7 @@ import {
   MetricsType,
 } from '@backstage-community/plugin-copilot-common';
 import { batchInsertInChunks } from '../utils/batchInsert';
+import { formatDate } from '../utils/dateUtils';
 import {
   convertToTeamSeatAnalysis,
   filterBaseMetrics,
@@ -73,7 +74,9 @@ export async function discoverOrganizationTeamMetrics({
 
         const lastDay = await db.getMostRecentDayFromMetricsV2(type, team.slug);
         logger.info(
-          `[discoverOrganizationTeamMetrics] Found last day: ${lastDay}`,
+          `[discoverOrganizationTeamMetrics] Found last day: ${formatDate(
+            lastDay,
+          )}`,
         );
 
         const newMetrics: CopilotMetrics[] = filterNewMetricsV2(

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/dateUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/dateUtils.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DateTime } from 'luxon';
+import { formatDate } from './dateUtils';
+
+describe('dateUtils', () => {
+  it('returns "date not available" when input is undefined', () => {
+    expect(formatDate(undefined)).toBe('date not available');
+  });
+
+  it('returns ISO string when input is a Date instance', () => {
+    const date = new Date('2025-11-05T13:04:40.712Z');
+
+    expect(formatDate(date)).toBe(DateTime.fromJSDate(date).toUTC().toISO());
+  });
+
+  it('returns ISO string when input is an ISO string', () => {
+    const isoString = '2025-11-05T00:00:00.000Z';
+
+    expect(formatDate(isoString)).toBe(
+      DateTime.fromISO(isoString).toUTC().toISO(),
+    );
+  });
+});

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/dateUtils.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/dateUtils.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DateTime } from 'luxon';
+
+/**
+ * Normalizes date values.
+ */
+export function formatDate(value: string | Date | undefined): string {
+  if (value === null || value === undefined) {
+    return 'date not available';
+  }
+
+  const dateTime =
+    value instanceof Date
+      ? DateTime.fromJSDate(value).toUTC()
+      : DateTime.fromJSDate(new Date(value)).toUTC();
+
+  if (!dateTime.isValid) {
+    return value instanceof Date ? value.toString() : String(value);
+  }
+
+  return dateTime.toISO();
+}

--- a/workspaces/copilot/yarn.lock
+++ b/workspaces/copilot/yarn.lock
@@ -1707,7 +1707,7 @@ __metadata:
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
-    luxon: "npm:^3.5.0"
+    luxon: "npm:^3.7.2"
     msw: "npm:^1.0.0"
     node-fetch: "npm:^2.6.7"
     supertest: "npm:^6.2.4"
@@ -21202,10 +21202,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "luxon@npm:3.5.0"
-  checksum: 10/48f86e6c1c96815139f8559456a3354a276ba79bcef0ae0d4f2172f7652f3ba2be2237b0e103b8ea0b79b47715354ac9fac04eb1db3485dcc72d5110491dd47f
+"luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.5.0, luxon@npm:^3.7.2":
+  version: 3.7.2
+  resolution: "luxon@npm:3.7.2"
+  checksum: 10/b24cd205ed306ce7415991687897dcc4027921ae413c9116590bc33a95f93b86ce52cf74ba72b4f5c5ab1c10090517f54ac8edfb127c049e0bf55b90dc2260be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It improves the way to display the date in copilot plugin logging tasks.

`Mon Nov 03 2025 01:00:00 GMT+0100 (Central European Standard Time)` -> `2025-11-03T00:00:00.000Z`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
