### PR TITLE
chore(mcp-chat): add prettier:fix command for auto version bump workflow

### DIFF
--- a/workspaces/mcp-chat/package.json
+++ b/workspaces/mcp-chat/package.json
@@ -21,6 +21,7 @@
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "new": "backstage-cli new --scope @backstage-community",
     "postinstall": "cd ../../ && yarn install"
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just adds `prettier:fix` command to the mcp-chat workspace so that the auto version bump workflow doesn't fail.

Failed job: https://github.com/backstage/community-plugins/actions/runs/20274288050/job/58218410793

Because of:

<img width="995" height="190" alt="image" src="https://github.com/user-attachments/assets/aaed3223-143c-4ca4-8f7e-310f79ef274a" />

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
