### PR TITLE
Version Packages (mta)

### DIFF
--- a/workspaces/mta/.changeset/bump-backstage-1494.md
+++ b/workspaces/mta/.changeset/bump-backstage-1494.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-frontend': patch
-'@backstage-community/backstage-plugin-mta-backend': patch
-'@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider': patch
-'@backstage-community/backstage-plugin-scaffolder-backend-module-mta': patch
----
-
-Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.

--- a/workspaces/mta/.changeset/renovate-59a068d.md
+++ b/workspaces/mta/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/mta/.changeset/renovate-59a7dbb.md
+++ b/workspaces/mta/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/mta/.changeset/renovate-9187fce.md
+++ b/workspaces/mta/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/backstage-plugin-mta-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider
 
+## 0.4.1
+
+### Patch Changes
+
+- 5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
+++ b/workspaces/mta/plugins/catalog-backend-module-mta-entity-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider",
   "description": "The mta-entity-provider backend module for the catalog plugin.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-backend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/backstage-plugin-mta-backend
 
+## 0.5.3
+
+### Patch Changes
+
+- 5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.5.2
 
 ### Patch Changes

--- a/workspaces/mta/plugins/mta-backend/package.json
+++ b/workspaces/mta/plugins/mta-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-backend",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
+++ b/workspaces/mta/plugins/mta-frontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-mta-frontend
 
+## 0.4.2
+
+### Patch Changes
+
+- 5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
+
 ## 0.4.1
 
 ### Patch Changes

--- a/workspaces/mta/plugins/mta-frontend/package.json
+++ b/workspaces/mta/plugins/mta-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/backstage-plugin-mta-frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/backstage-plugin-scaffolder-backend-module-mta
 
+## 0.5.1
+
+### Patch Changes
+
+- 5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
+++ b/workspaces/mta/plugins/scaffolder-backend-module-mta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/backstage-plugin-scaffolder-backend-module-mta",
   "description": "The mta module for @backstage/plugin-scaffolder-backend",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/backstage-plugin-catalog-backend-module-mta-entity-provider@0.4.1

### Patch Changes

-   5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.

## @backstage-community/backstage-plugin-mta-backend@0.5.3

### Patch Changes

-   5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.

## @backstage-community/backstage-plugin-mta-frontend@0.4.2

### Patch Changes

-   5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.

## @backstage-community/backstage-plugin-scaffolder-backend-module-mta@0.5.1

### Patch Changes

-   5adec44: Bumped Backstage dependencies to 1.49.4 for RHDH 1.10 compatibility.
