### PR TITLE
Version Packages (azure-storage-explorer)

### DIFF
--- a/workspaces/azure-storage-explorer/.changeset/large-spies-cough.md
+++ b/workspaces/azure-storage-explorer/.changeset/large-spies-cough.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-storage-explorer-backend': minor
----
-
-This PR adds a new optional configuration field `allowedContainers` to the Azure Blob Storage Backstage plugin. This allows users to restrict which storage containers are shown in the UI.

--- a/workspaces/azure-storage-explorer/plugins/azure-storage-backend/CHANGELOG.md
+++ b/workspaces/azure-storage-explorer/plugins/azure-storage-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-storage-explorer-backend
 
+## 0.11.0
+
+### Minor Changes
+
+- c20a704: This PR adds a new optional configuration field `allowedContainers` to the Azure Blob Storage Backstage plugin. This allows users to restrict which storage containers are shown in the UI.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/azure-storage-explorer/plugins/azure-storage-backend/package.json
+++ b/workspaces/azure-storage-explorer/plugins/azure-storage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-storage-explorer-backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-storage-explorer-backend@0.11.0

### Minor Changes

-   c20a704: This PR adds a new optional configuration field `allowedContainers` to the Azure Blob Storage Backstage plugin. This allows users to restrict which storage containers are shown in the UI.
