### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/olive-bananas-pull.md
+++ b/workspaces/kiali/.changeset/olive-bananas-pull.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
----
-
-Added support for basicAuth in Kiali plugin configuration and fetch. KialiFetcher now includes Authorization header if basicAuth is present.

--- a/workspaces/kiali/.changeset/open-parents-sell.md
+++ b/workspaces/kiali/.changeset/open-parents-sell.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-kiali-backend': minor
-'@backstage-community/plugin-kiali-common': minor
-'@backstage-community/plugin-kiali-react': minor
-'@backstage-community/plugin-kiali': minor
----
-
-Dependency upgrade: react-icons, supertest, monorepo

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.28.0
+
+### Minor Changes
+
+- 0a2dc47: Added support for basicAuth in Kiali plugin configuration and fetch. KialiFetcher now includes Authorization header if basicAuth is present.
+- 6de187e: Dependency upgrade: react-icons, supertest, monorepo
+
 ## 1.27.2
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.27.2",
+  "version": "1.28.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-common
 
+## 0.9.0
+
+### Minor Changes
+
+- 6de187e: Dependency upgrade: react-icons, supertest, monorepo
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-kiali-react
 
+## 0.6.0
+
+### Minor Changes
+
+- 6de187e: Dependency upgrade: react-icons, supertest, monorepo
+
+### Patch Changes
+
+- Updated dependencies [6de187e]
+  - @backstage-community/plugin-kiali-common@0.9.0
+
 ## 0.5.2
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Dependencies
 
+## 1.48.0
+
+### Minor Changes
+
+- 6de187e: Dependency upgrade: react-icons, supertest, monorepo
+
+### Patch Changes
+
+- Updated dependencies [6de187e]
+  - @backstage-community/plugin-kiali-common@0.9.0
+  - @backstage-community/plugin-kiali-react@0.6.0
+
 ## 1.47.0
 
 ### Minor Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.48.0

### Minor Changes

-   6de187e: Dependency upgrade: react-icons, supertest, monorepo

### Patch Changes

-   Updated dependencies [6de187e]
    -   @backstage-community/plugin-kiali-common@0.9.0
    -   @backstage-community/plugin-kiali-react@0.6.0

## @backstage-community/plugin-kiali-backend@1.28.0

### Minor Changes

-   0a2dc47: Added support for basicAuth in Kiali plugin configuration and fetch. KialiFetcher now includes Authorization header if basicAuth is present.
-   6de187e: Dependency upgrade: react-icons, supertest, monorepo

## @backstage-community/plugin-kiali-common@0.9.0

### Minor Changes

-   6de187e: Dependency upgrade: react-icons, supertest, monorepo

## @backstage-community/plugin-kiali-react@0.6.0

### Minor Changes

-   6de187e: Dependency upgrade: react-icons, supertest, monorepo

### Patch Changes

-   Updated dependencies [6de187e]
    -   @backstage-community/plugin-kiali-common@0.9.0
