### PR TITLE
announcements: make "Back to announcements" button context-aware

### DIFF
--- a/workspaces/announcements/.changeset/happy-dolls-fry.md
+++ b/workspaces/announcements/.changeset/happy-dolls-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-react': patch
+---
+
+Add translation for "Back to admin" button text

--- a/workspaces/announcements/.changeset/mean-ants-report.md
+++ b/workspaces/announcements/.changeset/mean-ants-report.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Update the back to announcements button to recognize whether to take you back to list of announcements or admin portal depending on where you came from.

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -277,6 +277,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'viewAnnouncementPage.by': 'By';
     readonly 'viewAnnouncementPage.announcements': 'Announcements';
     readonly 'viewAnnouncementPage.backToAnnouncements': 'Back to announcements';
+    readonly 'viewAnnouncementPage.backToAdmin': 'Back to admin';
     readonly 'viewAnnouncementPage.notFound': 'Announcement not found';
     readonly 'viewAnnouncementPage.tagsAriaLabel': 'Announcement Tags';
     readonly 'newAnnouncementBanner.markAsSeen': 'Mark as seen';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -141,6 +141,7 @@ export const announcementsTranslationRef = createTranslationRef({
     },
     viewAnnouncementPage: {
       backToAnnouncements: 'Back to announcements',
+      backToAdmin: 'Back to admin',
       notFound: 'Announcement not found',
       tagsAriaLabel: 'Announcement Tags',
       by: 'By',

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsContent.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementsContent.tsx
@@ -96,7 +96,8 @@ export const AnnouncementsContent = ({
   };
 
   const onPreviewClick = (announcement: Announcement) => {
-    navigate(viewAnnouncementLink?.({ id: announcement.id }) ?? '');
+    const link = viewAnnouncementLink?.({ id: announcement.id }) ?? '';
+    navigate(`${link}?from=admin`);
   };
 
   const onEditClick = (announcement: Announcement) => {

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/announcements/ViewAnnouncementPage.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/announcements/ViewAnnouncementPage.tsx
@@ -38,7 +38,7 @@ import {
   useAnalytics,
 } from '@backstage/core-plugin-api';
 import { Alert } from '@material-ui/lab';
-import { RiArrowLeftLine, RiHashtag, RiPriceTag3Line } from '@remixicon/react';
+import { RiHashtag, RiPriceTag3Line } from '@remixicon/react';
 import { EntityRefLink } from '@backstage/plugin-catalog-react';
 import {
   announcementsApiRef,
@@ -55,6 +55,7 @@ import {
   MarkdownRenderer,
   MarkdownRendererTypeProps,
 } from '../../../components';
+import { BackToAnnouncementsButton } from '../shared';
 
 const AnnouncementCategoryBadge = (props: {
   category: Category | undefined;
@@ -94,22 +95,6 @@ const AnnouncementTagsTagGroup = (props: { tags: AnnouncementTag[] }) => {
         </Tag>
       ))}
     </TagGroup>
-  );
-};
-
-const BackToAnnouncementsButton = () => {
-  const announcementsLink = useRouteRef(rootRouteRef);
-  const { t } = useAnnouncementsTranslation();
-  return (
-    <Link href={announcementsLink()} color="secondary" variant="body-x-small">
-      <Flex align="center" gap="2">
-        <RiArrowLeftLine size={16} />
-        <Text variant="body-small">
-          {' '}
-          {t('viewAnnouncementPage.backToAnnouncements')}
-        </Text>
-      </Flex>
-    </Link>
   );
 };
 
@@ -231,7 +216,9 @@ export const ViewAnnouncementPage = (props: ViewAnnouncementPageProps) => {
           </Grid.Item>
 
           <Grid.Item>
-            <BackToAnnouncementsButton />
+            <Box mb="8">
+              <BackToAnnouncementsButton />
+            </Box>
           </Grid.Item>
         </Grid.Root>
       </Container>

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/BackToAnnouncementsButton.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/BackToAnnouncementsButton.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen } from '@testing-library/react';
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
+
+import { BackToAnnouncementsButton } from './BackToAnnouncementsButton';
+import { rootRouteRef } from '../../../../routes';
+
+const renderBackToAnnouncementsButton = (routeEntry?: string) => {
+  renderInTestApp(
+    <TestApiProvider apis={[]}>
+      <BackToAnnouncementsButton />
+    </TestApiProvider>,
+    {
+      mountedRoutes: {
+        '/announcements': rootRouteRef,
+      },
+      initialRouteEntries: routeEntry
+        ? [routeEntry]
+        : ['/announcements/view/1'],
+    },
+  );
+};
+
+describe('BackToAnnouncementsButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders back to announcements link when not from admin', () => {
+    renderBackToAnnouncementsButton('/announcements/view/1');
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/announcements');
+    expect(screen.getByText('Back to announcements')).toBeInTheDocument();
+  });
+
+  it('renders back to admin link when from=admin query parameter is present', () => {
+    renderBackToAnnouncementsButton('/announcements/view/1?from=admin');
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+
+    expect(link).toHaveAttribute('href', '/announcements/admin');
+    expect(screen.getByText('Back to admin')).toBeInTheDocument();
+  });
+
+  it('renders back to announcements link when from query parameter has different value', () => {
+    renderBackToAnnouncementsButton('/announcements/view/1?from=other');
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/announcements');
+    expect(screen.getByText('Back to announcements')).toBeInTheDocument();
+  });
+
+  it('handles multiple query parameters correctly', () => {
+    renderBackToAnnouncementsButton(
+      '/announcements/view/1?from=admin&other=value',
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/announcements/admin');
+    expect(screen.getByText('Back to admin')).toBeInTheDocument();
+  });
+});

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/BackToAnnouncementsButton.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/BackToAnnouncementsButton.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useAnnouncementsTranslation } from '@backstage-community/plugin-announcements-react';
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { Flex, Link, Text } from '@backstage/ui';
+import { RiArrowLeftLine } from '@remixicon/react';
+import { useLocation } from 'react-router-dom';
+
+import { rootRouteRef, announcementAdminRouteRef } from '../../../../routes';
+
+export const BackToAnnouncementsButton = () => {
+  const { t } = useAnnouncementsTranslation();
+  const location = useLocation();
+  const announcementsLink = useRouteRef(rootRouteRef);
+  const adminLink = useRouteRef(announcementAdminRouteRef);
+
+  const queryParams = new URLSearchParams(location.search);
+  const fromAdmin = queryParams.get('from') === 'admin';
+
+  const backLink = fromAdmin
+    ? adminLink?.() ?? '/'
+    : announcementsLink?.() ?? '/';
+
+  const backLinkText = fromAdmin
+    ? t('viewAnnouncementPage.backToAdmin')
+    : t('viewAnnouncementPage.backToAnnouncements');
+
+  return (
+    <Link href={backLink} color="secondary" variant="body-x-small">
+      <Flex align="center" gap="2">
+        <RiArrowLeftLine size={16} />
+        <Text variant="body-small"> {backLinkText}</Text>
+      </Flex>
+    </Link>
+  );
+};

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/shared/BackToAnnouncementsButton/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { BackToAnnouncementsButton } from './BackToAnnouncementsButton';

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/shared/index.ts
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/shared/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './BackToAnnouncementsButton';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the "Back to announcements" button to be context-aware. Now, the button will take users back to either the list of announcements or the admin portal, depending on where they navigated from. 

Additionally, translation support for the new "Back to admin" text has been added, and related code has been refactored and tested for this new behavior.

<img width="464" height="391" alt="image" src="https://github.com/user-attachments/assets/c24af6a2-32c9-49cb-934a-dab21c638eca" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
