### PR TITLE
feat(npm): switch imports and export TranslationBlueprint for the NFS

### DIFF
--- a/workspaces/npm/.changeset/config.json
+++ b/workspaces/npm/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@backstage-community/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/workspaces/npm/.changeset/wise-bottles-flash.md
+++ b/workspaces/npm/.changeset/wise-bottles-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-npm': minor
+---
+
+This version changes the translation import from `@backstage/core-plugin-api/alpha` to the new frontend system import `@backstage/frontend-plugin-api` and exports now a TranslationBlueprint also in the NFS `/alpha` export.

--- a/workspaces/npm/plugins/npm/report-alpha.api.md
+++ b/workspaces/npm/plugins/npm/report-alpha.api.md
@@ -10,8 +10,9 @@ import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { isNpmAvailable } from '@backstage-community/plugin-npm-common';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
-import { TranslationRef } from '@backstage/core-plugin-api/alpha';
-import { TranslationResource } from '@backstage/core-plugin-api/alpha';
+import { TranslationMessages } from '@backstage/frontend-plugin-api';
+import { TranslationRef } from '@backstage/frontend-plugin-api';
+import { TranslationResource } from '@backstage/frontend-plugin-api';
 
 // @alpha
 const _default: OverridableFrontendPlugin<{}, {}, {}>;
@@ -43,6 +44,30 @@ export const npmBackendApi: ExtensionDefinition<{
   >(
     params: ApiFactory<TApi, TImpl, TDeps>,
   ) => ExtensionBlueprintParams<AnyApiFactory>;
+}>;
+
+// @alpha (undocumented)
+export const npmTranslation: ExtensionDefinition<{
+  kind: 'translation';
+  name: 'npmTranslation';
+  config: {};
+  configInput: {};
+  output: ExtensionDataRef<
+    | TranslationResource<string>
+    | TranslationMessages<
+        string,
+        {
+          [x: string]: string;
+        },
+        boolean
+      >,
+    'core.translation.translation',
+    {}
+  >;
+  inputs: {};
+  params: {
+    resource: TranslationResource | TranslationMessages;
+  };
 }>;
 
 // @public (undocumented)

--- a/workspaces/npm/plugins/npm/report.api.md
+++ b/workspaces/npm/plugins/npm/report.api.md
@@ -7,8 +7,8 @@ import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { isNpmAvailable } from '@backstage-community/plugin-npm-common';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { RouteRef } from '@backstage/core-plugin-api';
-import { TranslationRef } from '@backstage/core-plugin-api/alpha';
-import { TranslationResource } from '@backstage/core-plugin-api/alpha';
+import { TranslationRef } from '@backstage/frontend-plugin-api';
+import { TranslationResource } from '@backstage/frontend-plugin-api';
 
 // @public
 export const EntityNpmInfoCard: () => JSX_2.Element;

--- a/workspaces/npm/plugins/npm/src/alpha.tsx
+++ b/workspaces/npm/plugins/npm/src/alpha.tsx
@@ -18,6 +18,7 @@ import {
   createFrontendPlugin,
   discoveryApiRef,
   fetchApiRef,
+  TranslationBlueprint,
 } from '@backstage/frontend-plugin-api';
 import {
   EntityCardBlueprint,
@@ -26,6 +27,7 @@ import {
 import { isNpmAvailable } from '@backstage-community/plugin-npm-common';
 
 import { NpmBackendApiRef, NpmBackendClient } from './api';
+import { npmTranslations } from './translations';
 
 export { npmTranslationRef, npmTranslations } from './translations';
 
@@ -109,6 +111,16 @@ export const entityNpmReleaseTableCard: any = EntityContentBlueprint.make({
 });
 
 /**
+ * @alpha
+ */
+export const npmTranslation = TranslationBlueprint.make({
+  name: 'npmTranslation',
+  params: {
+    resource: npmTranslations,
+  },
+});
+
+/**
  * Backstage frontend plugin.
  *
  * @alpha
@@ -120,5 +132,6 @@ export default createFrontendPlugin({
     entityNpmReleaseTableCard,
     entityNpmInfoCard,
     entityNpmReleaseOverviewCard,
+    npmTranslation,
   ],
 });

--- a/workspaces/npm/plugins/npm/src/translations/de.ts
+++ b/workspaces/npm/plugins/npm/src/translations/de.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+import { createTranslationMessages } from '@backstage/frontend-plugin-api';
 
 import { npmTranslationRef } from './ref';
 

--- a/workspaces/npm/plugins/npm/src/translations/index.ts
+++ b/workspaces/npm/plugins/npm/src/translations/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { createTranslationResource } from '@backstage/frontend-plugin-api';
 
 import { npmTranslationRef } from './ref';
 

--- a/workspaces/npm/plugins/npm/src/translations/ref.ts
+++ b/workspaces/npm/plugins/npm/src/translations/ref.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { createTranslationRef } from '@backstage/frontend-plugin-api';
 
 /**
  * @public


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. change import from `@backstage/core-plugin-api/alpha` to the new frontend system import `@backstage/frontend-plugin-api` for the translation APIs
2. exports now a `TranslationBlueprint` also in the NFS `/alpha` export. Could not verify this yet but this should help to auto translate the plugin
3. Enable changeset [`fixed`](https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md) feature that ensures that backend and fronend (and commons package) are released together and share the same major and minor version

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
