### PR TITLE
Version Packages (bazaar)

### DIFF
--- a/workspaces/bazaar/.changeset/small-lions-cover.md
+++ b/workspaces/bazaar/.changeset/small-lions-cover.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bazaar': patch
----
-
-Replaces global JSX references with `React.JSX` import.

--- a/workspaces/bazaar/.changeset/strange-feet-exist.md
+++ b/workspaces/bazaar/.changeset/strange-feet-exist.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bazaar-backend': minor
----
-
-Drops support for the old backend system while cleaning up all existing deprecations

--- a/workspaces/bazaar/plugins/bazaar-backend/CHANGELOG.md
+++ b/workspaces/bazaar/plugins/bazaar-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-bazaar-backend
 
+## 0.19.0
+
+### Minor Changes
+
+- b10d4dc: Drops support for the old backend system while cleaning up all existing deprecations
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/bazaar/plugins/bazaar-backend/package.json
+++ b/workspaces/bazaar/plugins/bazaar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bazaar-backend",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "bazaar",

--- a/workspaces/bazaar/plugins/bazaar/CHANGELOG.md
+++ b/workspaces/bazaar/plugins/bazaar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-bazaar
 
+## 0.18.1
+
+### Patch Changes
+
+- b10d4dc: Replaces global JSX references with `React.JSX` import.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/bazaar/plugins/bazaar/package.json
+++ b/workspaces/bazaar/plugins/bazaar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bazaar",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "bazaar",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-bazaar-backend@0.19.0

### Minor Changes

-   b10d4dc: Drops support for the old backend system while cleaning up all existing deprecations

## @backstage-community/plugin-bazaar@0.18.1

### Patch Changes

-   b10d4dc: Replaces global JSX references with `React.JSX` import.
