### PR TITLE
announcements: replace switch components in announcements form with `@backstage/ui`

### DIFF
--- a/workspaces/announcements/.changeset/slimy-wasps-whisper.md
+++ b/workspaces/announcements/.changeset/slimy-wasps-whisper.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Switch components in the announcements form have been migrated to use `@backstage/ui`. The "Send notifications" label now includes support for translations.

--- a/workspaces/announcements/.changeset/sour-hotels-hang.md
+++ b/workspaces/announcements/.changeset/sour-hotels-hang.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-react': patch
+---
+
+Add missing translation for "Send notification" in the announcement form

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -200,6 +200,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementForm.title': 'Title';
     readonly 'announcementForm.submit': 'Submit';
     readonly 'announcementForm.excerpt': 'Excerpt';
+    readonly 'announcementForm.sendNotification': 'Send Notification';
     readonly 'announcementForm.editAnnouncement': 'Edit announcement';
     readonly 'announcementForm.newAnnouncement': 'New announcement';
     readonly 'announcementForm.startAt': 'Announcement start date';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -38,6 +38,7 @@ export const announcementsTranslationRef = createTranslationRef({
         label: 'Tags',
       },
       tagsLabel: 'Tags',
+      sendNotification: 'Send Notification',
     },
     announcementsPage: {
       announcements: 'Announcements',

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.test.tsx
@@ -59,16 +59,16 @@ const renderAnnouncementForm = async ({ active }: { active?: boolean }) => {
 describe('AnnouncementForm', () => {
   it('renders "active" switch checked by default', async () => {
     await renderAnnouncementForm({});
-    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+    expect(screen.getByRole('switch', { name: 'Active' })).toBeChecked();
   });
 
   it('renders "active" switch checked when initial value is true', async () => {
     await renderAnnouncementForm({ active: true });
-    expect(screen.getByRole('checkbox', { name: 'Active' })).toBeChecked();
+    expect(screen.getByRole('switch', { name: 'Active' })).toBeChecked();
   });
 
   it('renders "active" switch unchecked when initial value is false', async () => {
     await renderAnnouncementForm({ active: false });
-    expect(screen.getByRole('checkbox', { name: 'Active' })).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: 'Active' })).not.toBeChecked();
   });
 });

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import MDEditor from '@uiw/react-md-editor';
 import { DateTime } from 'luxon';
 import slugify from 'slugify';
@@ -27,6 +27,8 @@ import {
   Grid,
   Text,
   TextField,
+  Switch,
+  Flex,
 } from '@backstage/ui';
 import { RiSave2Line } from '@remixicon/react';
 import {
@@ -40,9 +42,6 @@ import CategoryInput from './CategoryInput';
 import OnBehalfTeamDropdown from './OnBehalfTeamDropdown';
 import TagsInput from './TagsInput';
 
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormGroup from '@mui/material/FormGroup';
-import Switch from '@mui/material/Switch';
 import MuiTextField from '@mui/material/TextField';
 
 type AnnouncementFormProps = {
@@ -79,13 +78,6 @@ export const AnnouncementForm = ({
   const [onBehalfOfSelectedTeam, setOnBehalfOfSelectedTeam] = useState(
     initialData.on_behalf_of || '',
   );
-
-  const handleChangeActive = (event: ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [event.target.name]: event.target.checked,
-    });
-  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     setLoading(true);
@@ -242,38 +234,31 @@ export const AnnouncementForm = ({
               </Grid.Item>
 
               <Grid.Item colSpan="12">
-                <FormGroup row style={{ justifyContent: 'flex-end' }}>
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        name="active"
-                        checked={form.active}
-                        onChange={handleChangeActive}
-                        color="primary"
-                      />
-                    }
+                <Flex justify="end">
+                  <Switch
+                    name="active"
                     label={t('announcementForm.active')}
-                  />
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        name="sendNotification"
-                        checked={form.sendNotification}
-                        onChange={handleChangeActive}
-                        color="primary"
-                      />
+                    isSelected={form.active}
+                    onChange={isSelected =>
+                      setForm({ ...form, active: isSelected })
                     }
-                    label="Send Notification"
+                  />
+                  <Switch
+                    name="sendNotification"
+                    label={t('announcementForm.sendNotification')}
+                    isSelected={form.sendNotification}
+                    onChange={isSelected =>
+                      setForm({ ...form, sendNotification: isSelected })
+                    }
                   />
                   <Button
                     type="submit"
-                    size="medium"
                     isDisabled={loading || !form.body}
                     iconStart={<RiSave2Line />}
                   >
                     {t('announcementForm.submit')}
                   </Button>
-                </FormGroup>
+                </Flex>
               </Grid.Item>
             </Grid.Root>
           </form>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

* Updates "Active" and "Send notification" switch components to use `<Switch />` from `@backstage/ui`
* Added missing translation for "Send notification"
* Converted button from 'medium' -> 'small' (default)

<img width="414" height="81" alt="image" src="https://github.com/user-attachments/assets/f95c3681-e1fc-41d7-81f1-66ba4157b613" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
