### PR TITLE
fix: use 'ReportPortal' branding consistently (one word)

### DIFF
--- a/workspaces/report-portal/.changeset/fix-branding-consistency.md
+++ b/workspaces/report-portal/.changeset/fix-branding-consistency.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-report-portal': patch
+'@backstage-community/plugin-report-portal-backend': patch
+'@backstage-community/plugin-report-portal-common': patch
+'@backstage-community/plugin-search-backend-module-report-portal': patch
+---
+
+Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io

--- a/workspaces/report-portal/README.md
+++ b/workspaces/report-portal/README.md
@@ -1,11 +1,11 @@
-# [Report Portal Plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/report-portal)
+# [ReportPortal Plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/report-portal)
 
-This conatins Backstage App for report portal workspace and Report portal plugins, Good Luck!
+This conatins Backstage App for ReportPortal workspace and ReportPortal plugins, Good Luck!
 
 Plugins:
 
-- [Report Portal Plugin](./plugins/report-portal/)
-- [Report Portal Backend Plugin](./plugins/report-portal-backend/)
+- [ReportPortal Plugin](./plugins/report-portal/)
+- [ReportPortal Backend Plugin](./plugins/report-portal-backend/)
 
 To start the app, run:
 

--- a/workspaces/report-portal/app-config.yaml
+++ b/workspaces/report-portal/app-config.yaml
@@ -1,9 +1,9 @@
 app:
-  title: Report Portal Example App
+  title: ReportPortal Example App
   baseUrl: http://localhost:3000
 
 organization:
-  name: Report Portal Example
+  name: ReportPortal Example
 
 backend:
   baseUrl: http://localhost:7007

--- a/workspaces/report-portal/examples/entities/example-report-portal.yaml
+++ b/workspaces/report-portal/examples/entities/example-report-portal.yaml
@@ -2,7 +2,7 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: report-portal-plugin
-  description: An example report portal component.
+  description: An example ReportPortal component.
   annotations:
     reportportal.io/launch-name: Demo Api Tests
     reportportal.io/project-name: dxp_qe

--- a/workspaces/report-portal/packages/app/src/components/Root/Root.tsx
+++ b/workspaces/report-portal/packages/app/src/components/Root/Root.tsx
@@ -105,7 +105,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
           <SidebarItem
             icon={ReportPortalIcon as IconComponent}
             to="report-portal"
-            text="Report Portal"
+            text="ReportPortal"
           />
         </SidebarScrollWrapper>
       </SidebarGroup>

--- a/workspaces/report-portal/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/report-portal/packages/app/src/components/catalog/EntityPage.tsx
@@ -198,7 +198,7 @@ const websiteEntityPage = (
     <EntityLayout.Route
       if={isReportPortalAvailable}
       path="/report-portal"
-      title="Report Portal"
+      title="ReportPortal"
     >
       <></>
     </EntityLayout.Route>

--- a/workspaces/report-portal/packages/app/src/components/search/SearchPage.tsx
+++ b/workspaces/report-portal/packages/app/src/components/search/SearchPage.tsx
@@ -88,7 +88,7 @@ const SearchPage = () => {
                 },
                 {
                   value: 'report-portal',
-                  name: 'Report Portal Projects',
+                  name: 'ReportPortal Projects',
                   icon: <ReportPortalIcon />,
                 },
               ]}

--- a/workspaces/report-portal/plugins/report-portal-backend/README.md
+++ b/workspaces/report-portal/plugins/report-portal-backend/README.md
@@ -28,7 +28,7 @@ It is only meant for local development, and the setup for it can be found inside
     const backend = createBackend();
     // All other plugins
     //...
