### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-906d33c.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-906d33c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.93.1`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-f0f2a99.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-f0f2a99.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.92.4`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-48-4.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-48-4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.14.0
+
+### Minor Changes
+
+- 68f9eb5: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- c7283a1: Updated dependency `@hey-api/openapi-ts` to `0.93.1`.
+- 9f0798f: Updated dependency `@hey-api/openapi-ts` to `0.92.4`.
+
 ## 2.13.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.14.0

### Minor Changes

-   68f9eb5: Backstage version bump to v1.48.4

### Patch Changes

-   c7283a1: Updated dependency `@hey-api/openapi-ts` to `0.93.1`.
-   9f0798f: Updated dependency `@hey-api/openapi-ts` to `0.92.4`.
