### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/renovate-6d380b1.md
+++ b/workspaces/analytics/.changeset/renovate-6d380b1.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-matomo': patch
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Updated dependency `@types/node` to `22.19.11`.

--- a/workspaces/analytics/.changeset/version-bump-1-48-2.md
+++ b/workspaces/analytics/.changeset/version-bump-1-48-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga4': minor
-'@backstage-community/plugin-analytics-module-matomo': minor
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Backstage version bump to v1.48.2

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.16.0
+
+### Minor Changes
+
+- 616b66c: Backstage version bump to v1.48.2
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-analytics-module-matomo
 
+## 1.25.0
+
+### Minor Changes
+
+- 616b66c: Backstage version bump to v1.48.2
+
+### Patch Changes
+
+- 497d5c6: Updated dependency `@types/node` to `22.19.11`.
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.16.0
+
+### Minor Changes
+
+- 616b66c: Backstage version bump to v1.48.2
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-analytics-provider-segment
 
+## 1.25.0
+
+### Minor Changes
+
+- 616b66c: Backstage version bump to v1.48.2
+
+### Patch Changes
+
+- 497d5c6: Updated dependency `@types/node` to `22.19.11`.
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga4@0.16.0

### Minor Changes

-   616b66c: Backstage version bump to v1.48.2

## @backstage-community/plugin-analytics-module-matomo@1.25.0

### Minor Changes

-   616b66c: Backstage version bump to v1.48.2

### Patch Changes

-   497d5c6: Updated dependency `@types/node` to `22.19.11`.

## @backstage-community/plugin-analytics-module-newrelic-browser@0.16.0

### Minor Changes

-   616b66c: Backstage version bump to v1.48.2

## @backstage-community/plugin-analytics-provider-segment@1.25.0

### Minor Changes

-   616b66c: Backstage version bump to v1.48.2

### Patch Changes

-   497d5c6: Updated dependency `@types/node` to `22.19.11`.
