### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-59a068d.md
+++ b/workspaces/rbac/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/rbac/.changeset/renovate-6f0b6bc.md
+++ b/workspaces/rbac/.changeset/renovate-6f0b6bc.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `qs` to `6.14.1`.

--- a/workspaces/rbac/.changeset/renovate-9c928d4.md
+++ b/workspaces/rbac/.changeset/renovate-9c928d4.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.19.3`.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 7.6.1
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+- 9714391: Updated dependency `qs` to `6.14.1`.
+- efdad9e: Updated dependency `@types/node` to `22.19.3`.
+
 ## 7.6.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Dependencies
 
+## 1.47.1
+
+### Patch Changes
+
+- efdad9e: Updated dependency `@types/node` to `22.19.3`.
+
 ## 1.47.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.47.0",
+  "version": "1.47.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.47.1

### Patch Changes

-   efdad9e: Updated dependency `@types/node` to `22.19.3`.

## @backstage-community/plugin-rbac-backend@7.6.1

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
-   9714391: Updated dependency `qs` to `6.14.1`.
-   efdad9e: Updated dependency `@types/node` to `22.19.3`.
