### PR TITLE
chore(acr): enable listDeprecations check

### DIFF
--- a/workspaces/acr/bcp.json
+++ b/workspaces/acr/bcp.json
@@ -1,4 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": false,
+  "listDeprecations": true
 }

--- a/workspaces/acr/plugins/acr/src/index.ts
+++ b/workspaces/acr/plugins/acr/src/index.ts
@@ -21,5 +21,15 @@
  * @packageDocumentation
  */
 
-export { acrPlugin, AcrImagesEntityContent, AcrPage } from './plugin';
+export { acrPlugin, AcrImagesEntityContent } from './plugin';
 export { isAcrAvailable } from './utils/isAcrAvailable';
+
+import { AcrImagesEntityContent } from './plugin';
+
+/**
+ * A catalog entity content (tab) that shows the ACR container images.
+ *
+ * @public
+ * @deprecated Please use `AcrImagesEntityContent` instead of `AcrPage`.
+ */
+export const AcrPage = AcrImagesEntityContent;

--- a/workspaces/acr/plugins/acr/src/plugin.ts
+++ b/workspaces/acr/plugins/acr/src/plugin.ts
@@ -68,11 +68,3 @@ export const AcrImagesEntityContent = acrPlugin.provide(
     },
   }),
 );
-
-/**
- * A catalog entity content (tab) that shows the ACR container images.
- *
- * @public
- * @deprecated Please use `AcrImagesEntityContent` instead of `AcrPage`.
- */
-export const AcrPage = AcrImagesEntityContent;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enable bcp.json `listDeprecations` option and move deprecated exports from plugins.ts to index.ts to disable "false positive" warnings.

Helps towards #5994.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
