### PR TITLE
Update .husky/pre-commit to run local git pre-commit if defined

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,24 @@
+#!/usr/bin/env sh
+set -e
+
 yarn lint-staged
+
+
+# Please keep this section at the bottom of the file.
+#
+# Run the pre-commit hook in the default the hooks directory if it exits.
+#
+# Husky overrides 'core.hooksPath' which doesn't allow running
+# the user's existing local hooks (like hooks they've configured in
+# 'init.templateDir'). This allows them to run both the project's hooks and
+# their own local hooks. If they do not have a local hook defined, this is
+# ignored.
+#
+# See https://git-scm.com/docs/githooks for more information.
+#
+hooks_dir="${GIT_DIR:-"$(git rev-parse --absolute-git-dir)"}/hooks"
+pre_commit_path="${hooks_dir}/pre-commit"
+if [ -x "${pre_commit_path}" ]
+then
+	exec "${pre_commit_path}"
+fi


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is a pull request for https://github.com/backstage/community-plugins/issues/7667

Here is an example of the output when I committed the change.

```
$ git commit -m 'Update .husky/pre-commit to run local git pre-commit if defined'
→ lint-staged could not find any staged files matching configured tasks.
Global rh-pre-commit.....................................................Passed
[pre-commit 4ecd0bba5] Update .husky/pre-commit to run local git pre-commit if defined
```

The extra output at the end there is because I have a local hook defined at `.git/hooks/pre-commit`.

Here's what it looks like if I remove my local hook and create a new commit:

```
$ git checkout -b example
Switched to a new branch 'example'
$ rm .git/hooks/pre-commit
$ git commit --allow-empty -m 'local hook removed'
→ lint-staged could not find any staged files.
[example 6078af58c] local hook removed
```

Note that the husky hook still runs and my hook does not.

Also here is confirming the existing hook will error like it's supposed to:

I made a small change on my example branch:

```diff
diff --git a/workspaces/copilot/plugins/copilot/config.d.ts b/workspaces/copilot/plugins/copilot/config.d.ts
index 11412392d..dacc73a0f 100644
--- a/workspaces/copilot/plugins/copilot/config.d.ts
+++ b/workspaces/copilot/plugins/copilot/config.d.ts
@@ -18,7 +18,8 @@
  * Configuration interface for the GitHub Copilot Plugin.
  */
 export interface Config {
-  /** Configuration options for the GitHub Copilot Plugin */
+  /**                                                    Configuration options for the GitHub Copilot Plugin */
+  1asdfasdfa[}{]
   copilot?: {
     /**
      * The name of the GitHub enterprise.
 ```

```
$ git commit -m 'expect an error'
✔ Backed up original state in git stash (bbd601eaf)
⚠ Running tasks for staged files...
  ❯ workspaces/copilot/package.json — 1 file
    ❯ *.{js,jsx,ts,tsx,mjs,cjs} — 1 file
      ✖ eslint --fix [FAILED]
      ◼ prettier --write
    ↓ *.{json,md} — no files
↓ Skipped because of errors from tasks.
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ eslint --fix:

/home/bplaxco/Workspace/backstage-community-plugins/workspaces/copilot/plugins/copilot/config.d.ts
  22:3  error  Parsing error: An identifier or keyword cannot immediately follow a numeric literal

✖ 1 problem (1 error, 0 warnings)


✖ eslint --fix failed to spawn:
Command failed with exit code 1: eslint --fix /home/bplaxco/Workspace/backstage-community-plugins/workspaces/copilot/plugins/copilot/config.d.ts
undefined
husky - pre-commit script failed (code 1)
```

**Note** the changes were not committed and my local pre-commit script that I re-enabled for this test did not run. It exited early as it should.


I also ran shellcheck on the script to look for any obvious errors:

```
$ shellcheck --shell=sh .husky/pre-commit
```


#### :heavy_check_mark: Checklist

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))~ (Didn't seem applicable since this isn't a change that's released but would be more than happy too if I was wrong and it is applicable :+1: )
- [ ] ~Added or updated documentation~ (left out because it didn't seem like something previously documented, but I can write docs if desired ^\_^)
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) (I did text snippets above since it's in the text output)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

