### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/renovate-9c928d4.md
+++ b/workspaces/analytics/.changeset/renovate-9c928d4.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `22.19.3`.

--- a/workspaces/analytics/.changeset/yellow-seahorses-appear.md
+++ b/workspaces/analytics/.changeset/yellow-seahorses-appear.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': minor
----
-
-Added enhanced identity-aware tracking so Matomo records page views only after a userId is available, fixing the issue where navigate events fired anonymously despite `identity` being enabled

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 1.22.0
+
+### Minor Changes
+
+- 009b7c5: Added enhanced identity-aware tracking so Matomo records page views only after a userId is available, fixing the issue where navigate events fired anonymously despite `identity` being enabled
+
+### Patch Changes
+
+- efdad9e: Updated dependency `@types/node` to `22.19.3`.
+
 ## 1.21.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.22.2
+
+### Patch Changes
+
+- efdad9e: Updated dependency `@types/node` to `22.19.3`.
+
 ## 1.22.1
 
 ### Patch Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-matomo@1.22.0

### Minor Changes

-   009b7c5: Added enhanced identity-aware tracking so Matomo records page views only after a userId is available, fixing the issue where navigate events fired anonymously despite `identity` being enabled

### Patch Changes

-   efdad9e: Updated dependency `@types/node` to `22.19.3`.

## @backstage-community/plugin-analytics-provider-segment@1.22.2

### Patch Changes

-   efdad9e: Updated dependency `@types/node` to `22.19.3`.
