### PR TITLE
ci: fix deprecated package detection in deprecate script

### DIFF
--- a/scripts/ci/deprecate-archived-plugins.sh
+++ b/scripts/ci/deprecate-archived-plugins.sh
@@ -28,7 +28,7 @@ jq -r '
 ' "$ARCHIVED_FILE" | while IFS='|' read -r package_name workspace plugin reason; do
 
     # Check if already deprecated
-    if npm view "$package_name" deprecated 2>/dev/null | grep -q "true\|deprecated"; then
+    if npm view "$package_name" deprecated 2>/dev/null | grep -q .; then
         echo "Already deprecated: $package_name"
         continue
     fi


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The deprecation check in `deprecate-archived-plugins.sh` currently only checks if the message contains "true" or "deprecated" to determine if a package has already been deprecated. Realistically, just checking if a deprecation message exists confirms that a package is deprecated, so the current script is unnecessarily strict. This issue presents itself with the odo packages not be flagged as deprecated, despite their deprecated status. See https://github.com/backstage/community-plugins/pull/6311#issuecomment-3603533545.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
