### PR TITLE
Hide create announcement button for unauthorized users

### DIFF
--- a/workspaces/announcements/.changeset/hide-create-button-unauthorized.md
+++ b/workspaces/announcements/.changeset/hide-create-button-unauthorized.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Hide create announcement button when user lacks permission instead of showing it disabled

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsPage/AnnouncementsPage.tsx
@@ -420,9 +420,8 @@ export const AnnouncementsPage = (props: AnnouncementsPageProps) => {
 
       <Content>
         <ContentHeader title="">
-          {!loadingCreatePermission && (
+          {!loadingCreatePermission && canCreate && (
             <LinkButton
-              disabled={!canCreate}
               to={newAnnouncementLink()}
               color="primary"
               variant="contained"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Changed the AnnouncementsPage to hide the 'New announcement' button when users lack create permission, rather than showing it in a disabled state. This provides a cleaner UI experience for users without the necessary permissions.

Added tests to verify the button visibility based on permissions.

after:
<img width="506" height="109" alt="image" src="https://github.com/user-attachments/assets/140ba1ca-cf46-41ca-9413-ac8efe8ae83e" />
<img width="506" height="179" alt="image" src="https://github.com/user-attachments/assets/e1fb1e6e-2485-437c-9231-99d6629dfcdf" />

before:
<img width="506" height="109" alt="image" src="https://github.com/user-attachments/assets/140ba1ca-cf46-41ca-9413-ac8efe8ae83e" />
<img width="506" height="179" alt="image" src="https://github.com/user-attachments/assets/c17470ad-f814-4416-86cc-9bd1d85e18b1" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
