### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-16174d4.md
+++ b/workspaces/ocm/.changeset/renovate-16174d4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.26.0`.

--- a/workspaces/ocm/.changeset/renovate-59a068d.md
+++ b/workspaces/ocm/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 5.12.1
+
+### Patch Changes
+
+- f52d810: Updated dependency `@openapitools/openapi-generator-cli` to `2.26.0`.
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+
 ## 5.12.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.12.0",
+  "version": "5.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm-backend@5.12.1

### Patch Changes

-   f52d810: Updated dependency `@openapitools/openapi-generator-cli` to `2.26.0`.
-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
