### PR TITLE
Removed `group:test` from the Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
     ":gitSignOff",
     ":rebaseStalePrs",
     "group:linters",
-    "group:test",
     ":preserveSemverRanges"
   ],
   "prConcurrentLimit": 20,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removed the `group:test` from the Renovate config and will help us avoid large PRs like this one: https://github.com/backstage/community-plugins/pull/5960

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
