### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/bright-buttons-chew.md
+++ b/workspaces/announcements/.changeset/bright-buttons-chew.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-The success message shown when an announcement is created is now transient

--- a/workspaces/announcements/.changeset/bright-cameras-live.md
+++ b/workspaces/announcements/.changeset/bright-cameras-live.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements-backend': minor
----
-
-Remove unused dependencies and update `uuid` to v13.

--- a/workspaces/announcements/.changeset/ninety-poets-hug.md
+++ b/workspaces/announcements/.changeset/ninety-poets-hug.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fixed routing issue where some links were incorrectly redirecting to `/announcements/admin` instead of `/announcements`. Changed `<AnnouncementsAdminPortal />` from a routable extension to a component extension to resolve the mount point conflict with the main `<AnnouncementsPage />`.

--- a/workspaces/announcements/.changeset/wet-dogs-shop.md
+++ b/workspaces/announcements/.changeset/wet-dogs-shop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Added announcement banner as app root element for the new frontend system.

--- a/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-backend
 
+## 0.16.0
+
+### Minor Changes
+
+- fdec0dd: Remove unused dependencies and update `uuid` to v13.
+
 ## 0.15.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements-backend",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements
 
+## 0.16.1
+
+### Patch Changes
+
+- 9987329: The success message shown when an announcement is created is now transient
+- ffb26dc: Fixed routing issue where some links were incorrectly redirecting to `/announcements/admin` instead of `/announcements`. Changed `<AnnouncementsAdminPortal />` from a routable extension to a component extension to resolve the mount point conflict with the main `<AnnouncementsPage />`.
+- f39d97f: Added announcement banner as app root element for the new frontend system.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements-backend@0.16.0

### Minor Changes

-   fdec0dd: Remove unused dependencies and update `uuid` to v13.

## @backstage-community/plugin-announcements@0.16.1

### Patch Changes

-   9987329: The success message shown when an announcement is created is now transient
-   ffb26dc: Fixed routing issue where some links were incorrectly redirecting to `/announcements/admin` instead of `/announcements`. Changed `<AnnouncementsAdminPortal />` from a routable extension to a component extension to resolve the mount point conflict with the main `<AnnouncementsPage />`.
-   f39d97f: Added announcement banner as app root element for the new frontend system.
