### PR TITLE
feat(tech-insights-maturity): allow all entities to have summary score

### DIFF
--- a/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
+++ b/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-maturity': patch
+---
+
+Allow non-component entities to have a maturity scorecard

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.ts
@@ -18,7 +18,6 @@ import {
   CompoundEntityRef,
   Entity,
   getCompoundEntityRef,
-  isComponentEntity,
   RELATION_HAS_PART,
   RELATION_OWNER_OF,
   RELATION_PARENT_OF,
@@ -115,14 +114,9 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
   private async getCheckResults(
     entity: Entity,
   ): Promise<MaturityCheckResult[]> {
-    if (isComponentEntity(entity)) {
-      return (await this.runChecks(
-        getCompoundEntityRef(entity),
-      )) as MaturityCheckResult[];
-    }
-
-    const entities = await this.getRelatedComponents(entity);
-    return await this.getGroupCheckResults(entities);
+    return (await this.runChecks(
+      getCompoundEntityRef(entity),
+    )) as MaturityCheckResult[];
   }
 
   private async getBulkCheckResults(entities: CompoundEntityRef[]) {
@@ -140,27 +134,6 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
         };
       }),
     );
-  }
-
-  private async getGroupCheckResults(
-    entities: CompoundEntityRef[],
-  ): Promise<MaturityCheckResult[]> {
-    /**
-     * Passing an empty array into techInsightsClient.runBulkChecks()
-     * now causes checks to run across the entire catalog.
-     * We don't want to run checks here if no entities were provided.
-     */
-    if (entities.length === 0) {
-      return [];
-    }
-
-    const results: MaturityCheckResult[] = [];
-    const bulkResponse = await this.runBulkChecks(entities);
-    for (const response of bulkResponse) {
-      Array.prototype.push.apply(results, response.results);
-    }
-
-    return results;
   }
 
   private async getRelatedComponents(

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturitySummaryPage/MaturitySummaryPage.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturitySummaryPage/MaturitySummaryPage.tsx
@@ -20,10 +20,10 @@ import { useEntity, useRelatedEntities } from '@backstage/plugin-catalog-react';
 import { EmptyState, Progress } from '@backstage/core-components';
 import Alert from '@mui/material/Alert';
 import Grid from '@mui/material/Grid';
-import { MaturityRankInfoCard } from '../MaturityRankInfoCard';
 import { MaturitySummaryTable } from '../MaturitySummaryTable';
 import { getSubEntityFilter } from '../../helpers/utils';
 import { maturityApiRef } from '../../api';
+import { MaturityScorePage } from '../MaturityScorePage';
 
 export const MaturitySummaryPage = () => {
   const { entity } = useEntity();
@@ -45,10 +45,10 @@ export const MaturitySummaryPage = () => {
 
   return (
     <Grid container spacing={1}>
-      <Grid item md={3}>
-        <MaturityRankInfoCard summary={value} />
+      <Grid item xs={12}>
+        <MaturityScorePage />
       </Grid>
-      <Grid item md={9}>
+      <Grid item md={12}>
         {entities && <MaturitySummaryTable entities={entities} />}
       </Grid>
     </Grid>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

```
Updates the tech-insights-maturity plugin so that all entities can have their individual score shown, instead of just
components. For entities that have a 'roll up' maturity element (systems, domains, groups), their dedicated summary page
now shows both their individual maturity information and the ranking of their 'children'.
```

This is for https://github.com/backstage/community-plugins/issues/7500

I tested this manually. Unfortunately I don't have any experience with Backstage outside of our internal instance and how that is run. I tried a couple of different things to test this:
- I tried using `yarn start`. But it said I couldn't authenticate and I'm not sure how to set that up for just a plugin.
- I tried `yarn link` to make the tech-insights-maturity plugin a global symlink and then to use it in a backstage local dev server. This didn't do anything.
- I tried using the `file:...` syntax in package.json of my local backstage instance to reference the local changes I made to the plugin, but that didn't resolve.
- I asked Claude (AI) to try to figure out some way to do it, and it could not make anything happen.

So...to test, I basically edited the actual compiled JS files in my local backstage node_modules folder, and once I got the result I needed, I went to the plugin files and made edits to the typescript files, and validated the compiled JS files afterwards had the changes I want.

The existing unit tests all pass.

### Entity page view for a System with the summary card:
<img width="1421" height="1019" alt="image" src="https://github.com/user-attachments/assets/b1438df9-4caa-44c1-bbdb-0e71fa03c49e" />

### Entity-scoped maturity page for a System with the score card of both itself and it's child components:
<img width="2376" height="1186" alt="image" src="https://github.com/user-attachments/assets/2f90e090-cac1-44ea-80ec-d70682612b69" />

### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
