### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/renovate-59a068d.md
+++ b/workspaces/mcp-chat/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.4.2
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat-backend@0.4.2

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
