### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/clever-mice-rhyme.md
+++ b/workspaces/rbac/.changeset/clever-mice-rhyme.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-exported rbacPlugin as a default and other minor updates

--- a/workspaces/rbac/.changeset/moody-penguins-perform.md
+++ b/workspaces/rbac/.changeset/moody-penguins-perform.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Added NFS support

--- a/workspaces/rbac/.changeset/renovate-8682ce0.md
+++ b/workspaces/rbac/.changeset/renovate-8682ce0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `supertest` to `7.2.2`.

--- a/workspaces/rbac/.changeset/tough-radios-warn.md
+++ b/workspaces/rbac/.changeset/tough-radios-warn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated the translation of a Japanese word.

--- a/workspaces/rbac/.changeset/update-available-languages.md
+++ b/workspaces/rbac/.changeset/update-available-languages.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Translation updated for German and Spanish

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.7.2
+
+### Patch Changes
+
+- 8c7bddb: Added NFS support
+- af998b7: Updated dependency `supertest` to `7.2.2`.
+
 ## 7.7.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.7.1",
+  "version": "7.7.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-rbac
 
+## 1.49.0
+
+### Minor Changes
+
+- 8c7bddb: Added NFS support
+
+### Patch Changes
+
+- 42c05f7: exported rbacPlugin as a default and other minor updates
+- a55af54: Updated the translation of a Japanese word.
+- 1d15595: Translation updated for German and Spanish
+
 ## 1.48.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.49.0

### Minor Changes

-   8c7bddb: Added NFS support

### Patch Changes

-   42c05f7: exported rbacPlugin as a default and other minor updates
-   a55af54: Updated the translation of a Japanese word.
-   1d15595: Translation updated for German and Spanish

## @backstage-community/plugin-rbac-backend@7.7.2

### Patch Changes

-   8c7bddb: Added NFS support
-   af998b7: Updated dependency `supertest` to `7.2.2`.
