### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/renovate-59a7dbb.md
+++ b/workspaces/quay/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/quay/.changeset/three-snails-scream.md
+++ b/workspaces/quay/.changeset/three-snails-scream.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': patch
-'@backstage-community/plugin-quay-common': patch
-'@backstage-community/plugin-quay': patch
----
-
-Removed unused dependencies

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.12.1
+
+### Patch Changes
+
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- f4d1bd1: Removed unused dependencies
+- Updated dependencies [f4d1bd1]
+  - @backstage-community/plugin-quay-common@1.17.1
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.17.1
+
+### Patch Changes
+
+- f4d1bd1: Removed unused dependencies
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-quay
 
+## 1.30.1
+
+### Patch Changes
+
+- f4d1bd1: Removed unused dependencies
+- Updated dependencies [f4d1bd1]
+  - @backstage-community/plugin-quay-common@1.17.1
+
 ## 1.30.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.30.1

### Patch Changes

-   f4d1bd1: Removed unused dependencies
-   Updated dependencies [f4d1bd1]
    -   @backstage-community/plugin-quay-common@1.17.1

## @backstage-community/plugin-quay-backend@1.12.1

### Patch Changes

-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   f4d1bd1: Removed unused dependencies
-   Updated dependencies [f4d1bd1]
    -   @backstage-community/plugin-quay-common@1.17.1

## @backstage-community/plugin-quay-common@1.17.1

### Patch Changes

-   f4d1bd1: Removed unused dependencies
