### PR TITLE
Display error if yarn changeset is invoked from the root

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": "20 || 22"
   },
   "scripts": {
+    "changeset": "echo 'Error: Please run yarn changeset from a workspace directory, not the root.' && exit 1",
     "create-workspace": "community-cli workspace create",
     "postinstall": "husky",
     "prettier:check": "prettier --check .",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding an informative errore when running `yarn changeset` as I've seen contributors committing `.changeset` directory from the root of the repo.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
