### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/fast-jokes-perform.md
+++ b/workspaces/ocm/.changeset/fast-jokes-perform.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Replace deprecated `createPermissionIntegrationRouter` API call with `permissionsRegistry` to resolve deprecation warnings

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.13.1
+
+### Patch Changes
+
+- 4f1b075: Replace deprecated `createPermissionIntegrationRouter` API call with `permissionsRegistry` to resolve deprecation warnings
+
 ## 5.13.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.13.0",
+  "version": "5.13.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm-backend@5.13.1

### Patch Changes

-   4f1b075: Replace deprecated `createPermissionIntegrationRouter` API call with `permissionsRegistry` to resolve deprecation warnings
