### PR TITLE
jenkins: deprecate `createPermissionIntegrationRouter` in favor of permissions registry

### DIFF
--- a/workspaces/jenkins/.changeset/calm-boats-join.md
+++ b/workspaces/jenkins/.changeset/calm-boats-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins-backend': patch
+---
+
+Migration from createPermissionIntegrationRouter to the Permissions Registry Service

--- a/workspaces/jenkins/plugins/jenkins-backend/src/plugin.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/plugin.ts
@@ -22,6 +22,7 @@ import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 
 import { DefaultJenkinsInfoProvider } from './service/jenkinsInfoProvider';
 import { JenkinsBuilder } from './service/JenkinsBuilder';
+import { jenkinsPermissions } from '@backstage-community/plugin-jenkins-common';
 
 /**
  * Jenkins backend plugin
@@ -35,6 +36,7 @@ export const jenkinsPlugin = createBackendPlugin({
       deps: {
         logger: coreServices.logger,
         permissions: coreServices.permissions,
+        permissionsRegistry: coreServices.permissionsRegistry,
         httpRouter: coreServices.httpRouter,
         config: coreServices.rootConfig,
         catalog: catalogServiceRef,
@@ -45,6 +47,7 @@ export const jenkinsPlugin = createBackendPlugin({
       async init({
         logger,
         permissions,
+        permissionsRegistry,
         httpRouter,
         config,
         catalog,
@@ -52,6 +55,8 @@ export const jenkinsPlugin = createBackendPlugin({
         auth,
         httpAuth,
       }) {
+        permissionsRegistry.addPermissions(jenkinsPermissions);
+
         const jenkinsInfoProvider = DefaultJenkinsInfoProvider.fromConfig({
           auth,
           httpAuth,

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
@@ -32,8 +32,6 @@ import {
 } from '@backstage/backend-plugin-api';
 
 import { Config } from '@backstage/config';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
-import { jenkinsPermissions } from '@backstage-community/plugin-jenkins-common';
 
 /** @public */
 export type JenkinsBuilderReturn = Promise<{
@@ -110,11 +108,6 @@ export class JenkinsBuilder {
 
     const router = Router();
     router.use(express.json());
-    router.use(
-      createPermissionIntegrationRouter({
-        permissions: jenkinsPermissions,
-      }),
-    );
 
     router.get(
       '/v1/entity/:namespace/:kind/:name/projects',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves deprecation notices around permissions by refactoring permissions to use the new Permissions Registry service. Changes are based on [migration guide](https://backstage.io/docs/backend-system/core-services/permissions-registry/#migrating-from-createpermissionintegrationrouter).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
