### PR TITLE
fix(repo): align the generated api-report in the version bump step with the CI check

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -177,7 +177,7 @@ jobs:
       # Update report-api as well
       - name: Update api reports
         working-directory: ./workspaces/${{ matrix.workspace }}
-        run: yarn tsc && yarn build:all && yarn build:api-reports
+        run: yarn tsc:full && yarn build:api-reports:only
         continue-on-error: true
 
       - name: 'Check for changes'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a follow-up on #6769 after I noticed in #6797 that the generated report-api in the version bump step doesn't match them in the CI job.

With this change this should work again.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
