### PR TITLE
chore(npm): prepare Backstage 1.46 upgrade / version bump

### DIFF
--- a/workspaces/npm/package.json
+++ b/workspaces/npm/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "20 || 22"
+    "node": "22 || 24"
   },
   "scripts": {
     "dev": "yarn workspaces foreach -A --include @backstage-community/plugin-npm --include @backstage-community/plugin-npm-backend --parallel -v -i run start",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Looked into the auto version bump failures. This might solve that the npm plugin. I will create a bigger PR of this works for this workspace.

Auto version bump actions:

<img width="409" height="631" alt="image" src="https://github.com/user-attachments/assets/29d861b7-7bb1-48a6-8800-e0fe78c5c1eb" />

<img width="1573" height="695" alt="image" src="https://github.com/user-attachments/assets/13bc5fa0-629a-4d54-a656-67da0a30da0c" />

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
