### PR TITLE
fix(adr): change status badge (tag/chip) to a more colorful variant

### DIFF
--- a/workspaces/adr/.changeset/late-lies-train.md
+++ b/workspaces/adr/.changeset/late-lies-train.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-adr': patch
+---
+
+Change status badge (tag/chip) to more colorful variants:
+
+1. "good" labels for the status "accepted" from the primary theme color to the success palette color.
+2. "warning" labels for the status "deprecated" from the secondary theme color to the warning palette color.
+3. "dangerous" labels for the status "rejected" from the secondary theme color to the error palette color.

--- a/workspaces/adr/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
+++ b/workspaces/adr/plugins/adr/src/components/EntityAdrContent/EntityAdrContent.tsx
@@ -67,6 +67,21 @@ const useStyles = makeStyles((theme: Theme) => ({
   adrMenu: {
     backgroundColor: theme.palette.background.paper,
   },
+  adrLabelGood: {
+    borderColor: theme.palette.success.main,
+    color: theme.palette.success.contrastText,
+    backgroundColor: theme.palette.success.main,
+  },
+  adrLabelWarning: {
+    borderColor: theme.palette.warning.main,
+    color: theme.palette.warning.contrastText,
+    backgroundColor: theme.palette.warning.main,
+  },
+  adrLabelDangerous: {
+    borderColor: theme.palette.error.main,
+    color: theme.palette.error.contrastText,
+    backgroundColor: theme.palette.error.main,
+  },
   adrContainerTitle: {
     color: theme.palette.grey[700],
     marginBottom: theme.spacing(1),
@@ -89,14 +104,18 @@ const AdrListContainer = (props: {
   const [open, setOpen] = React.useState(true);
 
   const getChipColor = (status: string) => {
-    switch (status) {
+    if (!status) {
+      return '';
+    }
+    switch (status.toLowerCase()) {
       case 'accepted':
-        return 'primary';
-      case 'rejected':
+        return classes.adrLabelGood;
       case 'deprecated':
-        return 'secondary';
+        return classes.adrLabelWarning;
+      case 'rejected':
+        return classes.adrLabelDangerous;
       default:
-        return 'default';
+        return '';
     }
   };
 
@@ -139,10 +158,10 @@ const AdrListContainer = (props: {
                     {adr.date}
                     {adr.status && (
                       <Chip
-                        color={getChipColor(adr.status)}
                         label={adr.status}
                         size="small"
                         variant="outlined"
+                        className={getChipColor(adr.status)}
                       />
                     )}
                   </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This addresses issue #6210 by changing

1. "good" labels for the status "accepted" from the primary theme color to the success palette color.
2. "warning" labels for the status "deprecated" from the secondary theme color to the warning palette color.
3. "dangerous" labels for the status "rejected" from the secondary theme color to the error palette color.

The issue exists esp. when the theme uses some other colors then the default colors as primary and secondary color.

UI change:

| Default theme | Before | With this change |
| --- | --- | --- |
| Light | <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-04-14" src="https://github.com/user-attachments/assets/1d496981-1406-45c6-8875-0a38dfae9b97" /> | <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-05-02" src="https://github.com/user-attachments/assets/3ef0a09b-d82f-4f7e-afb3-d9789c1dc268" /> |
| Dark | <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-04-07" src="https://github.com/user-attachments/assets/17e906ca-0d78-4724-b74b-b8876a6a4198" /> | <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-04-45" src="https://github.com/user-attachments/assets/acfd19e3-e0a6-46e3-be77-b86a71b7fab9" /> |

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
