### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/shaggy-feet-mate.md
+++ b/workspaces/code-coverage/.changeset/shaggy-feet-mate.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.12.1
+
+### Patch Changes
+
+- 20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage-backend@0.12.1

### Patch Changes

-   20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
