### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/renovate-93f977c.md
+++ b/workspaces/tekton/.changeset/renovate-93f977c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@types/lodash` to `4.17.21`.

--- a/workspaces/tekton/.changeset/tired-steaks-jam.md
+++ b/workspaces/tekton/.changeset/tired-steaks-jam.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-fix an issue with the detail buttons in the dark theme

--- a/workspaces/tekton/.changeset/version-bump-1-45-3.md
+++ b/workspaces/tekton/.changeset/version-bump-1-45-3.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-tekton': minor
-'@backstage-community/plugin-tekton-common': minor
----
-
-Backstage version bump to v1.45.3

--- a/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @janus-idp/backstage-plugin-tekton-common
 
+## 1.15.0
+
+### Minor Changes
+
+- 776a43f: Backstage version bump to v1.45.3
+
 ## 1.14.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton-common/package.json
+++ b/workspaces/tekton/plugins/tekton-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-tekton-common",
   "description": "Common functionalities for the tekton plugin",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Dependencies
 
+## 3.32.0
+
+### Minor Changes
+
+- 776a43f: Backstage version bump to v1.45.3
+
+### Patch Changes
+
+- b5310cb: Updated dependency `@types/lodash` to `4.17.21`.
+- 714f99c: fix an issue with the detail buttons in the dark theme
+- Updated dependencies [776a43f]
+  - @backstage-community/plugin-tekton-common@1.15.0
+
 ## 3.31.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.31.0",
+  "version": "3.32.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.32.0

### Minor Changes

-   776a43f: Backstage version bump to v1.45.3

### Patch Changes

-   b5310cb: Updated dependency `@types/lodash` to `4.17.21`.
-   714f99c: fix an issue with the detail buttons in the dark theme
-   Updated dependencies [776a43f]
    -   @backstage-community/plugin-tekton-common@1.15.0

## @backstage-community/plugin-tekton-common@1.15.0

### Minor Changes

-   776a43f: Backstage version bump to v1.45.3
