### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/serious-points-serve.md
+++ b/workspaces/linguist/.changeset/serious-points-serve.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
----
-
-Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.20.1
+
+### Patch Changes
+
+- 20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist-backend@0.20.1

### Patch Changes

-   20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
