### PR TITLE
Version Packages (bitbucket-pull-requests)

### DIFF
--- a/workspaces/bitbucket-pull-requests/.changeset/empty-dolls-drop.md
+++ b/workspaces/bitbucket-pull-requests/.changeset/empty-dolls-drop.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-bitbucket-pull-requests': patch
----
-
-Fixed an issue where the default filter displayed all pull requests but showed only open pull requests

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-bitbucket-pull-requests
 
+## 3.0.2
+
+### Patch Changes
+
+- c7ab4c7: Fixed an issue where the default filter displayed all pull requests but showed only open pull requests
+
 ## 3.0.1
 
 ### Patch Changes

--- a/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
+++ b/workspaces/bitbucket-pull-requests/plugins/bitbucket-pull-requests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-bitbucket-pull-requests",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-bitbucket-pull-requests@3.0.2

### Patch Changes

-   c7ab4c7: Fixed an issue where the default filter displayed all pull requests but showed only open pull requests
