### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/tidy-spiders-exercise.md
+++ b/workspaces/manage/.changeset/tidy-spiders-exercise.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage-backend': minor
-'@backstage-community/plugin-manage-node': minor
----
-
-- Include child groups (not only parent groups) in the ownership of entities. Solves #4569.
-- Added an (mcp) action to query owned entities.

--- a/workspaces/manage/plugins/manage-backend/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-manage-backend
 
+## 1.5.0
+
+### Minor Changes
+
+- 1aea844: - Include child groups (not only parent groups) in the ownership of entities. Solves #4569.
+  - Added an (mcp) action to query owned entities.
+
+### Patch Changes
+
+- Updated dependencies [1aea844]
+  - @backstage-community/plugin-manage-node@1.5.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-backend/package.json
+++ b/workspaces/manage/plugins/manage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-backend",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/manage/plugins/manage-node/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-manage-node
 
+## 1.5.0
+
+### Minor Changes
+
+- 1aea844: - Include child groups (not only parent groups) in the ownership of entities. Solves #4569.
+  - Added an (mcp) action to query owned entities.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-node/package.json
+++ b/workspaces/manage/plugins/manage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "Apache-2.0",
   "description": "Node.js library for the manage plugin",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage-backend@1.5.0

### Minor Changes

-   1aea844: - Include child groups (not only parent groups) in the ownership of entities. Solves #4569.
    -   Added an (mcp) action to query owned entities.

### Patch Changes

-   Updated dependencies [1aea844]
    -   @backstage-community/plugin-manage-node@1.5.0

## @backstage-community/plugin-manage-node@1.5.0

### Minor Changes

-   1aea844: - Include child groups (not only parent groups) in the ownership of entities. Solves #4569.
    -   Added an (mcp) action to query owned entities.
