### PR TITLE
Version Packages (github-actions)

### DIFF
--- a/workspaces/github-actions/.changeset/nine-jars-travel.md
+++ b/workspaces/github-actions/.changeset/nine-jars-travel.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-github-actions': minor
----
-
-Added a config for the entity content extension to change component layout between table and cards.
-
-**Breaking** Changed the name of the entity content extension from `entity-content:github-actions/github-actions-entity-content` to `entity-content:github-actions`.

--- a/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github-actions/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-github-actions
 
+## 0.17.0
+
+### Minor Changes
+
+- 5724534: Added a config for the entity content extension to change component layout between table and cards.
+
+  **Breaking** Changed the name of the entity content extension from `entity-content:github-actions/github-actions-entity-content` to `entity-content:github-actions`.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/github-actions/plugins/github-actions/package.json
+++ b/workspaces/github-actions/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@0.17.0

### Minor Changes

-   5724534: Added a config for the entity content extension to change component layout between table and cards.

    **Breaking** Changed the name of the entity content extension from `entity-content:github-actions/github-actions-entity-content` to `entity-content:github-actions`.
