### PR TITLE
docs: enhance workspace-level READMEs for ADR, Airbrake, and Allure

### DIFF
--- a/workspaces/adr/README.md
+++ b/workspaces/adr/README.md
@@ -1,10 +1,10 @@
-# [Backstage](https://backstage.io)
+# ADR Workspace
 
-This is your newly scaffolded Backstage App, Good Luck!
+This workspace contains plugins for managing and visualizing Architecture Decision Records (ADRs) within Backstage.
 
-To start the app, run:
+## Plugins
 
-```sh
-yarn install
-yarn start
-```
+- [adr](./plugins/adr): Frontend plugin that provides the ADR user interface.
+- [adr-backend](./plugins/adr-backend): Backend plugin logic for retrieving and processing ADRs.
+- [adr-common](./plugins/adr-common): Shared types and utilities for ADR plugins.
+- [search-backend-module-adr](./plugins/search-backend-module-adr): Collator module to index ADRs into the Backstage search.

--- a/workspaces/airbrake/README.md
+++ b/workspaces/airbrake/README.md
@@ -1,10 +1,8 @@
-# [Backstage](https://backstage.io)
+# Airbrake Workspace
 
-This is your newly scaffolded Backstage App, Good Luck!
+This workspace contains plugins for integrating Airbrake error monitoring into Backstage.
 
-To start the app, run:
+## Plugins
 
-```sh
-yarn install
-yarn start
-```
+- [airbrake](./plugins/airbrake): Frontend plugin that displays error tracking data from Airbrake.
+- [airbrake-backend](./plugins/airbrake-backend): Backend plugin to securely fetch data from Airbrake APIs.

--- a/workspaces/allure/README.md
+++ b/workspaces/allure/README.md
@@ -1,10 +1,7 @@
-# [Backstage](https://backstage.io)
+# Allure Workspace
 
-This is your newly scaffolded Backstage App, Good Luck!
+This workspace contains plugins for viewing Allure test reports within Backstage.
 
-To start the app, run:
+## Plugins
 
-```sh
-yarn install
-yarn start
-```
+- [allure](./plugins/allure): Frontend plugin to display Allure test reports.


### PR DESCRIPTION
Ref: #4056. Updates the defaulted scaffolded READMEs for the dr, irbrake, and llure workspaces to describe their purpose and list contained plugins.