### PR TITLE
fix(argocd): fix a conflict with Roadie Argo CD plugin so that both can installed at the same time

### DIFF
--- a/workspaces/argocd/.changeset/early-camels-end.md
+++ b/workspaces/argocd/.changeset/early-camels-end.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-argocd-backend': patch
+'@backstage-community/plugin-argocd': patch
+---
+
+Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.

--- a/workspaces/argocd/plugins/argocd-backend/src/plugin.ts
+++ b/workspaces/argocd/plugins/argocd-backend/src/plugin.ts
@@ -26,7 +26,7 @@ import { argocdPermissions } from '@backstage-community/plugin-argocd-common';
  * @public
  */
 export const argoCDPlugin = createBackendPlugin({
-  pluginId: 'argocd',
+  pluginId: 'backstage-community-argocd',
   register(env) {
     env.registerInit({
       deps: {

--- a/workspaces/argocd/plugins/argocd-backend/src/router.ts
+++ b/workspaces/argocd/plugins/argocd-backend/src/router.ts
@@ -67,6 +67,10 @@ export async function createRouter(
 
   router.use(checkPermission);
 
+  router.get('/check', async (_req: express.Request, res: express.Response) => {
+    res.send('OK');
+  });
+
   router.get(
     '/find/name/:appName',
     async (req: express.Request, res: express.Response) => {

--- a/workspaces/argocd/plugins/argocd/src/plugin.ts
+++ b/workspaces/argocd/plugins/argocd/src/plugin.ts
@@ -20,7 +20,8 @@ import {
   createApiFactory,
   createPlugin,
   createRoutableExtension,
-  identityApiRef,
+  discoveryApiRef,
+  fetchApiRef,
 } from '@backstage/core-plugin-api';
 
 import { argoCDApiRef, argoCDInstanceApiRef } from './api';
@@ -38,13 +39,14 @@ export const argocdPlugin = createPlugin({
     createApiFactory({
       api: argoCDApiRef,
       deps: {
-        identityApi: identityApiRef,
+        discoveryApi: discoveryApiRef,
+        fetchApi: fetchApiRef,
         configApi: configApiRef,
       },
-      factory: ({ identityApi, configApi }) =>
+      factory: ({ discoveryApi, fetchApi, configApi }) =>
         new ArgoCDApiClient({
-          identityApi,
-          backendBaseUrl: configApi.getString('backend.baseUrl'),
+          discoveryApi,
+          fetchApi,
           useNamespacedApps: Boolean(
             configApi.getOptionalBoolean('argocd.namespacedApps'),
           ),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changes the (mostly internal used) backend `pluginId` from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
