### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/silver-papers-wash.md
+++ b/workspaces/argocd/.changeset/silver-papers-wash.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd': patch
----
-
-Removed deprecations, switched to using `permissionsRegistry` instead of `permissionIntegrationRouter`. Fixed ERR_HTTP_HEADERS_SENT error when permissions are missing.

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.0.2
+
+### Patch Changes
+
+- 9ed8237: Removed deprecations, switched to using `permissionsRegistry` instead of `permissionIntegrationRouter`. Fixed ERR_HTTP_HEADERS_SENT error when permissions are missing.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd
 
+## 2.4.2
+
+### Patch Changes
+
+- 9ed8237: Removed deprecations, switched to using `permissionsRegistry` instead of `permissionIntegrationRouter`. Fixed ERR_HTTP_HEADERS_SENT error when permissions are missing.
+
 ## 2.4.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.4.2

### Patch Changes

-   9ed8237: Removed deprecations, switched to using `permissionsRegistry` instead of `permissionIntegrationRouter`. Fixed ERR_HTTP_HEADERS_SENT error when permissions are missing.

## @backstage-community/plugin-argocd-backend@1.0.2

### Patch Changes

-   9ed8237: Removed deprecations, switched to using `permissionsRegistry` instead of `permissionIntegrationRouter`. Fixed ERR_HTTP_HEADERS_SENT error when permissions are missing.
