### PR TITLE
fix(sentry): move @material-ui/core to peerDependencies to fix dark mode

### DIFF
--- a/workspaces/sentry/.changeset/fix-sentry-dark-mode-deps.md
+++ b/workspaces/sentry/.changeset/fix-sentry-dark-mode-deps.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sentry': patch
+---
+
+Moved `@material-ui/core` and `@material-table/core` from `dependencies` to `peerDependencies` to fix dark mode rendering in strict package managers like pnpm. When declared as direct dependencies, these packages could resolve to a separate module instance, causing the plugin's MUI components to miss the ThemeProvider context and fall back to the default light theme.

--- a/workspaces/sentry/plugins/sentry/package.json
+++ b/workspaces/sentry/plugins/sentry/package.json
@@ -62,8 +62,6 @@
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@date-io/core": "^1.3.13",
-    "@material-table/core": "^3.1.0",
-    "@material-ui/core": "^4.12.2",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "luxon": "^3.0.0",
     "react-sparklines": "^1.7.0",
@@ -84,6 +82,8 @@
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "peerDependencies": {
+    "@material-table/core": "^3.1.0",
+    "@material-ui/core": "^4.12.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"

--- a/workspaces/sentry/yarn.lock
+++ b/workspaces/sentry/yarn.lock
@@ -1359,8 +1359,6 @@ __metadata:
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@date-io/core": "npm:^1.3.13"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -1374,6 +1372,8 @@ __metadata:
     react-sparklines: "npm:^1.7.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
+    "@material-table/core": ^3.1.0
+    "@material-ui/core": ^4.12.2
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #6537

The sentry plugin declared `@material-ui/core` and `@material-table/core` as direct dependencies. With strict package managers like pnpm, this creates a duplicate module instance where the `ThemeProvider` from `UnifiedThemeProvider` populates one copy's React Context, but the plugin's MUI components resolve to a separate copy with no theme context and fall back to the default light theme.

I reproduced this locally by running `pnpm install` on a minimal Backstage app with the sentry plugin. Two separate `@material-ui/core@4.12.4` directories appear under `.pnpm/`:

- `@backstage/theme` (provides ThemeProvider) -> copy **74b2**
- `@material-table/core` (renders Paper) -> copy **74b2**
- `@backstage-community/plugin-sentry` (Select, Grid, etc.) -> copy **7d94** (different instance)

With npm/yarn this is masked by hoisting, but with pnpm's strict isolation it breaks. Other plugins like `todo` don't have this problem because they don't declare `@material-ui/core` as a direct dependency.

Moving these to `peerDependencies` ensures the plugin always uses the host app's copy.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))