### PR TITLE
Fix tekton/README.md: Fix "Zero instead of O" Typo

### DIFF
--- a/workspaces/tekton/plugins/tekton/README.md
+++ b/workspaces/tekton/plugins/tekton/README.md
@@ -226,7 +226,7 @@ annotations:
 
 ```
 
-results.name: `LINK_T0_SBOM`
+results.name: `LINK_TO_SBOM`
 
 results.value: `<sbom-viewer-url>`
 


### PR DESCRIPTION
Just a tiny Typo fix, that is hard to spot 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
