### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-2ebccce.md
+++ b/workspaces/ocm/.changeset/renovate-2ebccce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.29.0`.

--- a/workspaces/ocm/.changeset/renovate-8682ce0.md
+++ b/workspaces/ocm/.changeset/renovate-8682ce0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `supertest` to `7.2.2`.

--- a/workspaces/ocm/.changeset/renovate-999882c.md
+++ b/workspaces/ocm/.changeset/renovate-999882c.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.30.0`.

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.15.1
+
+### Patch Changes
+
+- 5c0c5f2: Updated dependency `@openapitools/openapi-generator-cli` to `2.29.0`.
+- af998b7: Updated dependency `supertest` to `7.2.2`.
+- de04885: Updated dependency `@openapitools/openapi-generator-cli` to `2.30.0`.
+
 ## 5.15.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.15.0",
+  "version": "5.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm-backend@5.15.1

### Patch Changes

-   5c0c5f2: Updated dependency `@openapitools/openapi-generator-cli` to `2.29.0`.
-   af998b7: Updated dependency `supertest` to `7.2.2`.
-   de04885: Updated dependency `@openapitools/openapi-generator-cli` to `2.30.0`.
