### PR TITLE
fix(argocd): add missing apis to argocd dev mode

### DIFF
--- a/workspaces/argocd/plugins/argocd/dev/index.tsx
+++ b/workspaces/argocd/plugins/argocd/dev/index.tsx
@@ -263,6 +263,8 @@ createDevApp()
           [configApiRef, new ConfigReader(mockArgocdConfig)],
           [argoCDApiRef, new MockArgoCDApiClient()],
           [argoCDInstanceApiRef, new MockArgoCDInstanceApiClient()],
+          [permissionApiRef, mockApis.permission()],
+          [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
         ]}
       >
         <EntityProvider entity={mockEntity}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!


Deployment summary page in the dev mode was missing some APIs and throwing permission denied errors.


**Before:**

![argocd_dev_mode_before](https://github.com/user-attachments/assets/2ec9bd62-9a34-4288-9144-ea7176320811)



**After fix:**


![argocd-dev-mode](https://github.com/user-attachments/assets/e4730568-c357-4a97-b3c9-8899da891e14)



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
