### PR TITLE
[announcements] support editing an announcement in admin portal

### DIFF
--- a/workspaces/announcements/.changeset/gold-cups-explain.md
+++ b/workspaces/announcements/.changeset/gold-cups-explain.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Adds support for editing an announcement in the admin portal. Clicking the edit icon will no longer take the end user to a separate edit page.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Unblocks https://github.com/backstage/community-plugins/pull/6273#issuecomment-3593002376

Adds support for editing an announcement in the admin portal. Clicking the edit button will now drop down the prefilled form directly within the admin portal.

<img width="1509" height="574" alt="image" src="https://github.com/user-attachments/assets/7a62a4df-f46c-4f3a-8a9f-57d41d9c1c50" />

<img width="278" height="137" alt="image" src="https://github.com/user-attachments/assets/6223c77b-72f3-4381-aecb-9f2df6dd498d" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
