### PR TITLE
plugin(azure-resources): fix repository link

### DIFF
--- a/workspaces/azure-resources/.changeset/three-lands-vanish.md
+++ b/workspaces/azure-resources/.changeset/three-lands-vanish.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-azure-resources': patch
+---
+
+fix repository link in package.json to remediate publish errors

--- a/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/package.json
+++ b/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/package.json
@@ -27,7 +27,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/backstage/backstage-community",
+    "url": "https://github.com/backstage/community-plugins",
     "directory": "workspaces/azure-resources/plugins/catalog-backend-module-azure-resources"
   },
   "keywords": [


### PR DESCRIPTION
I believe this will resolve the release error in https://github.com/backstage/community-plugins/actions/runs/19084406380/job/54521412650

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
