### PR TITLE
azure-devops - Marked `titleSuffix` as optional in config schema

### DIFF
--- a/workspaces/azure-devops/.changeset/three-cooks-travel.md
+++ b/workspaces/azure-devops/.changeset/three-cooks-travel.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-azure-devops': patch
+---
+
+Updated the `titleSuffix` to be optional in the config schema, the code already handles it as optional everywhere else.

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/config.d.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/config.d.ts
@@ -56,7 +56,7 @@ export interface Config {
           /**
            * A string to append to the title of articles to make them easier to identify as search results from the wiki; optional
            */
-          titleSuffix: string;
+          titleSuffix?: string;
         }>;
       };
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated the `titleSuffix` to be optional in the config schema, the code already handles it as optional everywhere else.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
