### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/grumpy-roses-do.md
+++ b/workspaces/announcements/.changeset/grumpy-roses-do.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Added analytics event tracking for announcement link clicks. When users click on an announcement with a `link` property, an analytics event is now captured using the [Plugin Analytics](https://backstage.io/docs/plugins/analytics/#capturing-events). This applies to the following components: `AnnouncementsCard`, `AnnouncementPage`,`NewAnnouncementBanner`.

--- a/workspaces/announcements/.changeset/poor-ravens-lay.md
+++ b/workspaces/announcements/.changeset/poor-ravens-lay.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Fix Announcements banner error `Routing context is not available` when using the banner with the new frontend system.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements
 
+## 0.16.2
+
+### Patch Changes
+
+- 43e6d99: Added analytics event tracking for announcement link clicks. When users click on an announcement with a `link` property, an analytics event is now captured using the [Plugin Analytics](https://backstage.io/docs/plugins/analytics/#capturing-events). This applies to the following components: `AnnouncementsCard`, `AnnouncementPage`,`NewAnnouncementBanner`.
+- 0b8dedf: Fix Announcements banner error `Routing context is not available` when using the banner with the new frontend system.
+
 ## 0.16.1
 
 ### Patch Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@0.16.2

### Patch Changes

-   43e6d99: Added analytics event tracking for announcement link clicks. When users click on an announcement with a `link` property, an analytics event is now captured using the [Plugin Analytics](https://backstage.io/docs/plugins/analytics/#capturing-events). This applies to the following components: `AnnouncementsCard`, `AnnouncementPage`,`NewAnnouncementBanner`.
-   0b8dedf: Fix Announcements banner error `Routing context is not available` when using the banner with the new frontend system.
