### PR TITLE
ci: add missing flag to release workflow for Yarn 4

### DIFF
--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -174,7 +174,7 @@ jobs:
       - name: publish
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          yarn workspaces foreach -v --no-private npm publish --access public --provenance --tolerate-republish --tag "maintenance"
+          yarn workspaces foreach -W -v --no-private npm publish --access public --provenance --tolerate-republish --tag "maintenance"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This shifts over the changes made to the `workspace-release-version` workflow in this PR: https://github.com/backstage/community-plugins/pull/7666 to the `workspace/rbac` PR.
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
