### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/renovate-59a068d.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.12.1
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd-backend@0.12.1

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
