### PR TITLE
tech-insights: add techInsightsNavItem to new frontend system plugin

### DIFF
--- a/workspaces/tech-insights/.changeset/metal-pets-hear.md
+++ b/workspaces/tech-insights/.changeset/metal-pets-hear.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+The new frontend system plugin now includes a tech insights navigation extension by default

--- a/workspaces/tech-insights/plugins/tech-insights/report-alpha.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights/report-alpha.api.md
@@ -13,6 +13,7 @@ import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityPredicate } from '@backstage/plugin-catalog-react/alpha';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
+import { IconComponent } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
@@ -147,6 +148,27 @@ const techInsightsPlugin: OverridableFrontendPlugin<
         loader: () => Promise<JSX.Element>;
         routeRef?: RouteRef<AnyRouteRefParams> | undefined;
         filter?: EntityPredicate | ((entity: Entity) => boolean) | undefined;
+      };
+    }>;
+    'nav-item:tech-insights': OverridableExtensionDefinition<{
+      kind: 'nav-item';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        {
+          title: string;
+          icon: IconComponent;
+          routeRef: RouteRef<undefined>;
+        },
+        'core.nav-item.target',
+        {}
+      >;
+      inputs: {};
+      params: {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
       };
     }>;
     'page:tech-insights': OverridableExtensionDefinition<{

--- a/workspaces/tech-insights/plugins/tech-insights/src/alpha/navItems.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/alpha/navItems.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NavItemBlueprint } from '@backstage/frontend-plugin-api';
+import EmojiObjectsIcon from '@material-ui/icons/EmojiObjects';
+import { rootRouteRef } from '../routes';
+
+/**
+ * @alpha
+ */
+export const techInsightsNavItem = NavItemBlueprint.make({
+  params: {
+    title: 'Tech Insights',
+    icon: EmojiObjectsIcon,
+    routeRef: rootRouteRef,
+  },
+});
+
+export default [techInsightsNavItem];

--- a/workspaces/tech-insights/plugins/tech-insights/src/alpha/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights/src/alpha/plugin.ts
@@ -18,6 +18,7 @@ import { techInsightsApi } from './apis';
 import { entityTechInsightsScorecardContent } from './entityContent';
 import { entityTechInsightsScorecardCard } from './entityCards';
 import { techInsightsScorecardPage } from './pages';
+import { techInsightsNavItem } from './navItems';
 
 /**
  * The Tech Insights frontend plugin for the new Backstage frontend system.
@@ -31,6 +32,7 @@ const techInsightsPlugin = createFrontendPlugin({
     techInsightsScorecardPage,
     entityTechInsightsScorecardContent,
     entityTechInsightsScorecardCard,
+    techInsightsNavItem,
   ],
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a nav item the nfs version of the plugin includes by default. This makes it so end users automatically receive a navigation item in the sidebar for tech insights. 

<img width="233" height="416" alt="image" src="https://github.com/user-attachments/assets/4e7f04cc-b7a3-49ed-a130-8e918218b42b" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
