### PR TITLE
Version Packages (copilot)

### DIFF
--- a/workspaces/copilot/.changeset/old-jobs-work.md
+++ b/workspaces/copilot/.changeset/old-jobs-work.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-copilot-backend': patch
----
-
-Normalized date format in task logs. Dates now display in ISO 8601 UTC format (`2025-11-03T00:00:00.000Z`) instead of locale-specific format (`Mon Nov 03 2025 01:00:00 GMT+0100 (Central European Standard Time)`).

--- a/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-copilot-backend
 
+## 0.15.5
+
+### Patch Changes
+
+- 0a904fd: Normalized date format in task logs. Dates now display in ISO 8601 UTC format (`2025-11-03T00:00:00.000Z`) instead of locale-specific format (`Mon Nov 03 2025 01:00:00 GMT+0100 (Central European Standard Time)`).
+
 ## 0.15.4
 
 ### Patch Changes

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot-backend",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "homepage": "https://backstage.io",
   "license": "Apache-2.0",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-copilot-backend@0.15.5

### Patch Changes

-   0a904fd: Normalized date format in task logs. Dates now display in ISO 8601 UTC format (`2025-11-03T00:00:00.000Z`) instead of locale-specific format (`Mon Nov 03 2025 01:00:00 GMT+0100 (Central European Standard Time)`).
