### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-59a7dbb.md
+++ b/workspaces/rbac/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/rbac/.changeset/renovate-6d380b1.md
+++ b/workspaces/rbac/.changeset/renovate-6d380b1.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.19.11`.

--- a/workspaces/rbac/.changeset/selfish-pets-unite.md
+++ b/workspaces/rbac/.changeset/selfish-pets-unite.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Fix - stop error on upgrade v1.47.x - allow all plugins in the arry to show

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.7.1
+
+### Patch Changes
+
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- 497d5c6: Updated dependency `@types/node` to `22.19.11`.
+- 9c7ae87: Fix - stop error on upgrade v1.47.x - allow all plugins in the arry to show
+
 ## 7.7.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rbac
 
+## 1.48.1
+
+### Patch Changes
+
+- 497d5c6: Updated dependency `@types/node` to `22.19.11`.
+
 ## 1.48.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.48.1

### Patch Changes

-   497d5c6: Updated dependency `@types/node` to `22.19.11`.

## @backstage-community/plugin-rbac-backend@7.7.1

### Patch Changes

-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   497d5c6: Updated dependency `@types/node` to `22.19.11`.
-   9c7ae87: Fix - stop error on upgrade v1.47.x - allow all plugins in the arry to show
