### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/breezy-spoons-vanish.md
+++ b/workspaces/tech-insights/.changeset/breezy-spoons-vanish.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': patch
----
-
-Added filter component to the ScorecardsPage to filter on entities with at least one failed check.
-Also added desc/asc order based on check results in the 'Results' column. Sort by number of failed checks first, then by total checks.

--- a/workspaces/tech-insights/.changeset/fuzzy-flowers-care.md
+++ b/workspaces/tech-insights/.changeset/fuzzy-flowers-care.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights': major
----
-
-All existing deprecation notices have been removed from the plugin

--- a/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-tech-insights
 
+## 1.0.0
+
+### Major Changes
+
+- 12c1773: All existing deprecation notices have been removed from the plugin
+
+### Patch Changes
+
+- ecd421a: Added filter component to the ScorecardsPage to filter on entities with at least one failed check.
+  Also added desc/asc order based on check results in the 'Results' column. Sort by number of failed checks first, then by total checks.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/workspaces/tech-insights/plugins/tech-insights/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "tech-insights",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights@1.0.0

### Major Changes

-   12c1773: All existing deprecation notices have been removed from the plugin

### Patch Changes

-   ecd421a: Added filter component to the ScorecardsPage to filter on entities with at least one failed check.
    Also added desc/asc order based on check results in the 'Results' column. Sort by number of failed checks first, then by total checks.
