### PR TITLE
Version Packages (redhat-argocd)

### DIFF
--- a/workspaces/redhat-argocd/.changeset/public-moments-study.md
+++ b/workspaces/redhat-argocd/.changeset/public-moments-study.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': minor
-'@backstage-community/plugin-redhat-argocd-common': minor
-'@backstage-community/plugin-redhat-argocd': minor
----
-
-Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.

--- a/workspaces/redhat-argocd/.changeset/renovate-59a068d.md
+++ b/workspaces/redhat-argocd/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-redhat-argocd-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-redhat-argocd-backend
 
+## 0.13.0
+
+### Minor Changes
+
+- a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+- Updated dependencies [a23ba3c]
+  - @backstage-community/plugin-redhat-argocd-common@1.11.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-backend/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-backend",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-redhat-argocd-common
 
+## 1.11.0
+
+### Minor Changes
+
+- a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd-common/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd-common",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/redhat-argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## @backstage-community/plugin-redhat-argocd
 
+## 2.3.0
+
+### Minor Changes
+
+- a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.
+
+### Patch Changes
+
+- Updated dependencies [a23ba3c]
+  - @backstage-community/plugin-redhat-argocd-common@1.11.0
+
 ## 2.2.0
 
 ### Minor Changes

--- a/workspaces/redhat-argocd/plugins/argocd/package.json
+++ b/workspaces/redhat-argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-redhat-argocd",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-redhat-argocd@2.3.0

### Minor Changes

-   a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.

### Patch Changes

-   Updated dependencies [a23ba3c]
    -   @backstage-community/plugin-redhat-argocd-common@1.11.0

## @backstage-community/plugin-redhat-argocd-backend@0.13.0

### Minor Changes

-   a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
-   Updated dependencies [a23ba3c]
    -   @backstage-community/plugin-redhat-argocd-common@1.11.0

## @backstage-community/plugin-redhat-argocd-common@1.11.0

### Minor Changes

-   a23ba3c: Adds ArgoCD application discovery from multiple clusters (ArgoCD instances) per Catalog entity. You can now specify multiple ArgoCD instances to fetch ArgoCD applications from in your entity via `argocd/instance-name` annotation, separated by commas. These instance names must match instance names configured in your `app-config.yaml`. Use `argocd/app-selector` annotation to filter ArgoCD applications for your entity across ArgoCD instances and namespaces. Use `argocd/app-name` annotation to filter out single ArgoCD application per ArgoCD instance. Without the `argocd/instance-name` annotation, the plugin now searches all available ArgoCD instances instead of defaulting to the first one. The order of displayed applications is determined by the order of instance names under `argocd/instance-name` annotation. If this annotation is missing, order is determined by the order of instances in the configuration.
