### PR TITLE
fix(adr): improve frontmatter decorator (show local date instead of Date.toString())

### DIFF
--- a/workspaces/adr/.changeset/chatty-experts-jam.md
+++ b/workspaces/adr/.changeset/chatty-experts-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-adr': patch
+---
+
+FrontMatter decorator shows now a local date without time and timezone instead of a full `Date.toString()` string. It also uppercase the first character for lowercase-only strings.

--- a/workspaces/adr/plugins/adr/src/components/AdrReader/decorators.ts
+++ b/workspaces/adr/plugins/adr/src/components/AdrReader/decorators.ts
@@ -54,14 +54,27 @@ export const adrDecoratorFactories = Object.freeze({
       let table = '';
       const attrs = parsedFrontmatter.attributes;
       if (Object.keys(attrs).length > 0) {
-        const stripNewLines = (val: unknown) =>
-          String(val).replaceAll('\n', '<br/>');
+        // Convert "alllowercase" strings into "First char uppercase" variants
+        const uppercaseFirstChar = (val: string) => {
+          if (val.match(/^[a-z]+$/)) {
+            return val.substring(0, 1).toUpperCase() + val.substring(1);
+          }
+          return val;
+        };
+        const stripNewLines = (val: unknown) => {
+          if (val instanceof Date) {
+            return val.toLocaleString(undefined, { dateStyle: 'medium' });
+          }
+          return String(val).replaceAll('\n', '<br/>');
+        };
         const row = (vals: string[]) => `|${vals.join('|')}|\n`;
-        table = `${row(Object.keys(attrs))}`;
-        table += `${row(Object.keys(attrs).map(() => '---'))}`;
-        table += `${row(Object.values(attrs).map(stripNewLines))}\n\n`;
+        table = row(Object.keys(attrs).map(uppercaseFirstChar));
+        table += row(Object.keys(attrs).map(() => '---'));
+        table += row(Object.values(attrs).map(stripNewLines));
+        table += '\n';
+        return { content: table + parsedFrontmatter.content };
       }
-      return { content: table + parsedFrontmatter.content };
+      return { content };
     };
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This addresses issue #6209 by changing two things:

1. It shows now a local date without time and timezone instead of a full `Date.toString()` string.
2. It also uppercase the first character for lowercase-only strings, like status => Status, author => Author

| Before | With this change |
| --- | --- |
| <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-04-14" src="https://github.com/user-attachments/assets/89c9ffe2-b849-4921-88a0-820eb80cb5bc" /> | <img width="1423" height="1040" alt="Screenshot From 2025-11-26 00-19-08" src="https://github.com/user-attachments/assets/4f3d6df9-b5a4-449a-9759-f2fe85f82e8d" /> |

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
