### PR TITLE
Version Packages (grafana)

### DIFF
--- a/workspaces/grafana/.changeset/empty-oranges-bake.md
+++ b/workspaces/grafana/.changeset/empty-oranges-bake.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': minor
----
-
-All existing deprecated references have been removed. If you were still using the `GRAFANA_ANNOTATION_TAG_SELECTOR` annotation, it is now required you replace it with the `GRAFANA_ANNOTATION_DASHBOARD_SELECTOR` annotation.

--- a/workspaces/grafana/plugins/grafana/CHANGELOG.md
+++ b/workspaces/grafana/plugins/grafana/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-grafana
 
+## 0.14.0
+
+### Minor Changes
+
+- 4477d23: All existing deprecated references have been removed. If you were still using the `GRAFANA_ANNOTATION_TAG_SELECTOR` annotation, it is now required you replace it with the `GRAFANA_ANNOTATION_DASHBOARD_SELECTOR` annotation.
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-grafana",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A Backstage backend plugin that integrates towards Grafana",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-grafana@0.14.0

### Minor Changes

-   4477d23: All existing deprecated references have been removed. If you were still using the `GRAFANA_ANNOTATION_TAG_SELECTOR` annotation, it is now required you replace it with the `GRAFANA_ANNOTATION_DASHBOARD_SELECTOR` annotation.
