### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/clean-fireants-sort.md
+++ b/workspaces/announcements/.changeset/clean-fireants-sort.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-For users on the new frontend system:
-
-- Prevents announcements table from erroring on invalid publisher ref
-- Fixes the size of the active status indicator and prevents it from stretching next to a smaller announcement title

--- a/workspaces/announcements/.changeset/cuddly-flies-poke.md
+++ b/workspaces/announcements/.changeset/cuddly-flies-poke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-The announcements table in the admin portal has been rewritten with `@backstage/ui` for users on the new frontend system. Users on the existing frontend system will not see any changes.

--- a/workspaces/announcements/.changeset/happy-dolls-fry.md
+++ b/workspaces/announcements/.changeset/happy-dolls-fry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements-react': patch
----
-
-Add translation for "Back to admin" button text

--- a/workspaces/announcements/.changeset/mean-ants-report.md
+++ b/workspaces/announcements/.changeset/mean-ants-report.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Update the back to announcements button to recognize whether to take you back to list of announcements or admin portal depending on where you came from.

--- a/workspaces/announcements/.changeset/pretty-rings-wink.md
+++ b/workspaces/announcements/.changeset/pretty-rings-wink.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-The announcements page in the new frontend system now shows only active announcements by default. For the existing frontend system, the `hideInactive` prop must still be passed to the `AnnouncementsPage` component to hide inactive announcements.

--- a/workspaces/announcements/.changeset/wise-fishes-visit.md
+++ b/workspaces/announcements/.changeset/wise-fishes-visit.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements-react': patch
----
-
-Add translation support for the message shown when deleting an announcement

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.18.1
+
+### Patch Changes
+
+- a6d55dd: Add translation for "Back to admin" button text
+- a065bb2: Add translation support for the message shown when deleting an announcement
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @backstage-community/plugin-announcements
 
+## 1.3.1
+
+### Patch Changes
+
+- c107e8f: For users on the new frontend system:
+
+  - Prevents announcements table from erroring on invalid publisher ref
+  - Fixes the size of the active status indicator and prevents it from stretching next to a smaller announcement title
+
+- a065bb2: The announcements table in the admin portal has been rewritten with `@backstage/ui` for users on the new frontend system. Users on the existing frontend system will not see any changes.
+- a6d55dd: Update the back to announcements button to recognize whether to take you back to list of announcements or admin portal depending on where you came from.
+- cd38562: The announcements page in the new frontend system now shows only active announcements by default. For the existing frontend system, the `hideInactive` prop must still be passed to the `AnnouncementsPage` component to hide inactive announcements.
+- Updated dependencies [a6d55dd]
+- Updated dependencies [a065bb2]
+  - @backstage-community/plugin-announcements-react@0.18.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@1.3.1

### Patch Changes

-   c107e8f: For users on the new frontend system:

    -   Prevents announcements table from erroring on invalid publisher ref
    -   Fixes the size of the active status indicator and prevents it from stretching next to a smaller announcement title

-   a065bb2: The announcements table in the admin portal has been rewritten with `@backstage/ui` for users on the new frontend system. Users on the existing frontend system will not see any changes.

-   a6d55dd: Update the back to announcements button to recognize whether to take you back to list of announcements or admin portal depending on where you came from.

-   cd38562: The announcements page in the new frontend system now shows only active announcements by default. For the existing frontend system, the `hideInactive` prop must still be passed to the `AnnouncementsPage` component to hide inactive announcements.

-   Updated dependencies [a6d55dd]

-   Updated dependencies [a065bb2]
    -   @backstage-community/plugin-announcements-react@0.18.1

## @backstage-community/plugin-announcements-react@0.18.1

### Patch Changes

-   a6d55dd: Add translation for "Back to admin" button text
-   a065bb2: Add translation support for the message shown when deleting an announcement
