### PR TITLE
feat(argocd): add externalBaseUrl and instance.externalUrl to expose external url to the client

### DIFF
--- a/workspaces/argocd/.changeset/shiny-sites-switch.md
+++ b/workspaces/argocd/.changeset/shiny-sites-switch.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-argocd-common': minor
+'@backstage-community/plugin-argocd': minor
+---
+
+add externalBaseUrl and instance.externalUrl to expose external url to the client

--- a/workspaces/argocd/plugins/argocd-common/report.api.md
+++ b/workspaces/argocd/plugins/argocd-common/report.api.md
@@ -100,6 +100,8 @@ export interface InitiatedBy {
 // @public (undocumented)
 export interface Instance {
   // (undocumented)
+  externalUrl?: string;
+  // (undocumented)
   name: string;
   // (undocumented)
   password?: string;

--- a/workspaces/argocd/plugins/argocd-common/src/types.ts
+++ b/workspaces/argocd/plugins/argocd-common/src/types.ts
@@ -41,6 +41,7 @@ export type ApplicationPayload = Omit<Application, 'status' | 'metadata'> & {
 export interface Instance {
   name: string;
   url: string;
+  externalUrl?: string;
   password?: string;
   token?: string;
   username?: string;

--- a/workspaces/argocd/plugins/argocd/config.d.ts
+++ b/workspaces/argocd/plugins/argocd/config.d.ts
@@ -22,6 +22,11 @@ export interface Config {
      */
     baseUrl?: string;
     /**
+     * The external URL to the ArgoCD instance that is exposed to the clients.
+     * @visibility frontend
+     */
+    externalBaseUrl?: string;
+    /**
      * Support for the ArgoCD beta feature "Applications in any namespace"
      * @visibility frontend
      */
@@ -63,6 +68,10 @@ export interface Config {
          * @visibility frontend
          */
         url: string;
+        /**
+         * @visibility frontend
+         */
+        externalUrl: string;
         /**
          * @visibility secret
          */

--- a/workspaces/argocd/plugins/argocd/src/api/ArgoCDInstanceApiClient.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/ArgoCDInstanceApiClient.ts
@@ -87,12 +87,20 @@ export class ArgoCDInstanceApiClient implements ArgoCDInstanceApi {
     if (
       application.metadata &&
       (!application.metadata.instance?.name ||
+        !application.metadata.instance?.externalUrl ||
         !application.metadata.instance?.url)
     ) {
-      const instanceUrl =
-        application.metadata.instance?.url ??
-        this.instances.find(instance => instance.name === instanceName)?.url;
-      application.metadata.instance = { name: instanceName, url: instanceUrl };
+      const instance = this.instances.find(
+        candidate => candidate.name === instanceName,
+      );
+      const instanceUrl = application.metadata.instance?.url || instance?.url;
+      const instanceExternalUrl =
+        application.metadata.instance?.externalUrl || instance?.externalUrl;
+      application.metadata.instance = {
+        name: instanceName,
+        url: instanceUrl!,
+        externalUrl: instanceExternalUrl,
+      };
     }
     return application;
   }

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleHeader.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleHeader.tsx
@@ -22,16 +22,13 @@ import { useArgocdConfig } from '../../hooks/useArgocdConfig';
 import { Application } from '@backstage-community/plugin-argocd-common';
 
 const DeploymentLifecycleHeader: FC<{ app: Application }> = ({ app }) => {
-  const { instances, baseUrl } = useArgocdConfig();
+  const { instances, baseUrl, externalBaseUrl } = useArgocdConfig();
 
-  const supportsMultipleArgoInstances = !!instances.length;
   const getBaseUrl = (row: Application): string | undefined => {
-    if (supportsMultipleArgoInstances && !baseUrl) {
-      return instances?.find(
-        value => value?.name === row.metadata?.instance?.name,
-      )?.url;
-    }
-    return baseUrl;
+    const instance = instances?.find(
+      value => value?.name === row.metadata?.instance?.name,
+    );
+    return instance?.externalUrl || instance?.url || externalBaseUrl || baseUrl;
   };
 
   const appUrl = app?.metadata?.namespace

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleHeader.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleHeader.test.tsx
@@ -24,45 +24,76 @@ import { mockApplication } from '../../../../dev/__data__';
 import DeploymentLifecycleHeader from '../DeploymentLifecycleHeader';
 
 describe('DeploymentLifecycleCardHeader', () => {
-  const wrapper = ({ children }: { children: ReactNode }) => {
-    return (
-      <TestApiProvider
-        apis={[
-          [
-            configApiRef,
-            mockApis.config({
-              data: {
-                argocd: {
-                  appLocatorMethods: [
-                    {
-                      instances: [
-                        {
-                          name: 'main',
-                          url: 'https://test.com',
-                        },
-                      ],
-                      type: 'config',
-                    },
-                  ],
+  test('should render the deployment lifecycle application header', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider
+          apis={[
+            [
+              configApiRef,
+              mockApis.config({
+                data: {
+                  argocd: {
+                    appLocatorMethods: [
+                      {
+                        instances: [
+                          {
+                            name: 'main',
+                            url: 'https://test.com',
+                          },
+                        ],
+                        type: 'config',
+                      },
+                    ],
+                  },
                 },
-              },
-            }),
-          ],
-        ]}
-      >
-        {children}
-      </TestApiProvider>
-    );
-  };
+              }),
+            ],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      );
+    };
 
-  test('should render the deployment lifecylce appliction header', () => {
     render(<DeploymentLifecycleHeader app={mockApplication} />, { wrapper });
 
     expect(screen.queryByText('quarkus-app-dev')).toBeInTheDocument();
     expect(screen.queryByTestId('quarkus-app-dev-link')).toBeInTheDocument();
   });
 
-  test('should render the deployment lifecylce appliction header link with instance url', () => {
+  test('should render the deployment lifecycle application header link with instance url', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider
+          apis={[
+            [
+              configApiRef,
+              mockApis.config({
+                data: {
+                  argocd: {
+                    appLocatorMethods: [
+                      {
+                        instances: [
+                          {
+                            name: 'main',
+                            url: 'https://test.com',
+                          },
+                        ],
+                        type: 'config',
+                      },
+                    ],
+                  },
+                },
+              }),
+            ],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      );
+    };
+
     render(<DeploymentLifecycleHeader app={mockApplication} />, { wrapper });
     const link = screen.queryByTestId(
       'quarkus-app-dev-link',
@@ -76,7 +107,53 @@ describe('DeploymentLifecycleCardHeader', () => {
     );
   });
 
-  test('should render the deployment lifecylce appliction header with base url', () => {
+  test('should render the deployment lifecycle application header link with instance external url', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider
+          apis={[
+            [
+              configApiRef,
+              mockApis.config({
+                data: {
+                  argocd: {
+                    appLocatorMethods: [
+                      {
+                        instances: [
+                          {
+                            name: 'main',
+                            url: 'https://test.com',
+                            externalUrl: 'https://external-test.com',
+                          },
+                        ],
+                        type: 'config',
+                      },
+                    ],
+                  },
+                },
+              }),
+            ],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      );
+    };
+
+    render(<DeploymentLifecycleHeader app={mockApplication} />, { wrapper });
+    const link = screen.queryByTestId(
+      'quarkus-app-dev-link',
+    ) as HTMLLinkElement;
+
+    fireEvent.click(link);
+
+    expect(link).toHaveAttribute(
+      'href',
+      'https://external-test.com/applications/quarkus-app-dev',
+    );
+  });
+
+  test('should render the deployment lifecycle application header with base url', () => {
     const apiProviderWrapper = ({ children }: { children: ReactNode }) => {
       return (
         <TestApiProvider
@@ -109,6 +186,43 @@ describe('DeploymentLifecycleCardHeader', () => {
     expect(link).toHaveAttribute(
       'href',
       'https://baseurl.com/applications/quarkus-app-dev',
+    );
+  });
+
+  test('should render the deployment lifecycle application header with external base url', () => {
+    const apiProviderWrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider
+          apis={[
+            [
+              configApiRef,
+              mockApis.config({
+                data: {
+                  argocd: {
+                    baseUrl: 'https://baseurl.com',
+                    externalBaseUrl: 'https://externalbaseurl.com',
+                    appLocatorMethods: [],
+                  },
+                },
+              }),
+            ],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      );
+    };
+
+    render(<DeploymentLifecycleHeader app={mockApplication} />, {
+      wrapper: apiProviderWrapper,
+    });
+    const link = screen.queryByTestId(
+      'quarkus-app-dev-link',
+    ) as HTMLLinkElement;
+
+    expect(link).toHaveAttribute(
+      'href',
+      'https://externalbaseurl.com/applications/quarkus-app-dev',
     );
   });
 });

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -51,7 +51,7 @@ const DeploymentSummary = ({
 }: DeploymentSummaryProps) => {
   const { entity } = useEntity();
 
-  const { baseUrl } = useArgocdConfig();
+  const { baseUrl, externalBaseUrl } = useArgocdConfig();
   const instanceNames = useMemo(() => getInstanceNames(entity), [entity]);
 
   const { appSelector, appName, projectName, appNamespace } =
@@ -90,7 +90,12 @@ const DeploymentSummary = ({
 
   const columns = useMemo<TableColumn<Application>[]>(() => {
     const getBaseUrl = (row: any): string | undefined => {
-      return row?.metadata?.instance?.url ?? baseUrl;
+      return (
+        row?.metadata?.instance?.externalUrl ||
+        row?.metadata?.instance?.url ||
+        externalBaseUrl ||
+        baseUrl
+      );
     };
 
     const buildAppUrl = (row: any): string | undefined => {

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
@@ -167,6 +167,37 @@ describe('DeploymentSummary', () => {
     });
   });
 
+  test('should link the application to instance external url', async () => {
+    (useApplications as any).mockReturnValue({
+      apps: [
+        {
+          ...mockApplication,
+          metadata: {
+            ...mockApplication.metadata,
+            instance: {
+              name: 'main',
+              url: 'https://main-instance-url.com',
+              externalUrl: 'https://external-main-instance-url.com',
+            },
+          },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    });
+
+    await renderInTestApp(<DeploymentSummary />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'quarkus-app-dev' }),
+      ).toHaveAttribute(
+        'href',
+        'https://external-main-instance-url.com/applications/quarkus-app-dev',
+      );
+    });
+  });
+
   test('should link the application to the base argocd url if no instance url', async () => {
     (useArgocdConfig as any).mockReturnValue({
       baseUrl: 'https://baseurl.com',
@@ -197,6 +228,41 @@ describe('DeploymentSummary', () => {
       ).toHaveAttribute(
         'href',
         'https://baseurl.com/applications/quarkus-app-dev',
+      );
+    });
+  });
+
+  test('should link the application to the external base argocd url if no instance url', async () => {
+    (useArgocdConfig as any).mockReturnValue({
+      baseUrl: 'https://baseurl.com',
+      externalBaseUrl: 'https://externalbaseurl.com',
+      instances: [{ name: 'main' }],
+      intervalMs: 10000,
+    });
+    (useApplications as any).mockReturnValue({
+      apps: [
+        {
+          ...mockApplication,
+          metadata: {
+            ...mockApplication.metadata,
+            instance: { name: 'main' },
+          },
+        },
+      ],
+      loading: false,
+      error: undefined,
+    });
+    await renderInTestApp(<DeploymentSummary />);
+
+    await waitFor(() => {
+      screen.getByText('Healthy');
+      screen.getByText('Synced');
+
+      expect(
+        screen.getByRole('link', { name: 'quarkus-app-dev' }),
+      ).toHaveAttribute(
+        'href',
+        'https://externalbaseurl.com/applications/quarkus-app-dev',
       );
     });
   });

--- a/workspaces/argocd/plugins/argocd/src/hooks/__tests__/useArgocdConfig.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/hooks/__tests__/useArgocdConfig.test.tsx
@@ -52,7 +52,7 @@ describe('useArgocdConfig', () => {
     expect(result.current.baseUrl).toBeUndefined();
   });
 
-  it('should return default name and url', () => {
+  it('should return default name, url and externalUrl', () => {
     const wrapper = ({ children }: { children: ReactNode }) => {
       return (
         <TestApiProvider
@@ -84,6 +84,7 @@ describe('useArgocdConfig', () => {
     expect(result.current.instances).toHaveLength(1);
     expect(result.current.instances[0].name).toBe('');
     expect(result.current.instances[0].url).toBe('');
+    expect(result.current.instances[0].externalUrl).toBe('');
   });
 
   it('should return base url', () => {
@@ -119,6 +120,43 @@ describe('useArgocdConfig', () => {
     expect(result.current.baseUrl).toBe('https://argo-base-url.com');
   });
 
+  it('should return external base url', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider
+          apis={[
+            [
+              configApiRef,
+              mockApis.config({
+                data: {
+                  argocd: {
+                    baseUrl: 'https://argo-base-url.com',
+                    externalBaseUrl: 'https://external-argo-base-url.com',
+                    appLocatorMethods: [
+                      {
+                        instances: [{}],
+                        type: 'config',
+                      },
+                    ],
+                  },
+                },
+              }),
+            ],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useArgocdConfig(), { wrapper });
+
+    expect(result.current.baseUrl).toBe('https://argo-base-url.com');
+    expect(result.current.externalBaseUrl).toBe(
+      'https://external-argo-base-url.com',
+    );
+  });
+
   it('should return configured instance and refreshInterval', () => {
     const mockConfig = mockApis.config({
       data: {
@@ -152,5 +190,42 @@ describe('useArgocdConfig', () => {
     expect(result.current.instances).toHaveLength(1);
     expect(result.current.instances[0].url).toBe('https://test.com');
     expect(result.current.intervalMs).toBe(50000);
+  });
+
+  it('should return configured instance with external url', () => {
+    const mockConfig = mockApis.config({
+      data: {
+        argocd: {
+          appLocatorMethods: [
+            {
+              instances: [
+                {
+                  name: 'test',
+                  url: 'https://test.com',
+                  externalUrl: 'https://external-test.com',
+                },
+              ],
+              type: 'config',
+            },
+          ],
+        },
+      },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      return (
+        <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+          {children}
+        </TestApiProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useArgocdConfig(), { wrapper });
+
+    expect(result.current.instances).toHaveLength(1);
+    expect(result.current.instances[0].url).toBe('https://test.com');
+    expect(result.current.instances[0].externalUrl).toBe(
+      'https://external-test.com',
+    );
   });
 });

--- a/workspaces/argocd/plugins/argocd/src/hooks/useArgocdConfig.ts
+++ b/workspaces/argocd/plugins/argocd/src/hooks/useArgocdConfig.ts
@@ -27,6 +27,7 @@ export const getArgocdInstances = (configApi: Config) => {
   ).map(config => ({
     name: config.getOptionalString('name') ?? '',
     url: config.getOptionalString('url') ?? '',
+    externalUrl: config.getOptionalString('externalUrl') ?? '',
   }));
 };
 
@@ -34,6 +35,7 @@ export const useArgocdConfig = (): {
   instances: Instance[];
   intervalMs: number;
   baseUrl: string | undefined;
+  externalBaseUrl: string | undefined;
 } => {
   const configApi = useApi(configApiRef);
 
@@ -41,8 +43,10 @@ export const useArgocdConfig = (): {
   const intervalMs =
     configApi.getOptionalNumber('argocd.refreshInterval') ?? 10000;
   const baseUrl = configApi.getOptionalString('argocd.baseUrl');
+  const externalBaseUrl = configApi.getOptionalString('argocd.externalBaseUrl');
   return {
     baseUrl,
+    externalBaseUrl,
     instances,
     intervalMs,
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- add externalBaseUrl and instance.externalUrl to the frontend plugin
- add externalUrl to the Instance interface to the common part

The PR introduces a new configuration item `externalBaseUrl` and per instance `externalUrl` to expose a reachable base URL to the frontend client. This allows backend to reach argocd in the closed environment within private environment while exposing same argocd to the clients via the URL the client can reach.

Closes https://github.com/backstage/community-plugins/issues/7478

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
