### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/chatty-experts-jam.md
+++ b/workspaces/adr/.changeset/chatty-experts-jam.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
----
-
-FrontMatter decorator shows now a local date without time and timezone instead of a full `Date.toString()` string. It also uppercase the first character for lowercase-only strings.

--- a/workspaces/adr/.changeset/late-lies-train.md
+++ b/workspaces/adr/.changeset/late-lies-train.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
----
-
-Change status badge (tag/chip) to more colorful variants:
-
-1. "good" labels for the status "accepted" from the primary theme color to the success palette color.
-2. "warning" labels for the status "deprecated" from the secondary theme color to the warning palette color.
-3. "dangerous" labels for the status "rejected" from the secondary theme color to the error palette color.

--- a/workspaces/adr/.changeset/version-bump-1-45-1.md
+++ b/workspaces/adr/.changeset/version-bump-1-45-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-adr': minor
-'@backstage-community/plugin-adr-backend': minor
-'@backstage-community/plugin-adr-common': minor
-'@backstage-community/search-backend-module-adr': minor
----
-
-Backstage version bump to v1.45.1

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.16.0
+
+### Minor Changes
+
+- 1afca36: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- Updated dependencies [1afca36]
+  - @backstage-community/plugin-adr-common@0.14.0
+  - @backstage-community/search-backend-module-adr@0.13.0
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.14.0
+
+### Minor Changes
+
+- 1afca36: Backstage version bump to v1.45.1
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @backstage-community/plugin-adr
 
+## 0.18.0
+
+### Minor Changes
+
+- 1afca36: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- 685783e: FrontMatter decorator shows now a local date without time and timezone instead of a full `Date.toString()` string. It also uppercase the first character for lowercase-only strings.
+- 7bc52c7: Change status badge (tag/chip) to more colorful variants:
+
+  1. "good" labels for the status "accepted" from the primary theme color to the success palette color.
+  2. "warning" labels for the status "deprecated" from the secondary theme color to the warning palette color.
+  3. "dangerous" labels for the status "rejected" from the secondary theme color to the error palette color.
+
+- Updated dependencies [1afca36]
+  - @backstage-community/plugin-adr-common@0.14.0
+
 ## 0.17.2
 
 ### Patch Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.13.0
+
+### Minor Changes
+
+- 1afca36: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- Updated dependencies [1afca36]
+  - @backstage-community/plugin-adr-common@0.14.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.18.0

### Minor Changes

-   1afca36: Backstage version bump to v1.45.1

### Patch Changes

-   685783e: FrontMatter decorator shows now a local date without time and timezone instead of a full `Date.toString()` string. It also uppercase the first character for lowercase-only strings.

-   7bc52c7: Change status badge (tag/chip) to more colorful variants:

    1.  "good" labels for the status "accepted" from the primary theme color to the success palette color.
    2.  "warning" labels for the status "deprecated" from the secondary theme color to the warning palette color.
    3.  "dangerous" labels for the status "rejected" from the secondary theme color to the error palette color.

-   Updated dependencies [1afca36]
    -   @backstage-community/plugin-adr-common@0.14.0

## @backstage-community/plugin-adr-backend@0.16.0

### Minor Changes

-   1afca36: Backstage version bump to v1.45.1

### Patch Changes

-   Updated dependencies [1afca36]
    -   @backstage-community/plugin-adr-common@0.14.0
    -   @backstage-community/search-backend-module-adr@0.13.0

## @backstage-community/plugin-adr-common@0.14.0

### Minor Changes

-   1afca36: Backstage version bump to v1.45.1

## @backstage-community/search-backend-module-adr@0.13.0

### Minor Changes

-   1afca36: Backstage version bump to v1.45.1

### Patch Changes

-   Updated dependencies [1afca36]
    -   @backstage-community/plugin-adr-common@0.14.0
