### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/sharp-lamps-tap.md
+++ b/workspaces/tekton/.changeset/sharp-lamps-tap.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton-common': patch
----
-
-Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.

--- a/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tekton-common
 
+## 1.18.1
+
+### Patch Changes
+
+- 4818f35: Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.
+
 ## 1.18.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton-common/package.json
+++ b/workspaces/tekton/plugins/tekton-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-tekton-common",
   "description": "Common functionalities for the tekton plugin",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton-common@1.18.1

### Patch Changes

-   4818f35: Updated the `repository.url` value to just be an HTTP URL in the `package.json` file following the common convention in this repo.
