### PR TITLE
enable knip reports for gitops-profiles workspace

### DIFF
--- a/workspaces/gitops-profiles/.changeset/strong-candles-smell.md
+++ b/workspaces/gitops-profiles/.changeset/strong-candles-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-gitops-profiles': patch
+---
+
+remove unused dependencies

--- a/workspaces/gitops-profiles/.prettierignore
+++ b/workspaces/gitops-profiles/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/gitops-profiles/bcp.json
+++ b/workspaces/gitops-profiles/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/gitops-profiles/plugins/gitops-profiles/knip-report.md
+++ b/workspaces/gitops-profiles/plugins/gitops-profiles/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/gitops-profiles/plugins/gitops-profiles/package.json
+++ b/workspaces/gitops-profiles/plugins/gitops-profiles/package.json
@@ -54,7 +54,6 @@
     "@backstage/core-app-api": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react-dom": "^18.2.19",

--- a/workspaces/gitops-profiles/yarn.lock
+++ b/workspaces/gitops-profiles/yarn.lock
@@ -365,7 +365,6 @@ __metadata:
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for gitops-profiles workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
