### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/early-camels-end.md
+++ b/workspaces/argocd/.changeset/early-camels-end.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd': patch
----
-
-Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.

--- a/workspaces/argocd/.changeset/lucky-ants-say.md
+++ b/workspaces/argocd/.changeset/lucky-ants-say.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-Use (mouse) cursor pointer (hand) to show that the deployment lifecycle card is clickable.

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.0.4
+
+### Patch Changes
+
+- 074cfaa: Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.
+
 ## 1.0.3
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-argocd
 
+## 2.4.6
+
+### Patch Changes
+
+- 074cfaa: Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.
+- 40d5b94: Use (mouse) cursor pointer (hand) to show that the deployment lifecycle card is clickable.
+
 ## 2.4.5
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.4.6

### Patch Changes

-   074cfaa: Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.
-   40d5b94: Use (mouse) cursor pointer (hand) to show that the deployment lifecycle card is clickable.

## @backstage-community/plugin-argocd-backend@1.0.4

### Patch Changes

-   074cfaa: Changes the (mostly internal used) pluginId from `argocd` to `backstage-community-argocd` to resolve a conflict with the Argo CD plugin from Roadie. This will allow users to install both plugins in parallel. Since the Backstage Community Argo CD plugin works fine with the Roadie Argo CD Backend plugin the frontend automatically falls back to the `argocd` backend if there is no `backstage-community-argocd` backend available.
