### PR TITLE
fix(argocd): use mouse cursor pointer to show that deployment lifecycle card is clickable

### DIFF
--- a/workspaces/argocd/.changeset/lucky-ants-say.md
+++ b/workspaces/argocd/.changeset/lucky-ants-say.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-argocd': patch
+---
+
+Use (mouse) cursor pointer (hand) to show that the deployment lifecycle card is clickable.

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleCard.tsx
@@ -79,7 +79,10 @@ const DeploymentLifecycleCard: FC<DeploymentLifecycleCardProps> = ({
       data-testid={`${app?.metadata?.name}-card`}
       key={app?.metadata?.uid}
       className={classes.card}
-      style={{ justifyContent: 'space-between' }}
+      style={{
+        cursor: onclick ? 'pointer' : 'default',
+        justifyContent: 'space-between',
+      }}
       onClick={onclick}
     >
       <CardHeader


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use mouse cursor pointer (hand) on this card when an `onClick` listener is defined:

<img width="1047" height="762" alt="image" src="https://github.com/user-attachments/assets/f8e996a3-791c-480b-af57-126bf3585820" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
