### PR TITLE
Version Packages (cost-insights)

### DIFF
--- a/workspaces/cost-insights/.changeset/two-onions-cheat.md
+++ b/workspaces/cost-insights/.changeset/two-onions-cheat.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cost-insights': minor
----
-
-The compare to dropdown in the cost insights page will not disappear anymore after selecting "none" instead of a business metric

--- a/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
+++ b/workspaces/cost-insights/plugins/cost-insights/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cost-insights
 
+## 0.25.0
+
+### Minor Changes
+
+- ae08883: The compare to dropdown in the cost insights page will not disappear anymore after selecting "none" instead of a business metric
+
 ## 0.24.1
 
 ### Patch Changes

--- a/workspaces/cost-insights/plugins/cost-insights/package.json
+++ b/workspaces/cost-insights/plugins/cost-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cost-insights",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "A Backstage plugin that helps you keep track of your cloud spend",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cost-insights@0.25.0

### Minor Changes

-   ae08883: The compare to dropdown in the cost insights page will not disappear anymore after selecting "none" instead of a business metric
