### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-070b5ee.md
+++ b/workspaces/ocm/.changeset/renovate-070b5ee.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.25`.

--- a/workspaces/ocm/.changeset/renovate-253d095.md
+++ b/workspaces/ocm/.changeset/renovate-253d095.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.25.2`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 5.11.1
+
+### Patch Changes
+
+- 636525d: Updated dependency `@types/express` to `4.17.25`.
+- 43ee3e5: Updated dependency `@openapitools/openapi-generator-cli` to `2.25.2`.
+
 ## 5.11.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm-backend@5.11.1

### Patch Changes

-   636525d: Updated dependency `@types/express` to `4.17.25`.
-   43ee3e5: Updated dependency `@openapitools/openapi-generator-cli` to `2.25.2`.
