### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/khaki-shrimps-kick.md
+++ b/workspaces/azure-devops/.changeset/khaki-shrimps-kick.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-azure-devops': minor
----
-
-**BREAKING** Fixed bug in `createAzureDevopsRunPipelineAction` where `pipelineRun.result` returned an integer instead of the corresponding string

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-azure-devops
 
+## 0.21.0
+
+### Minor Changes
+
+- 20faa44: **BREAKING** Fixed bug in `createAzureDevopsRunPipelineAction` where `pipelineRun.result` returned an integer instead of the corresponding string
+
 ## 0.20.1
 
 ### Patch Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-azure-devops",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-azure-devops@0.21.0

### Minor Changes

-   20faa44: **BREAKING** Fixed bug in `createAzureDevopsRunPipelineAction` where `pipelineRun.result` returned an integer instead of the corresponding string
