### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/renovate-59a7dbb.md
+++ b/workspaces/servicenow/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/servicenow/.changeset/version-bump-1-47-3.md
+++ b/workspaces/servicenow/.changeset/version-bump-1-47-3.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
----
-
-Backstage version bump to v1.47.3

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.8.0
+
+### Minor Changes
+
+- 5a2919f: Backstage version bump to v1.47.3
+
+### Patch Changes
+
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- Updated dependencies [5a2919f]
+  - @backstage-community/plugin-servicenow-common@1.7.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-servicenow-common
 
+## 1.7.0
+
+### Minor Changes
+
+- 5a2919f: Backstage version bump to v1.47.3
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-common/package.json
+++ b/workspaces/servicenow/plugins/servicenow-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-common",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the servicenow plugin",
   "main": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-servicenow
 
+## 1.8.0
+
+### Minor Changes
+
+- 5a2919f: Backstage version bump to v1.47.3
+
+### Patch Changes
+
+- Updated dependencies [5a2919f]
+  - @backstage-community/plugin-servicenow-common@1.7.0
+
 ## 1.7.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.8.0

### Minor Changes

-   5a2919f: Backstage version bump to v1.47.3

### Patch Changes

-   Updated dependencies [5a2919f]
    -   @backstage-community/plugin-servicenow-common@1.7.0

## @backstage-community/plugin-servicenow-backend@1.8.0

### Minor Changes

-   5a2919f: Backstage version bump to v1.47.3

### Patch Changes

-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   Updated dependencies [5a2919f]
    -   @backstage-community/plugin-servicenow-common@1.7.0

## @backstage-community/plugin-servicenow-common@1.7.0

### Minor Changes

-   5a2919f: Backstage version bump to v1.47.3
