### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/deep-link-overall-code.md
+++ b/workspaces/sonarqube/.changeset/deep-link-overall-code.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-Added `codeScope=overall` parameter to the SonarQubeCard deep link URL, so the link navigates to the Overall Code tab instead of the default New Code tab in SonarQube.

--- a/workspaces/sonarqube/packages/app-next/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app-next
 
+## 0.0.31
+
+### Patch Changes
+
+- Updated dependencies [eea16f0]
+  - @backstage-community/plugin-sonarqube@0.22.1
+
 ## 0.0.30
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app-next/package.json
+++ b/workspaces/sonarqube/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/packages/app/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.32
+
+### Patch Changes
+
+- Updated dependencies [eea16f0]
+  - @backstage-community/plugin-sonarqube@0.22.1
+
 ## 0.0.31
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app/package.json
+++ b/workspaces/sonarqube/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.22.1
+
+### Patch Changes
+
+- eea16f0: Added `codeScope=overall` parameter to the SonarQubeCard deep link URL, so the link navigates to the Overall Code tab instead of the default New Code tab in SonarQube.
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.22.1

### Patch Changes

-   eea16f0: Added `codeScope=overall` parameter to the SonarQubeCard deep link URL, so the link navigates to the Overall Code tab instead of the default New Code tab in SonarQube.

## app@0.0.32

### Patch Changes

-   Updated dependencies [eea16f0]
    -   @backstage-community/plugin-sonarqube@0.22.1

## app-next@0.0.31

### Patch Changes

-   Updated dependencies [eea16f0]
    -   @backstage-community/plugin-sonarqube@0.22.1
