### PR TITLE
fix(sonarqube): add codeScope=overall parameter to deep link URL

### DIFF
--- a/workspaces/sonarqube/.changeset/deep-link-overall-code.md
+++ b/workspaces/sonarqube/.changeset/deep-link-overall-code.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sonarqube': patch
+---
+
+Added `codeScope=overall` parameter to the SonarQubeCard deep link URL, so the link navigates to the Overall Code tab instead of the default New Code tab in SonarQube.

--- a/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
+++ b/workspaces/sonarqube/plugins/sonarqube/src/components/SonarQubeCard/SonarQubeCard.tsx
@@ -85,7 +85,7 @@ export const SonarQubeCard = (props: {
     !loading && summaryFinding?.metrics
       ? {
           title: t('sonarQubeCard.deepLinkTitle'),
-          link: summaryFinding.projectUrl,
+          link: `${summaryFinding.projectUrl}&codeScope=overall`,
         }
       : undefined;
 


### PR DESCRIPTION
The SonarQubeCard deep link now navigates to the Overall Code tab instead of the default New Code tab in SonarQube.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
