### PR TITLE
Version Packages (github-deployments)

### DIFF
--- a/workspaces/github-deployments/.changeset/wet-monkeys-fetch.md
+++ b/workspaces/github-deployments/.changeset/wet-monkeys-fetch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-deployments': patch
----
-
-Replaces global JSX reference with explicit React.JSX

--- a/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
+++ b/workspaces/github-deployments/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-deployments
 
+## 0.15.1
+
+### Patch Changes
+
+- 75ff365: Replaces global JSX reference with explicit React.JSX
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/github-deployments/plugins/github-deployments/package.json
+++ b/workspaces/github-deployments/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-deployments",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-deployments@0.15.1

### Patch Changes

-   75ff365: Replaces global JSX reference with explicit React.JSX
