### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-4729b32.md
+++ b/workspaces/ocm/.changeset/renovate-4729b32.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.

--- a/workspaces/ocm/.changeset/renovate-59a7dbb.md
+++ b/workspaces/ocm/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/ocm/.changeset/renovate-9fe9af3.md
+++ b/workspaces/ocm/.changeset/renovate-9fe9af3.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.28.2`.

--- a/workspaces/ocm/.changeset/renovate-f5415d7.md
+++ b/workspaces/ocm/.changeset/renovate-f5415d7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.28.3`.

--- a/workspaces/ocm/.changeset/version-bump-1-47-3.md
+++ b/workspaces/ocm/.changeset/version-bump-1-47-3.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.47.3

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.15.0
+
+### Minor Changes
+
+- 3134355: Backstage version bump to v1.47.3
+
+### Patch Changes
+
+- 95dd04e: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- 38128d5: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.2`.
+- 5f6da50: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.3`.
+- Updated dependencies [3134355]
+  - @backstage-community/plugin-ocm-common@3.18.0
+
 ## 5.14.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.18.0
+
+### Minor Changes
+
+- 3134355: Backstage version bump to v1.47.3
+
 ## 3.17.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-ocm
 
+## 5.14.0
+
+### Minor Changes
+
+- 3134355: Backstage version bump to v1.47.3
+
+### Patch Changes
+
+- Updated dependencies [3134355]
+  - @backstage-community/plugin-ocm-common@3.18.0
+
 ## 5.13.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.14.0

### Minor Changes

-   3134355: Backstage version bump to v1.47.3

### Patch Changes

-   Updated dependencies [3134355]
    -   @backstage-community/plugin-ocm-common@3.18.0

## @backstage-community/plugin-ocm-backend@5.15.0

### Minor Changes

-   3134355: Backstage version bump to v1.47.3

### Patch Changes

-   95dd04e: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.0`.
-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   38128d5: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.2`.
-   5f6da50: Updated dependency `@openapitools/openapi-generator-cli` to `2.28.3`.
-   Updated dependencies [3134355]
    -   @backstage-community/plugin-ocm-common@3.18.0

## @backstage-community/plugin-ocm-common@3.18.0

### Minor Changes

-   3134355: Backstage version bump to v1.47.3
