### PR TITLE
fix(shortcuts): preserve query parameters on use current page

### DIFF
--- a/workspaces/shortcuts/.changeset/early-ghosts-grow.md
+++ b/workspaces/shortcuts/.changeset/early-ghosts-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-shortcuts': patch
+---
+
+Fixed bug in Shortcuts where 'Use Current Page' did not preserve query parameters.

--- a/workspaces/shortcuts/plugins/shortcuts/src/AddShortcut.test.tsx
+++ b/workspaces/shortcuts/plugins/shortcuts/src/AddShortcut.test.tsx
@@ -143,7 +143,7 @@ describe('AddShortcut', () => {
         <AddShortcut {...props} />,
       </TestApiProvider>,
       {
-        routeEntries: ['/some-initial-url'],
+        routeEntries: ['/some-initial-url?filter=owned&kind=component'],
       },
     );
 
@@ -152,7 +152,7 @@ describe('AddShortcut', () => {
     await waitFor(() => {
       expect(spy).toHaveBeenCalledWith({
         title: 'some document title',
-        url: '/some-initial-url',
+        url: '/some-initial-url?filter=owned&kind=component',
       });
     });
   });

--- a/workspaces/shortcuts/plugins/shortcuts/src/AddShortcut.tsx
+++ b/workspaces/shortcuts/plugins/shortcuts/src/AddShortcut.tsx
@@ -55,7 +55,7 @@ export const AddShortcut = ({
 }: Props) => {
   const classes = useStyles();
   const alertApi = useApi(alertApiRef);
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const [formValues, setFormValues] = useState<FormValues>();
   const open = Boolean(anchorEl);
   const analytics = useAnalytics();
@@ -82,7 +82,7 @@ export const AddShortcut = ({
   };
 
   const handlePaste = () => {
-    setFormValues({ url: pathname, title: document.title });
+    setFormValues({ url: `${pathname}${search}`, title: document.title });
   };
 
   const handleClose = () => {


### PR DESCRIPTION
When clicking on the "Use current page" link in the shortcuts menu, also save any query parameters in the current URL. This is useful, for example, when trying to create a shortcut to a specific filter in the catalog.

Closes #3823.

## Hey, I just made a Pull Request!

<img width="475" height="337" alt="Screenshot 2026-01-09 at 23 52 21" src="https://github.com/user-attachments/assets/6c935d54-07c3-4649-83d8-3ba92a67d2b0" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
