### PR TITLE
[badges]: enable knip reports for workspace

### DIFF
--- a/workspaces/badges/.changeset/nasty-shrimps-teach.md
+++ b/workspaces/badges/.changeset/nasty-shrimps-teach.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-badges-backend': patch
+'@backstage-community/plugin-badges': patch
+---
+
+Remove unused dependencies

--- a/workspaces/badges/.prettierignore
+++ b/workspaces/badges/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/badges/bcp.json
+++ b/workspaces/badges/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/badges/plugins/badges-backend/knip-report.md
+++ b/workspaces/badges/plugins/badges-backend/knip-report.md
@@ -1,9 +1,2 @@
 # Knip report
 
-## Unused dependencies (3)
-
-| Name    | Location     | Severity |
-| :------ | :----------- | :------- |
-| winston | package.json | error    |
-| cors    | package.json | error    |
-| yn      | package.json | error    |

--- a/workspaces/badges/plugins/badges-backend/package.json
+++ b/workspaces/badges/plugins/badges-backend/package.json
@@ -51,14 +51,11 @@
     "@backstage/plugin-auth-node": "backstage:^",
     "@types/express": "^4.17.6",
     "badge-maker": "^5.0.0",
-    "cors": "^2.8.5",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",
-    "uuid": "^13.0.0",
-    "winston": "^3.2.1",
-    "yn": "^4.0.0"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",

--- a/workspaces/badges/plugins/badges/knip-report.md
+++ b/workspaces/badges/plugins/badges/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/badges/plugins/badges/package.json
+++ b/workspaces/badges/plugins/badges/package.json
@@ -51,7 +51,6 @@
     "@backstage/cli": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react-dom": "^18.2.19",

--- a/workspaces/badges/yarn.lock
+++ b/workspaces/badges/yarn.lock
@@ -1223,15 +1223,12 @@ __metadata:
     "@types/lodash": "npm:^4.14.151"
     "@types/supertest": "npm:^6.0.0"
     badge-maker: "npm:^5.0.0"
-    cors: "npm:^2.8.5"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     supertest: "npm:^7.0.0"
     uuid: "npm:^13.0.0"
-    winston: "npm:^3.2.1"
-    yn: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -1248,7 +1245,6 @@ __metadata:
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for badges workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
