### PR TITLE
fix(argocd): skip revision metadata calls for Helm chart sources in multi-source apps

### DIFF
--- a/workspaces/argocd/.changeset/fix-helm-multisource-revision-errors.md
+++ b/workspaces/argocd/.changeset/fix-helm-multisource-revision-errors.md
@@ -9,3 +9,4 @@ When an ArgoCD Application has multiple sources and one is a Helm chart (i.e. `s
 - `getRevisionDetailsList` now skips the revision metadata API call when the source at the given index is a Helm chart source.
 - `getUniqueRevisions` now excludes Helm chart version strings from multi-source apps so they are not passed to the revision metadata endpoint.
 - `isAppHelmChartType` now correctly returns `true` for multi-source apps that include at least one Helm chart source, fixing the revision link rendering in the Deployment Summary table.
+- Fixed the Revision column in the Deployment Summary table for multi-source apps: the previous `pop()` call mutated the cached history array causing the column to cycle between the commit SHA, the Helm version, and blank on successive React renders. The column now shows a stable combined string (e.g. `6.49.0 / abc1234`) — Helm chart versions in full and git SHAs truncated to 7 characters — linked to the first git source commit URL.

--- a/workspaces/argocd/.changeset/fix-helm-multisource-revision-errors.md
+++ b/workspaces/argocd/.changeset/fix-helm-multisource-revision-errors.md
@@ -1,0 +1,11 @@
+---
+'@backstage-community/plugin-argocd': patch
+---
+
+Fix HTTP 500 errors and incorrect rendering for multi-source ArgoCD applications that include Helm chart sources.
+
+When an ArgoCD Application has multiple sources and one is a Helm chart (i.e. `spec.sources[i].chart` is set), the backend was calling the ArgoCD revision metadata endpoint with the chart version string (e.g. `6.33.0`) as the revision ID. The ArgoCD API endpoint `/revisions/{revision}/metadata` only accepts git commit SHAs and returns HTTP 500 for chart version strings, producing a continuous stream of backend errors on every entity page load.
+
+- `getRevisionDetailsList` now skips the revision metadata API call when the source at the given index is a Helm chart source.
+- `getUniqueRevisions` now excludes Helm chart version strings from multi-source apps so they are not passed to the revision metadata endpoint.
+- `isAppHelmChartType` now correctly returns `true` for multi-source apps that include at least one Helm chart source, fixing the revision link rendering in the Deployment Summary table.

--- a/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
@@ -408,7 +408,7 @@ export const prodApplication: Application = {
   },
 };
 
-export const multiSourceHelmArgoApp = {
+export const multiSourceHelmArgoApp: Application = {
   metadata: {
     name: 'helm-git-app',
     namespace: 'argocd',
@@ -437,7 +437,6 @@ export const multiSourceHelmArgoApp = {
         repoURL: 'https://github.com/example-org/gitops-values.git',
         path: 'values',
         targetRevision: 'HEAD',
-        ref: 'values',
       },
     ],
   },
@@ -475,7 +474,6 @@ export const multiSourceHelmArgoApp = {
             repoURL: 'https://github.com/example-org/gitops-values.git',
             path: 'values',
             targetRevision: 'HEAD',
-            ref: 'values',
           },
         ],
         revisions: ['1.0.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],

--- a/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
@@ -408,6 +408,82 @@ export const prodApplication: Application = {
   },
 };
 
+export const multiSourceHelmArgoApp = {
+  metadata: {
+    name: 'loki-app',
+    namespace: 'argocd',
+    uid: '9abc1234-5678-90ef-ghij-klmnopqrstuv',
+    instance: {
+      name: 'main',
+      url: 'https://kubernetes.default.svc',
+    },
+  },
+  spec: {
+    destination: {
+      server: 'https://kubernetes.example.cluster:6443',
+      namespace: 'monitoring',
+    },
+    project: 'monitoring',
+    source: {
+      repoURL: '',
+    },
+    sources: [
+      {
+        repoURL: 'https://grafana.github.io/helm-charts',
+        chart: 'loki',
+        targetRevision: '6.33.0',
+      },
+      {
+        repoURL: 'https://github.com/example-org/gitops-values.git',
+        path: 'loki',
+        targetRevision: 'HEAD',
+        ref: 'values',
+      },
+    ],
+  },
+  status: {
+    health: {
+      status: 'Healthy',
+    },
+    sync: {
+      status: 'Synced',
+    },
+    operationState: {
+      operation: {
+        sync: {},
+      },
+      phase: 'Succeeded',
+    },
+    summary: {
+      images: [],
+    },
+    history: [
+      {
+        deployedAt: '2025-02-20T16:40:32Z',
+        id: 0,
+        source: {
+          repoURL: '',
+        },
+        deployStartedAt: '2025-02-20T16:40:31Z',
+        sources: [
+          {
+            repoURL: 'https://grafana.github.io/helm-charts',
+            chart: 'loki',
+            targetRevision: '6.33.0',
+          },
+          {
+            repoURL: 'https://github.com/example-org/gitops-values.git',
+            path: 'loki',
+            targetRevision: 'HEAD',
+            ref: 'values',
+          },
+        ],
+        revisions: ['6.33.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
+      },
+    ],
+  },
+};
+
 export const multiSourceArgoApp = {
   metadata: {
     name: 'demo',

--- a/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
@@ -410,7 +410,7 @@ export const prodApplication: Application = {
 
 export const multiSourceHelmArgoApp = {
   metadata: {
-    name: 'loki-app',
+    name: 'helm-git-app',
     namespace: 'argocd',
     uid: '9abc1234-5678-90ef-ghij-klmnopqrstuv',
     instance: {
@@ -421,21 +421,21 @@ export const multiSourceHelmArgoApp = {
   spec: {
     destination: {
       server: 'https://kubernetes.example.cluster:6443',
-      namespace: 'monitoring',
+      namespace: 'demo',
     },
-    project: 'monitoring',
+    project: 'demo',
     source: {
       repoURL: '',
     },
     sources: [
       {
-        repoURL: 'https://grafana.github.io/helm-charts',
-        chart: 'loki',
-        targetRevision: '6.33.0',
+        repoURL: 'https://charts.example.com/helm-charts',
+        chart: 'example-chart',
+        targetRevision: '1.0.0',
       },
       {
         repoURL: 'https://github.com/example-org/gitops-values.git',
-        path: 'loki',
+        path: 'values',
         targetRevision: 'HEAD',
         ref: 'values',
       },
@@ -467,18 +467,18 @@ export const multiSourceHelmArgoApp = {
         deployStartedAt: '2025-02-20T16:40:31Z',
         sources: [
           {
-            repoURL: 'https://grafana.github.io/helm-charts',
-            chart: 'loki',
-            targetRevision: '6.33.0',
+            repoURL: 'https://charts.example.com/helm-charts',
+            chart: 'example-chart',
+            targetRevision: '1.0.0',
           },
           {
             repoURL: 'https://github.com/example-org/gitops-values.git',
-            path: 'loki',
+            path: 'values',
             targetRevision: 'HEAD',
             ref: 'values',
           },
         ],
-        revisions: ['6.33.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
+        revisions: ['1.0.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
       },
     ],
   },

--- a/workspaces/argocd/plugins/argocd/src/api/ArgoCDApiClient.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/ArgoCDApiClient.ts
@@ -206,6 +206,16 @@ export class ArgoCDApiClient implements ArgoCDApi {
 
         relevantHistories.forEach(h => {
           const revisionSourceIndex = h.revisions?.indexOf(revisionID);
+          // Skip Helm chart sources — the revision is a chart version string,
+          // not a git SHA, and the ArgoCD revision metadata endpoint returns
+          // HTTP 500 for non-git revisions.
+          if (
+            revisionSourceIndex !== undefined &&
+            revisionSourceIndex >= 0 &&
+            multiSourceApp.spec.sources?.[revisionSourceIndex]?.chart
+          ) {
+            return;
+          }
           promises.push(
             this.getRevisionDetails({
               app: multiSourceApp.metadata.name as string,

--- a/workspaces/argocd/plugins/argocd/src/api/ArgoCDApiClient.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/ArgoCDApiClient.ts
@@ -212,7 +212,10 @@ export class ArgoCDApiClient implements ArgoCDApi {
           if (
             revisionSourceIndex !== undefined &&
             revisionSourceIndex >= 0 &&
-            multiSourceApp.spec.sources?.[revisionSourceIndex]?.chart
+            (
+              h.sources?.[revisionSourceIndex] ??
+              multiSourceApp.spec.sources?.[revisionSourceIndex]
+            )?.chart
           ) {
             return;
           }

--- a/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
@@ -435,7 +435,7 @@ describe('API calls', () => {
 
       // Both the Helm chart version and the git SHA are in history
       await client.getRevisionDetailsList({
-        apps: [multiSourceHelmArgoApp as any],
+        apps: [multiSourceHelmArgoApp],
         revisionIDs: ['1.0.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
         appNamespace: '',
       });

--- a/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
@@ -17,7 +17,11 @@ import { FetchApi } from '@backstage/core-plugin-api';
 import { mockApis } from '@backstage/test-utils';
 
 import { ArgoCDApiClient } from '..';
-import { mockApplication, multiSourceArgoApp } from '../../../dev/__data__';
+import {
+  mockApplication,
+  multiSourceArgoApp,
+  multiSourceHelmArgoApp,
+} from '../../../dev/__data__';
 
 describe('API calls', () => {
   const fetchMock = jest.fn();
@@ -419,6 +423,37 @@ describe('API calls', () => {
             'Content-Type': 'application/json',
           },
         }),
+      );
+    });
+
+    test('should skip revision metadata calls for Helm chart sources in multi-source apps', async () => {
+      const client = new ArgoCDApiClient({
+        discoveryApi,
+        fetchApi,
+        useNamespacedApps: false,
+      });
+
+      // Both the Helm chart version and the git SHA are in history
+      await client.getRevisionDetailsList({
+        apps: [multiSourceHelmArgoApp as any],
+        revisionIDs: ['6.33.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
+        appNamespace: '',
+      });
+
+      // The git SHA at sourceIndex=1 should be fetched
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://test.com/api/backstage-community-argocd/argoInstance/main/applications/name/loki-app/revisions/abc123def456ghi789jkl012mno345pqr678stu901/metadata?sourceIndex=1',
+        expect.objectContaining({
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      // The Helm chart version at sourceIndex=0 should NOT trigger a fetch
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('/revisions/6.33.0/metadata'),
+        expect.anything(),
       );
     });
   });

--- a/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/api/__tests__/ArgoCDApiClient.test.ts
@@ -436,13 +436,13 @@ describe('API calls', () => {
       // Both the Helm chart version and the git SHA are in history
       await client.getRevisionDetailsList({
         apps: [multiSourceHelmArgoApp as any],
-        revisionIDs: ['6.33.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
+        revisionIDs: ['1.0.0', 'abc123def456ghi789jkl012mno345pqr678stu901'],
         appNamespace: '',
       });
 
       // The git SHA at sourceIndex=1 should be fetched
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://test.com/api/backstage-community-argocd/argoInstance/main/applications/name/loki-app/revisions/abc123def456ghi789jkl012mno345pqr678stu901/metadata?sourceIndex=1',
+        'https://test.com/api/backstage-community-argocd/argoInstance/main/applications/name/helm-git-app/revisions/abc123def456ghi789jkl012mno345pqr678stu901/metadata?sourceIndex=1',
         expect.objectContaining({
           headers: {
             'Content-Type': 'application/json',
@@ -452,7 +452,7 @@ describe('API calls', () => {
 
       // The Helm chart version at sourceIndex=0 should NOT trigger a fetch
       expect(fetchMock).not.toHaveBeenCalledWith(
-        expect.stringContaining('/revisions/6.33.0/metadata'),
+        expect.stringContaining('/revisions/1.0.0/metadata'),
         expect.anything(),
       );
     });

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -144,13 +144,46 @@ const DeploymentSummary = ({
         render: (row: Application): ReactNode => {
           const historyList = row.status?.history ?? [];
           const latestRev = historyList.at(-1);
-          const repoUrl =
-            row?.spec?.sources?.[0]?.repoURL ??
-            row?.spec?.source?.repoURL ??
-            '';
+          const sources = row.spec.sources;
 
-          const latestRevision =
-            latestRev?.revision ?? latestRev?.revisions?.pop() ?? '';
+          // Multi-source: build a combined revision display (e.g. "6.49.0 / abc1234")
+          // showing Helm chart versions in full and git SHAs truncated to 7 chars.
+          if (latestRev?.revisions && sources?.length) {
+            const revisionText = sources
+              .map((source, idx) => {
+                const rev = latestRev.revisions?.[idx];
+                if (!rev) return null;
+                return source.chart ? rev : rev.substring(0, 7);
+              })
+              .filter(Boolean)
+              .join(' / ');
+
+            // Link to the first git source commit
+            const gitIdx = sources.findIndex(s => !s.chart);
+            const gitRev =
+              gitIdx >= 0 ? (latestRev.revisions?.[gitIdx] ?? '') : '';
+            const gitRepoUrl =
+              gitIdx >= 0 ? (sources[gitIdx]?.repoURL ?? '') : '';
+            const commitUrl = gitRev
+              ? getCommitUrl(
+                  gitRepoUrl,
+                  gitRev,
+                  entity?.metadata?.annotations || {},
+                )
+              : undefined;
+
+            return commitUrl ? (
+              <Link href={commitUrl} target="_blank" rel="noopener">
+                {revisionText || '-'}
+              </Link>
+            ) : (
+              <>{revisionText || '-'}</>
+            );
+          }
+
+          // Single-source fallback
+          const repoUrl = row?.spec?.source?.repoURL ?? '';
+          const latestRevision = latestRev?.revision ?? '';
           const commitUrl = isAppHelmChartType(row)
             ? repoUrl
             : getCommitUrl(
@@ -158,8 +191,12 @@ const DeploymentSummary = ({
                 latestRevision,
                 entity?.metadata?.annotations || {},
               );
-          const latestRevisionLinkText =
-            latestRevision === '' ? '-' : latestRevision?.substring(0, 7);
+          let latestRevisionLinkText = '-';
+          if (latestRevision !== '') {
+            latestRevisionLinkText = isAppHelmChartType(row)
+              ? latestRevision
+              : latestRevision.substring(0, 7);
+          }
           return (
             <Link href={commitUrl} target="_blank" rel="noopener">
               {latestRevisionLinkText}

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -161,9 +161,9 @@ const DeploymentSummary = ({
             // Link to the first git source commit
             const gitIdx = sources.findIndex(s => !s.chart);
             const gitRev =
-              gitIdx >= 0 ? (latestRev.revisions?.[gitIdx] ?? '') : '';
+              gitIdx >= 0 ? latestRev.revisions?.[gitIdx] ?? '' : '';
             const gitRepoUrl =
-              gitIdx >= 0 ? (sources[gitIdx]?.repoURL ?? '') : '';
+              gitIdx >= 0 ? sources[gitIdx]?.repoURL ?? '' : '';
             const commitUrl = gitRev
               ? getCommitUrl(
                   gitRepoUrl,

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -144,7 +144,7 @@ const DeploymentSummary = ({
         render: (row: Application): ReactNode => {
           const historyList = row.status?.history ?? [];
           const latestRev = historyList.at(-1);
-          const sources = row.spec.sources;
+          const sources = latestRev?.sources ?? row.spec.sources;
 
           // Multi-source: build a combined revision display (e.g. "6.49.0 / abc1234")
           // showing Helm chart versions in full and git SHAs truncated to 7 chars.

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/__tests__/DeploymentSummary.test.tsx
@@ -17,7 +17,12 @@ import { usePermission } from '@backstage/plugin-permission-react';
 
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
-import { mockApplication, mockEntity } from '../../../../dev/__data__';
+import {
+  mockApplication,
+  mockEntity,
+  multiSourceArgoApp,
+  multiSourceHelmArgoApp,
+} from '../../../../dev/__data__';
 import { useApplications } from '../../../hooks/useApplications';
 import { useArgocdConfig } from '../../../hooks/useArgocdConfig';
 import {
@@ -328,6 +333,58 @@ describe('DeploymentSummary', () => {
       const firstRow = within(tableBody).queryAllByRole('row')[0];
 
       expect(within(firstRow).getByText('OutOfSync')).toBeInTheDocument();
+    });
+  });
+
+  test('should show combined revision for multi-source Helm+git app', async () => {
+    (useApplications as any).mockReturnValue({
+      apps: [multiSourceHelmArgoApp],
+      loading: false,
+      error: undefined,
+    });
+
+    await renderInTestApp(<DeploymentSummary />);
+
+    await waitFor(() => {
+      // Helm version in full + git SHA truncated to 7 chars
+      expect(screen.getByText('1.0.0 / abc123d')).toBeInTheDocument();
+    });
+  });
+
+  test('should link revision to git commit for multi-source Helm+git app', async () => {
+    (useApplications as any).mockReturnValue({
+      apps: [multiSourceHelmArgoApp],
+      loading: false,
+      error: undefined,
+    });
+
+    await renderInTestApp(<DeploymentSummary />);
+
+    await waitFor(() => {
+      const revisionLink = screen.getByRole('link', {
+        name: '1.0.0 / abc123d',
+      });
+      // Provider is unknown (entity annotations don't contain github/gitlab),
+      // so getCommitUrl returns the sanitized repoURL without a commit path.
+      expect(revisionLink).toHaveAttribute(
+        'href',
+        'https://github.com/example-org/gitops-values',
+      );
+    });
+  });
+
+  test('should show combined revision for multi-source git+git app', async () => {
+    (useApplications as any).mockReturnValue({
+      apps: [multiSourceArgoApp],
+      loading: false,
+      error: undefined,
+    });
+
+    await renderInTestApp(<DeploymentSummary />);
+
+    await waitFor(() => {
+      // Both git SHAs truncated to 7 chars
+      expect(screen.getByText('331386c / de1631a')).toBeInTheDocument();
     });
   });
 

--- a/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
@@ -282,8 +282,8 @@ describe('Utils', () => {
 
     test('should exclude Helm chart revisions from multi-source apps', () => {
       const revisions = getUniqueRevisions([multiSourceHelmArgoApp as any]);
-      // The Helm chart version '6.33.0' should be excluded; only the git SHA remains
-      expect(revisions).not.toContain('6.33.0');
+      // The Helm chart version '1.0.0' should be excluded; only the git SHA remains
+      expect(revisions).not.toContain('1.0.0');
       expect(revisions).toContain('abc123def456ghi789jkl012mno345pqr678stu901');
     });
 

--- a/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
@@ -226,7 +226,7 @@ describe('Utils', () => {
     });
 
     test('should return true for a multi-source app with a Helm chart source', () => {
-      expect(isAppHelmChartType(multiSourceHelmArgoApp as any)).toBe(true);
+      expect(isAppHelmChartType(multiSourceHelmArgoApp)).toBe(true);
     });
   });
 
@@ -281,7 +281,7 @@ describe('Utils', () => {
     });
 
     test('should exclude Helm chart revisions from multi-source apps', () => {
-      const revisions = getUniqueRevisions([multiSourceHelmArgoApp as any]);
+      const revisions = getUniqueRevisions([multiSourceHelmArgoApp]);
       // The Helm chart version '1.0.0' should be excluded; only the git SHA remains
       expect(revisions).not.toContain('1.0.0');
       expect(revisions).toContain('abc123def456ghi789jkl012mno345pqr678stu901');

--- a/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { mockApplication, mockEntity } from '../../../dev/__data__';
+import {
+  mockApplication,
+  mockEntity,
+  multiSourceHelmArgoApp,
+} from '../../../dev/__data__';
 import {
   Application,
   History,
@@ -30,6 +34,7 @@ import {
   getProjectName,
   getUniqueRevisions,
   getResourceCreateTimestamp,
+  isAppHelmChartType,
   sortValues,
   removeDuplicateRevisions,
   getInstanceNames,
@@ -188,6 +193,43 @@ describe('Utils', () => {
     });
   });
 
+  describe('isAppHelmChartType', () => {
+    test('should return false for a git-only single-source app', () => {
+      expect(isAppHelmChartType(mockApplication)).toBe(false);
+    });
+
+    test('should return true for a single-source Helm chart app', () => {
+      expect(
+        isAppHelmChartType({
+          ...mockApplication,
+          spec: {
+            ...mockApplication.spec,
+            source: { ...mockApplication.spec.source, chart: 'my-chart' },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    test('should return false for a multi-source app with no Helm chart sources', () => {
+      expect(
+        isAppHelmChartType({
+          ...mockApplication,
+          spec: {
+            ...mockApplication.spec,
+            sources: [
+              { repoURL: 'https://github.com/org/repo.git', path: '.' },
+              { repoURL: 'https://github.com/org/values.git', path: '.' },
+            ],
+          },
+        }),
+      ).toBe(false);
+    });
+
+    test('should return true for a multi-source app with a Helm chart source', () => {
+      expect(isAppHelmChartType(multiSourceHelmArgoApp as any)).toBe(true);
+    });
+  });
+
   describe('getAppOperationState', () => {
     test('should return Succeeded if the operationState object is present', () => {
       expect(getAppOperationState(mockApplication).phase).toBe('Succeeded');
@@ -236,6 +278,13 @@ describe('Utils', () => {
 
     test('should return unique revision', () => {
       expect(getUniqueRevisions([mockApplication])).toHaveLength(1);
+    });
+
+    test('should exclude Helm chart revisions from multi-source apps', () => {
+      const revisions = getUniqueRevisions([multiSourceHelmArgoApp as any]);
+      // The Helm chart version '6.33.0' should be excluded; only the git SHA remains
+      expect(revisions).not.toContain('6.33.0');
+      expect(revisions).toContain('abc123def456ghi789jkl012mno345pqr678stu901');
     });
 
     test('should return unique revision for multiple applications', () => {

--- a/workspaces/argocd/plugins/argocd/src/utils/utils.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/utils.ts
@@ -96,7 +96,8 @@ export enum KnownProviders {
 }
 
 export const isAppHelmChartType = (application: Application) =>
-  !!application?.spec?.source?.chart;
+  !!application?.spec?.source?.chart ||
+  (application?.spec?.sources?.some(s => !!s.chart) ?? false);
 
 export const getGitProvider = (annotations: {
   [key: string]: string;
@@ -192,9 +193,15 @@ export const getUniqueRevisions = (apps: Application[]): string[] => {
 
     if (history.length > 0) {
       history.forEach(h => {
-        // Multi-source application
-        if (h?.revisions && !isSubset(h?.revisions, revisions)) {
-          revisions.push(...h?.revisions);
+        // Multi-source application - skip Helm chart sources (chart version
+        // strings are not git SHAs and cannot be used for revision metadata)
+        if (h?.revisions) {
+          const gitRevisions = h.revisions.filter(
+            (_, idx) => !app.spec.sources?.[idx]?.chart,
+          );
+          if (gitRevisions.length > 0 && !isSubset(gitRevisions, revisions)) {
+            revisions.push(...gitRevisions);
+          }
         }
 
         // Single source application

--- a/workspaces/argocd/plugins/argocd/src/utils/utils.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/utils.ts
@@ -197,7 +197,7 @@ export const getUniqueRevisions = (apps: Application[]): string[] => {
         // strings are not git SHAs and cannot be used for revision metadata)
         if (h?.revisions) {
           const gitRevisions = h.revisions.filter(
-            (_, idx) => !app.spec.sources?.[idx]?.chart,
+            (_, idx) => !(h.sources?.[idx] ?? app.spec.sources?.[idx])?.chart,
           );
           if (gitRevisions.length > 0 && !isSubset(gitRevisions, revisions)) {
             revisions.push(...gitRevisions);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #7784

### Problem

When an ArgoCD Application uses **multiple sources** and one of those sources is a **Helm chart** (`spec.sources[i].chart` is set), the frontend was calling the backend revision metadata endpoint with the chart version string (e.g. `1.0.0`) as the revision ID. The ArgoCD API endpoint `/revisions/{revision}/metadata` only accepts git commit SHAs and returns **HTTP 500** for chart version strings, producing a continuous stream of backend errors on every entity page load.

The same issue affected `isAppHelmChartType` in the frontend, which only checked `spec.source.chart` (single-source field) and therefore always returned `false` for multi-source apps, causing incorrect revision link rendering in the Deployment Summary table.

### Changes

**`src/api/ArgoCDApiClient.ts`**
- `getRevisionDetailsList` now skips the revision metadata fetch when the source at the resolved index has `chart` set.

**`src/utils/utils.ts`**
- `isAppHelmChartType` now also checks `spec.sources` for multi-source apps.
- `getUniqueRevisions` now filters out Helm chart version strings from multi-source history so they are never passed to the revision metadata endpoint.

**`dev/__data__/applications.ts`**
- New `multiSourceHelmArgoApp: Application` fixture (Helm chart source + git values source) for use in tests.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.