### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/two-vans-hang.md
+++ b/workspaces/cicd-statistics/.changeset/two-vans-hang.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-github': minor
----
-
-Updated Github Authentication methods to prompt for required scopes and refactored auth to align with Backstage GitHub plugin conventions

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics-module-github
 
+## 0.13.0
+
+### Minor Changes
+
+- 99baea4: Updated Github Authentication methods to prompt for required scopes and refactored auth to align with Backstage GitHub plugin conventions
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-github",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "CI/CD Statistics plugin module; Github CICD",
   "backstage": {
     "role": "frontend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics-module-github@0.13.0

### Minor Changes

-   99baea4: Updated Github Authentication methods to prompt for required scopes and refactored auth to align with Backstage GitHub plugin conventions
