### PR TITLE
chore(repo): prepare Backstage 1.46 upgrades / version bumps by using Node 22 (and 22+24 for CI jobs)

### DIFF
--- a/.github/workflows/auto-version-bump-scheduler.yml
+++ b/.github/workflows/auto-version-bump-scheduler.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
+      - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: 22.x
 
       - name: yarn install
         run: yarn install --immutable

--- a/.github/workflows/automate_renovate_changesets.yml
+++ b/.github/workflows/automate_renovate_changesets.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 22
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Configure Git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Find changed workspaces
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         workspace: ${{ fromJSON(needs.find-changed-workspaces.outputs.workspaces) }}
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
       fail-fast: false
     defaults:
       run:
@@ -190,10 +190,10 @@ jobs:
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Setup node
+      - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20.x
+          node-version: 22.x
       - name: Install root dependencies
         run: yarn install --immutable
       - name: Verify lockfile duplicates

--- a/.github/workflows/deprecate-archived-plugins.yml
+++ b/.github/workflows/deprecate-archived-plugins.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Deprecate packages

--- a/.github/workflows/regenerate_issue_templates.yml
+++ b/.github/workflows/regenerate_issue_templates.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Fetch previous commit for check

--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Get yarn cache directory path
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Install root dependencies

--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Get yarn cache directory path
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
       - name: Install root dependencies

--- a/.github/workflows/upgrade-dashboard.yml
+++ b/.github/workflows/upgrade-dashboard.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 22
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -50,10 +50,10 @@ jobs:
           fetch-depth: 1
 
       # Beginning of yarn setup
-      - name: use node.js 20.x
+      - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: cache all node_modules
         id: cache-modules


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates all GitHub actions / workflows to use Node.js 22 instead of 20 since the latest version bump works only with Node.js 22.

:warning:  Wdyt about updating the CI job matrix to Node.js 22 and 24 as well !? Can we expect that all workspaces works with this versions already? :man_shrugging: 

See esp. https://github.com/backstage/community-plugins/actions/workflows/version-bump.yml

Example failed job: https://github.com/backstage/community-plugins/actions/runs/20462345924/job/58797767494

<img width="409" height="631" alt="image" src="https://github.com/user-attachments/assets/416f2cb7-fa60-44da-99f6-4575a9d6aaf7" />

<img width="1573" height="695" alt="image" src="https://github.com/user-attachments/assets/b24bed2a-5f1e-4df1-9762-f17309430dcf" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
