### PR TITLE
docs - Explicit version bump requirement for Plugin Owners

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -19,12 +19,22 @@
   - [Maintaining and patching an older release line](#maintaining-and-patching-an-older-release-line)
     - [Patching an older release](#patching-an-older-release)
   - [FAQ](#faq)
+    - [The bot says I'm missing a changeset. How do I add one?](#the-bot-says-im-missing-a-changeset-how-do-i-add-one)
+    - [My PR is full of unrelated files ("Knip" changes, `yarn.lock` conflicts)!](#my-pr-is-full-of-unrelated-files-knip-changes-yarnlock-conflicts)
+    - [A GitHub check is stuck "waiting for status to be reported".](#a-github-check-is-stuck-waiting-for-status-to-be-reported)
+    - [The "API Report" check is failing.](#the-api-report-check-is-failing)
+    - [My build is failing with errors about `package.json` metadata.](#my-build-is-failing-with-errors-about-packagejson-metadata)
+    - [My CI workflow is failing due to linting errors.](#my-ci-workflow-is-failing-due-to-linting-errors)
+    - [How do I create a new plugin?](#how-do-i-create-a-new-plugin)
 
 ## Plugin Owner Expectations
 
 Plugin ownership is codified by the [CODEOWNERS](https://github.com/backstage/community-plugins/blob/main/.github/CODEOWNERS) file.
 
 Plugin ownership is a responsibility often taken on voluntarily and/or in addition to primary job roles. While there are expectations outlined here, this is **not a support commitment**. Timely responses are appreciated, but replies may not be immediate and will depend on availability.
+
+> [!IMPORTANT]
+> It is an explicit expectation that Plugin owners will [version bump](https://backstage.io/docs/getting-started/keeping-backstage-updated#updating-backstage-versions-with-backstage-cli) their plugins on a Monthly basis to keep them in line with Backstage versions. There is automation for [generating the version bump PR](#version-bumping) and the [optional ability to have the version bump PR automatically created](#opt-in-to-automatic-version-bump-prs) for you each month. We expect that this will mean you have roughly an hour or two commitment each month for this task. The Community Plugin Maintainers are happy to help with any issues you have with this process!
 
 ### PR Reviews & Merging
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the documentation around version bumps being a more explicit requirement for Plugins Owners. I don't think we made this clear in the docs right now. I'd also like to talk this over at the Community Plugins SIG next week on January 13th to make sure we are all aligned.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
