### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/better-waves-see.md
+++ b/workspaces/manage/.changeset/better-waves-see.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage-backend': patch
-'@backstage-community/plugin-manage-common': patch
-'@backstage-community/plugin-manage-node': patch
----
-
-Using the backstage yarn plugin for the workspace

--- a/workspaces/manage/.changeset/hip-glasses-send.md
+++ b/workspaces/manage/.changeset/hip-glasses-send.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage-module-tech-insights': minor
----
-
-The plugin module now uses the new frontend system!
-
-Support for the old frontend system is marked as deprecated.

--- a/workspaces/manage/.changeset/humble-brooms-lead.md
+++ b/workspaces/manage/.changeset/humble-brooms-lead.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage': major
----
-
-The plugin module now uses the new frontend system!
-
-Support for the old frontend system is marked as deprecated.

--- a/workspaces/manage/.changeset/sunny-moose-matter.md
+++ b/workspaces/manage/.changeset/sunny-moose-matter.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-manage-react': major
----
-
-This package now exposes blueprints for the new frontend system!
-
-BREAKING CHANGE:
-The DefaultApi now requires a `configApi` parameter. Note that when using the new frontend system, there is no need to manually register the API.

--- a/workspaces/manage/plugins/manage-backend/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-manage-backend
 
+## 1.5.1
+
+### Patch Changes
+
+- 073b5ec: Using the backstage yarn plugin for the workspace
+- Updated dependencies [073b5ec]
+  - @backstage-community/plugin-manage-common@1.4.1
+  - @backstage-community/plugin-manage-node@1.5.1
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-backend/package.json
+++ b/workspaces/manage/plugins/manage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-backend",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/manage/plugins/manage-common/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-manage-common
 
+## 1.4.1
+
+### Patch Changes
+
+- 073b5ec: Using the backstage yarn plugin for the workspace
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-common/package.json
+++ b/workspaces/manage/plugins/manage-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-common",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "Apache-2.0",
   "description": "Common functionalities for the manage plugin",
   "main": "src/index.ts",

--- a/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-manage-module-tech-insights
 
+## 0.6.0
+
+### Minor Changes
+
+- 073b5ec: The plugin module now uses the new frontend system!
+
+  Support for the old frontend system is marked as deprecated.
+
+### Patch Changes
+
+- Updated dependencies [073b5ec]
+  - @backstage-community/plugin-manage-react@2.0.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-module-tech-insights",
   "description": "Manage plugin - Tech Insights module",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage-node/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-manage-node
 
+## 1.5.1
+
+### Patch Changes
+
+- 073b5ec: Using the backstage yarn plugin for the workspace
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-node/package.json
+++ b/workspaces/manage/plugins/manage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-manage-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "Apache-2.0",
   "description": "Node.js library for the manage plugin",
   "main": "src/index.ts",

--- a/workspaces/manage/plugins/manage-react/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-react/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-manage-react
 
+## 2.0.0
+
+### Major Changes
+
+- 073b5ec: This package now exposes blueprints for the new frontend system!
+
+  BREAKING CHANGE:
+  The DefaultApi now requires a `configApi` parameter. Note that when using the new frontend system, there is no need to manually register the API.
+
+### Patch Changes
+
+- Updated dependencies [073b5ec]
+  - @backstage-community/plugin-manage-common@1.4.1
+
 ## 1.4.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-react",
   "description": "Manage plugin - react package",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "backstage": {
     "role": "web-library",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-manage
 
+## 1.0.0
+
+### Major Changes
+
+- 073b5ec: The plugin module now uses the new frontend system!
+
+  Support for the old frontend system is marked as deprecated.
+
+### Patch Changes
+
+- Updated dependencies [073b5ec]
+- Updated dependencies [073b5ec]
+  - @backstage-community/plugin-manage-common@1.4.1
+  - @backstage-community/plugin-manage-react@2.0.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage",
   "description": "Manage plugin - Shows a Manage page relevant to the user",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "manage",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage@1.0.0

### Major Changes

-   073b5ec: The plugin module now uses the new frontend system!

    Support for the old frontend system is marked as deprecated.

### Patch Changes

-   Updated dependencies [073b5ec]
-   Updated dependencies [073b5ec]
    -   @backstage-community/plugin-manage-common@1.4.1
    -   @backstage-community/plugin-manage-react@2.0.0

## @backstage-community/plugin-manage-react@2.0.0

### Major Changes

-   073b5ec: This package now exposes blueprints for the new frontend system!

    BREAKING CHANGE:
    The DefaultApi now requires a `configApi` parameter. Note that when using the new frontend system, there is no need to manually register the API.

### Patch Changes

-   Updated dependencies [073b5ec]
    -   @backstage-community/plugin-manage-common@1.4.1

## @backstage-community/plugin-manage-module-tech-insights@0.6.0

### Minor Changes

-   073b5ec: The plugin module now uses the new frontend system!

    Support for the old frontend system is marked as deprecated.

### Patch Changes

-   Updated dependencies [073b5ec]
    -   @backstage-community/plugin-manage-react@2.0.0

## @backstage-community/plugin-manage-backend@1.5.1

### Patch Changes

-   073b5ec: Using the backstage yarn plugin for the workspace
-   Updated dependencies [073b5ec]
    -   @backstage-community/plugin-manage-common@1.4.1
    -   @backstage-community/plugin-manage-node@1.5.1

## @backstage-community/plugin-manage-common@1.4.1

### Patch Changes

-   073b5ec: Using the backstage yarn plugin for the workspace

## @backstage-community/plugin-manage-node@1.5.1

### Patch Changes

-   073b5ec: Using the backstage yarn plugin for the workspace
