### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/dull-yaks-jam.md
+++ b/workspaces/rbac/.changeset/dull-yaks-jam.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-updated the permissionFactory to use the `FetchUrlReader.fromConfig`

--- a/workspaces/rbac/.changeset/renovate-803b0bd.md
+++ b/workspaces/rbac/.changeset/renovate-803b0bd.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.3`.

--- a/workspaces/rbac/.changeset/renovate-cd80c44.md
+++ b/workspaces/rbac/.changeset/renovate-cd80c44.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.19.7`.

--- a/workspaces/rbac/.changeset/version-bump-1-47-2.md
+++ b/workspaces/rbac/.changeset/version-bump-1-47-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': minor
-'@backstage-community/plugin-rbac-common': minor
-'@backstage-community/plugin-rbac-node': minor
----
-
-Backstage version bump to v1.47.2

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.7.0
+
+### Minor Changes
+
+- e6dbf70: Backstage version bump to v1.47.2
+
+### Patch Changes
+
+- e6dbf70: updated the permissionFactory to use the `FetchUrlReader.fromConfig`
+- a184943: Updated dependency `@types/node` to `22.19.7`.
+- Updated dependencies [e6dbf70]
+  - @backstage-community/plugin-rbac-common@1.23.0
+  - @backstage-community/plugin-rbac-node@1.17.0
+
 ## 7.6.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.23.0
+
+### Minor Changes
+
+- e6dbf70: Backstage version bump to v1.47.2
+
 ## 1.22.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.17.0
+
+### Minor Changes
+
+- e6dbf70: Backstage version bump to v1.47.2
+
 ## 1.16.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-rbac
 
+## 1.48.0
+
+### Minor Changes
+
+- e6dbf70: Backstage version bump to v1.47.2
+
+### Patch Changes
+
+- 658c2c9: Updated dependency `start-server-and-test` to `2.1.3`.
+- a184943: Updated dependency `@types/node` to `22.19.7`.
+- Updated dependencies [e6dbf70]
+  - @backstage-community/plugin-rbac-common@1.23.0
+
 ## 1.47.4
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.47.4",
+  "version": "1.48.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.48.0

### Minor Changes

-   e6dbf70: Backstage version bump to v1.47.2

### Patch Changes

-   658c2c9: Updated dependency `start-server-and-test` to `2.1.3`.
-   a184943: Updated dependency `@types/node` to `22.19.7`.
-   Updated dependencies [e6dbf70]
    -   @backstage-community/plugin-rbac-common@1.23.0

## @backstage-community/plugin-rbac-backend@7.7.0

### Minor Changes

-   e6dbf70: Backstage version bump to v1.47.2

### Patch Changes

-   e6dbf70: updated the permissionFactory to use the `FetchUrlReader.fromConfig`
-   a184943: Updated dependency `@types/node` to `22.19.7`.
-   Updated dependencies [e6dbf70]
    -   @backstage-community/plugin-rbac-common@1.23.0
    -   @backstage-community/plugin-rbac-node@1.17.0

## @backstage-community/plugin-rbac-common@1.23.0

### Minor Changes

-   e6dbf70: Backstage version bump to v1.47.2

## @backstage-community/plugin-rbac-node@1.17.0

### Minor Changes

-   e6dbf70: Backstage version bump to v1.47.2
