### PR TITLE
fix(npm): update better-sqlite3 to Backstage 1.42+ aligned version to prepare Backstage 1.46 upgrade

### DIFF
--- a/workspaces/npm/packages/backend/package.json
+++ b/workspaces/npm/packages/backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/plugin-search-backend-node": "^1.3.17",
     "@backstage/plugin-techdocs-backend": "^2.1.2",
     "app": "link:../app",
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": "^12.0.0",
     "node-gyp": "^10.0.0",
     "pg": "^8.11.3"
   },

--- a/workspaces/npm/yarn.lock
+++ b/workspaces/npm/yarn.lock
@@ -14771,7 +14771,7 @@ __metadata:
     "@backstage/plugin-search-backend-node": "npm:^1.3.17"
     "@backstage/plugin-techdocs-backend": "npm:^2.1.2"
     app: "link:../app"
-    better-sqlite3: "npm:^9.0.0"
+    better-sqlite3: "npm:^12.0.0"
     node-gyp: "npm:^10.0.0"
     pg: "npm:^8.11.3"
   languageName: unknown
@@ -14916,17 +14916,6 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
   checksum: 10/2662e321237624d5813a7b97528dfc11fc5110b068d57f4096de82d7136e7e4a4b722a2a4266ddfb5095070712fd3d2542f6212ccb68e2d3eb2042498269e1cf
-  languageName: node
-  linkType: hard
-
-"better-sqlite3@npm:^9.0.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
-  dependencies:
-    bindings: "npm:^1.5.0"
-    node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/06b3d95221071a06c2e22a9746d9b7049c0bce7962e5e3290ccf088fffbf4d4d52868f0d98b8ae2565fe33b1adab89823145f23c6f6eb63ecc4fc1b883f9082c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After the switch from Node 20 and 22 to Node 22 and 24 with #6719 I noticed in #6797 that the Node 22 job passed but 24 failed with an native compiler issue of better-sqlite3.

Failed job: https://github.com/backstage/community-plugins/actions/runs/20798977522/job/59739553355?pr=6797

<img width="2019" height="699" alt="image" src="https://github.com/user-attachments/assets/b83f472c-6c5a-4b43-a284-a141cd660ce0" />

This dependency is only used in the Backstage backend of the included test apps, and was updated in Backstage 1.42 from better-sqlite 9 to 12, see https://backstage.github.io/upgrade-helper/?from=1.41.0&to=1.42.0&yarnPlugin=0.

This PR will not solve the Node 24 CI errors, but it will allow us to use the version bump to Backstage 1.46 (next week)!

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
