### PR TITLE
Disable security-related Renovate for Backstage packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,10 @@
     {
       "matchManagers": ["npm"],
       "enabled": false,
-      "matchPackageNames": ["@backstage/**"]
+      "matchPackageNames": ["@backstage/**"],
+      "vulnerabilityAlerts": {
+        "enabled": false
+      }
     },
     {
       "matchPackageNames": ["node-fetch"],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Renovate currently still creates security-related PRs like #7001 for Backstage packages that should instead be addressed in version bumps. This PR explicitly disables these kinds of PRs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
