### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/popular-shrimps-type.md
+++ b/workspaces/playlist/.changeset/popular-shrimps-type.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-playlist-backend': patch
----
-
-Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.19
+
+### Patch Changes
+
+- Updated dependencies [20f8821]
+  - @backstage-community/plugin-playlist-backend@0.14.1
+
 ## 0.0.18
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.14.1
+
+### Patch Changes
+
+- 20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist-backend@0.14.1

### Patch Changes

-   20f8821: Updated dependency `uuid` to `^13.0.0` and remove deprecated and redundant `@types/uuid` package.

## backend@0.0.19

### Patch Changes

-   Updated dependencies [20f8821]
    -   @backstage-community/plugin-playlist-backend@0.14.1
