### PR TITLE
fix(repo-tools): correct scope syntax in workspace template

### DIFF
--- a/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
+++ b/workspaces/repo-tools/packages/cli/src/lib/workspaces/templates/workspace/package.json.hbs
@@ -21,7 +21,7 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "prettier:fix": "prettier --write .",
-    "new": "backstage-cli new --scope @backstage-community",
+    "new": "backstage-cli new --scope backstage-community",
     "postinstall": "cd ../../ && yarn install"
   },
   "workspaces": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes an [issue](https://github.com/backstage/community-plugins/issues/6047) in the workspace template where the `--scope` flag syntax was incorrect, causing the `yarn new` command to generate plugins with missing `name` fields in their `package.json` files.

## Problem

When running `yarn new` in a workspace (e.g., `workspaces/my-workspace`), the generated plugin's `package.json` was missing the `name` field. This caused the following error during the template execution:

Error while loading rule '@backstage/no-forbidden-package-imports':
The following package.jsons are missing the "name" field:
plugins/my-workspace/package.json


## Root Cause

The workspace template file `package.json.hbs` had an incorrect scope syntax:

```json
"new": "backstage-cli new --scope @backstage-community"
```
The --scope flag should not include the @ symbol, as backstage-cli adds it automatically. This caused the scope to be interpreted as @@backstage-community, preventing proper package name templating.


## Solution
Changed the template to use the correct scope syntax:

```json
"new": "backstage-cli new --scope backstage-community"
```


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
