### PR TITLE
Remove Material-UI dependencies from grafana plugin

### DIFF
--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -55,8 +55,6 @@
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/core": "^4.12.2",
-    "@material-ui/lab": "4.0.0-alpha.61",
     "cross-fetch": "^4.0.0",
     "jsep": "^1.3.8",
     "react-use": "^17.2.4"

--- a/workspaces/grafana/plugins/grafana/src/components/AlertsCard/AlertsCard.tsx
+++ b/workspaces/grafana/plugins/grafana/src/components/AlertsCard/AlertsCard.tsx
@@ -17,6 +17,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import {
   Progress,
+  ResponseErrorPanel,
   TableColumn,
   Table,
   StatusOK,
@@ -34,7 +35,6 @@ import {
 import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { grafanaApiRef } from '../../api';
 import useAsync from 'react-use/lib/useAsync';
-import { Alert } from '@material-ui/lab';
 import { AlertsCardOpts, Alert as GrafanaAlert } from '../../types';
 import {
   GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR,
@@ -137,7 +137,7 @@ const Alerts = ({ entity, opts }: { entity: Entity; opts: AlertsCardOpts }) => {
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <ResponseErrorPanel error={error} />;
   }
 
   return <AlertsTable alerts={value || []} opts={opts} />;

--- a/workspaces/grafana/plugins/grafana/src/components/DashboardsCard/DashboardsCard.tsx
+++ b/workspaces/grafana/plugins/grafana/src/components/DashboardsCard/DashboardsCard.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Progress, TableColumn, Table, Link } from '@backstage/core-components';
+import {
+  Progress,
+  ResponseErrorPanel,
+  TableColumn,
+  Table,
+  Link,
+} from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import {
   MissingAnnotationEmptyState,
@@ -23,9 +29,6 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { grafanaApiRef } from '../../api';
 import useAsync from 'react-use/lib/useAsync';
-import Alert from '@material-ui/lab/Alert';
-import Tooltip from '@material-ui/core/Tooltip';
-import Typography from '@material-ui/core/Typography';
 import { Dashboard, DashboardCardOpts } from '../../types';
 import {
   dashboardSelectorFromEntity,
@@ -64,13 +67,13 @@ export const DashboardsTable = ({
   ];
 
   const titleElm = (
-    <Tooltip
-      title={`Note: only dashboard with the "${dashboardSelectorFromEntity(
+    <span
+      title={`Note: only dashboards with the "${dashboardSelectorFromEntity(
         entity,
       )}" selector are displayed.`}
     >
-      <Typography variant="h5">{opts.title || 'Dashboards'}</Typography>
-    </Tooltip>
+      {opts.title || 'Dashboards'}
+    </span>
   );
 
   return (
@@ -112,7 +115,7 @@ const Dashboards = ({
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <ResponseErrorPanel error={error} />;
   }
 
   return (

--- a/workspaces/grafana/yarn.lock
+++ b/workspaces/grafana/yarn.lock
@@ -410,8 +410,6 @@ __metadata:
     "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@testing-library/user-event": "npm:^14.0.0"


### PR DESCRIPTION
## Summary

- Removes `@material-ui/core` and `@material-ui/lab` from the grafana plugin dependencies
- Replaces `<Alert severity="error">` (MUI lab) with `<ResponseErrorPanel>` from `@backstage/core-components`
- Replaces `<Tooltip>` + `<Typography>` (MUI core) with a plain `<span>` using the native `title` attribute

Contributes to #7023.

## Test plan

- [x] `yarn tsc:full` passes with zero errors
- [x] All 6 existing tests pass (4 suites)
- [x] No changes to test files required
- [x] Verified `ResponseErrorPanel` provides consistent error display with other Backstage plugins