### PR TITLE
refactor(announcements): replace `TextField` in announcements form with `@backstage/ui` equivalent

### DIFF
--- a/workspaces/announcements/.changeset/short-rivers-pay.md
+++ b/workspaces/announcements/.changeset/short-rivers-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Updates all non-date related text inputs to use the `TextField` from `@backstage/ui`.

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
@@ -26,6 +26,7 @@ import {
   CardHeader,
   Grid,
   Text,
+  TextField,
 } from '@backstage/ui';
 import { RiSave2Line } from '@remixicon/react';
 import {
@@ -42,7 +43,7 @@ import TagsInput from './TagsInput';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
 import Switch from '@mui/material/Switch';
-import TextField from '@mui/material/TextField';
+import MuiTextField from '@mui/material/TextField';
 
 type AnnouncementFormProps = {
   initialData: Announcement;
@@ -78,13 +79,6 @@ export const AnnouncementForm = ({
   const [onBehalfOfSelectedTeam, setOnBehalfOfSelectedTeam] = useState(
     initialData.on_behalf_of || '',
   );
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [event.target.id]: event.target.value,
-    });
-  };
 
   const handleChangeActive = (event: ChangeEvent<HTMLInputElement>) => {
     setForm({
@@ -159,26 +153,19 @@ export const AnnouncementForm = ({
             <Grid.Root columns="12">
               <Grid.Item colSpan="12">
                 <TextField
-                  id="title"
                   label={t('announcementForm.title')}
                   value={form.title}
-                  onChange={handleChange}
-                  variant="outlined"
-                  fullWidth
-                  required
+                  onChange={title => setForm({ ...form, title })}
+                  isRequired
                 />
               </Grid.Item>
 
               <Grid.Item colSpan="12">
                 <TextField
-                  id="excerpt"
                   label={t('announcementForm.excerpt')}
                   value={form.excerpt}
-                  onChange={handleChange}
-                  variant="outlined"
-                  fullWidth
-                  required
-                  multiline
+                  onChange={excerpt => setForm({ ...form, excerpt })}
+                  isRequired
                 />
               </Grid.Item>
 
@@ -212,7 +199,7 @@ export const AnnouncementForm = ({
               </Grid.Item>
 
               <Grid.Item colSpan={{ xs: '12', md: '4' }}>
-                <TextField
+                <MuiTextField
                   variant="outlined"
                   label={t('announcementForm.startAt')}
                   id="start-at-date"
@@ -231,7 +218,7 @@ export const AnnouncementForm = ({
               </Grid.Item>
 
               <Grid.Item colSpan={{ xs: '12', md: '4' }}>
-                <TextField
+                <MuiTextField
                   variant="outlined"
                   label={t('announcementForm.untilDate')}
                   id="until-date"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces text inputs with their `@backstage/ui` equivalent. This excludes the date components. Those will remain in Material UI for the time-being. 

<img width="915" height="180" alt="image" src="https://github.com/user-attachments/assets/3f2ed245-551b-4b5e-8aa1-9f2e36e15df9" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
