### PR TITLE
[dynatrace]: enable knip reports for dynatrace  workspace

### DIFF
--- a/workspaces/dynatrace/.changeset/tall-avocados-hope.md
+++ b/workspaces/dynatrace/.changeset/tall-avocados-hope.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-dynatrace': patch
+---
+
+enable knip reports and remove unused dependencies

--- a/workspaces/dynatrace/.prettierignore
+++ b/workspaces/dynatrace/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/dynatrace/bcp.json
+++ b/workspaces/dynatrace/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/dynatrace/plugins/dynatrace/knip-report.md
+++ b/workspaces/dynatrace/plugins/dynatrace/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/dynatrace/plugins/dynatrace/package.json
+++ b/workspaces/dynatrace/plugins/dynatrace/package.json
@@ -50,7 +50,6 @@
     "@backstage/dev-utils": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react-dom": "^18.2.19",

--- a/workspaces/dynatrace/yarn.lock
+++ b/workspaces/dynatrace/yarn.lock
@@ -706,7 +706,6 @@ __metadata:
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependancies for the dynatrace workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
