### PR TITLE
chore(repo): auto update api-reports in version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -163,6 +163,8 @@ jobs:
               echo "Creating new branch"
               git checkout -b "$BRANCH_NAME"
           fi
+
+      # Run the version bump
       - name: Run backstage-cli versions:bump --release ${{ inputs.release_line || 'main' }} command
         working-directory: ./workspaces/${{ matrix.workspace }}
         run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'main' }}
@@ -171,6 +173,13 @@ jobs:
       - name: Run dedupe
         working-directory: ./workspaces/${{ matrix.workspace }}
         run: yarn dedupe
+
+      # Update report-api as well
+      - name: Update api reports
+        working-directory: ./workspaces/${{ matrix.workspace }}
+        run: yarn tsc && yarn build:all && yarn build:api-reports
+        continue-on-error: true
+
       - name: 'Check for changes'
         id: check_for_changes
         run: |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This resolves (hopefully) #6112

Some version bump changes requires also that the api-report or knip-reports needs to be changed.

This regenerates the api-report, and for workspaces that has opt-in for knip-reports also these reports in the version bump workflow.

### Version bump issues before

For 1.45 PR #6096 needs to be updated manually to resolve https://github.com/backstage/community-plugins/actions/runs/19549391233/job/55976586316?pr=6096

<img width="975" height="408" alt="image" src="https://github.com/user-attachments/assets/f3fab212-6da8-42dd-b68d-bfd70e0e6241" />

### With this PR

<img width="929" height="262" alt="image" src="https://github.com/user-attachments/assets/1e296780-e614-4233-9d78-eb53bf246197" />

<img width="929" height="473" alt="image" src="https://github.com/user-attachments/assets/7d0d283f-69f8-4aa4-8027-b4d0522f7b86" />

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
