### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-3efaa88.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-3efaa88.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.90.2`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-7168083.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-7168083.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.90.1`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-46-2.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-46-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': minor
----
-
-Backstage version bump to v1.46.2

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Dependencies
 
+## 2.12.0
+
+### Minor Changes
+
+- 01e2d87: Backstage version bump to v1.46.2
+
+### Patch Changes
+
+- fb94653: Updated dependency `@hey-api/openapi-ts` to `0.90.2`.
+- b2c4feb: Updated dependency `@hey-api/openapi-ts` to `0.90.1`.
+
 ## 2.11.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.12.0

### Minor Changes

-   01e2d87: Backstage version bump to v1.46.2

### Patch Changes

-   fb94653: Updated dependency `@hey-api/openapi-ts` to `0.90.2`.
-   b2c4feb: Updated dependency `@hey-api/openapi-ts` to `0.90.1`.
