### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/flat-lobsters-speak.md
+++ b/workspaces/azure-devops/.changeset/flat-lobsters-speak.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': minor
----
-
-**BREAKING** Backstage UI (BUI) is now required for the Azure DevOps plugin to function
-
-Initial Migration to Backstage UI (BUI) including Azure Pipelines, Azure Repos, Azure Repos Git Tags, and Azure Readme

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.27.0
+
+### Minor Changes
+
+- 516a7f1: **BREAKING** Backstage UI (BUI) is now required for the Azure DevOps plugin to function
+
+  Initial Migration to Backstage UI (BUI) including Azure Pipelines, Azure Repos, Azure Repos Git Tags, and Azure Readme
+
 ## 0.26.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.27.0

### Minor Changes

-   516a7f1: **BREAKING** Backstage UI (BUI) is now required for the Azure DevOps plugin to function

    Initial Migration to Backstage UI (BUI) including Azure Pipelines, Azure Repos, Azure Repos Git Tags, and Azure Readme
