### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/pink-ghosts-applaud.md
+++ b/workspaces/cost-insights/.changeset/pink-ghosts-applaud.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': patch
----
-
-The cost breakdown tab for the cost insights page will have a horizontal scroll when adding multiple cost breakdowns

--- a/workspaces/cost-insights/.changeset/renovate-83e38ae.md
+++ b/workspaces/cost-insights/.changeset/renovate-83e38ae.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': patch
----
-
-Updated dependency `@types/recharts` to `^2.0.0`.

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.24.1
+
+### Patch Changes
+
+- efd0824: The cost breakdown tab for the cost insights page will have a horizontal scroll when adding multiple cost breakdowns
+- 9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
+
 ## 0.24.0
 
 ### Minor Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.24.1

### Patch Changes

-   efd0824: The cost breakdown tab for the cost insights page will have a horizontal scroll when adding multiple cost breakdowns
-   9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
