### PR TITLE
frontend/alpha: disable entity card by default

### DIFF
--- a/workspaces/announcements/.changeset/small-pots-give.md
+++ b/workspaces/announcements/.changeset/small-pots-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Switched the entity card extension to be disabled by default.

--- a/workspaces/announcements/plugins/announcements/src/alpha/entityCards.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/entityCards.tsx
@@ -21,6 +21,7 @@ import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
  */
 export const entityAnnouncementsCard = EntityCardBlueprint.make({
   name: 'announcements',
+  disabled: true,
   params: {
     filter: 'kind:component,system',
     loader: async () =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

With #6086 shipped I'm thinking it's best to disable the entity card extension by default as well. Not finding that one to be something that's worth having in the default set of enabled extensions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
