### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/modern-masks-repeat.md
+++ b/workspaces/kiali/.changeset/modern-masks-repeat.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kiali-common': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Fix header styles for OpenShift. Use new cluster metrics API.

--- a/workspaces/kiali/.changeset/renovate-070b5ee.md
+++ b/workspaces/kiali/.changeset/renovate-070b5ee.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.25`.

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.27.1
+
+### Patch Changes
+
+- 636525d: Updated dependency `@types/express` to `4.17.25`.
+
 ## 1.27.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-common
 
+## 0.8.0
+
+### Minor Changes
+
+- f1697c9: Fix header styles for OpenShift. Use new cluster metrics API.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kiali-react
 
+## 0.5.2
+
+### Patch Changes
+
+- Updated dependencies [f1697c9]
+  - @backstage-community/plugin-kiali-common@0.8.0
+
 ## 0.5.1
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.46.0
+
+### Minor Changes
+
+- f1697c9: Fix header styles for OpenShift. Use new cluster metrics API.
+
+### Patch Changes
+
+- Updated dependencies [f1697c9]
+  - @backstage-community/plugin-kiali-common@0.8.0
+  - @backstage-community/plugin-kiali-react@0.5.2
+
 ## 1.45.1
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.46.0

### Minor Changes

-   f1697c9: Fix header styles for OpenShift. Use new cluster metrics API.

### Patch Changes

-   Updated dependencies [f1697c9]
    -   @backstage-community/plugin-kiali-common@0.8.0
    -   @backstage-community/plugin-kiali-react@0.5.2

## @backstage-community/plugin-kiali-common@0.8.0

### Minor Changes

-   f1697c9: Fix header styles for OpenShift. Use new cluster metrics API.

## @backstage-community/plugin-kiali-backend@1.27.1

### Patch Changes

-   636525d: Updated dependency `@types/express` to `4.17.25`.

## @backstage-community/plugin-kiali-react@0.5.2

### Patch Changes

-   Updated dependencies [f1697c9]
    -   @backstage-community/plugin-kiali-common@0.8.0
