### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/renovate-95136b6.md
+++ b/workspaces/argocd/.changeset/renovate-95136b6.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd-common': patch
-'@backstage-community/plugin-argocd': patch
----
-
-Updated dependency `@kubernetes/client-node` to `1.4.0`.

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.0.1
+
+### Patch Changes
+
+- 536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
+- Updated dependencies [536b783]
+  - @backstage-community/plugin-argocd-common@1.12.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.12.1
+
+### Patch Changes
+
+- 536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-argocd
 
+## 2.4.1
+
+### Patch Changes
+
+- 536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
+- Updated dependencies [536b783]
+  - @backstage-community/plugin-argocd-common@1.12.1
+
 ## 2.4.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.4.1

### Patch Changes

-   536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
-   Updated dependencies [536b783]
    -   @backstage-community/plugin-argocd-common@1.12.1

## @backstage-community/plugin-argocd-backend@1.0.1

### Patch Changes

-   536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
-   Updated dependencies [536b783]
    -   @backstage-community/plugin-argocd-common@1.12.1

## @backstage-community/plugin-argocd-common@1.12.1

### Patch Changes

-   536b783: Updated dependency `@kubernetes/client-node` to `1.4.0`.
