### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/version-bump-1-45-1.md
+++ b/workspaces/redhat-argocd/.changeset/version-bump-1-45-1.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd': minor
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd-common': minor
----
-
-Backstage version bump to v1.45.1

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.12.0
+
+### Minor Changes
+
+- c5dc1a5: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- Updated dependencies [c5dc1a5]
+  - @backstage-community/plugin-redhat-argocd-common@1.10.0
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.10.0
+
+### Minor Changes
+
+- c5dc1a5: Backstage version bump to v1.45.1
+
 ## 1.9.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 2.2.0
+
+### Minor Changes
+
+- c5dc1a5: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- Updated dependencies [c5dc1a5]
+  - @backstage-community/plugin-redhat-argocd-common@1.10.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@2.2.0

### Minor Changes

-   c5dc1a5: Backstage version bump to v1.45.1

### Patch Changes

-   Updated dependencies [c5dc1a5]
    -   @backstage-community/plugin-redhat-argocd-common@1.10.0

## @backstage-community/plugin-redhat-argocd-backend@0.12.0

### Minor Changes

-   c5dc1a5: Backstage version bump to v1.45.1

### Patch Changes

-   Updated dependencies [c5dc1a5]
    -   @backstage-community/plugin-redhat-argocd-common@1.10.0

## @backstage-community/plugin-redhat-argocd-common@1.10.0

### Minor Changes

-   c5dc1a5: Backstage version bump to v1.45.1
