### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/crazy-insects-push.md
+++ b/workspaces/servicenow/.changeset/crazy-insects-push.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-servicenow': patch
----
-
-- Added internationalization (i18n) support with translations for German, French, Spanish, Italian, and Japanese

--- a/workspaces/servicenow/.changeset/renovate-59a068d.md
+++ b/workspaces/servicenow/.changeset/renovate-59a068d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': patch
----
-
-Updated dependency `supertest` to `^7.0.0`.

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.5.1
+
+### Patch Changes
+
+- 6d3ed24: Updated dependency `supertest` to `^7.0.0`.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-servicenow
 
+## 1.5.1
+
+### Patch Changes
+
+- 40b4d6c: - Added internationalization (i18n) support with translations for German, French, Spanish, Italian, and Japanese
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.5.1

### Patch Changes

-   40b4d6c: - Added internationalization (i18n) support with translations for German, French, Spanish, Italian, and Japanese

## @backstage-community/plugin-servicenow-backend@1.5.1

### Patch Changes

-   6d3ed24: Updated dependency `supertest` to `^7.0.0`.
