### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/legal-suns-lie.md
+++ b/workspaces/argocd/.changeset/legal-suns-lie.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': major
----
-
-Renamed @backstage-community/plugin-redhat-argocd-backend to @backstage-community/plugin-argocd-backend

--- a/workspaces/argocd/.changeset/olive-foxes-roll.md
+++ b/workspaces/argocd/.changeset/olive-foxes-roll.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-common': minor
----
-
-Renamed @backstage-community/plugin-redhat-argocd-common to @backstage-community/plugin-argocd-common

--- a/workspaces/argocd/.changeset/tall-tires-serve.md
+++ b/workspaces/argocd/.changeset/tall-tires-serve.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
----
-
-Renamed @backstage-community/plugin-redhat-argocd to @backstage-community/plugin-argocd

--- a/workspaces/argocd/.changeset/thirty-gifts-attend.md
+++ b/workspaces/argocd/.changeset/thirty-gifts-attend.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': major
----
-
-Release the major version of argocd backend plugin

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.0.0
+
+### Major Changes
+
+- 6d47b9f: Renamed @backstage-community/plugin-redhat-argocd-backend to @backstage-community/plugin-argocd-backend
+- 6d47b9f: Release the major version of argocd backend plugin
+
+### Patch Changes
+
+- Updated dependencies [6d47b9f]
+  - @backstage-community/plugin-argocd-common@1.12.0
+
 # @backstage-community/plugin-redhat-argocd-backend
 
 ## 0.13.0

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "0.13.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.12.0
+
+### Minor Changes
+
+- 6d47b9f: Renamed @backstage-community/plugin-redhat-argocd-common to @backstage-community/plugin-argocd-common
+
 # @backstage-community/plugin-redhat-argocd-common
 
 ## 1.11.0

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd
 
+## 2.4.0
+
+### Minor Changes
+
+- 6d47b9f: Renamed @backstage-community/plugin-redhat-argocd to @backstage-community/plugin-argocd
+
+### Patch Changes
+
+- Updated dependencies [6d47b9f]
+  - @backstage-community/plugin-argocd-common@1.12.0
+
 # @backstage-community/plugin-redhat-argocd
 
 ## 2.3.0

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd-backend@1.0.0

### Major Changes

-   6d47b9f: Renamed @backstage-community/plugin-redhat-argocd-backend to @backstage-community/plugin-argocd-backend
-   6d47b9f: Release the major version of argocd backend plugin

### Patch Changes

-   Updated dependencies [6d47b9f]
    -   @backstage-community/plugin-argocd-common@1.12.0

# @backstage-community/plugin-redhat-argocd-backend

## @backstage-community/plugin-argocd@2.4.0

### Minor Changes

-   6d47b9f: Renamed @backstage-community/plugin-redhat-argocd to @backstage-community/plugin-argocd

### Patch Changes

-   Updated dependencies [6d47b9f]
    -   @backstage-community/plugin-argocd-common@1.12.0

# @backstage-community/plugin-redhat-argocd

## @backstage-community/plugin-argocd-common@1.12.0

### Minor Changes

-   6d47b9f: Renamed @backstage-community/plugin-redhat-argocd-common to @backstage-community/plugin-argocd-common

# @backstage-community/plugin-redhat-argocd-common
