### PR TITLE
Version Packages (stack-overflow)

### DIFF
--- a/workspaces/stack-overflow/.changeset/renovate-323a420.md
+++ b/workspaces/stack-overflow/.changeset/renovate-323a420.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-stack-overflow-backend': patch
-'@backstage-community/plugin-stack-overflow': patch
----
-
-Updated dependency `qs` to `^6.14.2`.

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-stack-overflow-backend
 
+## 0.15.1
+
+### Patch Changes
+
+- fc67402: Updated dependency `qs` to `^6.14.2`.
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
+++ b/workspaces/stack-overflow/plugins/stack-overflow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-stack-overflow-backend",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead",
   "deprecated": "Deprecated, use @backstage/plugin-search-backend-module-stack-overflow-collator instead",
   "backstage": {

--- a/workspaces/stack-overflow/plugins/stack-overflow/CHANGELOG.md
+++ b/workspaces/stack-overflow/plugins/stack-overflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-stack-overflow
 
+## 0.14.1
+
+### Patch Changes
+
+- fc67402: Updated dependency `qs` to `^6.14.2`.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/stack-overflow/plugins/stack-overflow/package.json
+++ b/workspaces/stack-overflow/plugins/stack-overflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-stack-overflow",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "stack-overflow",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-stack-overflow@0.14.1

### Patch Changes

-   fc67402: Updated dependency `qs` to `^6.14.2`.

## @backstage-community/plugin-stack-overflow-backend@0.15.1

### Patch Changes

-   fc67402: Updated dependency `qs` to `^6.14.2`.
