### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/chilly-moons-ring.md
+++ b/workspaces/quay/.changeset/chilly-moons-ring.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-fix inconsistent date rendering in quay repository table

--- a/workspaces/quay/.changeset/renovate-59a068d.md
+++ b/workspaces/quay/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/quay/.changeset/renovate-a2c9455.md
+++ b/workspaces/quay/.changeset/renovate-a2c9455.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `cross-fetch` to `4.1.0`.

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.10.1
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+
 ## 1.10.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Dependencies
 
+## 1.28.1
+
+### Patch Changes
+
+- 6fbecf3: fix inconsistent date rendering in quay repository table
+- 699c87f: Updated dependency `cross-fetch` to `4.1.0`.
+
 ## 1.28.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.28.1

### Patch Changes

-   6fbecf3: fix inconsistent date rendering in quay repository table
-   699c87f: Updated dependency `cross-fetch` to `4.1.0`.

## @backstage-community/plugin-quay-backend@1.10.1

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
