### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/renovate-83e38ae.md
+++ b/workspaces/code-coverage/.changeset/renovate-83e38ae.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage': patch
----
-
-Updated dependency `@types/recharts` to `^2.0.0`.

--- a/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-code-coverage
 
+## 0.12.1
+
+### Patch Changes
+
+- 9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/code-coverage/plugins/code-coverage/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-code-coverage",
   "description": "A Backstage plugin that helps you keep track of your code coverage",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage@0.12.1

### Patch Changes

-   9a6edd2: Updated dependency `@types/recharts` to `^2.0.0`.
