### PR TITLE
Announcements: Link Entity to Announcement

### DIFF
--- a/workspaces/announcements/.changeset/pretty-jokes-scream.md
+++ b/workspaces/announcements/.changeset/pretty-jokes-scream.md
@@ -5,4 +5,4 @@
 '@backstage-community/plugin-announcements': minor
 ---
 
-Announcements: added support for linking entities to an announcement. The backend is created with flexibility in mind to allow for linking multiple entities to an announcement. The UI for now is constrained to support a single announcement to keep things simple to start with.
+Added support for linking entities to an announcement. The backend is created with flexibility in mind to allow for linking multiple entities to an announcement. The UI for now is constrained to support a single announcement to keep things simple to start with.

--- a/workspaces/announcements/.changeset/pretty-jokes-scream.md
+++ b/workspaces/announcements/.changeset/pretty-jokes-scream.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-announcements-backend': minor
+'@backstage-community/plugin-announcements-common': minor
+'@backstage-community/plugin-announcements-react': minor
+'@backstage-community/plugin-announcements': minor
+---
+
+Announcements: added support for linking entities to an announcement. The backend is created with flexibility in mind to allow for linking multiple entities to an announcement. The UI for now is constrained to support a single announcement to keep things simple to start with.

--- a/workspaces/announcements/app-config.local.yaml.sample
+++ b/workspaces/announcements/app-config.local.yaml.sample
@@ -6,12 +6,3 @@ backend:
       port: ${POSTGRES_PORT}
       user: ${POSTGRES_USER}
       password: ${POSTGRES_PASSWORD}
-
-auth:
-  providers:
-    # allows you to select a user and group to be the owner of the announcement
-    # when creating announcements locally
-    guest:
-      userEntityRef: user:default/user-1
-      ownershipEntityRefs: [group:default/team-a]
-      dangerouslyAllowOutsideDevelopment: false

--- a/workspaces/announcements/app-config.yaml
+++ b/workspaces/announcements/app-config.yaml
@@ -40,7 +40,12 @@ backend:
 
 auth:
   providers:
-    guest: {}
+    # allows you to select a user and group to be the owner of the announcement
+    # when creating announcements locally
+    guest:
+      userEntityRef: user:default/user-1
+      ownershipEntityRefs: [group:default/team-a]
+      dangerouslyAllowOutsideDevelopment: false
 
 catalog:
   import:

--- a/workspaces/announcements/plugins/announcements-backend/README.md
+++ b/workspaces/announcements/plugins/announcements-backend/README.md
@@ -46,7 +46,7 @@ backend.add(import('@backstage-community/plugin-announcements-backend'));
 curl http://localhost:7007/api/announcements/announcements
 
 # get announcements for a specific entity
-curl http://localhost:7007/api/announcements/announcements?entity_ref=component:default/my-service
+curl http://localhost:7007/api/announcements/announcements?entityRef=component:default/my-service
 
 # get all categories
 curl http://localhost:7007/api/categories
@@ -65,7 +65,7 @@ return data;
 
 // get announcements for a specific entity
 const response = await fetch(
-  'http://localhost:7007/api/announcements/announcements?entity_ref=component:default/my-service',
+  'http://localhost:7007/api/announcements/announcements?entityRef=component:default/my-service',
 );
 const data = await response.json();
 return data;

--- a/workspaces/announcements/plugins/announcements-backend/README.md
+++ b/workspaces/announcements/plugins/announcements-backend/README.md
@@ -45,6 +45,9 @@ backend.add(import('@backstage-community/plugin-announcements-backend'));
 # get all announcements
 curl http://localhost:7007/api/announcements/announcements
 
+# get announcements for a specific entity
+curl http://localhost:7007/api/announcements/announcements?entity_ref=component:default/my-service
+
 # get all categories
 curl http://localhost:7007/api/categories
 
@@ -56,6 +59,13 @@ curl http://localhost:7007/api/tags
 // get all announcements
 const response = await fetch(
   'http://localhost:7007/api/announcements/announcements',
+);
+const data = await response.json();
+return data;
+
+// get announcements for a specific entity
+const response = await fetch(
+  'http://localhost:7007/api/announcements/announcements?entity_ref=component:default/my-service',
 );
 const data = await response.json();
 return data;

--- a/workspaces/announcements/plugins/announcements-backend/db/migrations/20260130114146_add_entity_ref.js
+++ b/workspaces/announcements/plugins/announcements-backend/db/migrations/20260130114146_add_entity_ref.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  // Create join table for announcement-entity relationships
+  await knex.schema.createTable('announcement_entities', table => {
+    table.comment(
+      'Join table linking announcements to catalog entities (many-to-many)',
+    );
+    table
+      .text('announcement_id')
+      .notNullable()
+      .comment('Reference to announcement ID');
+    table
+      .text('entity_ref')
+      .notNullable()
+      .comment('Catalog entity reference (e.g., component:default/my-service)');
+    table.primary(['announcement_id', 'entity_ref']);
+    table
+      .foreign('announcement_id')
+      .references('announcements.id')
+      .onDelete('CASCADE');
+    table.index('entity_ref', 'announcement_entities_entity_ref_idx');
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  if (await knex.schema.hasTable('announcement_entities')) {
+    await knex.schema.dropTable('announcement_entities');
+  }
+};

--- a/workspaces/announcements/plugins/announcements-backend/db/seeds/03_announcements.js
+++ b/workspaces/announcements/plugins/announcements-backend/db/seeds/03_announcements.js
@@ -1223,4 +1223,13 @@ We'd love to hear what other templates would be useful. Drop suggestions in #dev
       active: true,
     },
   ]);
+
+  // Seed announcement-entity relationships
+  await knex('announcement_entities').del();
+  await knex('announcement_entities').insert([
+    {
+      announcement_id: '17',
+      entity_ref: 'component:default/ci-runner',
+    },
+  ]);
 };

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -349,7 +349,7 @@ describe('createRouter', () => {
       expectAuditorSuccess();
     });
 
