### PR TITLE
Version Packages (badges)

### DIFF
--- a/workspaces/badges/.changeset/selfish-islands-drum.md
+++ b/workspaces/badges/.changeset/selfish-islands-drum.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-badges-backend': patch
----
-
-Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

--- a/workspaces/badges/plugins/badges-backend/CHANGELOG.md
+++ b/workspaces/badges/plugins/badges-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-badges-backend
 
+## 0.17.1
+
+### Patch Changes
+
+- 20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-badges-backend",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A Backstage backend plugin that generates README badges for your entities",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-badges-backend@0.17.1

### Patch Changes

-   20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
