### PR TITLE
Version Packages (git-release-manager)

### DIFF
--- a/workspaces/git-release-manager/.changeset/renovate-83e38ae.md
+++ b/workspaces/git-release-manager/.changeset/renovate-83e38ae.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-git-release-manager': patch
----
-
-Updated dependency `@types/recharts` to `^2.0.0`.

--- a/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
+++ b/workspaces/git-release-manager/plugins/git-release-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-git-release-manager
 
+## 0.13.1
+
+### Patch Changes
+
+- 9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
+
 ## 0.13.0
 
 ### Minor Changes

--- a/workspaces/git-release-manager/plugins/git-release-manager/package.json
+++ b/workspaces/git-release-manager/plugins/git-release-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-git-release-manager",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A Backstage plugin that helps you manage releases in git",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-git-release-manager@0.13.1

### Patch Changes

-   9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
