### PR TITLE
Version Packages (shortcuts)

### DIFF
--- a/workspaces/shortcuts/.changeset/early-ghosts-grow.md
+++ b/workspaces/shortcuts/.changeset/early-ghosts-grow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-shortcuts': patch
----
-
-Fixed bug in Shortcuts where 'Use Current Page' did not preserve query parameters.

--- a/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
+++ b/workspaces/shortcuts/plugins/shortcuts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-shortcuts
 
+## 0.17.1
+
+### Patch Changes
+
+- a82af01: Fixed bug in Shortcuts where 'Use Current Page' did not preserve query parameters.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/shortcuts/plugins/shortcuts/package.json
+++ b/workspaces/shortcuts/plugins/shortcuts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-shortcuts",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A Backstage plugin that provides a shortcuts feature to the sidebar",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-shortcuts@0.17.1

### Patch Changes

-   a82af01: Fixed bug in Shortcuts where 'Use Current Page' did not preserve query parameters.
