### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/nervous-geckos-act.md
+++ b/workspaces/azure-devops/.changeset/nervous-geckos-act.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Added an icon to the `azureDevOpsWikiArticleSearchResultListItem` used by the New Frontend System so that the results look better and easier to identify where they come from.

--- a/workspaces/azure-devops/.changeset/three-cooks-travel.md
+++ b/workspaces/azure-devops/.changeset/three-cooks-travel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-azure-devops': patch
----
-
-Updated the `titleSuffix` to be optional in the config schema, the code already handles it as optional everywhere else.

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.24.1
+
+### Patch Changes
+
+- 2d46e09: Added an icon to the `azureDevOpsWikiArticleSearchResultListItem` used by the New Frontend System so that the results look better and easier to identify where they come from.
+
 ## 0.24.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-azure-devops
 
+## 0.2.1
+
+### Patch Changes
+
+- 50fe5c4: Updated the `titleSuffix` to be optional in the config schema, the code already handles it as optional everywhere else.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "name": "@backstage-community/plugin-search-backend-module-azure-devops",
   "description": "The azure-devops backend module for the search plugin.",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.24.1

### Patch Changes

-   2d46e09: Added an icon to the `azureDevOpsWikiArticleSearchResultListItem` used by the New Frontend System so that the results look better and easier to identify where they come from.

## @backstage-community/plugin-search-backend-module-azure-devops@0.2.1

### Patch Changes

-   50fe5c4: Updated the `titleSuffix` to be optional in the config schema, the code already handles it as optional everywhere else.
