### PR TITLE
costOverviewCard scroll

### DIFF
--- a/workspaces/cost-insights/.changeset/pink-ghosts-applaud.md
+++ b/workspaces/cost-insights/.changeset/pink-ghosts-applaud.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cost-insights': patch
+---
+
+The cost breakdown tab for the cost insights page will have a horizontal scroll when adding multiple cost breakdowns

--- a/workspaces/cost-insights/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
+++ b/workspaces/cost-insights/plugins/cost-insights/src/components/CostOverviewCard/CostOverviewCard.tsx
@@ -90,6 +90,8 @@ export const CostOverviewCard = ({
           indicatorColor="primary"
           onChange={(_, index) => setTabIndex(index)}
           value={safeTabIndex}
+          variant="scrollable"
+          scrollButtons="auto"
         >
           {tabs.map((tab, index) => (
             <Tab


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #5353

The costOverviewCard has a tab header that did not have scrolling enabled, producing some of our cost breakdowns not to shown like you can see in the issue #5353

The current behaviour is shown in this video:

https://github.com/user-attachments/assets/aafc6b04-2f2b-4707-ad34-f1b1954da74a




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
