### PR TITLE
enable knip reports for jfrog-artifactory workspace

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/twenty-kings-start.md
+++ b/workspaces/jfrog-artifactory/.changeset/twenty-kings-start.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jfrog-artifactory': patch
+---
+
+remove unused dependencies

--- a/workspaces/jfrog-artifactory/.prettierignore
+++ b/workspaces/jfrog-artifactory/.prettierignore
@@ -3,3 +3,4 @@ dist-types
 coverage
 .vscode
 .eslintrc.js
+knip-report.md

--- a/workspaces/jfrog-artifactory/bcp.json
+++ b/workspaces/jfrog-artifactory/bcp.json
@@ -1,6 +1,6 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "playwrightTests": true,
   "listDeprecations": true
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/knip-report.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/knip-report.md
@@ -1,1 +1,2 @@
 # Knip report
+

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -48,7 +48,6 @@
     "@backstage/plugin-catalog-react": "^1.21.4",
     "@backstage/theme": "^0.7.1",
     "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.11.3",
     "filesize": "^10.1.6",
     "luxon": "^3.6.1",
     "react-use": "^17.4.0"

--- a/workspaces/jfrog-artifactory/yarn.lock
+++ b/workspaces/jfrog-artifactory/yarn.lock
@@ -410,7 +410,6 @@ __metadata:
     "@backstage/test-utils": "npm:^1.7.14"
     "@backstage/theme": "npm:^0.7.1"
     "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.11.3"
     "@playwright/test": "npm:^1.57.0"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:14.3.1"
@@ -2556,7 +2555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@material-ui/icons@npm:^4.11.3, @material-ui/icons@npm:^4.9.1":
+"@material-ui/icons@npm:^4.9.1":
   version: 4.11.3
   resolution: "@material-ui/icons@npm:4.11.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Issue: https://github.com/backstage/community-plugins/issues/5992

Enabled `knipReports` and removed all unused dependencies for jfrog-artifactory workspace. 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
