### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: community-plugins
+  annotations:
+    github.com/project-slug: backstage/community-plugins
+spec:
+  type: other
+  owner: backstage
+  lifecycle: unknown


### PR DESCRIPTION
This PR adds a default catalog-info.yaml for Backstage.