### PR TITLE
update docs on patching older release lines

### DIFF
--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -188,15 +188,12 @@ When patching an older release, follow the steps below to ensure the correct wor
 
    In **GitHub > Repo > Settings > Branches**, add a rule for the requested `workspace/${workspace}` branch and apply these settings:
 
-   - ☑ Require pull request before merging
-     - ☑ Require approvals
-     - ☑ Dismiss stale approvals when new commits are pushed
-     - ☑ Require review from Code Owners
-   - ☑ Require status checks to pass before merging
    - ☑ Restrict who can push: **CODEOWNERS for the workspace**
    - ☑ Restrict pushes that create matching branches
    - ☑ Allow force pushes
      - ☑ Specify who can force push: **CODEOWNERS for the workspace**
+
+   The workflow requires that pull requests targeting the `workspace/${workspace}` branch be opened from a branch within the `backstage/community-plugins` repository. Therefore, in addition to the `workspace/${workspace}` branch, a corresponding branch must also be created with the same branch protection settings described above.
 
    </details>
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Based on my recent experience of using the workflow for patching older release lines, I've made the following changes to the docs:
1. Removed "Require pull request before merging": The workspace branch needs to be forced pushed to be reset to a previous version and this constraint leads to the "Changes must be made through a pull request" error.
2. Explicitly mentioned under the "Community Plugins Maintainers - Branch Protection Settings" that a new branch needs to be created that can be used to make PRs targeting the workspace branch.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
