### PR TITLE
feat(workflow): Support specific version in version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,7 +12,7 @@ on:
           - next
           - custom
       custom_version:
-        description: 'Custom Version (only used if release_line is "custom", e.g., 1.42.1)'
+        description: 'Custom Backstage version (only used if release line is "custom") to bump to'
         required: false
         type: string
       workspace_input:

--- a/scripts/ci/set-release-name.js
+++ b/scripts/ci/set-release-name.js
@@ -96,6 +96,26 @@ async function main() {
 
   // Get the current Backstage version from the backstage.json file
   const backstageVersion = await getBackstageVersion(workspace);
+
+  // Check if releaseLine is a custom version
+  const isCustomVersion = releaseLine !== 'main' && releaseLine !== 'next';
+
+  if (isCustomVersion) {
+    console.log(`Current Backstage version is: v${backstageVersion}`);
+    console.log(`Using custom version: ${releaseLine}`);
+    console.log();
+
+    await fs.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `release_version=${releaseLine}${EOL}`,
+    );
+    await fs.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `current_version=${backstageVersion}${EOL}`,
+    );
+    return;
+  }
+
   // Get the latest Backstage Release from the GitHub API
   const latestRelease = await getLatestRelease();
   // Get the latest Backstage Pre-release from the GitHub API


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR introduces an option for the version bump workflow to add a custom version when running the action. When updating plugins, we often run into the issue that we haven’t yet updated to a new minor version (e.g. 1.42) when another version comes out (e.g. 1.43). We then have to run all the steps manually locally, which takes much more time than if we were able to simply specify a version directly when running the action.

Hence, the suggestion is to add another option to the script alongside `main` and `next`, called `custom`, which would just take a simple string.

<img width="326" height="482" alt="image" src="https://github.com/user-attachments/assets/933b42c3-da06-4f1b-8544-3abac27813ad" />

I tested the functionality in my fork of community-plugins; you can see an example PR [here](https://github.com/djanickova/community-plugins/pull/10).

I’d be glad to hear your opinions about this and any code suggestions as well. This is just an idea that could potentially help save some time when updating plugins to new versions. :)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
