### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/weak-spoons-turn.md
+++ b/workspaces/linguist/.changeset/weak-spoons-turn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linguist-backend': patch
----
-
-Replace O(n) REST calls to catalog backend with single call when cleaning up linguist entities by merging it with the add call.

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.21.1
+
+### Patch Changes
+
+- 462895f: Replace O(n) REST calls to catalog backend with single call when cleaning up linguist entities by merging it with the add call.
+
 ## 0.21.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/package.json
+++ b/workspaces/linguist/plugins/linguist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist-backend",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist-backend@0.21.1

### Patch Changes

-   462895f: Replace O(n) REST calls to catalog backend with single call when cleaning up linguist entities by merging it with the add call.
