### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-adcfdc5.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-adcfdc5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.90.9`.

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.12.1
+
+### Patch Changes
+
+- d567697: Updated dependency `@hey-api/openapi-ts` to `0.90.9`.
+
 ## 2.12.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.12.1

### Patch Changes

-   d567697: Updated dependency `@hey-api/openapi-ts` to `0.90.9`.
