### PR TITLE
fix(copilot): choose enterprise or org page based on configuration

### DIFF
--- a/workspaces/copilot/.changeset/fuzzy-mangos-shake.md
+++ b/workspaces/copilot/.changeset/fuzzy-mangos-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot': patch
+---
+
+Check configuration to determine whether to show enterprise or organization page.

--- a/workspaces/copilot/plugins/copilot/src/components/Pages/HomePage.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Pages/HomePage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSX } from 'react';
+import { JSX, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import Box from '@mui/material/Box';
@@ -79,6 +79,18 @@ export const HomePage = (): JSX.Element => {
   const organizationConfig = configApi.getOptionalString(
     'copilot.organization',
   );
+
+  // Auto-redirect when only one option is configured
+  useEffect(() => {
+    const hasEnterprise = !!enterpriseConfig;
+    const hasOrganization = !!organizationConfig;
+
+    if (hasEnterprise && !hasOrganization) {
+      navigate('/copilot/enterprise', { replace: true });
+    } else if (hasOrganization && !hasEnterprise) {
+      navigate('/copilot/organization', { replace: true });
+    }
+  }, [enterpriseConfig, organizationConfig, navigate]);
 
   const handleNavigate = (path: string) => {
     navigate(path);

--- a/workspaces/copilot/plugins/copilot/src/components/Sidebar/Sidebar.tsx
+++ b/workspaces/copilot/plugins/copilot/src/components/Sidebar/Sidebar.tsx
@@ -38,6 +38,29 @@ export const Sidebar = (): JSX.Element => {
     'copilot.organization',
   );
 
+  const hasEnterprise = !!enterpriseConfig;
+  const hasOrganization = !!organizationConfig;
+  const hasBoth = hasEnterprise && hasOrganization;
+
+  // Determine the direct link path when only one option is configured
+  const getDirectPath = () => {
+    if (hasEnterprise && !hasOrganization) return 'copilot/enterprise';
+    if (hasOrganization && !hasEnterprise) return 'copilot/organization';
+    return 'copilot';
+  };
+
+  // If only one option is configured (or none), show a simple sidebar item without submenu
+  if (!hasBoth) {
+    return (
+      <SidebarItem
+        icon={SupportAgentIcon as IconComponent}
+        to={getDirectPath()}
+        text="Copilot"
+      />
+    );
+  }
+
+  // If both are configured, show the submenu
   return (
     <SidebarItem
       icon={SupportAgentIcon as IconComponent}
@@ -45,20 +68,16 @@ export const Sidebar = (): JSX.Element => {
       text="Copilot"
     >
       <SidebarSubmenu title="Copilot">
-        {enterpriseConfig && (
-          <SidebarSubmenuItem
-            title="Enterprise"
-            to="copilot/enterprise"
-            icon={BusinessIcon as IconComponent}
-          />
-        )}
-        {organizationConfig && (
-          <SidebarSubmenuItem
-            title="Organization"
-            to="copilot/organization"
-            icon={GroupIcon as IconComponent}
-          />
-        )}
+        <SidebarSubmenuItem
+          title="Enterprise"
+          to="copilot/enterprise"
+          icon={BusinessIcon as IconComponent}
+        />
+        <SidebarSubmenuItem
+          title="Organization"
+          to="copilot/organization"
+          icon={GroupIcon as IconComponent}
+        />
       </SidebarSubmenu>
     </SidebarItem>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR improves the navigation UX for the GitHub Copilot plugin by automatically redirecting users to the appropriate page when only one configuration option (enterprise or organization) is available.

Fixes #5906 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
