### PR TITLE
chore(nexus): updated it, ja and fr translation files

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/real-rabbits-jog.md
+++ b/workspaces/nexus-repository-manager/.changeset/real-rabbits-jog.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-nexus-repository-manager': patch
+---
+
+Updated fr, it and ja translation files

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/index.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/index.ts
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { createApp } from '@backstage/frontend-defaults';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+// eslint-disable-next-line
 import '@backstage/ui/css/styles.css';
 
 import { NexusRepositoryManagerApiRef } from '../../src/api';

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/fr.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/fr.ts
@@ -13,26 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
 import { nexusRepositoryManagerTranslationRef } from './ref';
 
+/**
+ * fr translation for plugin.nexus-repository-manager.
+ * @public
+ */
 const nexusRepositoryManagerTranslationFr = createTranslationMessages({
   ref: nexusRepositoryManagerTranslationRef,
-  full: true,
   messages: {
-    'table.title': 'Nexus Repository Manager : {{title}}',
-    'table.searchPlaceholder': 'Filtrer',
+    'table.title': 'Nexus Repository Manager: {{title}}',
+    'table.searchPlaceholder': 'Filtre',
     'table.labelRowsSelect': 'Lignes',
     'table.columns.version': 'Version',
-    'table.columns.artifact': 'Artefact',
-    'table.columns.repositoryType': 'Type de dépôt',
-    'table.columns.checksum': 'Somme de contrôle',
+    'table.columns.artifact': 'Artifact',
+    'table.columns.repositoryType': 'Type de référentiel',
+    'table.columns.checksum': 'Checksum',
     'table.columns.modified': 'Modifié',
     'table.columns.size': 'Taille',
-    'table.emptyValue': 'N/D',
-    'table.emptyContent.message': "Aucune donnée n'a encore été ajoutée,",
-    'table.emptyContent.linkText': 'apprenez comment ajouter des données',
-    'entityContent.title': 'Artefacts de build',
+    'table.emptyValue': 'N/A',
+    'table.emptyContent.message':
+      'Aucune donnée n’a été ajouté pour l’instant,',
+    'table.emptyContent.linkText': 'apprenez comment ajouter des données.',
+    'entityContent.title': 'Build Artifacts',
   },
 });
 

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/it.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/it.ts
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
 import { nexusRepositoryManagerTranslationRef } from './ref';
 
+/**
+ * Italian translation for plugin.nexus-repository-manager.
+ * @public
+ */
 const nexusRepositoryManagerTranslationIt = createTranslationMessages({
   ref: nexusRepositoryManagerTranslationRef,
-  full: true,
   messages: {
-    'table.title': 'Nexus Repository Manager: {{title}}',
+    'table.title': 'Gestore del repository Nexus: {{title}}',
     'table.searchPlaceholder': 'Filtra',
     'table.labelRowsSelect': 'Righe',
     'table.columns.version': 'Versione',
@@ -31,8 +35,8 @@ const nexusRepositoryManagerTranslationIt = createTranslationMessages({
     'table.columns.size': 'Dimensione',
     'table.emptyValue': 'N/D',
     'table.emptyContent.message': 'Nessun dato è stato ancora aggiunto,',
-    'table.emptyContent.linkText': 'impara come aggiungere dati',
-    'entityContent.title': 'Artefatti di build',
+    'table.emptyContent.linkText': 'scopri come aggiungere dati',
+    'entityContent.title': 'Costruire artefatti',
   },
 });
 

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/ja.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/translations/ja.ts
@@ -13,25 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
 import { nexusRepositoryManagerTranslationRef } from './ref';
 
+/**
+ * Japanese translation for plugin.nexus-repository-manager.
+ * @public
+ */
 const nexusRepositoryManagerTranslationJa = createTranslationMessages({
   ref: nexusRepositoryManagerTranslationRef,
-  full: true,
   messages: {
     'table.title': 'Nexus Repository Manager: {{title}}',
     'table.searchPlaceholder': 'フィルター',
     'table.labelRowsSelect': '行',
     'table.columns.version': 'バージョン',
     'table.columns.artifact': 'アーティファクト',
-    'table.columns.repositoryType': 'リポジトリタイプ',
+    'table.columns.repositoryType': 'リポジトリータイプ',
     'table.columns.checksum': 'チェックサム',
-    'table.columns.modified': '変更日時',
+    'table.columns.modified': '更新済み',
     'table.columns.size': 'サイズ',
     'table.emptyValue': '該当なし',
-    'table.emptyContent.message': 'データがまだ追加されていません。',
-    'table.emptyContent.linkText': 'データの追加方法を学ぶ',
+    'table.emptyContent.message': 'まだデータが追加されていません。',
+    'table.emptyContent.linkText': 'データの追加方法をご覧ください',
     'entityContent.title': 'ビルドアーティファクト',
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

 updated it, ja and fr translation files in nexus-artifactory-manager for backstge 1.45.x

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