-    // add report portal plugin
+    // add ReportPortal plugin
     backend.add(import('@backstage-community/plugin-report-portal-backend'));
     backend.start();
     ```
@@ -41,7 +41,7 @@ It is only meant for local development, and the setup for it can be found inside
     supportEmail: ${REPORT_PORTAL_SUPPORT_MAIL}
 
     # under integrations you can configure
-    # multiple instances of report portal
+    # multiple instances of ReportPortal
     integrations:
       # host address of your instance
       # for e.g: report-portal.mycorp.com

--- a/workspaces/report-portal/plugins/report-portal-backend/config.d.ts
+++ b/workspaces/report-portal/plugins/report-portal-backend/config.d.ts
@@ -15,7 +15,7 @@
  */
 export interface Config {
   /**
-   * Configuration values for Report Portal plugin
+   * Configuration values for ReportPortal plugin
    * @visibility frontend
    */
   reportPortal?: {
@@ -34,12 +34,12 @@ export interface Config {
      */
     integrations?: Array<{
       /**
-       * Host of report portal url
+       * Host of ReportPortal url
        * @visibility frontend
        */
       host: string;
       /**
-       * Base api url for report portal instance, add trailing '/' in url
+       * Base api url for ReportPortal instance, add trailing '/' in url
        * @visibility backend
        */
       baseUrl: string;

--- a/workspaces/report-portal/plugins/report-portal-backend/src/service/router.ts
+++ b/workspaces/report-portal/plugins/report-portal-backend/src/service/router.ts
@@ -49,7 +49,7 @@ export async function createRouter(
 ): Promise<express.Router> {
   const { config, logger } = options;
 
-  logger.info('Report portal backend plugin initialized');
+  logger.info('ReportPortal backend plugin initialized');
   const hostsConfig = config.getConfigArray('reportPortal.integrations');
 
   const router = Router();

--- a/workspaces/report-portal/plugins/report-portal-common/src/types.ts
+++ b/workspaces/report-portal/plugins/report-portal-common/src/types.ts
@@ -38,7 +38,7 @@ export interface ReportPortalDocument extends IndexableDocument {
    */
   projectName?: string;
   /**
-   * Entity Ref of the entity that is linked with report portal
+   * Entity Ref of the entity that is linked with ReportPortal
    */
   entityRef?: string;
 }

--- a/workspaces/report-portal/plugins/report-portal/README.md
+++ b/workspaces/report-portal/plugins/report-portal/README.md
@@ -1,10 +1,10 @@
-# Report Portal Plugin
+# ReportPortal Plugin
 
 Welcome to the report-portal plugin!
 
 [ReportPortal](https://reportportal.io) is an open-source test automation dashboard that allows teams to manage and analyze test results from various test automation frameworks. It provides a centralized platform for aggregating test reports, offering real-time insights into test execution and helping to identify and address issues quickly.
 
-The plugin integrates report portal instances to show projects and launches directly in backstage. This will be helpful for not just developers but also QEs
+The plugin integrates ReportPortal instances to show projects and launches directly in backstage. This will be helpful for not just developers but also QEs
 
 ### Getting started
 
@@ -63,7 +63,7 @@ It is only meant for local development, and the setup for it can be found inside
       <SidebarPage>
 
         <!-- Add the link to route in your sidebar component -->
-        <SidebarItem icon={ReportPortalIcon as IconComponent} to="report-portal" text="Report Portal" />
+        <SidebarItem icon={ReportPortalIcon as IconComponent} to="report-portal" text="ReportPortal" />
       </SidebarPage>
     )
     ```
@@ -94,7 +94,7 @@ It is only meant for local development, and the setup for it can be found inside
     supportEmailTemplate: ${REPORT_PORTAL_SUPPORT_MAIL}
 
     # Under integrations you can configure
-    # multiple instances of report portal
+    # multiple instances of ReportPortal
     integrations:
       # host address of your instance
       # for e.g: report-portal.mycorp.com

