### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/renovate-93f977c.md
+++ b/workspaces/keycloak/.changeset/renovate-93f977c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Updated dependency `@types/lodash` to `4.17.21`.

--- a/workspaces/keycloak/.changeset/version-bump-1-45-3.md
+++ b/workspaces/keycloak/.changeset/version-bump-1-45-3.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': minor
----
-
-Backstage version bump to v1.45.3

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 3.16.0
+
+### Minor Changes
+
+- 16e9fae: Backstage version bump to v1.45.3
+
+### Patch Changes
+
+- b5310cb: Updated dependency `@types/lodash` to `4.17.21`.
+
 ## 3.15.0
 
 ### Minor Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.16.0

### Minor Changes

-   16e9fae: Backstage version bump to v1.45.3

### Patch Changes

-   b5310cb: Updated dependency `@types/lodash` to `4.17.21`.
