### PR TITLE
Fix dependabot issues on quay workspace

### DIFF
--- a/workspaces/quay/package.json
+++ b/workspaces/quay/package.json
@@ -51,7 +51,8 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "refractor@npm:3.6.0/prismjs": "^1.30.0"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -27841,13 +27841,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:~1.27.0":
-  version: 1.27.0
-  resolution: "prismjs@npm:1.27.0"
-  checksum: 10/dc83e2e09170b53526182f5435fae056fc200b109cac39faa88eb48d992311c7f59b94990318962fa93299190a9b33a404920ed150e5b364ce48c897f2ba1e8e
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^5.0.0":
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"


### PR DESCRIPTION
Upgraded dependencies: form-data, tar-fs, tmp, and @octokit/plugin-paginate-rest dependency

However, there are some dependencies that could not be upgraded:
1. @octokit/plugin-paginate-rest | target version: ≥ 9.2.2 | affected version: >= 1.0.0, < 9.2.2
`@backstage/backend-defaults → @octokit/rest@19.0.13 → @octokit/plugin-paginate-rest@6.1.2`
2. @octokit/plugin-paginate-rest | target version: ≥ 11.4.1 | affected version: >= 9.3.0-beta.1, < 11.4.1
`@backstage/plugin-scaffolder-backend-module-github → octokit@3.2.1 → @octokit/plugin-paginate-rest@11.3.1`
3. prismjs | target version: ≥ 1.30.0 **(can be fixed through forcing a resolution)** | affected version: < 1.30.0
`@backstage/core-components → react-syntax-highlighter@15.6.6 → refractor@3.6.0 → prismjs@1.27.0`
4. tmp | target version: ≥ 0.2.4 **(can be ignored because it is a cli dependency)** | affected version: <= 0.2.3
`@changesets/cli@2.27.12 → external-editor@3.1.0 → tmp@0.0.33`
5. cookie | target version: ≥ 0.7.0 | affected version: < 0.7.0
`@backstage-community/plugin-quay → msw@1.3.5 → cookie@0.4.2`
6. tar-fs | target version: ≥ 2.1.3 **(testcontainers can be ignored)** | affected version: >= 2.0.0, < 2.1.3
`testcontainers@10.17.2 → dockerode@3.3.5 → tar-fs@2.0.1`
`@backstage/plugin-techdocs-node → dockerode@4.0.4 → tar-fs@2.0.1`