--- a/workspaces/report-portal/plugins/report-portal/config.d.ts
+++ b/workspaces/report-portal/plugins/report-portal/config.d.ts
@@ -15,7 +15,7 @@
  */
 export interface Config {
   /**
-   * Configuration values for Report Portal plugin
+   * Configuration values for ReportPortal plugin
    * @visibility frontend
    */
   reportPortal?: {
@@ -34,7 +34,7 @@ export interface Config {
      */
     integrations?: Array<{
       /**
-       * Host of report portal url
+       * Host of ReportPortal url
        * @visibility frontend
        */
       host: string;

--- a/workspaces/report-portal/plugins/report-portal/src/components/LaunchesPage/LaunchesPage.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/LaunchesPage/LaunchesPage.tsx
@@ -54,7 +54,7 @@ export const LaunchesPage = (props: { themeId?: string }) => {
         title={
           <>
             <Breadcrumbs style={{ marginBottom: '8px' }}>
-              <Link to={rootPage()}>Report Portal</Link>
+              <Link to={rootPage()}>ReportPortal</Link>
               <Link to={projectsPage().concat(`?host=${hostName}`)}>
                 {hostName}
               </Link>

--- a/workspaces/report-portal/plugins/report-portal/src/components/ProjectsPage/ProjectsPage.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/ProjectsPage/ProjectsPage.tsx
@@ -51,7 +51,7 @@ export const ProjectsPage = (props: { themeId?: string }) => {
         title={
           <>
             <Breadcrumbs style={{ marginBottom: '8px' }}>
-              <Link to={rootPage()}>Report Portal</Link>
+              <Link to={rootPage()}>ReportPortal</Link>
               {hostName}
             </Breadcrumbs>
             <div>{hostName}</div>
@@ -64,7 +64,7 @@ export const ProjectsPage = (props: { themeId?: string }) => {
           style={{ marginRight: '16px' }}
           to={`https://${hostName}`}
         >
-          Report Portal
+          ReportPortal
         </StyledButton>
       </Header>
       <Content>

--- a/workspaces/report-portal/plugins/report-portal/src/components/ProjectsPage/ProjectsPageContent/ProjectsPageContent.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/ProjectsPage/ProjectsPageContent/ProjectsPageContent.tsx
@@ -178,7 +178,7 @@ export const ProjectsPageContent = (props: { host: string }) => {
       align: 'center',
       width: '5%',
       render: row => (
-        <Tooltip title="View on report portal" disableInteractive>
+        <Tooltip title="View on ReportPortal" disableInteractive>
           <IconButton
             style={{ padding: 0 }}
             href={`https://${host}/ui/#${row.projectName}`}

--- a/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalGlobalPage/ReportPortalGlobalPage.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalGlobalPage/ReportPortalGlobalPage.tsx
@@ -40,7 +40,7 @@ export const ReportPortalGlobalPage = (props: ReportPortalGlobalPageProps) => {
     <PageWithHeader
       themeId={props.theme ?? 'app'}
       subtitle={props.subtitle}
-      title={props.title ?? 'Report Portal'}
+      title={props.title ?? 'ReportPortal'}
     >
       <Content>
         <Grid container>

--- a/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalOverviewCard/ReportPortalOverviewCard.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalOverviewCard/ReportPortalOverviewCard.tsx
@@ -147,7 +147,7 @@ const ReportPortalStatisticsCard = (props: { variant: InfoCardVariants }) => {
       divider
       deepLink={{
         link: `https://${hostName}/ui/#${projectId}/launches/latest/${launchDetails?.id}`,
-        title: 'View on Report Portal',
+        title: 'View on ReportPortal',
       }}
     >
       <Grid container spacing={3}>

--- a/workspaces/report-portal/plugins/report-portal/src/index.ts
+++ b/workspaces/report-portal/plugins/report-portal/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Report portal frontend plugin
+ * ReportPortal frontend plugin
  * @packageDocumentation
  */
 export {

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/README.md
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/README.md
@@ -6,7 +6,7 @@ _This plugin was created through the Backstage CLI_
 
 ## Installation
 
-1. Run the following command to install report portal search collator module:
+1. Run the following command to install ReportPortal search collator module:
 
    ```sh
    yarn workspace backend add @backstage-community/plugin-search-backend-module-report-portal

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/src/module.ts
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/src/module.ts
@@ -36,7 +36,7 @@ const defaults: {
 };
 
 /**
- * Report portal collator
+ * ReportPortal collator
  * @public
  */
 export const searchModuleReportPortalCollator = createBackendModule({


### PR DESCRIPTION
Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io

Fixes #6314

## Summary

Updated all user-facing text and documentation to use the correct 'ReportPortal' branding (one word) as used on the official reportportal.io website.

### Changes
- Updated page titles, breadcrumbs, and link text in frontend components
- Updated README files and config comments
- Updated example app configuration

Note: CHANGELOG entries were intentionally left unchanged as they are historical records.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [x] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message
