### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/metal-pets-hear.md
+++ b/workspaces/tech-insights/.changeset/metal-pets-hear.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-The new frontend system plugin now includes a tech insights navigation extension by default

--- a/workspaces/tech-insights/.changeset/wet-planes-beg.md
+++ b/workspaces/tech-insights/.changeset/wet-planes-beg.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': minor
----
-
-The plugin now supports the new frontend system by importing from `@backstage-community/plugin-tech-insights/alpha`.

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-tech-insights
 
+## 0.8.0
+
+### Minor Changes
+
+- b5f45fd: The plugin now supports the new frontend system by importing from `@backstage-community/plugin-tech-insights/alpha`.
+
+### Patch Changes
+
+- 450c5aa: The new frontend system plugin now includes a tech insights navigation extension by default
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights@0.8.0

### Minor Changes

-   b5f45fd: The plugin now supports the new frontend system by importing from `@backstage-community/plugin-tech-insights/alpha`.

### Patch Changes

-   450c5aa: The new frontend system plugin now includes a tech insights navigation extension by default
