### PR TITLE
fix(quay): fixed inconsistent date rendering in quay plugin

### DIFF
--- a/workspaces/quay/.changeset/chilly-moons-ring.md
+++ b/workspaces/quay/.changeset/chilly-moons-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-quay': patch
+---
+
+fix inconsistent date rendering in quay repository table

--- a/workspaces/quay/plugins/quay/dev/__data__/tags.ts
+++ b/workspaces/quay/plugins/quay/dev/__data__/tags.ts
@@ -54,6 +54,7 @@ export const tags = {
       is_manifest_list: false,
       size: 235862608,
       last_modified: 'Tue, 06 Feb 2024 09:39:24 -0000',
+      expiration: 'Sat, 10 Feb 2024 09:39:24 -0000',
     },
     {
       name: 'v1',

--- a/workspaces/quay/plugins/quay/src/hooks/quay.tsx
+++ b/workspaces/quay/plugins/quay/src/hooks/quay.tsx
@@ -109,7 +109,9 @@ export const useTags = (
             {shortHash}
           </Box>
         ),
-        expiration: tag.expiration,
+        expiration: tag.expiration
+          ? formatDate(tag.expiration)
+          : tag.expiration,
         securityDetails: tagManifestLayers[tag.manifest_digest],
         securityStatus: tagManifestStatuses[tag.manifest_digest],
         manifest_digest_raw: tag.manifest_digest,

--- a/workspaces/quay/plugins/quay/src/hooks/useTags.test.ts
+++ b/workspaces/quay/plugins/quay/src/hooks/useTags.test.ts
@@ -17,6 +17,7 @@ import { useApi } from '@backstage/core-plugin-api';
 
 import { renderHook, waitFor } from '@testing-library/react';
 
+import { formatDate } from '../utils';
 import { useTags } from './quay';
 
 jest.mock('@backstage/core-plugin-api', () => ({
@@ -76,6 +77,36 @@ describe('useTags', () => {
       expect(result.current.data).toHaveLength(1);
       expect(result.current.data[0].securityStatus).toBe('scanned');
       expect(result.current.data[0].securityDetails).toEqual({});
+    });
+  });
+
+  it('should format last_modified and expiration consistently', async () => {
+    const lastModified = 'Wed, 15 Mar 2023 18:22:18 -0000';
+    const expiration = 'Tue, 06 Feb 2031 09:39:24 -0000';
+    (useApi as jest.Mock).mockReturnValue({
+      getSecurityDetails: jest
+        .fn()
+        .mockReturnValue({ data: null, status: 'unsupported' }),
+      getTags: jest.fn().mockReturnValue({
+        tags: [
+          {
+            name: 'tag1',
+            manifest_digest: 'sha256:abc123',
+            last_modified: lastModified,
+            expiration: expiration,
+            size: 1000,
+          },
+        ],
+      }),
+    });
+    const { result } = renderHook(() => useTags(undefined, 'foo', 'bar'));
+    await waitFor(() => {
+      expect(result.current.loading).toBeFalsy();
+      expect(result.current.data).toHaveLength(1);
+      expect(result.current.data[0].last_modified).toBe(
+        formatDate(lastModified),
+      );
+      expect(result.current.data[0].expiration).toBe(formatDate(expiration));
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes:** 

https://issues.redhat.com/browse/RHDHBUGS-2294

<img width="1905" height="1014" alt="Screenshot 2026-01-05 at 8 30 02 PM" src="https://github.com/user-attachments/assets/3be059bd-d66e-40e3-961a-e2968fff211c" />


<img width="1905" height="1014" alt="Screenshot 2026-01-06 at 2 10 35 PM" src="https://github.com/user-attachments/assets/e2f2a3c0-7280-4dfb-9dc7-088bbc4c3a4c" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
