### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/selfish-actors-boil.md
+++ b/workspaces/announcements/.changeset/selfish-actors-boil.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-announcements': minor
-'@backstage-community/plugin-announcements-react': minor
----
-
-`AnnouncementsOptions` has been dropped as an optional arg for the `useAnnouncements` hook in favor of handling state and dependencies internally.

--- a/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements-react
 
+## 0.21.0
+
+### Minor Changes
+
+- 57c349e: `AnnouncementsOptions` has been dropped as an optional arg for the `useAnnouncements` hook in favor of handling state and dependencies internally.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-announcements-react",
   "description": "Web library for the announcements plugin",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-announcements
 
+## 2.2.0
+
+### Minor Changes
+
+- 57c349e: `AnnouncementsOptions` has been dropped as an optional arg for the `useAnnouncements` hook in favor of handling state and dependencies internally.
+
+### Patch Changes
+
+- Updated dependencies [57c349e]
+  - @backstage-community/plugin-announcements-react@0.21.0
+
 ## 2.1.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@2.2.0

### Minor Changes

-   57c349e: `AnnouncementsOptions` has been dropped as an optional arg for the `useAnnouncements` hook in favor of handling state and dependencies internally.

### Patch Changes

-   Updated dependencies [57c349e]
    -   @backstage-community/plugin-announcements-react@0.21.0

## @backstage-community/plugin-announcements-react@0.21.0

### Minor Changes

-   57c349e: `AnnouncementsOptions` has been dropped as an optional arg for the `useAnnouncements` hook in favor of handling state and dependencies internally.
