### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/pink-trees-hide.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/pink-trees-hide.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': minor
----
-
-Adds ability to automatically create PRs/MRs to keep scaffolded repositories in sync with their source templates. Includes file comparison, multi-VCS support (GitHub/GitLab), and automatic reviewer assignment. By default, the feature is disabled and can be enabled in config.

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 2.11.0
+
+### Minor Changes
+
+- 76bfe5a: Adds ability to automatically create PRs/MRs to keep scaffolded repositories in sync with their source templates. Includes file comparison, multi-VCS support (GitHub/GitLab), and automatic reviewer assignment. By default, the feature is disabled and can be enabled in config.
+
 ## 2.10.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@2.11.0

### Minor Changes

-   76bfe5a: Adds ability to automatically create PRs/MRs to keep scaffolded repositories in sync with their source templates. Includes file comparison, multi-VCS support (GitHub/GitLab), and automatic reviewer assignment. By default, the feature is disabled and can be enabled in config.
