### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-a66497d.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-a66497d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.89.2`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-45-3.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-45-3.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': minor
----
-
-Backstage version bump to v1.45.3

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 2.11.0
+
+### Minor Changes
+
+- 2b493f2: Backstage version bump to v1.45.3
+
+### Patch Changes
+
+- 140bfbb: Updated dependency `@hey-api/openapi-ts` to `0.89.2`.
+
 ## 2.10.2
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.10.2",
+  "version": "2.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.11.0

### Minor Changes

-   2b493f2: Backstage version bump to v1.45.3

### Patch Changes

-   140bfbb: Updated dependency `@hey-api/openapi-ts` to `0.89.2`.
