### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-4729b32.md
+++ b/workspaces/ocm/.changeset/renovate-4729b32.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.

--- a/workspaces/ocm/.changeset/renovate-59a7dbb.md
+++ b/workspaces/ocm/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.14.1
+
+### Patch Changes
+
+- 95dd04e: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+
 ## 5.14.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.14.0",
+  "version": "5.14.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm-backend@5.14.1

### Patch Changes

-   95dd04e: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.
-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
