### PR TITLE
ci(version-bump): increase limit for PR retrieval

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -101,11 +101,12 @@ jobs:
           script: |
             const workspace = '${{ matrix.workspace }}';
 
-            const { data: allOpenPRs } = await github.rest.pulls.list({
+            const allOpenPRs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              base: 'main'
+              base: 'main',
+              per_page: 100
             });
 
             const workspacePRs = allOpenPRs.filter(pr =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small followup on https://github.com/backstage/community-plugins/pull/5899 after a [version bump to test](https://github.com/backstage/community-plugins/actions/runs/19144202727/job/54717349626#step:11:46) didn't follow expected behaviour. An older PR did exist for this workspace, so the goal was for the version bump to update this PR, though the workflow did not detect it. 

By default, the REST API only lists the PRs on the first page (up to 30), which did not include the old version bump PR. This update ensures all PRs are listed and inspected so that the new version bump workflow can work as expected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
