### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/wise-bottles-flash.md
+++ b/workspaces/npm/.changeset/wise-bottles-flash.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': minor
----
-
-This version changes the translation import from `@backstage/core-plugin-api/alpha` to the new frontend system import `@backstage/frontend-plugin-api` and exports now a TranslationBlueprint also in the NFS `/alpha` export.

--- a/workspaces/npm/plugins/npm-backend/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm-backend
 
+## 1.14.0
+
+### Patch Changes
+
+- @backstage-community/plugin-npm-common@1.14.0
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-backend/package.json
+++ b/workspaces/npm/plugins/npm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-npm-backend",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm-common/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @backstage-community/plugin-npm-common
 
+## 1.14.0
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-common/package.json
+++ b/workspaces/npm/plugins/npm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm-common",
   "description": "Common functionalities for the npm plugin",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-npm
 
+## 1.14.0
+
+### Minor Changes
+
+- 945db23: This version changes the translation import from `@backstage/core-plugin-api/alpha` to the new frontend system import `@backstage/frontend-plugin-api` and exports now a TranslationBlueprint also in the NFS `/alpha` export.
+
+### Patch Changes
+
+- @backstage-community/plugin-npm-common@1.14.0
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.14.0

### Minor Changes

-   945db23: This version changes the translation import from `@backstage/core-plugin-api/alpha` to the new frontend system import `@backstage/frontend-plugin-api` and exports now a TranslationBlueprint also in the NFS `/alpha` export.

### Patch Changes

-   @backstage-community/plugin-npm-common@1.14.0

## @backstage-community/plugin-npm-backend@1.14.0

### Patch Changes

-   @backstage-community/plugin-npm-common@1.14.0

## @backstage-community/plugin-npm-common@1.14.0


