### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/grumpy-radios-cover.md
+++ b/workspaces/announcements/.changeset/grumpy-radios-cover.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-announcements': minor
----
-
-- Added support for overriding `title`, `hideStartAt` and `markdownRenderer` via app-config for announcements page.
-- `category` and `defaultInactive` props are now deprecated and will be removed in future releases. Use URL state to filter by category (e.g. `?category=...`). Inactive announcements are now hidden by default.
-- Update @uiw/react-md-editor dependency to version 4.0.11.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-announcements
 
+## 2.3.0
+
+### Minor Changes
+
+- 5a984ed: - Added support for overriding `title`, `hideStartAt` and `markdownRenderer` via app-config for announcements page.
+  - `category` and `defaultInactive` props are now deprecated and will be removed in future releases. Use URL state to filter by category (e.g. `?category=...`). Inactive announcements are now hidden by default.
+  - Update @uiw/react-md-editor dependency to version 4.0.11.
+
 ## 2.2.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@2.3.0

### Minor Changes

-   5a984ed: - Added support for overriding `title`, `hideStartAt` and `markdownRenderer` via app-config for announcements page.
    -   `category` and `defaultInactive` props are now deprecated and will be removed in future releases. Use URL state to filter by category (e.g. `?category=...`). Inactive announcements are now hidden by default.
    -   Update @uiw/react-md-editor dependency to version 4.0.11.
