### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/fuzzy-seahorses-smile.md
+++ b/workspaces/jenkins/.changeset/fuzzy-seahorses-smile.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins': patch
----
-
-Replaces global JSX import with React.JSX

--- a/workspaces/jenkins/.changeset/kind-crabs-enjoy.md
+++ b/workspaces/jenkins/.changeset/kind-crabs-enjoy.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins-backend': minor
----
-
-Drops support for old backend system which includes removing exports for JenkinsBuilder. Please migrate to the new backend system way of installing the plugin.

--- a/workspaces/jenkins/.changeset/small-fans-guess.md
+++ b/workspaces/jenkins/.changeset/small-fans-guess.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-jenkins': patch
-'@backstage-community/plugin-jenkins-backend': patch
-'@backstage-community/plugin-jenkins-common': patch
-'@backstage-community/plugin-jenkins': patch
----
-
-remove unused dependencies

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.25.0
+
+### Minor Changes
+
+- 5141efa: Drops support for old backend system which includes removing exports for JenkinsBuilder. Please migrate to the new backend system way of installing the plugin.
+
+### Patch Changes
+
+- fc25522: remove unused dependencies
+- Updated dependencies [fc25522]
+  - @backstage-community/plugin-jenkins-common@0.16.1
+
 ## 0.24.1
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-common
 
+## 0.16.1
+
+### Patch Changes
+
+- fc25522: remove unused dependencies
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins-common/package.json
+++ b/workspaces/jenkins/plugins/jenkins-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-common",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "backstage": {
     "role": "common-library",
     "pluginId": "jenkins",

--- a/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-jenkins
 
+## 0.28.1
+
+### Patch Changes
+
+- 5141efa: Replaces global JSX import with React.JSX
+- fc25522: remove unused dependencies
+- Updated dependencies [fc25522]
+  - @backstage-community/plugin-jenkins-common@0.16.1
+
 ## 0.28.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins/package.json
+++ b/workspaces/jenkins/plugins/jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "A Backstage plugin that integrates towards Jenkins",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-scaffolder-backend-module-jenkins
 
+## 0.18.1
+
+### Patch Changes
+
+- fc25522: remove unused dependencies
+- Updated dependencies [fc25522]
+  - @backstage-community/plugin-jenkins-common@0.16.1
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-jenkins",
   "description": "Scaffolder plugin for Jenkins",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins-backend@0.25.0

### Minor Changes

-   5141efa: Drops support for old backend system which includes removing exports for JenkinsBuilder. Please migrate to the new backend system way of installing the plugin.

### Patch Changes

-   fc25522: remove unused dependencies
-   Updated dependencies [fc25522]
    -   @backstage-community/plugin-jenkins-common@0.16.1

## @backstage-community/plugin-jenkins@0.28.1

### Patch Changes

-   5141efa: Replaces global JSX import with React.JSX
-   fc25522: remove unused dependencies
-   Updated dependencies [fc25522]
    -   @backstage-community/plugin-jenkins-common@0.16.1

## @backstage-community/plugin-jenkins-common@0.16.1

### Patch Changes

-   fc25522: remove unused dependencies

## @backstage-community/plugin-scaffolder-backend-module-jenkins@0.18.1

### Patch Changes

-   fc25522: remove unused dependencies
-   Updated dependencies [fc25522]
    -   @backstage-community/plugin-jenkins-common@0.16.1
