### PR TITLE
Implement default namespace selection

### DIFF
--- a/workspaces/kiali/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
+++ b/workspaces/kiali/plugins/kiali/src/pages/Kiali/Header/NamespaceSelector.tsx
@@ -27,6 +27,33 @@ import { KialiAppState, KialiContext } from '../../../store';
 export const NamespaceSelector = (props: { page?: boolean }) => {
   const kialiState = React.useContext(KialiContext) as KialiAppState;
 
+  const defaultSetRef = React.useRef(false);
+
+  React.useEffect(() => {
+    const allNamespaces = kialiState.namespaces.items || [];
+    
+    if (defaultSetRef.current || allNamespaces.length === 0) {
+      return;
+    }
+
+    const defaultNamespace = allNamespaces.find(ns => ns.name === 'default');
+
+    if (defaultNamespace) {
+      kialiState.dispatch.namespaceDispatch(
+        NamespaceActions.setActiveNamespaces([defaultNamespace]),
+      );
+    } else {
+      kialiState.dispatch.namespaceDispatch(
+        NamespaceActions.setActiveNamespaces(allNamespaces),
+      );
+    }
+
+    defaultSetRef.current = true;
+  }, [
+    kialiState.namespaces.items,
+    kialiState.dispatch.namespaceDispatch,
+  ]);
+
   const handleChange = (event: any) => {
     const {
       target: { value },


### PR DESCRIPTION
Add default namespace selection logic in NamespaceSelector.

## Hey, I just made a Pull Request!

All namespaces are chosen by default which makes the UI very buggy. There is no need for this. We can make only `default` namespace selected at first.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
