### PR TITLE
[entity-validation]: enable knip reports for entity-validation workspace

### DIFF
--- a/workspaces/entity-validation/.changeset/short-readers-flow.md
+++ b/workspaces/entity-validation/.changeset/short-readers-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-validation': patch
+---
+
+Remove unused dependencies

--- a/workspaces/entity-validation/.prettierignore
+++ b/workspaces/entity-validation/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/entity-validation/bcp.json
+++ b/workspaces/entity-validation/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/entity-validation/plugins/entity-validation/knip-report.md
+++ b/workspaces/entity-validation/plugins/entity-validation/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/entity-validation/plugins/entity-validation/package.json
+++ b/workspaces/entity-validation/plugins/entity-validation/package.json
@@ -77,7 +77,6 @@
     "@backstage/frontend-defaults": "backstage:^",
     "@backstage/frontend-test-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/lodash": "^4.14.151",

--- a/workspaces/entity-validation/yarn.lock
+++ b/workspaces/entity-validation/yarn.lock
@@ -377,7 +377,6 @@ __metadata:
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@react-hookz/web": "npm:^25.0.0"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/lodash": "npm:^4.14.151"


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for the entity-validation workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
