### PR TITLE
ci: add missing flag to release workflow for Yarn 4

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -174,7 +174,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --provenance --tolerate-republish --tag "maintenance"
+          yarn workspaces foreach -W -v --no-private npm publish --access public --provenance --tolerate-republish --tag "maintenance"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

[Most recent run](https://github.com/backstage/community-plugins/actions/runs/22296915693/job/64495382477) of the Prior Version Release Workspace workflow failed due to a missing flag in `yarn workspaces foreach` required in Yarn 4. This PR adds this flag, and aligns with the main [Release Workspace](https://github.com/backstage/community-plugins/blob/d256a29da15fc0f60d1d413c64ad5902c3e7f9be/.github/workflows/release_workspace.yml#L160) workflow.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
