### PR TITLE
enable knip reports for graphql-voyager workspace

### DIFF
--- a/workspaces/graphql-voyager/.changeset/big-houses-act.md
+++ b/workspaces/graphql-voyager/.changeset/big-houses-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-graphql-voyager': patch
+---
+
+remove unused dependencies

--- a/workspaces/graphql-voyager/.prettierignore
+++ b/workspaces/graphql-voyager/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/graphql-voyager/bcp.json
+++ b/workspaces/graphql-voyager/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/graphql-voyager/plugins/graphql-voyager/knip-report.md
+++ b/workspaces/graphql-voyager/plugins/graphql-voyager/knip-report.md
@@ -1,8 +1,2 @@
 # Knip report
 
-## Unused devDependencies (2)
-
-| Name                 | Location     | Severity |
-| :------------------- | :----------- | :------- |
-| @testing-library/dom | package.json | error    |
-| canvas               | package.json | error    |

--- a/workspaces/graphql-voyager/plugins/graphql-voyager/package.json
+++ b/workspaces/graphql-voyager/plugins/graphql-voyager/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@backstage/cli": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
     "@types/react-dom": "^18.2.19",

--- a/workspaces/graphql-voyager/yarn.lock
+++ b/workspaces/graphql-voyager/yarn.lock
@@ -363,7 +363,6 @@ __metadata:
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
-    "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for  graphql-voyager workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))