### PR TITLE
Version Packages (shortcuts)

### DIFF
--- a/workspaces/shortcuts/.changeset/nasty-lizards-remember.md
+++ b/workspaces/shortcuts/.changeset/nasty-lizards-remember.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-shortcuts': patch
----
-
-Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

--- a/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
+++ b/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-shortcuts
 
+## 0.14.1
+
+### Patch Changes
+
+- 20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/shortcuts/plugins/shortcuts/package.json
+++ b/workspaces/shortcuts/plugins/shortcuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-shortcuts",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A Backstage plugin that provides a shortcuts feature to the sidebar",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-shortcuts@0.14.1

### Patch Changes

-   20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
