### PR TITLE
fix(azure-resources): remove unsupported comment to fix parsing error

### DIFF
--- a/workspaces/azure-resources/tsconfig.json
+++ b/workspaces/azure-resources/tsconfig.json
@@ -7,7 +7,6 @@
     "plugins/*/migrations",
     "plugins/catalog-backend-module-azure-resources/__fixtures__"
   ],
-  // "files": ["node_modules/@backstage/cli/asset-types/asset-types.d.ts"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "outDir": "dist-types",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a small fix I found while running a script to see which workspaces had adopted the new JSX transform. Ran into a parsing error in `tsconfig.json` since comments are not supported in JSON.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
