### PR TITLE
Version Packages (acs)

### DIFF
--- a/workspaces/acs/.changeset/renovate-6ef2277.md
+++ b/workspaces/acs/.changeset/renovate-6ef2277.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-component-groups` to `^6.0.0`.

--- a/workspaces/acs/plugins/acs/CHANGELOG.md
+++ b/workspaces/acs/plugins/acs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-acs
 
+## 0.1.1
+
+### Patch Changes
+
+- 9b77dac: Updated dependency `@patternfly/react-component-groups` to `^6.0.0`.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/acs/plugins/acs/package.json
+++ b/workspaces/acs/plugins/acs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-acs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acs@0.1.1

### Patch Changes

-   9b77dac: Updated dependency `@patternfly/react-component-groups` to `^6.0.0`.
