### PR TITLE
[allure]: enable knip reports for workspace

### DIFF
--- a/workspaces/allure/.changeset/kind-gorillas-mix.md
+++ b/workspaces/allure/.changeset/kind-gorillas-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-allure': patch
+---
+
+Remove unused dependencies

--- a/workspaces/allure/.prettierignore
+++ b/workspaces/allure/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/allure/bcp.json
+++ b/workspaces/allure/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/allure/plugins/allure/knip-report.md
+++ b/workspaces/allure/plugins/allure/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/allure/plugins/allure/package.json
+++ b/workspaces/allure/plugins/allure/package.json
@@ -48,7 +48,6 @@
     "@backstage/cli": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react-dom": "^18.2.19",

--- a/workspaces/allure/yarn.lock
+++ b/workspaces/allure/yarn.lock
@@ -363,7 +363,6 @@ __metadata:
     "@backstage/dev-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for allure workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
