### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/hungry-rings-smash.md
+++ b/workspaces/rbac/.changeset/hungry-rings-smash.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Backport: Remove usage of breaking imports from @backstage/backend-defaults
-
-This backports the fix from commit 9c7ae87 to avoid compatibility issue when @backstage/backend-defaults resolves to 0.13.2, which introduced breaking changes to address a CVE. By removing the problematic import, this plugin remains compatible with both 0.13.1 and 0.13.2 and does not use the code containing the CVE.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Dependencies
 
+## 7.6.2
+
+### Patch Changes
+
+- 9a07184: Backport: Remove usage of breaking imports from @backstage/backend-defaults
+
+  This backports the fix from commit 9c7ae87 to avoid compatibility issue when @backstage/backend-defaults resolves to 0.13.2, which introduced breaking changes to address a CVE. By removing the problematic import, this plugin remains compatible with both 0.13.1 and 0.13.2 and does not use the code containing the CVE.
+
 ## 7.6.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@7.6.2

### Patch Changes

-   9a07184: Backport: Remove usage of breaking imports from @backstage/backend-defaults

    This backports the fix from commit 9c7ae87 to avoid compatibility issue when @backstage/backend-defaults resolves to 0.13.2, which introduced breaking changes to address a CVE. By removing the problematic import, this plugin remains compatible with both 0.13.1 and 0.13.2 and does not use the code containing the CVE.
