### PR TITLE
plugin(rbac-backend): Backport removal of UrlReader (7.5.1)

### DIFF
--- a/workspaces/rbac/.changeset/young-boxes-nail.md
+++ b/workspaces/rbac/.changeset/young-boxes-nail.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Backport: Remove usage of breaking imports from @backstage/backend-defaults
+
+This backports the fix from commit 9c7ae87 to avoid compatibility issues when @backstage backend-defaults resolves to 0.13.2, which introduced breaking changes to address a CVE. By removing the problematic import, this plugin remains compatible with both 0.13.1 and 0.13.2 and does not use the code containing the CVE.

--- a/workspaces/rbac/plugins/rbac-backend/src/service/plugin-endpoints.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/plugin-endpoints.ts
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  FetchUrlReader,
-  ReaderFactory,
-  UrlReaders,
-} from '@backstage/backend-defaults/urlReader';
 import type {
   AuthService,
   DiscoveryService,
   LoggerService,
-  UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import type { Config } from '@backstage/config';
 import { isError } from '@backstage/errors';
@@ -60,11 +54,9 @@ export class PluginPermissionMetadataCollector {
   private readonly pluginIdProvider: ExtendablePluginIdProvider;
   private readonly discovery: DiscoveryService;
   private readonly logger: LoggerService;
-  private readonly urlReader: UrlReaderService;
 
   constructor({
     deps,
-    optional,
   }: {
     deps: {
       discovery: DiscoveryService;
@@ -72,21 +64,11 @@ export class PluginPermissionMetadataCollector {
       logger: LoggerService;
       config: Config;
     };
-    optional?: {
-      urlReader?: UrlReaderService;
-    };
   }) {
-    const { discovery, logger, config, pluginIdProvider } = deps;
+    const { discovery, logger, pluginIdProvider } = deps;
     this.discovery = discovery;
     this.pluginIdProvider = pluginIdProvider;
     this.logger = logger;
-    this.urlReader =
-      optional?.urlReader ??
-      UrlReaders.default({
-        config,
-        logger,
-        factories: [PluginPermissionMetadataCollector.permissionFactory],
-      });
   }
 
   async getPluginConditionRules(
@@ -120,10 +102,6 @@ export class PluginPermissionMetadataCollector {
         };
       });
   }
-
-  private static permissionFactory: ReaderFactory = () => {
-    return [{ reader: new FetchUrlReader(), predicate: (_url: URL) => true }];
-  };
 
   private async getPluginMetaData(
     auth: AuthService,
@@ -176,11 +154,17 @@ export class PluginPermissionMetadataCollector {
       const baseEndpoint = await this.discovery.getBaseUrl(pluginId);
       const wellKnownURL = `${baseEndpoint}/.well-known/backstage/permissions/metadata`;
 
-      const permResp = await this.urlReader.readUrl(wellKnownURL, { token });
-      const permMetaDataRaw = (await permResp.buffer()).toString();
+      const response = await fetch(wellKnownURL, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch metadata for ${pluginId}: ${response.status}`,
+        );
+      }
 
       try {
-        permMetaData = JSON.parse(permMetaDataRaw);
+        permMetaData = await response.json();
       } catch (err) {
         // workaround for https://issues.redhat.com/browse/RHIDP-1456
         return undefined;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is the exact same backport as [7.6.2](https://github.com/backstage/community-plugins/pull/7621):

> @backstage/backend-defaults 0.13.2 introduced a breaking change to fix a CVE. Instead of resolving the breaking change, we have decided to backport the fix done https://github.com/backstage/community-plugins/issues/7556 where the usage of UrlReader was removed in favor of using a simple fetch. This means rbac-backend will not use the code affected by the CVE and it remains compatible with both @backstage/backend-defaults 0.13.1 and 0.13.2.
> 
> I locally tested the issue fixed by https://github.com/backstage/community-plugins/issues/7556 and can confirm everything worked correctly. When running yarn up -R @backstage/backend-defaults locally, the problem described in https://issues.redhat.com/browse/RHDHBUGS-2587 does not appear anymore since FetchUrlReader is no longer used.

Merging this PR and its associated Version packages PR should lead to a new published interim patch release 7.5.1 of rbac-backend.

I committed the [Yarn 4 CI fix](https://github.com/backstage/community-plugins/pull/7767) to the workspace/rbac branch to hopefully avoid the [problem](https://github.com/backstage/community-plugins/actions/runs/22296915693/job/64769186272) that we had when merging the previous version packages PR for 7.6.2.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
