### PR TITLE
Version Packages (report-portal)

### DIFF
--- a/workspaces/report-portal/.changeset/fix-branding-consistency.md
+++ b/workspaces/report-portal/.changeset/fix-branding-consistency.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-report-portal': patch
-'@backstage-community/plugin-report-portal-backend': patch
-'@backstage-community/plugin-report-portal-common': patch
-'@backstage-community/plugin-search-backend-module-report-portal': patch
----
-
-Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io

--- a/workspaces/report-portal/plugins/report-portal-backend/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/report-portal-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-report-portal-backend
 
+## 1.1.2
+
+### Patch Changes
+
+- 68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
+
 ## 1.1.1
 
 ### Patch Changes

--- a/workspaces/report-portal/plugins/report-portal-backend/package.json
+++ b/workspaces/report-portal/plugins/report-portal-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-report-portal-backend",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/report-portal/plugins/report-portal-common/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/report-portal-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-report-portal-common
 
+## 1.2.1
+
+### Patch Changes
+
+- 68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/report-portal/plugins/report-portal-common/package.json
+++ b/workspaces/report-portal/plugins/report-portal-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-report-portal-common",
   "description": "Common functionalities for the report-portal plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/report-portal/plugins/report-portal/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/report-portal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-report-portal
 
+## 1.5.1
+
+### Patch Changes
+
+- 68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
+- Updated dependencies [68ca4ab]
+  - @backstage-community/plugin-report-portal-common@1.2.1
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/report-portal/plugins/report-portal/package.json
+++ b/workspaces/report-portal/plugins/report-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-report-portal",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-report-portal
 
+## 1.1.3
+
+### Patch Changes
+
+- 68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
+- Updated dependencies [68ca4ab]
+  - @backstage-community/plugin-report-portal-common@1.2.1
+
 ## 1.1.2
 
 ### Patch Changes

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/package.json
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-report-portal",
   "description": "The report-portal-collator backend module for the search plugin.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-report-portal@1.5.1

### Patch Changes

-   68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
-   Updated dependencies [68ca4ab]
    -   @backstage-community/plugin-report-portal-common@1.2.1

## @backstage-community/plugin-report-portal-backend@1.1.2

### Patch Changes

-   68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io

## @backstage-community/plugin-report-portal-common@1.2.1

### Patch Changes

-   68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io

## @backstage-community/plugin-search-backend-module-report-portal@1.1.3

### Patch Changes

-   68ca4ab: Fixed branding to use 'ReportPortal' (one word) instead of 'Report Portal' (two words) to align with official product branding from reportportal.io
-   Updated dependencies [68ca4ab]
    -   @backstage-community/plugin-report-portal-common@1.2.1
