### PR TITLE
fix(sentry): add theme-aware styles for dark mode support

### DIFF
--- a/workspaces/sentry/.changeset/fix-sentry-dark-mode.md
+++ b/workspaces/sentry/.changeset/fix-sentry-dark-mode.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sentry': patch
+---
+
+Fixed dark mode support for the Sentry issues table title area. Added explicit theme-aware styles using `makeStyles` for the filter dropdown, form control, and title container so they properly inherit colors from the active Backstage theme instead of using MUI v4 defaults.

--- a/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
+++ b/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
@@ -27,6 +27,26 @@ import { Options } from '@material-table/core';
 import FormControl from '@material-ui/core/FormControl';
 import Grid from '@material-ui/core/Grid';
 import MenuItem from '@material-ui/core/MenuItem';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  titleContainer: {
+    color: theme.palette.text.primary,
+    alignItems: 'center',
+  },
+  select: {
+    color: theme.palette.text.primary,
+    '& .MuiSelect-icon': {
+      color: theme.palette.text.secondary,
+    },
+  },
+  formControl: {
+    marginLeft: theme.spacing(1),
+    '& .MuiOutlinedInput-notchedOutline': {
+      borderColor: theme.palette.text.secondary,
+    },
+  },
+}));
 
 const ONE_DAY_IN_MILLIS = 86400000;
 const SEVEN_DAYS_IN_MILLIS = ONE_DAY_IN_MILLIS * 7;
@@ -76,6 +96,7 @@ type SentryIssuesTableProps = {
 
 const SentryIssuesTable = (props: SentryIssuesTableProps) => {
   const { sentryIssues, statsFor, tableOptions } = props;
+  const classes = useStyles();
   const [selected, setSelected] = useState(ONE_DAY_IN_MILLIS);
 
   const filterByDate = useCallback(
@@ -110,11 +131,23 @@ const SentryIssuesTable = (props: SentryIssuesTableProps) => {
         columns={columns}
         options={tableOptions}
         title={
-          <Grid data-testid="sentry-issues-grid" container>
+          <Grid
+            data-testid="sentry-issues-grid"
+            container
+            className={classes.titleContainer}
+          >
             <Grid item>Sentry Issues</Grid>
             <Grid item>
-              <FormControl variant="outlined" size="small">
-                <Select value={selected} onChange={handleFilterChange}>
+              <FormControl
+                variant="outlined"
+                size="small"
+                className={classes.formControl}
+              >
+                <Select
+                  value={selected}
+                  onChange={handleFilterChange}
+                  className={classes.select}
+                >
                   <MenuItem value={ONE_DAY_IN_MILLIS}>24H</MenuItem>
                   <MenuItem value={SEVEN_DAYS_IN_MILLIS}>7D</MenuItem>
                   <MenuItem value={FOURTEEN_DAYS_IN_MILLIS}>14D</MenuItem>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the Sentry plugin always rendering in light mode when used with the new frontend system (Backstage 1.46+). MUI v4 components in the table title area lose theme context due to package duplication in the new system.

**Changes:**
- Add `makeStyles` with explicit `theme.palette` references so colors, borders, and icons follow the active Backstage theme (light or dark)
- Apply themed styles to the filter `Select`, `FormControl`, and title `Grid` container

Fixes #6537

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))