### PR TITLE
ci(version-bump): remove branch rename and reinstall dependencies after existing branch checkout

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -155,6 +155,10 @@ jobs:
               echo "Remote branch exists, checking it out"
               git fetch origin "$BRANCH_NAME"
               git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
+
+              echo "Re-installing workspace dependencies..."
+              cd workspaces/${{ matrix.workspace }}
+              yarn install --immutable
           else
               echo "Creating new branch"
               git checkout -b "$BRANCH_NAME"
@@ -243,20 +247,6 @@ jobs:
 
               const updatedTitle = workspace + ' - version:bump to v' + releaseVersion;
               const updatedBody = prBody + '\n\n---\n\n<details>\n<summary>Previous version bump information</summary>\n\n' + existingPRData.body + '\n\n</details>';
-
-              const newBranchName = `${workspace}/v${releaseVersion}`;
-              const currentBranchName = existingPRData.head.ref;
-
-              if (currentBranchName !== newBranchName) {
-                console.log(`Renaming branch from ${currentBranchName} to ${newBranchName}`);
-                await github.rest.repos.renameBranch({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  branch: currentBranchName,
-                  new_name: newBranchName
-                });
-                console.log(`Successfully renamed branch to ${newBranchName}`);
-              }
 
               await github.rest.pulls.update({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Another followup on #5899 to address [this error](https://github.com/backstage/community-plugins/actions/runs/19235592416/job/54984530412) in running the new version bump workflow on a workspace with an existing version bump PR.

I think the `workspace yarn install` step can run after the `Create or checkout workspace branch`, as its just the root dependencies that need to be installed to run the steps between this and the setup. For simplicity sake while this new workflow is still being tested, though, I thought it best to leave the order as is and re-run it for this single use case. Once this is confirmed to work I think it'll would be good to clean this file up and extract a couple of the longer steps into their own JavaScript files.

Additionally, I discovered that when you rename a branch, GitHub closes all pull requests from that branch, which obviously is not desired behaviour. This PR also removes that change from the workflow.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
