### PR TITLE
Version Packages (newrelic)

### DIFF
--- a/workspaces/newrelic/.changeset/famous-terms-jog.md
+++ b/workspaces/newrelic/.changeset/famous-terms-jog.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-newrelic-dashboard': minor
----
-
-Removes all existing deprecation notices. If you are still using `DashboardSnapshotComponent`, this will be a breaking change.

--- a/workspaces/newrelic/plugins/newrelic-dashboard/CHANGELOG.md
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-newrelic-dashboard
 
+## 0.19.0
+
+### Minor Changes
+
+- 5711f69: Removes all existing deprecation notices. If you are still using `DashboardSnapshotComponent`, this will be a breaking change.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/newrelic/plugins/newrelic-dashboard/package.json
+++ b/workspaces/newrelic/plugins/newrelic-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-newrelic-dashboard",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "newrelic-dashboard",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-newrelic-dashboard@0.19.0

### Minor Changes

-   5711f69: Removes all existing deprecation notices. If you are still using `DashboardSnapshotComponent`, this will be a breaking change.
