### PR TITLE
chore(rbac): update changelog to contain 7.5.1 maintenance release

### DIFF
--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -51,6 +51,14 @@
   - @backstage-community/plugin-rbac-common@1.22.0
   - @backstage-community/plugin-rbac-node@1.16.0
 
+## 7.5.1
+
+### Patch Changes
+
+- 0743ffa: Backport: Remove usage of breaking imports from @backstage/backend-defaults
+
+  This backports the fix from commit 9c7ae87 to avoid compatibility issues when @backstage backend-defaults resolves to 0.13.2, which introduced breaking changes to address a CVE. By removing the problematic import, this plugin remains compatible with both 0.13.1 and 0.13.2 and does not use the code containing the CVE.
+
 ## 7.5.0
 
 ### Minor Changes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Based on the [tutorial on patching an older release line](https://github.com/backstage/community-plugins/blob/main/docs/plugin-maintainers-guide.md#maintaining-and-patching-an-older-release-line), I am creating this PR to update the changeset on main to contain the latest 7.5.1 maintenance release.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
