### PR TITLE
opencost and sentry - Removed Removed unused `@date-io/*` dependency

### DIFF
--- a/workspaces/opencost/.changeset/flat-hats-crash.md
+++ b/workspaces/opencost/.changeset/flat-hats-crash.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-opencost': patch
+---
+
+Removed unused `@date-io/luxon` dependency

--- a/workspaces/opencost/plugins/opencost/package.json
+++ b/workspaces/opencost/plugins/opencost/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
-    "@date-io/luxon": "1.x",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/pickers": "^3.3.10",

--- a/workspaces/opencost/yarn.lock
+++ b/workspaces/opencost/yarn.lock
@@ -701,7 +701,6 @@ __metadata:
     "@backstage/core-components": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"
-    "@date-io/luxon": "npm:1.x"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/pickers": "npm:^3.3.10"
@@ -1932,17 +1931,6 @@ __metadata:
   peerDependencies:
     date-fns: ^2.0.0
   checksum: 10/0b7ce35b2fcc5502b06671a037c1ca9ba8ede4a0f3d9d46cc58acc687484b40fe753a85ed30252c872fa5de75d23b3337ad6f5fe8f09ad0f8d342a5583446642
-  languageName: node
-  linkType: hard
-
-"@date-io/luxon@npm:1.x":
-  version: 1.3.13
-  resolution: "@date-io/luxon@npm:1.3.13"
-  dependencies:
-    "@date-io/core": "npm:^1.3.13"
-  peerDependencies:
-    luxon: ^1.21.3
-  checksum: 10/6583ddf55d76aab1a9bdc7ef10ae30f67300d2617ae3969ac95def7bde87f2a680c5ceaf1b57308974f9b2cd83352903905c9cbbc5b66df1facfed4640f1e228
   languageName: node
   linkType: hard
 

--- a/workspaces/sentry/.changeset/silly-rabbits-pay.md
+++ b/workspaces/sentry/.changeset/silly-rabbits-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sentry': patch
+---
+
+Removed unused `@date-io/core` dependency

--- a/workspaces/sentry/plugins/sentry/package.json
+++ b/workspaces/sentry/plugins/sentry/package.json
@@ -61,7 +61,6 @@
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@date-io/core": "^1.3.13",
     "@material-table/core": "^3.1.0",
     "@material-ui/core": "^4.12.2",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/sentry/yarn.lock
+++ b/workspaces/sentry/yarn.lock
@@ -1699,7 +1699,6 @@ __metadata:
     "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@date-io/core": "npm:^1.3.13"
     "@material-table/core": "npm:^3.1.0"
     "@material-ui/core": "npm:^4.12.2"
     "@testing-library/dom": "npm:^10.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed Removed unused `@date-io/*` dependency. This will help clean up https://github.com/backstage/community-plugins/pull/5961

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
