### PR TITLE
fix(copilot): Changes app selection to require you to set AllowedInstallationOwners

### DIFF
--- a/workspaces/copilot/.changeset/pretty-weeks-kiss.md
+++ b/workspaces/copilot/.changeset/pretty-weeks-kiss.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+---
+
+Fixes the selection of the GithubApp to use to require you to set "allowedInstallationOwners" for the app you want to use.
+This might possibly be a breaking change if you were relying on the default behavior of picking the first app found and only using one app.

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
@@ -365,7 +365,7 @@ describe('getGithubCredentials', () => {
     );
   });
 
-  it('should use app with empty allowedInstallationOwners for any organization', async () => {
+  it('should require allowedInstallationOwners to be configured for organization', async () => {
     const mockConfig = mockServices.rootConfig({
       data: {
         integrations: {
@@ -379,7 +379,7 @@ describe('getGithubCredentials', () => {
                   clientSecret: 'test1',
                   privateKey: `test1`,
                   webhookSecret: 'shhh1',
-                  // No allowedInstallationOwners means it works for any org
+                  // No allowedInstallationOwners - should not be selected
                 },
               ],
             },
@@ -388,16 +388,15 @@ describe('getGithubCredentials', () => {
       },
     });
 
-    const result = await getGithubCredentials(mockConfig, {
-      host: 'github.com',
-      organization: 'any-org',
-      apiBaseUrl: '',
-    });
-
-    expect(result.enterprise).toBeUndefined();
-    expect(typeof result.organization).toBe('object');
-    expect(result.organization).toHaveProperty('appId', 1111);
-    expect(result.organization).toHaveProperty('privateKey');
+    await expect(
+      getGithubCredentials(mockConfig, {
+        host: 'github.com',
+        organization: 'any-org',
+        apiBaseUrl: '',
+      }),
+    ).rejects.toThrow(
+      'No GitHub App configured for organization "any-org". Check allowedInstallationOwners in your GitHub integration config.',
+    );
   });
 
   it('should match organization case-insensitively', async () => {

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
@@ -100,12 +100,13 @@ export const getGithubCredentials = async (
 
   if (organization) {
     if (githubConfig.apps && githubConfig.apps.length > 0) {
-      // Filter apps that allow this organization (case-insensitive comparison)
+      // Filter apps that explicitly allow this organization (case-insensitive comparison)
+      // Only select apps that have allowedInstallationOwners configured with the target org
       const orgLowerCase = organization.toLowerCase();
       const allowedApp = githubConfig.apps.find(
         app =>
-          !app.allowedInstallationOwners ||
-          app.allowedInstallationOwners.length === 0 ||
+          app.allowedInstallationOwners &&
+          app.allowedInstallationOwners.length > 0 &&
           app.allowedInstallationOwners.some(
             owner => owner.toLowerCase() === orgLowerCase,
           ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!
We ran into a problem with the app selection when we added a new integration app on the top of our integrations-config, this new all lacked the "allowedInstallationOwners".

So the app selection-logic simply selected this new app, which caused our stats to stop working.

So in order to mitigate this, I changed the logic to require you to set "allowedInstallationOwners" in your github app.

This is also already in the example documentation.

However, this might break some installations if they only use one app and it lacks this setting.

I thought about allowing the first app if only one is present, but opted not to do that since that might break things in the future if they add more apps.

This only affects Organisation-metrics and if you use a GithubApp. Enterprises and static tokens are not affected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
