### PR TITLE
Version Packages (bitbucket-pull-requests)

### DIFF
--- a/workspaces/bitbucket-pull-requests/.changeset/eight-plums-admire.md
+++ b/workspaces/bitbucket-pull-requests/.changeset/eight-plums-admire.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bitbucket-pull-requests': patch
----
-
-Replace cross-fetch with Backstage fetchApi and add config visibility for bitbucket.proxyPath

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-bitbucket-pull-requests
 
+## 3.0.1
+
+### Patch Changes
+
+- d1c665e: Replace cross-fetch with Backstage fetchApi and add config visibility for bitbucket.proxyPath
+
 ## 3.0.0
 
 ### Major Changes

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bitbucket-pull-requests",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-bitbucket-pull-requests@3.0.1

### Patch Changes

-   d1c665e: Replace cross-fetch with Backstage fetchApi and add config visibility for bitbucket.proxyPath
