### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/beige-squids-travel.md
+++ b/workspaces/adr/.changeset/beige-squids-travel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/search-backend-module-adr': patch
----
-
-Remove unused dependencies luxon and marked

--- a/workspaces/adr/.changeset/hip-rats-remember.md
+++ b/workspaces/adr/.changeset/hip-rats-remember.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
----
-
-Switch for errors from `WarningPanel` to `ErrorPanel` to allow users to see error stacktraces

--- a/workspaces/adr/.changeset/unlucky-carrots-dream.md
+++ b/workspaces/adr/.changeset/unlucky-carrots-dream.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Remove unused dependencies (@backstage/catalog-client, @backstage/config, @backstage/integration, @backstage/plugin-search-common, luxon, node-fetch and yn)

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.16.1
+
+### Patch Changes
+
+- 0b42b41: Remove unused dependencies (@backstage/catalog-client, @backstage/config, @backstage/integration, @backstage/plugin-search-common, luxon, node-fetch and yn)
+- Updated dependencies [0b42b41]
+  - @backstage-community/search-backend-module-adr@0.13.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr
 
+## 0.18.1
+
+### Patch Changes
+
+- 0b42b41: Switch for errors from `WarningPanel` to `ErrorPanel` to allow users to see error stacktraces
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.13.1
+
+### Patch Changes
+
+- 0b42b41: Remove unused dependencies luxon and marked
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.18.1

### Patch Changes

-   0b42b41: Switch for errors from `WarningPanel` to `ErrorPanel` to allow users to see error stacktraces

## @backstage-community/plugin-adr-backend@0.16.1

### Patch Changes

-   0b42b41: Remove unused dependencies (@backstage/catalog-client, @backstage/config, @backstage/integration, @backstage/plugin-search-common, luxon, node-fetch and yn)
-   Updated dependencies [0b42b41]
    -   @backstage-community/search-backend-module-adr@0.13.1

## @backstage-community/search-backend-module-adr@0.13.1

### Patch Changes

-   0b42b41: Remove unused dependencies luxon and marked
