### PR TITLE
fix(argocd): add missing translations on summary page

### DIFF
--- a/workspaces/argocd/.changeset/spicy-webs-stare.md
+++ b/workspaces/argocd/.changeset/spicy-webs-stare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-argocd': patch
+---
+
+Add missing translations on argocd summary page

--- a/workspaces/argocd/plugins/argocd/report-alpha.api.md
+++ b/workspaces/argocd/plugins/argocd/report-alpha.api.md
@@ -100,9 +100,11 @@ export const argocdTranslationRef: TranslationRef<
     readonly 'deploymentSummary.deploymentSummary.tableTitle': string;
     readonly 'deploymentSummary.deploymentSummary.columns.syncStatus': string;
     readonly 'deploymentSummary.deploymentSummary.columns.healthStatus': string;
+    readonly 'deploymentSummary.deploymentSummary.columns.namespace': string;
     readonly 'deploymentSummary.deploymentSummary.columns.revision': string;
     readonly 'deploymentSummary.deploymentSummary.columns.instance': string;
     readonly 'deploymentSummary.deploymentSummary.columns.server': string;
+    readonly 'deploymentSummary.deploymentSummary.columns.application': string;
     readonly 'deploymentSummary.deploymentSummary.columns.lastDeployed': string;
   }
 >;

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/ResourcesHealthStatus.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/ResourcesHealthStatus.tsx
@@ -15,19 +15,33 @@
  */
 import type { FC } from 'react';
 
-import { AppHealthIcon } from '../../../AppStatus/StatusIcons';
 import { HealthStatus } from '@backstage-community/plugin-argocd-common';
+import { TranslationFunction } from '@backstage/core-plugin-api/alpha';
+
+import { AppHealthIcon } from '../../../AppStatus/StatusIcons';
+import { argocdTranslationRef } from '../../../../translations/ref';
+import { useTranslation } from '../../../../hooks/useTranslation';
 
 interface ResourceHealthStatusProps {
   healthStatus: string;
 }
 
+const getHealthStatusTranslation = (
+  status: HealthStatus,
+  t: TranslationFunction<typeof argocdTranslationRef.T>,
+) => {
+  return t(`appStatus.appHealthStatus.${status}`);
+};
+
 export const ResourceHealthStatus: FC<ResourceHealthStatusProps> = ({
   healthStatus,
 }) => {
+  const { t } = useTranslation();
+
   return (
     <>
-      <AppHealthIcon status={healthStatus as HealthStatus} /> {healthStatus}
+      <AppHealthIcon status={healthStatus as HealthStatus} />{' '}
+      {getHealthStatusTranslation(healthStatus as HealthStatus, t)}
     </>
   );
 };

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/ResourcesSyncStatus.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/ResourcesSyncStatus.tsx
@@ -15,19 +15,33 @@
  */
 import type { FC } from 'react';
 
-import { SyncIcon } from '../../../AppStatus/StatusIcons';
 import { SyncStatusCode } from '@backstage-community/plugin-argocd-common';
+import { TranslationFunction } from '@backstage/core-plugin-api/alpha';
+
+import { SyncIcon } from '../../../AppStatus/StatusIcons';
+import { useTranslation } from '../../../../hooks/useTranslation';
+import { argocdTranslationRef } from '../../../../translations/ref';
 
 interface ResourceSyncStatusProps {
   syncStatus: string;
 }
 
+const getSyncStatusTranslation = (
+  status: SyncStatusCode,
+  t: TranslationFunction<typeof argocdTranslationRef.T>,
+) => {
+  return t(`appStatus.appSyncStatus.${status}`);
+};
+
 export const ResourceSyncStatus: FC<ResourceSyncStatusProps> = ({
   syncStatus,
 }) => {
+  const { t } = useTranslation();
+
   return (
     <>
-      <SyncIcon status={syncStatus as SyncStatusCode} /> {syncStatus}
+      <SyncIcon status={syncStatus as SyncStatusCode} />{' '}
+      {getSyncStatusTranslation(syncStatus as SyncStatusCode, t)}
     </>
   );
 };

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/__tests__/ResourcesHealthStatus.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/__tests__/ResourcesHealthStatus.test.tsx
@@ -23,6 +23,12 @@ jest.mock('../../../../AppStatus/StatusIcons', () => ({
   AppHealthIcon: jest.fn(() => <span>Mocked Health Icon</span>),
 }));
 
