### PR TITLE
fix(ocm): replace deprecated `createPermissionIntegrationRouter` with `permissionsRegistry`

### DIFF
--- a/workspaces/ocm/.changeset/fast-jokes-perform.md
+++ b/workspaces/ocm/.changeset/fast-jokes-perform.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-ocm-backend': patch
+---
+
+Replace deprecated `createPermissionIntegrationRouter` API call with `permissionsRegistry` to resolve deprecation warnings

--- a/workspaces/ocm/.prettierignore
+++ b/workspaces/ocm/.prettierignore
@@ -1,5 +1,6 @@
 dist
 dist-types
 coverage
+knip-report.md
 .vscode
 .eslintrc.js

--- a/workspaces/ocm/bcp.json
+++ b/workspaces/ocm/bcp.json
@@ -1,4 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": true,
+  "listDeprecations": true
 }

--- a/workspaces/ocm/packages/app/knip-report.md
+++ b/workspaces/ocm/packages/app/knip-report.md
@@ -14,3 +14,4 @@
 | @backstage/test-utils       | package.json:55:6 | error    |
 | @testing-library/dom        | package.json:57:6 | error    |
 | cross-env                   | package.json:62:6 | error    |
+

--- a/workspaces/ocm/packages/backend/knip-report.md
+++ b/workspaces/ocm/packages/backend/knip-report.md
@@ -12,3 +12,4 @@
 | node-gyp                              | package.json:47:6 | error    |
 | app                                   | package.json:45:6 | error    |
 | pg                                    | package.json:48:6 | error    |
+

--- a/workspaces/ocm/plugins/ocm-backend/knip-report.md
+++ b/workspaces/ocm/plugins/ocm-backend/knip-report.md
@@ -4,5 +4,6 @@
 
 | Name                                       | Location          | Severity |
 | :----------------------------------------- | :---------------- | :------- |
-| @backstage/backend-dynamic-feature-service | package.json:61:6 | error    |
-| @openapitools/openapi-generator-cli        | package.json:66:6 | error    |
+| @backstage/backend-dynamic-feature-service | package.json:60:6 | error    |
+| @openapitools/openapi-generator-cli        | package.json:65:6 | error    |
+

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -52,7 +52,6 @@
     "@backstage/errors": "^1.2.7",
     "@backstage/plugin-catalog-node": "^1.20.1",
     "@backstage/plugin-permission-common": "^0.9.3",
-    "@backstage/plugin-permission-node": "^0.10.7",
     "@kubernetes/client-node": "1.4.0",
     "express": "^4.18.2",
     "semver": "^7.5.4"

--- a/workspaces/ocm/plugins/ocm-backend/src/service/router.ts
+++ b/workspaces/ocm/plugins/ocm-backend/src/service/router.ts
@@ -28,7 +28,6 @@ import {
   AuthorizeResult,
   BasicPermission,
 } from '@backstage/plugin-permission-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 
 import express, { Request } from 'express';
 
@@ -69,12 +68,7 @@ async function createRouter(deps: {
   const { config, logger, httpAuth, permissions } = deps;
   const router = await createOpenApiRouter();
 
-  const permissionsIntegrationRouter = createPermissionIntegrationRouter({
-    permissions: ocmEntityPermissions,
-  });
-
   router.use(express.json());
-  router.use(permissionsIntegrationRouter);
 
   const providerConfigs = readOcmConfigs(config);
 
@@ -201,8 +195,18 @@ export const ocmPlugin = createBackendPlugin({
         http: coreServices.httpRouter,
         httpAuth: coreServices.httpAuth,
         permissions: coreServices.permissions,
+        permissionsRegistry: coreServices.permissionsRegistry,
       },
-      async init({ config, logger, http, httpAuth, permissions }) {
+      async init({
+        config,
+        logger,
+        http,
+        httpAuth,
+        permissions,
+        permissionsRegistry,
+      }) {
+        permissionsRegistry.addPermissions(ocmEntityPermissions);
+
         http.use(await createRouter({ config, logger, httpAuth, permissions }));
       },
     });

--- a/workspaces/ocm/plugins/ocm-common/knip-report.md
+++ b/workspaces/ocm/plugins/ocm-common/knip-report.md
@@ -1,1 +1,2 @@
 # Knip report
+

--- a/workspaces/ocm/plugins/ocm/knip-report.md
+++ b/workspaces/ocm/plugins/ocm/knip-report.md
@@ -14,3 +14,4 @@
 | @backstage/core-app-api     | package.json:59:6 | error    |
 | @testing-library/dom        | package.json:63:6 | error    |
 | msw                         | package.json:70:6 | error    |
+

--- a/workspaces/ocm/yarn.lock
+++ b/workspaces/ocm/yarn.lock
@@ -1478,7 +1478,6 @@ __metadata:
     "@backstage/plugin-catalog-backend": "npm:^3.3.0"
     "@backstage/plugin-catalog-node": "npm:^1.20.1"
     "@backstage/plugin-permission-common": "npm:^0.9.3"
-    "@backstage/plugin-permission-node": "npm:^0.10.7"
     "@kubernetes/client-node": "npm:1.4.0"
     "@openapitools/openapi-generator-cli": "npm:2.27.0"
     "@types/express": "npm:4.17.25"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. Enabled `knipReports` and `listDeprecations` for the CI
2. replace deprecated createPermissionIntegrationRouter with permissionsRegistry, by following https://backstage.io/docs/backend-system/core-services/permissions-registry/#migrating-from-createpermissionintegrationrouter to resolve the deprecation warning of `yarn backstage-cli repo list-deprecations`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
