### PR TITLE
fix(tekton): fix an issue with the detail buttons in the dark theme

### DIFF
--- a/workspaces/tekton/.changeset/tired-steaks-jam.md
+++ b/workspaces/tekton/.changeset/tired-steaks-jam.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+fix an issue with the detail buttons in the dark theme

--- a/workspaces/tekton/examples/entities.yaml
+++ b/workspaces/tekton/examples/entities.yaml
@@ -13,10 +13,25 @@ kind: Component
 metadata:
   name: example-service
   annotations:
+    backstage.io/kubernetes-id: example-service
+    # backstage.io/kubernetes-namespace: example-namespace
     tekton.dev/cicd: 'true'
 spec:
   type: service
   lifecycle: experimental
   owner: guests
   system: examples
-  providesApis: [example-grpc-api]
+---
+# https://backstage.io/docs/features/software-catalog/descriptor-format#kind-component
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: another-service-without-tekton
+  annotations:
+    backstage.io/kubernetes-id: example-service
+    # backstage.io/kubernetes-namespace: example-namespace
+spec:
+  type: service
+  lifecycle: experimental
+  owner: guests
+  system: examples

--- a/workspaces/tekton/plugins/tekton/src/components/Icons/LinkToSbomIcon.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/Icons/LinkToSbomIcon.tsx
@@ -21,10 +21,10 @@ import classNames from 'classnames';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     icon: {
-      fill: 'var(--pf-t--global--icon--color--100)',
+      fill: theme.palette.text.primary,
     },
     disabledButton: {
-      fill: theme.palette.grey[600],
+      fill: theme.palette.text.disabled,
     },
   }),
 );

--- a/workspaces/tekton/plugins/tekton/src/components/Icons/OutputIcon.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/Icons/OutputIcon.tsx
@@ -21,10 +21,10 @@ import classNames from 'classnames';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     icon: {
-      fill: 'var(--pf-t--global--icon--color--100)',
+      fill: theme.palette.text.primary,
     },
     disabledButton: {
-      fill: theme.palette.grey[600],
+      fill: theme.palette.text.disabled,
     },
   }),
 );

--- a/workspaces/tekton/plugins/tekton/src/components/Icons/ViewLogsIcon.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/Icons/ViewLogsIcon.tsx
@@ -21,10 +21,10 @@ import classNames from 'classnames';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     icon: {
-      fill: 'var(--pf-t--global--icon--color--100)',
+      fill: theme.palette.text.primary,
     },
     disabledButton: {
-      fill: theme.palette.grey[600],
+      fill: theme.palette.text.disabled,
     },
   }),
 );

--- a/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PodLogsDownloadLink.tsx
+++ b/workspaces/tekton/plugins/tekton/src/components/PipelineRunLogs/PodLogsDownloadLink.tsx
@@ -21,9 +21,8 @@ import { useApi } from '@backstage/core-plugin-api';
 import { kubernetesProxyApiRef } from '@backstage/plugin-kubernetes-react';
 
 import { V1Pod } from '@kubernetes/client-node';
-import { createStyles, Link, makeStyles, Theme } from '@material-ui/core';
+import { Button } from '@material-ui/core';
 import DownloadIcon from '@mui/icons-material/FileDownloadOutlined';
-import classNames from 'classnames';
 
 import { TektonResourcesContext } from '../../hooks/TektonResourcesContext';
 import { ContainerScope } from '../../hooks/usePodLogsOfPipelineRun';
@@ -33,27 +32,11 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { tektonTranslationRef } from '../../translations/index.ts';
 import { downloadLogFile } from '../../utils/download-log-file-utils';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    downloadAction: {
-      position: 'relative',
-      marginBottom: 'var(--pf-t--global--spacer--sm)',
-      color: 'var(--pf-t--global--icon--color--100)',
-      cursor: 'pointer',
-    },
-    buttonDisabled: {
-      color: theme.palette.grey[400],
-      cursor: 'not-allowed',
-    },
-  }),
-);
-
 const PodLogsDownloadLink: FC<{
   pods: V1Pod[];
   fileName: string;
   downloadTitle: string;
 }> = ({ pods, fileName, downloadTitle, ...props }): ReactElement => {
-  const classes = useStyles();
   const [downloading, setDownloading] = useState<boolean>(false);
   const kubernetesProxyApi = useApi(kubernetesProxyApiRef);
   const { t } = useTranslationRef(tektonTranslationRef);
@@ -73,10 +56,7 @@ const PodLogsDownloadLink: FC<{
   };
 
   return (
-    <Link
-      component="button"
-      variant="body2"
-      underline="none"
+    <Button
       disabled={downloading}
       title={
         downloading
@@ -96,14 +76,11 @@ const PodLogsDownloadLink: FC<{
             setDownloading(false);
           });
       }}
-      className={classNames(classes.downloadAction, {
-        [classes.buttonDisabled]: downloading,
-      })}
       {...props}
     >
       <DownloadIcon style={{ verticalAlign: '-0.180em' }} />
       {downloadTitle || t('pipelineRunLogs.podLogsDownloadLink.title')}
-    </Link>
+    </Button>
   );
 };
 export default PodLogsDownloadLink;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR solves a small issue with the dark theme that is already visible in the included Backstage app

### Before

Before the **view logs** button on the right side was using a dark color instead of a light one in the dark theme:

<img width="1595" height="861" alt="Screenshot From 2025-12-09 15-12-24" src="https://github.com/user-attachments/assets/787cb62b-08df-44ae-a243-d1ee64f10c69" />

The "Download" buttons on the top right corner are just dark and bad visible:

<img width="1595" height="861" alt="Screenshot From 2025-12-09 15-12-29" src="https://github.com/user-attachments/assets/ea2f7271-a634-40a9-a54f-beee08c9611e" />

### With this PR

<img width="1595" height="861" alt="Screenshot From 2025-12-09 15-26-40" src="https://github.com/user-attachments/assets/f4c4fdfe-6637-4f08-8b57-d0b3926ca88d" />

<img width="1595" height="861" alt="Screenshot From 2025-12-09 15-26-47" src="https://github.com/user-attachments/assets/5906c709-4bb6-4aff-9492-1511e58eed2f" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