+jest.mock('../../../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop(),
+  }),
+}));
+
 describe('ResourceHealthStatus Component', () => {
   const renderComponent = (healthStatus: string) => {
     render(<ResourceHealthStatus healthStatus={healthStatus} />);

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/__tests__/ResourcesSyncStatus.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/sidebar/resources/__tests__/ResourcesSyncStatus.test.tsx
@@ -23,6 +23,12 @@ jest.mock('../../../../AppStatus/StatusIcons', () => ({
   SyncIcon: jest.fn(() => <span>Mocked Sync Icon</span>),
 }));
 
+jest.mock('../../../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop(),
+  }),
+}));
+
 describe('ResourceSyncStatus Component', () => {
   const renderComponent = (syncStatus: string) => {
     render(<ResourceSyncStatus syncStatus={syncStatus} />);

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -37,7 +37,7 @@ import {
   isAppHelmChartType,
 } from '../../utils/utils';
 import AppSyncStatus from '../AppStatus/AppSyncStatus';
-import { AppHealthIcon } from '../AppStatus/StatusIcons';
+import AppHealthStatus from '../AppStatus/AppHealthStatus';
 import { useTranslation } from '../../hooks/useTranslation';
 
 const DeploymentSummary = () => {
@@ -75,6 +75,8 @@ const DeploymentSummary = () => {
   // Translated text
   const tableTitle = t('deploymentSummary.deploymentSummary.tableTitle');
   const columnTitles = {
+    application: t('deploymentSummary.deploymentSummary.columns.application'),
+    namespace: t('deploymentSummary.deploymentSummary.columns.namespace'),
     instance: t('deploymentSummary.deploymentSummary.columns.instance'),
     server: t('deploymentSummary.deploymentSummary.columns.server'),
     revision: t('deploymentSummary.deploymentSummary.columns.revision'),
@@ -85,7 +87,7 @@ const DeploymentSummary = () => {
 
   const columns: TableColumn<Application>[] = [
     {
-      title: 'ArgoCD App',
+      title: `${columnTitles.application}`,
       field: 'name',
       render: (row: Application): ReactNode =>
         getBaseUrl(row) ? (
@@ -100,7 +102,7 @@ const DeploymentSummary = () => {
         ),
     },
     {
-      title: 'Namespace',
+      title: `${columnTitles.namespace}`,
       field: 'namespace',
       render: (row: Application): ReactNode => {
         return <>{row.spec.destination.namespace}</>;
@@ -196,12 +198,7 @@ const DeploymentSummary = () => {
           healthStatusOrder.indexOf(b?.status?.health?.status)
         );
       },
-      render: (row: Application): ReactNode => (
-        <>
-          <AppHealthIcon status={row.status.health.status as HealthStatus} />{' '}
-          {row?.status?.health?.status}
-        </>
-      ),
+      render: (row: Application): ReactNode => <AppHealthStatus app={row} />,
     },
   ];
 

--- a/workspaces/argocd/plugins/argocd/src/translations/fr.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/fr.ts
@@ -175,6 +175,8 @@ const argocdTranslationFr = createTranslationMessages({
     'deploymentLifecycle.deploymentLifecycleDrawer.instanceDefaultValue':
       'défaut',
     'deploymentSummary.deploymentSummary.tableTitle': 'Résumé du déploiement',
+    'deploymentSummary.deploymentSummary.columns.application': 'Application',
+    'deploymentSummary.deploymentSummary.columns.namespace': 'Espace de noms',
     'deploymentSummary.deploymentSummary.columns.instance': 'Exemple',
     'deploymentSummary.deploymentSummary.columns.server': 'Serveur',
     'deploymentSummary.deploymentSummary.columns.revision': 'Révision',

--- a/workspaces/argocd/plugins/argocd/src/translations/it.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/it.ts
@@ -177,6 +177,8 @@ const argocdTranslationIt = createTranslationMessages({
       'predefinito',
     'deploymentSummary.deploymentSummary.tableTitle':
       'Riepilogo della distribuzione',
+    'deploymentSummary.deploymentSummary.columns.application': 'Applicazione',
+    'deploymentSummary.deploymentSummary.columns.namespace': 'Spazio dei nomi',
     'deploymentSummary.deploymentSummary.columns.instance': 'Istanza',
     'deploymentSummary.deploymentSummary.columns.server': 'Server',
     'deploymentSummary.deploymentSummary.columns.revision': 'Revisione',

--- a/workspaces/argocd/plugins/argocd/src/translations/ja.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/ja.ts
@@ -61,17 +61,17 @@ const argocdTranslationJa = createTranslationMessages({
     'deploymentLifecycle.sidebar.resources.resource.deploymentMetadata.metadataItemWithTooltip.tooltipText':
       'これらは、ArgoCD アプリケーションの全デプロイメントで使用されているイメージです。',
     'deploymentLifecycle.sidebar.resources.resource.deploymentMetadata.namespace':
-      'Namespace',
+      '名前空間',
     'deploymentLifecycle.sidebar.resources.resource.deploymentMetadata.commit':
       'コミット',
     'deploymentLifecycle.sidebar.resources.resource.rolloutMetadata.namespace':
-      'Namespace',
+      '名前空間',
     'deploymentLifecycle.sidebar.resources.resource.rolloutMetadata.strategy':
       'ストラテジー',
     'deploymentLifecycle.sidebar.resources.resource.rolloutMetadata.status':
       'ステータス',
     'deploymentLifecycle.sidebar.resources.resource.resourceMetadata.namespace':
-      'Namespace',
+      '名前空間',
     'deploymentLifecycle.sidebar.resources.resourcesKebabMenuOptions.iconButton.ariaLabel':
       '詳細',
     'deploymentLifecycle.sidebar.resources.resourcesKebabMenuOptions.refresh':
@@ -157,7 +157,7 @@ const argocdTranslationJa = createTranslationMessages({
       'ArgoCD プラグインを使用して、namespace にデプロイされたコンポーネント/システムをレビューします',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'インスタンス',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'サーバー',
-    'deploymentLifecycle.deploymentLifecycleCard.namespace': 'Namespace',
+    'deploymentLifecycle.deploymentLifecycleCard.namespace': '名前空間',
     'deploymentLifecycle.deploymentLifecycleCard.commit': 'コミット',
     'deploymentLifecycle.deploymentLifecycleCard.tooltipText':
       '下に表示されているコミット SHA は、最初に定義されたアプリケーションソースの最新のコミットです。',
@@ -168,13 +168,16 @@ const argocdTranslationJa = createTranslationMessages({
       'ドロワーを閉じる',
     'deploymentLifecycle.deploymentLifecycleDrawer.instance': 'インスタンス',
     'deploymentLifecycle.deploymentLifecycleDrawer.cluster': 'クラスター',
-    'deploymentLifecycle.deploymentLifecycleDrawer.namespace': 'Namespace',
+    'deploymentLifecycle.deploymentLifecycleDrawer.namespace': '名前空間',
     'deploymentLifecycle.deploymentLifecycleDrawer.commit': 'コミット',
     'deploymentLifecycle.deploymentLifecycleDrawer.revision': 'リビジョン',
     'deploymentLifecycle.deploymentLifecycleDrawer.resources': 'リソース',
     'deploymentLifecycle.deploymentLifecycleDrawer.instanceDefaultValue':
       'デフォルト',
     'deploymentSummary.deploymentSummary.tableTitle': 'デプロイメントの概要',
+    'deploymentSummary.deploymentSummary.columns.application':
+      'アプリケーション',
+    'deploymentSummary.deploymentSummary.columns.namespace': '名前空間',
     'deploymentSummary.deploymentSummary.columns.instance': 'インスタンス',
     'deploymentSummary.deploymentSummary.columns.server': 'サーバー',
     'deploymentSummary.deploymentSummary.columns.revision': 'リビジョン',

--- a/workspaces/argocd/plugins/argocd/src/translations/ref.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/ref.ts
@@ -193,6 +193,8 @@ export const argocdMessages = {
     deploymentSummary: {
       tableTitle: 'Deployment Summary',
       columns: {
+        application: 'Application',
+        namespace: 'Namespace',
         instance: 'Instance',
         server: 'Server',
         revision: 'Revision',

--- a/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
+++ b/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
@@ -95,10 +95,8 @@ test.describe('ArgoCD plugin', () => {
     test('Verify column names', async () => {
       const cols = translations.deploymentSummary.deploymentSummary.columns;
       const columns = [
-        'ArgoCD App',
-        // Commenting because of missing translation in UI for Namespace https://issues.redhat.com/browse/RHDHBUGS-2601
-        // translations.deploymentLifecycle.deploymentLifecycleCard.namespace,
-        'NAMESPACE',
+        cols.application,
+        cols.namespace,
         cols.instance,
         cols.server,
         cols.revision,
@@ -135,7 +133,13 @@ test.describe('ArgoCD plugin', () => {
           row.getByRole('cell', { name: revision }).first(),
         ).toBeVisible();
         await expect(
-          row.getByRole('cell', { name: app.status.health.status }).first(),
+          row
+            .getByRole('cell', {
+              name: translations.appStatus.appHealthStatus[
+                app.status.health.status
+              ],
+            })
+            .first(),
         ).toBeVisible();
         await expect(
           row


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR added missing translations on ArgoCD summary page. And changed the column header from ArgoCD App to Application.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
## Screecshots

#### English
<img width="1695" height="699" alt="Screenshot 2026-02-11 at 9 14 26 AM" src="https://github.com/user-attachments/assets/bd94f2b7-a32a-4c68-bb0d-c67fe68fcab7" />

#### French
<img width="1696" height="639" alt="Screenshot 2026-02-11 at 9 16 03 AM" src="https://github.com/user-attachments/assets/96fc2709-2a28-4393-8348-cd222bbea853" />

#### Japanese
<img width="1696" height="639" alt="Screenshot 2026-02-11 at 9 16 58 AM" src="https://github.com/user-attachments/assets/d61886eb-66e5-4672-9bf7-501b6e168aa1" />

#### italian
<img width="1695" height="641" alt="Screenshot 2026-02-11 at 9 17 37 AM" src="https://github.com/user-attachments/assets/397bb9d0-8c09-4707-a7e7-83a2c2662225" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
