### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/nice-ducks-love.md
+++ b/workspaces/cicd-statistics/.changeset/nice-ducks-love.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-buildkite': patch
-'@backstage-community/plugin-cicd-statistics-module-github': patch
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
-'@backstage-community/plugin-cicd-statistics': patch
----
-
-Remove unused dependencies

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.13.1
+
+### Patch Changes
+
+- 4e95de7: Remove unused dependencies
+- Updated dependencies [4e95de7]
+  - @backstage-community/plugin-cicd-statistics@0.14.1
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-github
 
+## 0.11.1
+
+### Patch Changes
+
+- 4e95de7: Remove unused dependencies
+- Updated dependencies [4e95de7]
+  - @backstage-community/plugin-cicd-statistics@0.14.1
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-github",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "CI/CD Statistics plugin module; Github CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.14.1
+
+### Patch Changes
+
+- 4e95de7: Remove unused dependencies
+- Updated dependencies [4e95de7]
+  - @backstage-community/plugin-cicd-statistics@0.14.1
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.14.1
+
+### Patch Changes
+
+- 4e95de7: Remove unused dependencies
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.14.1

### Patch Changes

-   4e95de7: Remove unused dependencies

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.13.1

### Patch Changes

-   4e95de7: Remove unused dependencies
-   Updated dependencies [4e95de7]
    -   @backstage-community/plugin-cicd-statistics@0.14.1

## @backstage-community/plugin-cicd-statistics-module-github@0.11.1

### Patch Changes

-   4e95de7: Remove unused dependencies
-   Updated dependencies [4e95de7]
    -   @backstage-community/plugin-cicd-statistics@0.14.1

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.14.1

### Patch Changes

-   4e95de7: Remove unused dependencies
-   Updated dependencies [4e95de7]
    -   @backstage-community/plugin-cicd-statistics@0.14.1
