### PR TITLE
Version Packages (graphiql)

### DIFF
--- a/workspaces/graphiql/.changeset/rich-sloths-listen.md
+++ b/workspaces/graphiql/.changeset/rich-sloths-listen.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-graphiql': patch
----
-
-Replaces global JSX reference with React.JSX

--- a/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
+++ b/workspaces/graphiql/plugins/graphiql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-graphiql
 
+## 0.11.1
+
+### Patch Changes
+
+- adfea13: Replaces global JSX reference with React.JSX
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/graphiql/plugins/graphiql/package.json
+++ b/workspaces/graphiql/plugins/graphiql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-graphiql",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Backstage plugin for browsing GraphQL APIs",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-graphiql@0.11.1

### Patch Changes

-   adfea13: Replaces global JSX reference with React.JSX
