### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/fifty-papayas-scream.md
+++ b/workspaces/azure-devops/.changeset/fifty-papayas-scream.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Fix bearer token authentication for Git clone operations

--- a/workspaces/azure-devops/.changeset/silver-experts-fix.md
+++ b/workspaces/azure-devops/.changeset/silver-experts-fix.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': minor
----
-
-Add option that marks action as failed if pipeline result is not successful

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.18.0
+
+### Minor Changes
+
+- c2644cb: Add option that marks action as failed if pipeline result is not successful
+
+### Patch Changes
+
+- 3c0a6e4: Fix bearer token authentication for Git clone operations
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.18.0

### Minor Changes

-   c2644cb: Add option that marks action as failed if pipeline result is not successful

### Patch Changes

-   3c0a6e4: Fix bearer token authentication for Git clone operations
