### PR TITLE
Version Packages (azure-resources)

### DIFF
--- a/workspaces/azure-resources/.changeset/puny-carrots-run.md
+++ b/workspaces/azure-resources/.changeset/puny-carrots-run.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-azure-resources-node': minor
----
-
-**deprecation:**
-
-- The `azure-resources` configuration key is now deprecated in favor of `azureResources` (camelCase)
-- The `azure-resources` config key will be removed in an up coming release.

--- a/workspaces/azure-resources/.changeset/tough-poets-spend.md
+++ b/workspaces/azure-resources/.changeset/tough-poets-spend.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-azure-resources': patch
-'@backstage-community/plugin-azure-resources-node': patch
----
-
-Fixed configuration schemas (`config.d.ts`).

--- a/workspaces/azure-resources/.changeset/yummy-memes-cry.md
+++ b/workspaces/azure-resources/.changeset/yummy-memes-cry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-azure-resources': patch
----
-
-Fix #7343 - Adding config.d.ts to files in package.json

--- a/workspaces/azure-resources/plugins/azure-resources-node/CHANGELOG.md
+++ b/workspaces/azure-resources/plugins/azure-resources-node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-azure-resources-node
 
+## 0.8.0
+
+### Minor Changes
+
+- 2fe4de4: **deprecation:**
+
+  - The `azure-resources` configuration key is now deprecated in favor of `azureResources` (camelCase)
+  - The `azure-resources` config key will be removed in an up coming release.
+
+### Patch Changes
+
+- 2fe4de4: Fixed configuration schemas (`config.d.ts`).
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/azure-resources/plugins/azure-resources-node/package.json
+++ b/workspaces/azure-resources/plugins/azure-resources-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-azure-resources-node",
   "description": "Node.js library for the azure-resources plugin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/CHANGELOG.md
+++ b/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-catalog-backend-module-azure-resources
 
+## 0.5.1
+
+### Patch Changes
+
+- 2fe4de4: Fixed configuration schemas (`config.d.ts`).
+- fc52dba: Fix #7343 - Adding config.d.ts to files in package.json
+- Updated dependencies [2fe4de4]
+- Updated dependencies [2fe4de4]
+  - @backstage-community/plugin-azure-resources-node@0.8.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/package.json
+++ b/workspaces/azure-resources/plugins/catalog-backend-module-azure-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-resources",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "description": "The azure-resources backend module for the catalog plugin.",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-resources-node@0.8.0

### Minor Changes

-   2fe4de4: **deprecation:**

    -   The `azure-resources` configuration key is now deprecated in favor of `azureResources` (camelCase)
    -   The `azure-resources` config key will be removed in an up coming release.

### Patch Changes

-   2fe4de4: Fixed configuration schemas (`config.d.ts`).

## @backstage-community/plugin-catalog-backend-module-azure-resources@0.5.1

### Patch Changes

-   2fe4de4: Fixed configuration schemas (`config.d.ts`).
-   fc52dba: Fix #7343 - Adding config.d.ts to files in package.json
-   Updated dependencies [2fe4de4]
-   Updated dependencies [2fe4de4]
    -   @backstage-community/plugin-azure-resources-node@0.8.0
