### PR TITLE
Version Packages (copilot)

### DIFF
--- a/workspaces/copilot/.changeset/tasty-flies-reply.md
+++ b/workspaces/copilot/.changeset/tasty-flies-reply.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-copilot-backend': patch
----
-
-Improves error logging. Changes Octokit to use the built in CreateAppAuth in order to automatically refresh expired tokens.

--- a/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-copilot-backend
 
+## 0.15.4
+
+### Patch Changes
+
+- 14bf95c: Improves error logging. Changes Octokit to use the built in CreateAppAuth in order to automatically refresh expired tokens.
+
 ## 0.15.3
 
 ### Patch Changes

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot-backend",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "homepage": "https://backstage.io",
   "license": "Apache-2.0",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-copilot-backend@0.15.4

### Patch Changes

-   14bf95c: Improves error logging. Changes Octokit to use the built in CreateAppAuth in order to automatically refresh expired tokens.
