### PR TITLE
fix: revert uuid from v13 to v11

### DIFF
--- a/workspaces/announcements/.changeset/tricky-files-lick.md
+++ b/workspaces/announcements/.changeset/tricky-files-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-backend': patch
+---
+
+Reverts upgrading the uuid library to v11 after upgrading from v9 -> v13 as v11 is the latest version compatible with the current version of Backstage.

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -52,7 +52,7 @@
     "knex": "^3.0.1",
     "luxon": "^3.2.0",
     "slugify": "^1.6.6",
-    "uuid": "^13.0.0"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.35.1",

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -1372,7 +1372,7 @@ __metadata:
     luxon: "npm:^3.2.0"
     slugify: "npm:^1.6.6"
     supertest: "npm:^7.0.0"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.0.0"
   languageName: unknown
   linkType: soft
 
@@ -31031,15 +31031,6 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/251385563195709eb0697c74a834764eef28e1656d61174e35edbd129288acb4d95a43f4ce8a77b8c2fc128e2b55924296a0945f964b05b9173469d045625ff2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

tbh, not 100% sure, but hoping this should resolve https://github.com/backstage/community-plugins/issues/6754. 

I chose to revert this back to v11 after searching what other plugins are doing

https://github.com/search?q=repo%3Abackstage%2Fbackstage+%22%5C%22uuid%5C%22%3A+%5C%22%22&type=code

https://github.com/search?q=repo%3Abackstage%2Fcommunity-plugins++%22%5C%22uuid%5C%22%3A+%5C%22%22&type=code

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