-    it('filters announcements by entity_ref', async () => {
+    it('filters announcements by entityRef', async () => {
       announcementsMock.mockReturnValueOnce({
         results: [
           {
@@ -362,14 +362,14 @@ describe('createRouter', () => {
             start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
-            entity_refs: ['component:default/service-a'],
+            entityRefs: ['component:default/service-a'],
           },
         ],
         count: 1,
       });
 
       const response = await request(app).get(
-        '/announcements?entity_ref=component:default/service-a',
+        '/announcements?entityRef=component:default/service-a',
       );
 
       expect(response.status).toEqual(200);
@@ -381,24 +381,24 @@ describe('createRouter', () => {
         sortBy: 'created_at',
         order: 'desc',
         current: undefined,
-        entity_ref: 'component:default/service-a',
+        entityRef: 'component:default/service-a',
       });
 
       expect(response.body.results).toHaveLength(1);
-      expect(response.body.results[0].entity_refs).toEqual([
+      expect(response.body.results[0].entityRefs).toEqual([
         'component:default/service-a',
       ]);
       expectAuditorSuccess();
     });
 
-    it('returns empty results when entity_ref has no matches', async () => {
+    it('returns empty results when entityRef has no matches', async () => {
       announcementsMock.mockReturnValueOnce({
         results: [],
         count: 0,
       });
 
       const response = await request(app).get(
-        '/announcements?entity_ref=component:default/nonexistent',
+        '/announcements?entityRef=component:default/nonexistent',
       );
 
       expect(response.status).toEqual(200);
@@ -410,7 +410,7 @@ describe('createRouter', () => {
         sortBy: 'created_at',
         order: 'desc',
         current: undefined,
-        entity_ref: 'component:default/nonexistent',
+        entityRef: 'component:default/nonexistent',
       });
 
       expect(response.body.results).toHaveLength(0);
@@ -418,7 +418,7 @@ describe('createRouter', () => {
       expectAuditorSuccess();
     });
 
-    it('combines entity_ref filter with other filters', async () => {
+    it('combines entityRef filter with other filters', async () => {
       announcementsMock.mockReturnValueOnce({
         results: [
           {
@@ -431,14 +431,14 @@ describe('createRouter', () => {
             start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
-            entity_refs: ['component:default/service-a'],
+            entityRefs: ['component:default/service-a'],
           },
         ],
         count: 1,
       });
 
       const response = await request(app).get(
-        '/announcements?entity_ref=component:default/service-a&active=true',
+        '/announcements?entityRef=component:default/service-a&active=true',
       );
 
       expect(response.status).toEqual(200);
@@ -450,17 +450,17 @@ describe('createRouter', () => {
         sortBy: 'created_at',
         order: 'desc',
         current: undefined,
-        entity_ref: 'component:default/service-a',
+        entityRef: 'component:default/service-a',
       });
 
       expect(response.body.results).toHaveLength(1);
-      expect(response.body.results[0].entity_refs).toEqual([
+      expect(response.body.results[0].entityRefs).toEqual([
         'component:default/service-a',
       ]);
       expectAuditorSuccess();
     });
 
-    it('returns announcements with multiple entity_refs', async () => {
+    it('returns announcements with multiple entityRefs', async () => {
       announcementsMock.mockReturnValueOnce({
         results: [
           {
@@ -473,7 +473,7 @@ describe('createRouter', () => {
             start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
             updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
-            entity_refs: [
+            entityRefs: [
               'component:default/service-a',
               'component:default/service-b',
             ],
@@ -483,12 +483,12 @@ describe('createRouter', () => {
       });
 
       const response = await request(app).get(
-        '/announcements?entity_ref=component:default/service-a',
+        '/announcements?entityRef=component:default/service-a',
       );
 
       expect(response.status).toEqual(200);
       expect(response.body.results).toHaveLength(1);
-      expect(response.body.results[0].entity_refs).toEqual([
+      expect(response.body.results[0].entityRefs).toEqual([
         'component:default/service-a',
         'component:default/service-b',
       ]);
@@ -497,7 +497,7 @@ describe('createRouter', () => {
   });
 
   describe('GET /announcements/:id', () => {
-    it('returns announcement with entity_refs', async () => {
+    it('returns announcement with entityRefs', async () => {
       announcementByIDMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'title',
@@ -508,19 +508,17 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const response = await request(app).get('/announcements/uuid');
 
       expect(response.status).toEqual(200);
-      expect(response.body.entity_refs).toEqual([
-        'component:default/service-a',
-      ]);
+      expect(response.body.entityRefs).toEqual(['component:default/service-a']);
       expectAuditorSuccess();
     });
 
-    it('returns announcement with empty entity_refs', async () => {
+    it('returns announcement with empty entityRefs', async () => {
       announcementByIDMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'title',
@@ -531,13 +529,13 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: [],
+        entityRefs: [],
       });
 
       const response = await request(app).get('/announcements/uuid');
 
       expect(response.status).toEqual(200);
-      expect(response.body.entity_refs).toEqual([]);
+      expect(response.body.entityRefs).toEqual([]);
       expectAuditorSuccess();
     });
   });
@@ -549,7 +547,7 @@ describe('createRouter', () => {
       ]);
     });
 
-    it('creates announcement with entity_refs', async () => {
+    it('creates announcement with entityRefs', async () => {
       insertAnnouncementMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'New Announcement',
@@ -560,7 +558,7 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const response = await request(app)
@@ -574,17 +572,15 @@ describe('createRouter', () => {
           until_date: '2022-12-02T15:28:08.539Z',
           active: true,
           sendNotification: false,
-          entity_refs: ['component:default/service-a'],
+          entityRefs: ['component:default/service-a'],
         });
 
       expect(response.status).toEqual(201);
-      expect(response.body.entity_refs).toEqual([
-        'component:default/service-a',
-      ]);
+      expect(response.body.entityRefs).toEqual(['component:default/service-a']);
       expectAuditorSuccess();
     });
 
-    it('creates announcement with multiple entity_refs', async () => {
+    it('creates announcement with multiple entityRefs', async () => {
       insertAnnouncementMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'New Announcement',
@@ -595,7 +591,7 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: [
+        entityRefs: [
           'component:default/service-a',
           'component:default/service-b',
         ],
@@ -612,21 +608,21 @@ describe('createRouter', () => {
           until_date: '2022-12-02T15:28:08.539Z',
           active: true,
           sendNotification: false,
-          entity_refs: [
+          entityRefs: [
             'component:default/service-a',
             'component:default/service-b',
           ],
         });
 
       expect(response.status).toEqual(201);
-      expect(response.body.entity_refs).toEqual([
+      expect(response.body.entityRefs).toEqual([
         'component:default/service-a',
         'component:default/service-b',
       ]);
       expectAuditorSuccess();
     });
 
-    it('creates announcement without entity_refs', async () => {
+    it('creates announcement without entityRefs', async () => {
       insertAnnouncementMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'New Announcement',
@@ -637,7 +633,7 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: [],
+        entityRefs: [],
       });
 
       const response = await request(app).post('/announcements').send({
@@ -652,11 +648,11 @@ describe('createRouter', () => {
       });
 
       expect(response.status).toEqual(201);
-      expect(response.body.entity_refs).toEqual([]);
+      expect(response.body.entityRefs).toEqual([]);
       expectAuditorSuccess();
     });
 
-    it('creates announcement with empty entity_refs array', async () => {
+    it('creates announcement with empty entityRefs array', async () => {
       insertAnnouncementMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'New Announcement',
@@ -667,7 +663,7 @@ describe('createRouter', () => {
         start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
-        entity_refs: [],
+        entityRefs: [],
       });
 
       const response = await request(app).post('/announcements').send({
@@ -679,11 +675,11 @@ describe('createRouter', () => {
         until_date: '2022-12-02T15:28:08.539Z',
         active: true,
         sendNotification: false,
-        entity_refs: [],
+        entityRefs: [],
       });
 
       expect(response.status).toEqual(201);
-      expect(response.body.entity_refs).toEqual([]);
+      expect(response.body.entityRefs).toEqual([]);
       expectAuditorSuccess();
     });
   });
@@ -695,7 +691,7 @@ describe('createRouter', () => {
       ]);
     });
 
-    it('updates announcement to add entity_refs', async () => {
+    it('updates announcement to add entityRefs', async () => {
       announcementByIDMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'Existing Announcement',
@@ -707,7 +703,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: [],
+        entityRefs: [],
       });
 
       updateAnnouncementMock.mockReturnValueOnce({
@@ -721,7 +717,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const response = await request(app)
@@ -734,17 +730,15 @@ describe('createRouter', () => {
           start_at: '2022-11-02T15:28:08.539Z',
           until_date: '2022-12-02T15:28:08.539Z',
           active: true,
-          entity_refs: ['component:default/service-a'],
+          entityRefs: ['component:default/service-a'],
         });
 
       expect(response.status).toEqual(200);
-      expect(response.body.entity_refs).toEqual([
-        'component:default/service-a',
-      ]);
+      expect(response.body.entityRefs).toEqual(['component:default/service-a']);
       expectAuditorSuccess();
     });
 
-    it('updates announcement to change entity_refs', async () => {
+    it('updates announcement to change entityRefs', async () => {
       announcementByIDMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'Existing Announcement',
@@ -756,7 +750,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       updateAnnouncementMock.mockReturnValueOnce({
@@ -770,7 +764,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: [
+        entityRefs: [
           'component:default/service-b',
           'component:default/service-c',
         ],
@@ -786,21 +780,21 @@ describe('createRouter', () => {
           start_at: '2022-11-02T15:28:08.539Z',
           until_date: '2022-12-02T15:28:08.539Z',
           active: true,
-          entity_refs: [
+          entityRefs: [
             'component:default/service-b',
             'component:default/service-c',
           ],
         });
 
       expect(response.status).toEqual(200);
-      expect(response.body.entity_refs).toEqual([
+      expect(response.body.entityRefs).toEqual([
         'component:default/service-b',
         'component:default/service-c',
       ]);
       expectAuditorSuccess();
     });
 
-    it('updates announcement to remove entity_refs', async () => {
+    it('updates announcement to remove entityRefs', async () => {
       announcementByIDMock.mockReturnValueOnce({
         id: 'uuid',
         title: 'Existing Announcement',
@@ -812,7 +806,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       updateAnnouncementMock.mockReturnValueOnce({
@@ -826,7 +820,7 @@ describe('createRouter', () => {
         until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
         updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
         active: true,
-        entity_refs: [],
+        entityRefs: [],
       });
 
       const response = await request(app).put('/announcements/uuid').send({
@@ -837,11 +831,11 @@ describe('createRouter', () => {
         start_at: '2022-11-02T15:28:08.539Z',
         until_date: '2022-12-02T15:28:08.539Z',
         active: true,
-        entity_refs: [],
+        entityRefs: [],
       });
 
       expect(response.status).toEqual(200);
-      expect(response.body.entity_refs).toEqual([]);
+      expect(response.body.entityRefs).toEqual([]);
       expectAuditorSuccess();
     });
   });

--- a/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.test.ts
@@ -348,5 +348,501 @@ describe('createRouter', () => {
       expect(response.body.count).toEqual(0);
       expectAuditorSuccess();
     });
+
+    it('filters announcements by entity_ref', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [
+          {
+            id: 'uuid1',
+            title: 'Entity Announcement',
+            excerpt: 'Linked to entity',
+            body: 'Full content',
+            publisher: 'user:default/name',
+            created_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            entity_refs: ['component:default/service-a'],
+          },
+        ],
+        count: 1,
+      });
+
+      const response = await request(app).get(
+        '/announcements?entity_ref=component:default/service-a',
+      );
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: false,
+        sortBy: 'created_at',
+        order: 'desc',
+        current: undefined,
+        entity_ref: 'component:default/service-a',
+      });
+
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].entity_refs).toEqual([
+        'component:default/service-a',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('returns empty results when entity_ref has no matches', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [],
+        count: 0,
+      });
+
+      const response = await request(app).get(
+        '/announcements?entity_ref=component:default/nonexistent',
+      );
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: false,
+        sortBy: 'created_at',
+        order: 'desc',
+        current: undefined,
+        entity_ref: 'component:default/nonexistent',
+      });
+
+      expect(response.body.results).toHaveLength(0);
+      expect(response.body.count).toEqual(0);
+      expectAuditorSuccess();
+    });
+
+    it('combines entity_ref filter with other filters', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [
+          {
+            id: 'uuid1',
+            title: 'Active Entity Announcement',
+            excerpt: 'Active and linked',
+            body: 'Full content',
+            publisher: 'user:default/name',
+            created_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            entity_refs: ['component:default/service-a'],
+          },
+        ],
+        count: 1,
+      });
+
+      const response = await request(app).get(
+        '/announcements?entity_ref=component:default/service-a&active=true',
+      );
+
+      expect(response.status).toEqual(200);
+      expect(announcementsMock).toHaveBeenCalledWith({
+        category: undefined,
+        max: undefined,
+        offset: undefined,
+        active: true,
+        sortBy: 'created_at',
+        order: 'desc',
+        current: undefined,
+        entity_ref: 'component:default/service-a',
+      });
+
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].entity_refs).toEqual([
+        'component:default/service-a',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('returns announcements with multiple entity_refs', async () => {
+      announcementsMock.mockReturnValueOnce({
+        results: [
+          {
+            id: 'uuid1',
+            title: 'Multi-entity Announcement',
+            excerpt: 'Linked to multiple entities',
+            body: 'Full content',
+            publisher: 'user:default/name',
+            created_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            start_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            until_date: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            updated_at: DateTime.fromISO('2023-01-01T10:00:00.000Z'),
+            entity_refs: [
+              'component:default/service-a',
+              'component:default/service-b',
+            ],
+          },
+        ],
+        count: 1,
+      });
+
+      const response = await request(app).get(
+        '/announcements?entity_ref=component:default/service-a',
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].entity_refs).toEqual([
+        'component:default/service-a',
+        'component:default/service-b',
+      ]);
+      expectAuditorSuccess();
+    });
+  });
+
+  describe('GET /announcements/:id', () => {
+    it('returns announcement with entity_refs', async () => {
+      announcementByIDMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const response = await request(app).get('/announcements/uuid');
+
+      expect(response.status).toEqual(200);
+      expect(response.body.entity_refs).toEqual([
+        'component:default/service-a',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('returns announcement with empty entity_refs', async () => {
+      announcementByIDMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: [],
+      });
+
+      const response = await request(app).get('/announcements/uuid');
+
+      expect(response.status).toEqual(200);
+      expect(response.body.entity_refs).toEqual([]);
+      expectAuditorSuccess();
+    });
+  });
+
+  describe('POST /announcements', () => {
+    beforeEach(() => {
+      (mockPermissions.authorize as jest.Mock).mockReturnValue([
+        { result: 'ALLOW' },
+      ]);
+    });
+
+    it('creates announcement with entity_refs', async () => {
+      insertAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const response = await request(app)
+        .post('/announcements')
+        .send({
+          title: 'New Announcement',
+          excerpt: 'excerpt',
+          body: 'body',
+          publisher: 'user:default/name',
+          start_at: '2022-11-02T15:28:08.539Z',
+          until_date: '2022-12-02T15:28:08.539Z',
+          active: true,
+          sendNotification: false,
+          entity_refs: ['component:default/service-a'],
+        });
+
+      expect(response.status).toEqual(201);
+      expect(response.body.entity_refs).toEqual([
+        'component:default/service-a',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('creates announcement with multiple entity_refs', async () => {
+      insertAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: [
+          'component:default/service-a',
+          'component:default/service-b',
+        ],
+      });
+
+      const response = await request(app)
+        .post('/announcements')
+        .send({
+          title: 'New Announcement',
+          excerpt: 'excerpt',
+          body: 'body',
+          publisher: 'user:default/name',
+          start_at: '2022-11-02T15:28:08.539Z',
+          until_date: '2022-12-02T15:28:08.539Z',
+          active: true,
+          sendNotification: false,
+          entity_refs: [
+            'component:default/service-a',
+            'component:default/service-b',
+          ],
+        });
+
+      expect(response.status).toEqual(201);
+      expect(response.body.entity_refs).toEqual([
+        'component:default/service-a',
+        'component:default/service-b',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('creates announcement without entity_refs', async () => {
+      insertAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: [],
+      });
+
+      const response = await request(app).post('/announcements').send({
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        start_at: '2022-11-02T15:28:08.539Z',
+        until_date: '2022-12-02T15:28:08.539Z',
+        active: true,
+        sendNotification: false,
+      });
+
+      expect(response.status).toEqual(201);
+      expect(response.body.entity_refs).toEqual([]);
+      expectAuditorSuccess();
+    });
+
+    it('creates announcement with empty entity_refs array', async () => {
+      insertAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        entity_refs: [],
+      });
+
+      const response = await request(app).post('/announcements').send({
+        title: 'New Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        start_at: '2022-11-02T15:28:08.539Z',
+        until_date: '2022-12-02T15:28:08.539Z',
+        active: true,
+        sendNotification: false,
+        entity_refs: [],
+      });
+
+      expect(response.status).toEqual(201);
+      expect(response.body.entity_refs).toEqual([]);
+      expectAuditorSuccess();
+    });
+  });
+
+  describe('PUT /announcements/:id', () => {
+    beforeEach(() => {
+      (mockPermissions.authorize as jest.Mock).mockReturnValue([
+        { result: 'ALLOW' },
+      ]);
+    });
+
+    it('updates announcement to add entity_refs', async () => {
+      announcementByIDMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Existing Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: [],
+      });
+
+      updateAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Updated Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const response = await request(app)
+        .put('/announcements/uuid')
+        .send({
+          title: 'Updated Announcement',
+          excerpt: 'excerpt',
+          body: 'body',
+          publisher: 'user:default/name',
+          start_at: '2022-11-02T15:28:08.539Z',
+          until_date: '2022-12-02T15:28:08.539Z',
+          active: true,
+          entity_refs: ['component:default/service-a'],
+        });
+
+      expect(response.status).toEqual(200);
+      expect(response.body.entity_refs).toEqual([
+        'component:default/service-a',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('updates announcement to change entity_refs', async () => {
+      announcementByIDMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Existing Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: ['component:default/service-a'],
+      });
+
+      updateAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Updated Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: [
+          'component:default/service-b',
+          'component:default/service-c',
+        ],
+      });
+
+      const response = await request(app)
+        .put('/announcements/uuid')
+        .send({
+          title: 'Updated Announcement',
+          excerpt: 'excerpt',
+          body: 'body',
+          publisher: 'user:default/name',
+          start_at: '2022-11-02T15:28:08.539Z',
+          until_date: '2022-12-02T15:28:08.539Z',
+          active: true,
+          entity_refs: [
+            'component:default/service-b',
+            'component:default/service-c',
+          ],
+        });
+
+      expect(response.status).toEqual(200);
+      expect(response.body.entity_refs).toEqual([
+        'component:default/service-b',
+        'component:default/service-c',
+      ]);
+      expectAuditorSuccess();
+    });
+
+    it('updates announcement to remove entity_refs', async () => {
+      announcementByIDMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Existing Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: ['component:default/service-a'],
+      });
+
+      updateAnnouncementMock.mockReturnValueOnce({
+        id: 'uuid',
+        title: 'Updated Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        created_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        start_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        until_date: DateTime.fromISO('2022-12-02T15:28:08.539Z'),
+        updated_at: DateTime.fromISO('2022-11-02T15:28:08.539Z'),
+        active: true,
+        entity_refs: [],
+      });
+
+      const response = await request(app).put('/announcements/uuid').send({
+        title: 'Updated Announcement',
+        excerpt: 'excerpt',
+        body: 'body',
+        publisher: 'user:default/name',
+        start_at: '2022-11-02T15:28:08.539Z',
+        until_date: '2022-12-02T15:28:08.539Z',
+        active: true,
+        entity_refs: [],
+      });
+
+      expect(response.status).toEqual(200);
+      expect(response.body.entity_refs).toEqual([]);
+      expectAuditorSuccess();
+    });
   });
 });

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -57,6 +57,7 @@ interface AnnouncementRequest {
   sendNotification: boolean;
   on_behalf_of?: string;
   tags?: string[];
+  entity_refs?: string[];
 }
 
 interface CategoryRequest {
@@ -76,6 +77,7 @@ type GetAnnouncementsQueryParams = {
   order?: 'asc' | 'desc';
   current?: boolean;
   tags?: string[];
+  entity_ref?: string;
 };
 
 export async function createRouter(
@@ -143,6 +145,7 @@ export async function createRouter(
           order = 'desc',
           current,
           tags,
+          entity_ref,
         },
       } = req;
 
@@ -160,6 +163,7 @@ export async function createRouter(
           order: ['asc', 'desc'].includes(order) ? order : 'desc',
           current,
           tags: tagsFilter,
+          entity_ref,
         },
       );
       await auditorEvent.success();
@@ -353,6 +357,7 @@ export async function createRouter(
           start_at,
           until_date,
           on_behalf_of,
+          entity_refs,
           tags,
         },
       } = req;
@@ -392,6 +397,7 @@ export async function createRouter(
             start_at: DateTime.fromISO(start_at),
             until_date: until_date ? DateTime.fromISO(until_date) : undefined,
             on_behalf_of,
+            entity_refs,
             tags: validatedTags,
           },
         });

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -57,7 +57,7 @@ interface AnnouncementRequest {
   sendNotification: boolean;
   on_behalf_of?: string;
   tags?: string[];
-  entity_refs?: string[];
+  entityRefs?: string[];
 }
 
 interface CategoryRequest {
@@ -77,7 +77,7 @@ type GetAnnouncementsQueryParams = {
   order?: 'asc' | 'desc';
   current?: boolean;
   tags?: string[];
-  entity_ref?: string;
+  entityRef?: string;
 };
 
 export async function createRouter(
@@ -145,7 +145,7 @@ export async function createRouter(
           order = 'desc',
           current,
           tags,
-          entity_ref,
+          entityRef,
         },
       } = req;
 
@@ -163,7 +163,7 @@ export async function createRouter(
           order: ['asc', 'desc'].includes(order) ? order : 'desc',
           current,
           tags: tagsFilter,
-          entity_ref,
+          entityRef,
         },
       );
       await auditorEvent.success();
@@ -357,7 +357,7 @@ export async function createRouter(
           start_at,
           until_date,
           on_behalf_of,
-          entity_refs,
+          entityRefs,
           tags,
         },
       } = req;
@@ -397,7 +397,7 @@ export async function createRouter(
             start_at: DateTime.fromISO(start_at),
             until_date: until_date ? DateTime.fromISO(until_date) : undefined,
             on_behalf_of,
-            entity_refs,
+            entityRefs,
             tags: validatedTags,
           },
         });

--- a/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -86,7 +86,7 @@ describe('AnnouncementsDatabase', () => {
       until_date: null,
       on_behalf_of: 'group:default/team-a',
       updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-      entity_refs: [],
+      entityRefs: [],
     });
   });
 
@@ -121,7 +121,7 @@ describe('AnnouncementsDatabase', () => {
       until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
       on_behalf_of: 'group:default/team-a',
       updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-      entity_refs: [],
+      entityRefs: [],
     });
   });
 
@@ -159,7 +159,7 @@ describe('AnnouncementsDatabase', () => {
           until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
           on_behalf_of: 'group:default/team-a',
           updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-          entity_refs: [],
+          entityRefs: [],
         },
       ],
     });
@@ -215,7 +215,7 @@ describe('AnnouncementsDatabase', () => {
           until_date: timestampToDateTime('2025-03-18T13:00:00.708Z'),
           on_behalf_of: 'group:default/team-a',
           updated_at: timestampToDateTime(time.toISO()),
-          entity_refs: [],
+          entityRefs: [],
         },
       ],
     });
@@ -337,7 +337,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id',
@@ -356,7 +356,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -412,7 +412,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -496,7 +496,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -580,7 +580,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id2',
@@ -596,7 +596,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -653,7 +653,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-19T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-27T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id1',
@@ -669,7 +669,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -726,7 +726,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id2',
@@ -742,7 +742,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-27T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -799,7 +799,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id1',
@@ -815,7 +815,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-17T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-25T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
@@ -872,7 +872,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2025-10-27T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
           {
             id: 'id1',
@@ -888,15 +888,15 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-17T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2025-10-25T15:28:08.539Z'),
-            entity_refs: [],
+            entityRefs: [],
           },
         ],
       });
     });
   });
 
-  describe('entity_ref queries', () => {
-    it('should filter announcements by entity_ref', async () => {
+  describe('entityRef queries', () => {
+    it('should filter announcements by entityRef', async () => {
       await store.insertAnnouncement({
         id: 'id1',
         publisher: 'publisher1',
@@ -909,7 +909,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       await store.insertAnnouncement({
@@ -924,7 +924,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-b'],
+        entityRefs: ['component:default/service-b'],
       });
 
       await store.insertAnnouncement({
@@ -942,7 +942,7 @@ describe('AnnouncementsDatabase', () => {
       });
 
       const announcements = await store.announcements({
-        entity_ref: 'component:default/service-a',
+        entityRef: 'component:default/service-a',
       });
 
       expect(announcements).toEqual({
@@ -962,13 +962,13 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: ['component:default/service-a'],
+            entityRefs: ['component:default/service-a'],
           },
         ],
       });
     });
 
-    it('should return empty results when entity_ref has no matches', async () => {
+    it('should return empty results when entityRef has no matches', async () => {
       await store.insertAnnouncement({
         id: 'id1',
         publisher: 'publisher1',
@@ -981,11 +981,11 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const announcements = await store.announcements({
-        entity_ref: 'component:default/nonexistent',
+        entityRef: 'component:default/nonexistent',
       });
 
       expect(announcements).toEqual({
@@ -994,7 +994,7 @@ describe('AnnouncementsDatabase', () => {
       });
     });
 
-    it('should combine entity_ref filter with other filters', async () => {
+    it('should combine entityRef filter with other filters', async () => {
       await store.insertAnnouncement({
         id: 'id1',
         publisher: 'publisher1',
@@ -1007,7 +1007,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       await store.insertAnnouncement({
@@ -1022,11 +1022,11 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const announcements = await store.announcements({
-        entity_ref: 'component:default/service-a',
+        entityRef: 'component:default/service-a',
         active: true,
       });
 
@@ -1047,13 +1047,13 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-            entity_refs: ['component:default/service-a'],
+            entityRefs: ['component:default/service-a'],
           },
         ],
       });
     });
 
-    it('should populate entity_refs for multiple announcements', async () => {
+    it('should populate entityRefs for multiple announcements', async () => {
       await store.insertAnnouncement({
         id: 'id1',
         publisher: 'publisher1',
@@ -1066,7 +1066,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: [
+        entityRefs: [
           'component:default/service-a',
           'component:default/service-b',
         ],
@@ -1089,16 +1089,16 @@ describe('AnnouncementsDatabase', () => {
       const announcements = await store.announcements({});
 
       expect(announcements.count).toBe(2);
-      expect(announcements.results[1].entity_refs).toEqual([
+      expect(announcements.results[1].entityRefs).toEqual([
         'component:default/service-a',
         'component:default/service-b',
       ]);
-      expect(announcements.results[0].entity_refs).toEqual([]);
+      expect(announcements.results[0].entityRefs).toEqual([]);
     });
   });
 
-  describe('entity_refs operations', () => {
-    it('should return announcement with entity_refs by id', async () => {
+  describe('entityRefs operations', () => {
+    it('should return announcement with entityRefs by id', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1111,7 +1111,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const announcement = await store.announcementByID('id');
@@ -1130,11 +1130,11 @@ describe('AnnouncementsDatabase', () => {
         until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
     });
 
-    it('should return announcement with multiple entity_refs by id', async () => {
+    it('should return announcement with multiple entityRefs by id', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1147,7 +1147,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: [
+        entityRefs: [
           'component:default/service-a',
           'component:default/service-b',
           'system:default/system-a',
@@ -1156,14 +1156,14 @@ describe('AnnouncementsDatabase', () => {
 
       const announcement = await store.announcementByID('id');
 
-      expect(announcement?.entity_refs).toEqual([
+      expect(announcement?.entityRefs).toEqual([
         'component:default/service-a',
         'component:default/service-b',
         'system:default/system-a',
       ]);
     });
 
-    it('should return announcement with empty entity_refs by id', async () => {
+    it('should return announcement with empty entityRefs by id', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1180,10 +1180,10 @@ describe('AnnouncementsDatabase', () => {
 
       const announcement = await store.announcementByID('id');
 
-      expect(announcement?.entity_refs).toEqual([]);
+      expect(announcement?.entityRefs).toEqual([]);
     });
 
-    it('should insert announcement with entity_refs', async () => {
+    it('should insert announcement with entityRefs', async () => {
       const inserted = await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1196,16 +1196,16 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
-      expect(inserted.entity_refs).toEqual(['component:default/service-a']);
+      expect(inserted.entityRefs).toEqual(['component:default/service-a']);
 
       const fromDb = await store.announcementByID('id');
-      expect(fromDb?.entity_refs).toEqual(['component:default/service-a']);
+      expect(fromDb?.entityRefs).toEqual(['component:default/service-a']);
     });
 
-    it('should insert announcement with multiple entity_refs', async () => {
+    it('should insert announcement with multiple entityRefs', async () => {
       const inserted = await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1218,19 +1218,19 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: [
+        entityRefs: [
           'component:default/service-a',
           'component:default/service-b',
         ],
       });
 
-      expect(inserted.entity_refs).toEqual([
+      expect(inserted.entityRefs).toEqual([
         'component:default/service-a',
         'component:default/service-b',
       ]);
     });
 
-    it('should insert announcement without entity_refs', async () => {
+    it('should insert announcement without entityRefs', async () => {
       const inserted = await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1245,10 +1245,10 @@ describe('AnnouncementsDatabase', () => {
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
       });
 
-      expect(inserted.entity_refs).toEqual([]);
+      expect(inserted.entityRefs).toEqual([]);
     });
 
-    it('should update announcement to add entity_refs', async () => {
+    it('should update announcement to add entityRefs', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1275,13 +1275,13 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
-      expect(updated.entity_refs).toEqual(['component:default/service-a']);
+      expect(updated.entityRefs).toEqual(['component:default/service-a']);
     });
 
-    it('should update announcement to change entity_refs', async () => {
+    it('should update announcement to change entityRefs', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1294,7 +1294,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const updated = await store.updateAnnouncement({
@@ -1309,25 +1309,25 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: [
+        entityRefs: [
           'component:default/service-b',
           'component:default/service-c',
         ],
       });
 
-      expect(updated.entity_refs).toEqual([
+      expect(updated.entityRefs).toEqual([
         'component:default/service-b',
         'component:default/service-c',
       ]);
 
       const fromDb = await store.announcementByID('id');
-      expect(fromDb?.entity_refs).toEqual([
+      expect(fromDb?.entityRefs).toEqual([
         'component:default/service-b',
         'component:default/service-c',
       ]);
     });
 
-    it('should update announcement to remove entity_refs', async () => {
+    it('should update announcement to remove entityRefs', async () => {
       await store.insertAnnouncement({
         id: 'id',
         publisher: 'publisher',
@@ -1340,7 +1340,7 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: ['component:default/service-a'],
+        entityRefs: ['component:default/service-a'],
       });
 
       const updated = await store.updateAnnouncement({
@@ -1355,13 +1355,13 @@ describe('AnnouncementsDatabase', () => {
         until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
         on_behalf_of: 'group:default/team-a',
         updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
-        entity_refs: [],
+        entityRefs: [],
       });
 
-      expect(updated.entity_refs).toEqual([]);
+      expect(updated.entityRefs).toEqual([]);
 
       const fromDb = await store.announcementByID('id');
-      expect(fromDb?.entity_refs).toEqual([]);
+      expect(fromDb?.entityRefs).toEqual([]);
     });
   });
 });

--- a/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.test.ts
@@ -44,6 +44,7 @@ describe('AnnouncementsDatabase', () => {
   });
 
   afterEach(async () => {
+    await testDbClient('announcement_entities').delete();
     await testDbClient('announcements').delete();
   });
 
@@ -85,6 +86,7 @@ describe('AnnouncementsDatabase', () => {
       until_date: null,
       on_behalf_of: 'group:default/team-a',
       updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+      entity_refs: [],
     });
   });
 
@@ -119,6 +121,7 @@ describe('AnnouncementsDatabase', () => {
       until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
       on_behalf_of: 'group:default/team-a',
       updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+      entity_refs: [],
     });
   });
 
@@ -156,6 +159,7 @@ describe('AnnouncementsDatabase', () => {
           until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
           on_behalf_of: 'group:default/team-a',
           updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+          entity_refs: [],
         },
       ],
     });
@@ -211,6 +215,7 @@ describe('AnnouncementsDatabase', () => {
           until_date: timestampToDateTime('2025-03-18T13:00:00.708Z'),
           on_behalf_of: 'group:default/team-a',
           updated_at: timestampToDateTime(time.toISO()),
+          entity_refs: [],
         },
       ],
     });
@@ -332,6 +337,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id',
@@ -350,6 +356,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -405,6 +412,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -488,6 +496,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -571,6 +580,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id2',
@@ -586,6 +596,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -642,6 +653,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-19T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-27T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id1',
@@ -657,6 +669,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -713,6 +726,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id2',
@@ -728,6 +742,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-27T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -784,6 +799,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id1',
@@ -799,6 +815,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-17T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2023-10-25T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
@@ -855,6 +872,7 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2025-10-27T15:28:08.539Z'),
+            entity_refs: [],
           },
           {
             id: 'id1',
@@ -870,9 +888,480 @@ describe('AnnouncementsDatabase', () => {
             until_date: timestampToDateTime('2025-02-17T13:00:00.708Z'),
             on_behalf_of: 'group:default/team-a',
             updated_at: timestampToDateTime('2025-10-25T15:28:08.539Z'),
+            entity_refs: [],
           },
         ],
       });
+    });
+  });
+
+  describe('entity_ref queries', () => {
+    it('should filter announcements by entity_ref', async () => {
+      await store.insertAnnouncement({
+        id: 'id1',
+        publisher: 'publisher1',
+        title: 'title1',
+        excerpt: 'excerpt1',
+        body: 'body1',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-b'],
+      });
+
+      await store.insertAnnouncement({
+        id: 'id3',
+        publisher: 'publisher3',
+        title: 'title3',
+        excerpt: 'excerpt3',
+        body: 'body3',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcements = await store.announcements({
+        entity_ref: 'component:default/service-a',
+      });
+
+      expect(announcements).toEqual({
+        count: 1,
+        results: [
+          {
+            id: 'id1',
+            publisher: 'publisher1',
+            title: 'title1',
+            excerpt: 'excerpt1',
+            body: 'body1',
+            category: undefined,
+            tags: [],
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            active: 1,
+            start_at: timestampToDateTime('2025-01-18T13:00:00.708Z'),
+            until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
+            on_behalf_of: 'group:default/team-a',
+            updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: ['component:default/service-a'],
+          },
+        ],
+      });
+    });
+
+    it('should return empty results when entity_ref has no matches', async () => {
+      await store.insertAnnouncement({
+        id: 'id1',
+        publisher: 'publisher1',
+        title: 'title1',
+        excerpt: 'excerpt1',
+        body: 'body1',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const announcements = await store.announcements({
+        entity_ref: 'component:default/nonexistent',
+      });
+
+      expect(announcements).toEqual({
+        count: 0,
+        results: [],
+      });
+    });
+
+    it('should combine entity_ref filter with other filters', async () => {
+      await store.insertAnnouncement({
+        id: 'id1',
+        publisher: 'publisher1',
+        title: 'title1',
+        excerpt: 'excerpt1',
+        body: 'body1',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: false,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const announcements = await store.announcements({
+        entity_ref: 'component:default/service-a',
+        active: true,
+      });
+
+      expect(announcements).toEqual({
+        count: 1,
+        results: [
+          {
+            id: 'id1',
+            publisher: 'publisher1',
+            title: 'title1',
+            excerpt: 'excerpt1',
+            body: 'body1',
+            category: undefined,
+            tags: [],
+            created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            active: 1,
+            start_at: timestampToDateTime('2025-01-18T13:00:00.708Z'),
+            until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
+            on_behalf_of: 'group:default/team-a',
+            updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+            entity_refs: ['component:default/service-a'],
+          },
+        ],
+      });
+    });
+
+    it('should populate entity_refs for multiple announcements', async () => {
+      await store.insertAnnouncement({
+        id: 'id1',
+        publisher: 'publisher1',
+        title: 'title1',
+        excerpt: 'excerpt1',
+        body: 'body1',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: [
+          'component:default/service-a',
+          'component:default/service-b',
+        ],
+      });
+
+      await store.insertAnnouncement({
+        id: 'id2',
+        publisher: 'publisher2',
+        title: 'title2',
+        excerpt: 'excerpt2',
+        body: 'body2',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcements = await store.announcements({});
+
+      expect(announcements.count).toBe(2);
+      expect(announcements.results[1].entity_refs).toEqual([
+        'component:default/service-a',
+        'component:default/service-b',
+      ]);
+      expect(announcements.results[0].entity_refs).toEqual([]);
+    });
+  });
+
+  describe('entity_refs operations', () => {
+    it('should return announcement with entity_refs by id', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const announcement = await store.announcementByID('id');
+
+      expect(announcement).toEqual({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        category: undefined,
+        tags: [],
+        created_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+        active: 1,
+        start_at: timestampToDateTime('2025-01-18T13:00:00.708Z'),
+        until_date: timestampToDateTime('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: timestampToDateTime('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+    });
+
+    it('should return announcement with multiple entity_refs by id', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: [
+          'component:default/service-a',
+          'component:default/service-b',
+          'system:default/system-a',
+        ],
+      });
+
+      const announcement = await store.announcementByID('id');
+
+      expect(announcement?.entity_refs).toEqual([
+        'component:default/service-a',
+        'component:default/service-b',
+        'system:default/system-a',
+      ]);
+    });
+
+    it('should return announcement with empty entity_refs by id', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const announcement = await store.announcementByID('id');
+
+      expect(announcement?.entity_refs).toEqual([]);
+    });
+
+    it('should insert announcement with entity_refs', async () => {
+      const inserted = await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      expect(inserted.entity_refs).toEqual(['component:default/service-a']);
+
+      const fromDb = await store.announcementByID('id');
+      expect(fromDb?.entity_refs).toEqual(['component:default/service-a']);
+    });
+
+    it('should insert announcement with multiple entity_refs', async () => {
+      const inserted = await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: [
+          'component:default/service-a',
+          'component:default/service-b',
+        ],
+      });
+
+      expect(inserted.entity_refs).toEqual([
+        'component:default/service-a',
+        'component:default/service-b',
+      ]);
+    });
+
+    it('should insert announcement without entity_refs', async () => {
+      const inserted = await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      expect(inserted.entity_refs).toEqual([]);
+    });
+
+    it('should update announcement to add entity_refs', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+      });
+
+      const updated = await store.updateAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      expect(updated.entity_refs).toEqual(['component:default/service-a']);
+    });
+
+    it('should update announcement to change entity_refs', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const updated = await store.updateAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: [
+          'component:default/service-b',
+          'component:default/service-c',
+        ],
+      });
+
+      expect(updated.entity_refs).toEqual([
+        'component:default/service-b',
+        'component:default/service-c',
+      ]);
+
+      const fromDb = await store.announcementByID('id');
+      expect(fromDb?.entity_refs).toEqual([
+        'component:default/service-b',
+        'component:default/service-c',
+      ]);
+    });
+
+    it('should update announcement to remove entity_refs', async () => {
+      await store.insertAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: ['component:default/service-a'],
+      });
+
+      const updated = await store.updateAnnouncement({
+        id: 'id',
+        publisher: 'publisher',
+        title: 'title',
+        excerpt: 'excerpt',
+        body: 'body',
+        created_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        active: true,
+        start_at: DateTime.fromISO('2025-01-18T13:00:00.708Z'),
+        until_date: DateTime.fromISO('2025-02-18T13:00:00.708Z'),
+        on_behalf_of: 'group:default/team-a',
+        updated_at: DateTime.fromISO('2023-10-26T15:28:08.539Z'),
+        entity_refs: [],
+      });
+
+      expect(updated.entity_refs).toEqual([]);
+
+      const fromDb = await store.announcementByID('id');
+      expect(fromDb?.entity_refs).toEqual([]);
     });
   });
 });

--- a/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/persistence/AnnouncementsDatabase.ts
@@ -44,7 +44,7 @@ type AnnouncementUpsert = Omit<
  */
 type DbAnnouncement = Omit<
   Announcement,
-  'category' | 'tags' | 'start_at' | 'until_date' | 'entity_refs'
+  'category' | 'tags' | 'start_at' | 'until_date' | 'entityRefs'
 > & {
   category?: string;
   tags?: string | string[];
@@ -172,7 +172,7 @@ const DBToAnnouncementWithCategory = (
       : null,
     updated_at: timestampToDateTime(announcementDb.updated_at),
     on_behalf_of: announcementDb.on_behalf_of,
-    entity_refs: [],
+    entityRefs: [],
   };
 };
 
@@ -195,7 +195,7 @@ export class AnnouncementsDatabase {
       sortBy = 'created_at',
       order = 'desc',
       current,
-      entity_ref,
+      entityRef,
     } = request;
 
     const filterBase = <TRecord extends {}, TResult>(
@@ -207,13 +207,13 @@ export class AnnouncementsDatabase {
       if (active) {
         qb.where('active', active);
       }
-      if (entity_ref) {
+      if (entityRef) {
         // Filter by entity using join table
         qb.innerJoin(
           'announcement_entities',
           'announcements.id',
           'announcement_entities.announcement_id',
-        ).where('announcement_entities.entity_ref', entity_ref);
+        ).where('announcement_entities.entity_ref', entityRef);
       }
       if (current) {
         const today = DateTime.now().toISO();
@@ -277,7 +277,7 @@ export class AnnouncementsDatabase {
             .whereIn('announcement_id', announcementIds)
         : [];
 
-    // Build a map of announcement_id -> entity_refs[]
+    // Build a map of announcement_id -> entityRefs[]
     const entityRefMap = new Map<string, string[]>();
     entityRefs.forEach(row => {
       if (!entityRefMap.has(row.announcement_id)) {
@@ -318,12 +318,12 @@ export class AnnouncementsDatabase {
         return {
           ...announcement,
           tags: updatedTags,
-          entity_refs: entityRefMap.get(announcement.id) || [],
+          entityRefs: entityRefMap.get(announcement.id) || [],
         };
       }
       return {
         ...announcement,
-        entity_refs: entityRefMap.get(announcement.id) || [],
+        entityRefs: entityRefMap.get(announcement.id) || [],
       };
     });
 
@@ -379,7 +379,7 @@ export class AnnouncementsDatabase {
       .select('entity_ref')
       .where('announcement_id', id);
 
-    announcementBase.entity_refs = entityRefs.map(row => row.entity_ref);
+    announcementBase.entityRefs = entityRefs.map(row => row.entity_ref);
 
     if (announcementBase.tags && announcementBase.tags.length > 0) {
       const tagSlugs = announcementBase.tags.map(t => t.slug);
@@ -411,9 +411,9 @@ export class AnnouncementsDatabase {
     );
 
     // Insert entity relationships if present
-    if (announcement.entity_refs && announcement.entity_refs.length > 0) {
+    if (announcement.entityRefs && announcement.entityRefs.length > 0) {
       await this.db('announcement_entities').insert(
-        announcement.entity_refs.map(entity_ref => ({
+        announcement.entityRefs.map(entity_ref => ({
           announcement_id: announcement.id,
           entity_ref,
         })),
@@ -441,9 +441,9 @@ export class AnnouncementsDatabase {
       .where('announcement_id', announcement.id)
       .delete();
 
-    if (announcement.entity_refs && announcement.entity_refs.length > 0) {
+    if (announcement.entityRefs && announcement.entityRefs.length > 0) {
       await this.db('announcement_entities').insert(
-        announcement.entity_refs.map(entity_ref => ({
+        announcement.entityRefs.map(entity_ref => ({
           announcement_id: announcement.id,
           entity_ref,
         })),

--- a/workspaces/announcements/plugins/announcements-common/report.api.md
+++ b/workspaces/announcements/plugins/announcements-common/report.api.md
@@ -21,6 +21,7 @@ export type Announcement = {
   tags?: Tag[];
   sendNotification?: boolean;
   updated_at: string;
+  entityRefs?: string[];
 };
 
 // @public
@@ -48,6 +49,7 @@ export type AnnouncementsFilters = {
   order?: 'asc' | 'desc';
   current?: boolean;
   sendNotification?: boolean;
+  entityRef?: string;
 };
 
 // @public

--- a/workspaces/announcements/plugins/announcements-common/src/types.ts
+++ b/workspaces/announcements/plugins/announcements-common/src/types.ts
@@ -72,6 +72,8 @@ export type Announcement = {
   sendNotification?: boolean;
   /** Timestamp when the announcement was last updated */
   updated_at: string;
+  /** Optional catalog entity references this announcement is linked to */
+  entity_refs?: string[];
 };
 
 /**
@@ -112,6 +114,8 @@ export type AnnouncementsFilters = {
   current?: boolean;
   /** Whether the notification is enabled */
   sendNotification?: boolean;
+  /** Filter by catalog entity reference (single value for filtering) */
+  entity_ref?: string;
 };
 
 /**

--- a/workspaces/announcements/plugins/announcements-common/src/types.ts
+++ b/workspaces/announcements/plugins/announcements-common/src/types.ts
@@ -73,7 +73,7 @@ export type Announcement = {
   /** Timestamp when the announcement was last updated */
   updated_at: string;
   /** Optional catalog entity references this announcement is linked to */
-  entity_refs?: string[];
+  entityRefs?: string[];
 };
 
 /**
@@ -115,7 +115,7 @@ export type AnnouncementsFilters = {
   /** Whether the notification is enabled */
   sendNotification?: boolean;
   /** Filter by catalog entity reference (single value for filtering) */
-  entity_ref?: string;
+  entityRef?: string;
 };
 
 /**

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -201,6 +201,7 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementForm.startAt': 'Announcement start date';
     readonly 'announcementForm.untilDate': 'Announcement end date';
     readonly 'announcementForm.onBehalfOf': 'On behalf of';
+    readonly 'announcementForm.entity': 'Entity';
     readonly 'announcementForm.tagsLabel': 'Tags';
     readonly 'announcementForm.categoryInput.label': 'Category';
     readonly 'announcementForm.categoryInput.create': 'Create';

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -201,7 +201,9 @@ export const announcementsTranslationRef: TranslationRef<
     readonly 'announcementForm.startAt': 'Announcement start date';
     readonly 'announcementForm.untilDate': 'Announcement end date';
     readonly 'announcementForm.onBehalfOf': 'On behalf of';
-    readonly 'announcementForm.entity': 'Entity';
+    readonly 'announcementForm.entity': 'Link to entity';
+    readonly 'announcementForm.entityPlaceholder': 'Select an entity';
+    readonly 'announcementForm.entitySearchPlaceholder': 'Search entities...';
     readonly 'announcementForm.tagsLabel': 'Tags';
     readonly 'announcementForm.categoryInput.label': 'Category';
     readonly 'announcementForm.categoryInput.create': 'Create';

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -29,6 +29,7 @@ export const announcementsTranslationRef = createTranslationRef({
       startAt: 'Announcement start date',
       untilDate: 'Announcement end date',
       onBehalfOf: 'On behalf of',
+      entity: 'Entity',
       categoryInput: {
         create: 'Create',
         label: 'Category',

--- a/workspaces/announcements/plugins/announcements-react/src/translation.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/translation.ts
@@ -29,7 +29,9 @@ export const announcementsTranslationRef = createTranslationRef({
       startAt: 'Announcement start date',
       untilDate: 'Announcement end date',
       onBehalfOf: 'On behalf of',
-      entity: 'Entity',
+      entity: 'Link to entity',
+      entityPlaceholder: 'Select an entity',
+      entitySearchPlaceholder: 'Search entities...',
       categoryInput: {
         create: 'Create',
         label: 'Category',

--- a/workspaces/announcements/plugins/announcements/README.md
+++ b/workspaces/announcements/plugins/announcements/README.md
@@ -10,6 +10,10 @@ This plugin provides:
 - a component to display the latest announcements, for example on a homepage
 - a component to display the latest announcement as a banner, if there is one
 - an admin portal to manage announcements
+- organize announcements with categories and tags
+- publish announcements on behalf of a team
+- link announcements to catalog entities
+- schedule announcements with start and end dates
 
 ## Installation
 

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
@@ -54,6 +54,7 @@ import { CategorySelectInput, TagsSelectInput } from '../../../shared';
 import { CreateCategoryDialog } from '../../categories';
 import { CreateTagDialog } from '../../tags';
 import OnBehalfTeamDropdown from './OnBehalfTeamDropdown';
+import EntityDropdown from './EntityDropdown';
 
 import MuiTextField from '@mui/material/TextField';
 
@@ -97,6 +98,9 @@ export const AnnouncementForm = ({
   const [loading, setLoading] = useState(false);
   const [onBehalfOfSelectedTeam, setOnBehalfOfSelectedTeam] = useState(
     initialData.on_behalf_of || '',
+  );
+  const [selectedEntity, setSelectedEntity] = useState(
+    initialData.entity_refs?.[0] || '',
   );
   const [showCreateCategoryDialog, setShowCreateCategoryDialog] =
     useState(false);
@@ -207,6 +211,7 @@ export const AnnouncementForm = ({
       tags: formTags?.map(tag => tag.slug),
       publisher: userIdentity.userEntityRef,
       on_behalf_of: onBehalfOfSelectedTeam,
+      entity_refs: selectedEntity ? [selectedEntity] : undefined,
     };
 
     try {
@@ -288,6 +293,13 @@ export const AnnouncementForm = ({
                 <OnBehalfTeamDropdown
                   selectedTeam={onBehalfOfSelectedTeam}
                   onChange={setOnBehalfOfSelectedTeam}
+                />
+              </Grid.Item>
+
+              <Grid.Item colSpan={{ xs: '12', md: '4' }}>
+                <EntityDropdown
+                  selectedEntity={selectedEntity}
+                  onChange={setSelectedEntity}
                 />
               </Grid.Item>
 

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
@@ -100,7 +100,7 @@ export const AnnouncementForm = ({
     initialData.on_behalf_of || '',
   );
   const [selectedEntity, setSelectedEntity] = useState(
-    initialData.entity_refs?.[0] || '',
+    initialData.entityRefs?.[0] || '',
   );
   const [showCreateCategoryDialog, setShowCreateCategoryDialog] =
     useState(false);
@@ -211,7 +211,7 @@ export const AnnouncementForm = ({
       tags: formTags?.map(tag => tag.slug),
       publisher: userIdentity.userEntityRef,
       on_behalf_of: onBehalfOfSelectedTeam,
-      entity_refs: selectedEntity ? [selectedEntity] : undefined,
+      entityRefs: selectedEntity ? [selectedEntity] : undefined,
     };
 
     try {

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.test.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EntityDropdown from './EntityDropdown';
+
+jest.mock('@backstage-community/plugin-announcements-react', () => ({
+  useAnnouncementsTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockIdentityApi = {
+  getBackstageIdentity: jest.fn().mockResolvedValue({
+    userEntityRef: 'user:default/test-user',
+    ownershipEntityRefs: ['group:default/team-a'],
+  }),
+};
+
+const mockCatalogApi = {
+  queryEntities: jest.fn().mockResolvedValue({
+    items: [
+      {
+        kind: 'Component',
+        metadata: {
+          name: 'service-a',
+          namespace: 'default',
+          title: 'Service A',
+        },
+      },
+      {
+        kind: 'System',
+        metadata: {
+          name: 'system-b',
+          namespace: 'default',
+        },
+      },
+      {
+        kind: 'API',
+        metadata: {
+          name: 'api-c',
+          namespace: 'default',
+          title: 'API C',
+        },
+      },
+    ],
+  }),
+};
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  identityApiRef: {},
+  useApi: (ref: any) => {
+    if (ref === require('@backstage/core-plugin-api').identityApiRef) {
+      return mockIdentityApi;
+    }
+    if (ref === require('@backstage/plugin-catalog-react').catalogApiRef) {
+      return mockCatalogApi;
+    }
+    return undefined;
+  },
+}));
+
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  catalogApiRef: {},
+}));
+
+jest.mock('@backstage/catalog-model', () => ({
+  stringifyEntityRef: (entity: any) =>
+    `${entity.kind.toLowerCase()}:${entity.metadata.namespace || 'default'}/${
+      entity.metadata.name
+    }`,
+}));
+
+describe('EntityDropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should display the dropdown with correct entity options', async () => {
+    const handleChange = jest.fn();
+
+    render(<EntityDropdown selectedEntity="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith({
+        filter: [
+          {
+            kind: ['Component', 'System', 'API', 'Domain', 'Resource'],
+            'relations.ownedBy': [
+              'user:default/test-user',
+              'group:default/team-a',
+            ],
+          },
+        ],
+      });
+    });
+
+    const dropdown = screen.getByLabelText('announcementForm.entity');
+    await userEvent.click(dropdown);
+
+    await waitFor(() => {
+      const serviceAOptions = screen.getAllByText(
+        'component:default/service-a',
+      );
+      expect(serviceAOptions.length).toBeGreaterThan(0);
+
+      const systemBOptions = screen.getAllByText('system:default/system-b');
+      expect(systemBOptions.length).toBeGreaterThan(0);
+
+      const apiCOptions = screen.getAllByText('api:default/api-c');
+      expect(apiCOptions.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('should call onChange when an entity is selected', async () => {
+    const handleChange = jest.fn();
+
+    render(<EntityDropdown selectedEntity="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+    });
+
+    const dropdown = screen.getByLabelText('announcementForm.entity');
+    await userEvent.click(dropdown);
+
+    const options = await screen.findAllByText('component:default/service-a');
+    // Click the visible option (not the hidden select option)
+    await userEvent.click(options[1]);
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith('component:default/service-a');
+    });
+  });
+
+  it('should handle empty entities list', async () => {
+    mockCatalogApi.queryEntities.mockResolvedValueOnce({
+      items: [],
+    });
+
+    const handleChange = jest.fn();
+
+    render(<EntityDropdown selectedEntity="" onChange={handleChange} />);
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+    });
+
+    const dropdown = screen.getByLabelText('announcementForm.entity');
+    expect(dropdown).toBeDisabled();
+  });
+
+  it('should display selected entity', async () => {
+    const handleChange = jest.fn();
+
+    render(
+      <EntityDropdown
+        selectedEntity="component:default/service-a"
+        onChange={handleChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalled();
+    });
+
+    // Check that the selected entity is displayed in the button
+    const selectedText = await screen.findAllByText(
+      'component:default/service-a',
+    );
+    expect(selectedText[0]).toBeInTheDocument();
+  });
+});

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Key, useMemo } from 'react';
+import { Select } from '@backstage/ui';
+import { identityApiRef, useApi } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { useAnnouncementsTranslation } from '@backstage-community/plugin-announcements-react';
+import useAsync from 'react-use/esm/useAsync';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+
+type EntityDropdownProps = {
+  selectedEntity: string;
+  onChange: (entityRef: string) => void;
+};
+
+const ENTITY_KINDS = ['Component', 'System', 'API', 'Domain', 'Resource'];
+
+export default function EntityDropdown({
+  selectedEntity,
+  onChange,
+}: EntityDropdownProps) {
+  const { t } = useAnnouncementsTranslation();
+  const identityApi = useApi(identityApiRef);
+  const catalogApi = useApi(catalogApiRef);
+
+  const { value: entities, loading: entitiesLoading } = useAsync(async () => {
+    const identity = await identityApi.getBackstageIdentity();
+    const ownershipRefs = [
+      identity.userEntityRef,
+      ...identity.ownershipEntityRefs,
+    ];
+
+    const response = await catalogApi.queryEntities({
+      filter: [
+        {
+          kind: ENTITY_KINDS,
+          'relations.ownedBy': ownershipRefs,
+        },
+      ],
+    });
+
+    return response.items;
+  }, [identityApi, catalogApi]);
+
+  const selectOptions = useMemo(() => {
+    if (!entities) return [];
+
+    return entities.map(entity => {
+      const entityRef = stringifyEntityRef(entity);
+
+      return {
+        value: entityRef,
+        label: entityRef,
+      };
+    });
+  }, [entities]);
+
+  const handleChange = (value: Key[] | Key | null) => {
+    if (!value) {
+      onChange('');
+      return;
+    }
+
+    let stringValue: string | null = null;
+
+    if (Array.isArray(value)) {
+      stringValue = String(value[0] ?? '');
+    } else {
+      stringValue = String(value);
+    }
+
+    onChange(stringValue || '');
+  };
+
+  return (
+    <Select
+      key={selectedEntity || 'none'}
+      name="entity"
+      label={t('announcementForm.entity')}
+      searchable
+      placeholder={t('announcementForm.entity')}
+      value={selectedEntity || null}
+      onChange={handleChange}
+      options={selectOptions}
+      isDisabled={entitiesLoading || selectOptions.length === 0}
+    />
+  );
+}

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/EntityDropdown.tsx
@@ -91,7 +91,8 @@ export default function EntityDropdown({
       name="entity"
       label={t('announcementForm.entity')}
       searchable
-      placeholder={t('announcementForm.entity')}
+      placeholder={t('announcementForm.entityPlaceholder')}
+      searchPlaceholder={t('announcementForm.entitySearchPlaceholder')}
       value={selectedEntity || null}
       onChange={handleChange}
       options={selectOptions}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for linking entities to an announcement. 

As per suggestion of package maintainer @kurtaking:
 - The backend is designed with future flexibility in mind and supports linking multiple entities to an announcement
 - The frontend for now starts with linking a single entity in order to keep things simple at the start

<img width="1728" height="878" alt="announcement-entity-linking" src="https://github.com/user-attachments/assets/0dcfb3a3-3e27-429a-a3f4-97cddb15382d" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Closes #7392 
