### PR TITLE
announcements: fix where invalid publisher entity ref crashes announcements table in nfs

### DIFF
--- a/workspaces/announcements/.changeset/clean-fireants-sort.md
+++ b/workspaces/announcements/.changeset/clean-fireants-sort.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+For users on the new frontend system:
+
+- Prevents announcements table from erroring on invalid publisher ref
+- Fixes the size of the active status indicator and prevents it from stretching next to a smaller announcement title

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/ActiveInactiveAnnouncementIndicator.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/ActiveInactiveAnnouncementIndicator.tsx
@@ -68,15 +68,20 @@ export const ActiveInactiveAnnouncementIndicatorIcon = (props: {
   const { t } = useAnnouncementsTranslation();
 
   return (
-    <RiCircleFill
-      color={
-        announcement.active ? ACTIVE_INDICATOR_COLOR : INACTIVE_INDICATOR_COLOR
-      }
-      aria-label={
-        announcement.active
-          ? t('admin.announcementsContent.table.active')
-          : t('admin.announcementsContent.table.inactive')
-      }
-    />
+    <Flex style={{ flexShrink: 0 }} align="center">
+      <RiCircleFill
+        size="12"
+        color={
+          announcement.active
+            ? ACTIVE_INDICATOR_COLOR
+            : INACTIVE_INDICATOR_COLOR
+        }
+        aria-label={
+          announcement.active
+            ? t('admin.announcementsContent.table.active')
+            : t('admin.announcementsContent.table.inactive')
+        }
+      />
+    </Flex>
   );
 };

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsTable.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsTable.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DateTime } from 'luxon';
+import { screen } from '@testing-library/react';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { Announcement } from '@backstage-community/plugin-announcements-common';
+
+import { AnnouncementsTable } from './AnnouncementsTable';
+import { rootRouteRef } from '../../../../routes';
+
+const renderAnnouncementsTable = async (announcements: Announcement[]) => {
+  await renderInTestApp(
+    <TestApiProvider apis={[[catalogApiRef, catalogApiMock()]]}>
+      <AnnouncementsTable data={announcements} />
+    </TestApiProvider>,
+    {
+      mountedRoutes: {
+        '/announcements': rootRouteRef,
+        '/catalog/:namespace/:kind/:name': entityRouteRef,
+      },
+    },
+  );
+};
+
+describe('AnnouncementsTable', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty state when no announcements', async () => {
+    await renderAnnouncementsTable([]);
+
+    expect(screen.getByText(/No announcements found/i)).toBeInTheDocument();
+  });
+
+  describe('publisher', () => {
+    it('renders announcement with valid entityRef publisher', async () => {
+      const announcement: Announcement = {
+        id: '1',
+        title: 'Test Announcement',
+        excerpt: 'Test Excerpt',
+        body: 'Test Body',
+        publisher: 'user:default/test-user',
+        created_at: DateTime.now().toISO(),
+        updated_at: DateTime.now().toISO(),
+        active: true,
+        start_at: DateTime.now().toISO(),
+      };
+
+      await renderAnnouncementsTable([announcement]);
+
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('renders empty placeholder when publisher is missing', async () => {
+      const announcement: Announcement = {
+        id: '1',
+        title: 'Test Announcement',
+        excerpt: 'Test Excerpt',
+        body: 'Test Body',
+        publisher: '',
+        created_at: DateTime.now().toISO(),
+        updated_at: DateTime.now().toISO(),
+        active: true,
+        start_at: DateTime.now().toISO(),
+      };
+
+      await renderAnnouncementsTable([announcement]);
+
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+      // Should not crash - empty placeholder should be rendered
+      const cells = screen.getAllByText('-');
+      expect(cells.length).toBeGreaterThan(0);
+    });
+
+    it('handles invalid entityRef publisher gracefully without crashing', async () => {
+      const announcement: Announcement = {
+        id: '1',
+        title: 'Test Announcement',
+        excerpt: 'Test Excerpt',
+        body: 'Test Body',
+        publisher: 'invalid-entity-ref',
+        created_at: DateTime.now().toISO(),
+        updated_at: DateTime.now().toISO(),
+        active: true,
+        start_at: DateTime.now().toISO(),
+      };
+
+      // This should not throw an error
+      await expect(
+        renderAnnouncementsTable([announcement]),
+      ).resolves.not.toThrow();
+
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+    });
+
+    it('handles malformed entityRef publisher gracefully without crashing', async () => {
+      const announcement: Announcement = {
+        id: '1',
+        title: 'Test Announcement',
+        excerpt: 'Test Excerpt',
+        body: 'Test Body',
+        publisher: 'fdasfdsafs',
+        created_at: DateTime.now().toISO(),
+        updated_at: DateTime.now().toISO(),
+        active: true,
+        start_at: DateTime.now().toISO(),
+      };
+
+      // This should not throw an error
+      await expect(
+        renderAnnouncementsTable([announcement]),
+      ).resolves.not.toThrow();
+
+      expect(screen.getByText('Test Announcement')).toBeInTheDocument();
+      const cells = screen.getAllByText('-');
+      expect(cells.length).toBeGreaterThan(0);
+    });
+
+    it('renders multiple announcements with mixed valid and invalid publishers', async () => {
+      const announcements: Announcement[] = [
+        {
+          id: '1',
+          title: 'Valid Publisher',
+          excerpt: 'Excerpt 1',
+          body: 'Body 1',
+          publisher: 'user:default/valid-user',
+          created_at: DateTime.now().toISO(),
+          updated_at: DateTime.now().toISO(),
+          active: true,
+          start_at: DateTime.now().toISO(),
+        },
+        {
+          id: '2',
+          title: 'Invalid Publisher',
+          excerpt: 'Excerpt 2',
+          body: 'Body 2',
+          publisher: 'invalid-ref',
+          created_at: DateTime.now().toISO(),
+          updated_at: DateTime.now().toISO(),
+          active: true,
+          start_at: DateTime.now().toISO(),
+        },
+        {
+          id: '3',
+          title: 'No Publisher',
+          excerpt: 'Excerpt 3',
+          body: 'Body 3',
+          publisher: '',
+          created_at: DateTime.now().toISO(),
+          updated_at: DateTime.now().toISO(),
+          active: true,
+          start_at: DateTime.now().toISO(),
+        },
+      ];
+
+      // This should not throw an error
+      await expect(
+        renderAnnouncementsTable(announcements),
+      ).resolves.not.toThrow();
+
+      expect(screen.getByText('Valid Publisher')).toBeInTheDocument();
+      expect(screen.getByText('Invalid Publisher')).toBeInTheDocument();
+      expect(screen.getByText('No Publisher')).toBeInTheDocument();
+    });
+  });
+});

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsTable.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsTable.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { DateTime } from 'luxon';
+import { parseEntityRef } from '@backstage/catalog-model';
 import { Announcement } from '@backstage-community/plugin-announcements-common';
 import { useAnnouncementsTranslation } from '@backstage-community/plugin-announcements-react';
 import {
@@ -62,6 +63,18 @@ const EmptyPlaceholder = () => {
   return <CellText title="-" />;
 };
 
+const isValidEntityRef = (entityRef: string): boolean => {
+  if (!entityRef) {
+    return false;
+  }
+  try {
+    parseEntityRef(entityRef);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const AnnouncementTableRow = (props: AnnouncementTableRowProps) => {
   const {
     announcement,
@@ -80,6 +93,9 @@ const AnnouncementTableRow = (props: AnnouncementTableRowProps) => {
     return `${text.substring(0, maxLength)}...`;
   };
 
+  const hasValidPublisher =
+    announcement.publisher && isValidEntityRef(announcement.publisher);
+
   return (
     <Row key={announcement.id}>
       <Cell>
@@ -95,9 +111,15 @@ const AnnouncementTableRow = (props: AnnouncementTableRowProps) => {
       <Cell>
         <Text variant="body-small">{truncateText(announcement.body)}</Text>
       </Cell>
-      <Cell>
-        <EntityRefLink entityRef={announcement.publisher} />
-      </Cell>
+
+      {hasValidPublisher ? (
+        <Cell>
+          <EntityRefLink entityRef={parseEntityRef(announcement.publisher)} />
+        </Cell>
+      ) : (
+        <EmptyPlaceholder />
+      )}
+
       {announcement.category ? (
         <Cell>
           <Text variant="body-small">{announcement.category.title}</Text>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Passing an invalid value to `<EntityRefLink />` for publisher would cause the entire table to crash. This fix ensures that won't happen with tests to prevent regression. 

It also includes a small change to prevent the active status indicator from stretching when next to a small announcement title.

<img width="181" height="401" alt="image" src="https://github.com/user-attachments/assets/0650deec-1983-4e35-8228-ece9f8f61b2d" />

<img width="1309" height="476" alt="image" src="https://github.com/user-attachments/assets/bd533337-7887-43ae-9896-c93b8759bf37" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
