### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-070b5ee.md
+++ b/workspaces/rbac/.changeset/renovate-070b5ee.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@types/express` to `4.17.25`.

--- a/workspaces/rbac/.changeset/version-bump-1-45-1.md
+++ b/workspaces/rbac/.changeset/version-bump-1-45-1.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': minor
-'@backstage-community/plugin-rbac-common': minor
-'@backstage-community/plugin-rbac-node': minor
----
-
-Backstage version bump to v1.45.1

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Dependencies
 
+## 7.6.0
+
+### Minor Changes
+
+- e2d17e1: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- 636525d: Updated dependency `@types/express` to `4.17.25`.
+- Updated dependencies [e2d17e1]
+  - @backstage-community/plugin-rbac-common@1.22.0
+  - @backstage-community/plugin-rbac-node@1.16.0
+
 ## 7.5.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.5.0",
+  "version": "7.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.22.0
+
+### Minor Changes
+
+- e2d17e1: Backstage version bump to v1.45.1
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.16.0
+
+### Minor Changes
+
+- e2d17e1: Backstage version bump to v1.45.1
+
 ## 1.15.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 1.47.0
+
+### Minor Changes
+
+- e2d17e1: Backstage version bump to v1.45.1
+
+### Patch Changes
+
+- Updated dependencies [e2d17e1]
+  - @backstage-community/plugin-rbac-common@1.22.0
+
 ## 1.46.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.47.0

### Minor Changes

-   e2d17e1: Backstage version bump to v1.45.1

### Patch Changes

-   Updated dependencies [e2d17e1]
    -   @backstage-community/plugin-rbac-common@1.22.0

## @backstage-community/plugin-rbac-backend@7.6.0

### Minor Changes

-   e2d17e1: Backstage version bump to v1.45.1

### Patch Changes

-   636525d: Updated dependency `@types/express` to `4.17.25`.
-   Updated dependencies [e2d17e1]
    -   @backstage-community/plugin-rbac-common@1.22.0
    -   @backstage-community/plugin-rbac-node@1.16.0

## @backstage-community/plugin-rbac-common@1.22.0

### Minor Changes

-   e2d17e1: Backstage version bump to v1.45.1

## @backstage-community/plugin-rbac-node@1.16.0

### Minor Changes

-   e2d17e1: Backstage version bump to v1.45.1
