### PR TITLE
linguist-backend: Replace O(n) REST calls to catalog backend with sin…

### DIFF
--- a/workspaces/linguist/.changeset/weak-spoons-turn.md
+++ b/workspaces/linguist/.changeset/weak-spoons-turn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-linguist-backend': patch
+---
+
+Replace O(n) REST calls to catalog backend with single call when cleaning up linguist entities by merging it with the add call.


### PR DESCRIPTION
…gle call when cleaning up linguist entities by merging it with the add call.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
