### PR TITLE
change tech-radar's node engine field to include 22 and 24

### DIFF
--- a/workspaces/tech-radar/package.json
+++ b/workspaces/tech-radar/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "20 || 22"
+    "node": "22 || 24"
   },
   "scripts": {
     "start": "backstage-cli repo start",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Tech radar was updated to v1.46 and based on this PR (https://github.com/backstage/community-plugins/pull/6805) its node engine field should be updated to include 22 and 24.

This should help fix the CI error in https://github.com/backstage/community-plugins/pull/6817

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
