### PR TITLE
Version Packages (scaffolder-backend-module-kubernetes)

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/renovate-95136b6.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/renovate-95136b6.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': patch
----
-
-Updated dependency `@kubernetes/client-node` to `1.4.0`.

--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-46-2.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-46-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': minor
----
-
-Backstage version bump to v1.46.2

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Dependencies
 
+## 2.14.0
+
+### Minor Changes
+
+- 65b2acf: Backstage version bump to v1.46.2
+
+### Patch Changes
+
+- 536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
+
 ## 2.13.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.14.0

### Minor Changes

-   65b2acf: Backstage version bump to v1.46.2

### Patch Changes

-   536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
