### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/fair-lights-allow.md
+++ b/workspaces/argocd/.changeset/fair-lights-allow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-common': patch
----
-
-Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.

--- a/workspaces/argocd/.changeset/renovate-59a7dbb.md
+++ b/workspaces/argocd/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.0.3
+
+### Patch Changes
+
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- Updated dependencies [4818f35]
+  - @backstage-community/plugin-argocd-common@1.12.2
+
 ## 1.0.2
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.12.2
+
+### Patch Changes
+
+- 4818f35: Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.
+
 ## 1.12.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-argocd
 
+## 2.4.5
+
+### Patch Changes
+
+- Updated dependencies [4818f35]
+  - @backstage-community/plugin-argocd-common@1.12.2
+
 ## 2.4.4
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.4.5

### Patch Changes

-   Updated dependencies [4818f35]
    -   @backstage-community/plugin-argocd-common@1.12.2

## @backstage-community/plugin-argocd-backend@1.0.3

### Patch Changes

-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   Updated dependencies [4818f35]
    -   @backstage-community/plugin-argocd-common@1.12.2

## @backstage-community/plugin-argocd-common@1.12.2

### Patch Changes

-   4818f35: Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.
