### PR TITLE
Version Packages (sonarqube)

### DIFF
--- a/workspaces/sonarqube/.changeset/fix-gate-link-new-tab.md
+++ b/workspaces/sonarqube/.changeset/fix-gate-link-new-tab.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-sonarqube': patch
----
-
-Fixed the "Gate passed/failed" button on the SonarCloud scorecard to open in a new tab, consistent with other links on the card.

--- a/workspaces/sonarqube/packages/app-next/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app-next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app-next
 
+## 0.0.32
+
+### Patch Changes
+
+- Updated dependencies [10bbfbd]
+  - @backstage-community/plugin-sonarqube@0.22.2
+
 ## 0.0.31
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app-next/package.json
+++ b/workspaces/sonarqube/packages/app-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-next",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/packages/app/CHANGELOG.md
+++ b/workspaces/sonarqube/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.33
+
+### Patch Changes
+
+- Updated dependencies [10bbfbd]
+  - @backstage-community/plugin-sonarqube@0.22.2
+
 ## 0.0.32
 
 ### Patch Changes

--- a/workspaces/sonarqube/packages/app/package.json
+++ b/workspaces/sonarqube/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
+++ b/workspaces/sonarqube/plugins/sonarqube/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-sonarqube
 
+## 0.22.2
+
+### Patch Changes
+
+- 10bbfbd: Fixed the "Gate passed/failed" button on the SonarCloud scorecard to open in a new tab, consistent with other links on the card.
+
 ## 0.22.1
 
 ### Patch Changes

--- a/workspaces/sonarqube/plugins/sonarqube/package.json
+++ b/workspaces/sonarqube/plugins/sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-sonarqube",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-sonarqube@0.22.2

### Patch Changes

-   10bbfbd: Fixed the "Gate passed/failed" button on the SonarCloud scorecard to open in a new tab, consistent with other links on the card.

## app@0.0.33

### Patch Changes

-   Updated dependencies [10bbfbd]
    -   @backstage-community/plugin-sonarqube@0.22.2

## app-next@0.0.32

### Patch Changes

-   Updated dependencies [10bbfbd]
    -   @backstage-community/plugin-sonarqube@0.22.2
