### PR TITLE
Version Packages (gocd)

### DIFF
--- a/workspaces/gocd/.changeset/unlucky-ants-cover.md
+++ b/workspaces/gocd/.changeset/unlucky-ants-cover.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gocd': patch
----
-
-Replaces global JSX reference with React.JSX import

--- a/workspaces/gocd/plugins/gocd/CHANGELOG.md
+++ b/workspaces/gocd/plugins/gocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gocd
 
+## 0.14.1
+
+### Patch Changes
+
+- fe81357: Replaces global JSX reference with React.JSX import
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/gocd/plugins/gocd/package.json
+++ b/workspaces/gocd/plugins/gocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gocd",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A Backstage plugin that integrates towards GoCD",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gocd@0.14.1

### Patch Changes

-   fe81357: Replaces global JSX reference with React.JSX import
