### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/renovate-59bc6ef.md
+++ b/workspaces/azure-devops/.changeset/renovate-59bc6ef.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-azure-devops': patch
----
-
-Updated dependency `axios-retry` to `^4.0.0`.

--- a/workspaces/azure-devops/.changeset/renovate-fd8fe68.md
+++ b/workspaces/azure-devops/.changeset/renovate-fd8fe68.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': patch
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
----
-
-Updated dependency `azure-devops-node-api` to `^15.0.0`.

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.24.1
+
+### Patch Changes
+
+- 7c297d4: Updated dependency `azure-devops-node-api` to `^15.0.0`.
+
 ## 0.24.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.19.1
+
+### Patch Changes
+
+- 7c297d4: Updated dependency `azure-devops-node-api` to `^15.0.0`.
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-azure-devops
 
+## 0.2.2
+
+### Patch Changes
+
+- 568c68b: Updated dependency `axios-retry` to `^4.0.0`.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "name": "@backstage-community/plugin-search-backend-module-azure-devops",
   "description": "The azure-devops backend module for the search plugin.",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops-backend@0.24.1

### Patch Changes

-   7c297d4: Updated dependency `azure-devops-node-api` to `^15.0.0`.

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.19.1

### Patch Changes

-   7c297d4: Updated dependency `azure-devops-node-api` to `^15.0.0`.

## @backstage-community/plugin-search-backend-module-azure-devops@0.2.2

### Patch Changes

-   568c68b: Updated dependency `axios-retry` to `^4.0.0`.
