### PR TITLE
Version Packages (catalog)

### DIFF
--- a/workspaces/catalog/.changeset/hungry-maps-read.md
+++ b/workspaces/catalog/.changeset/hungry-maps-read.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-codeowners': minor
----
-
-Added a new Catalog backend module for the `CodeOwnersProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-codeowners) for more details

--- a/workspaces/catalog/.changeset/ready-toys-listen.md
+++ b/workspaces/catalog/.changeset/ready-toys-listen.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-annotate-scm-slug': minor
----
-
-Added a new Catalog backend module for the `AnnotateScmSlugEntityProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug) for more details

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/CHANGELOG.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-catalog-backend-module-annotate-scm-slug
+
+## 0.1.0
+
+### Minor Changes
+
+- b0d0837: Added a new Catalog backend module for the `AnnotateScmSlugEntityProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug) for more details

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-annotate-scm-slug",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "description": "The annotate-scm-slug backend module for the catalog plugin.",
   "main": "src/index.ts",

--- a/workspaces/catalog/plugins/catalog-backend-module-codeowners/CHANGELOG.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-codeowners/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-catalog-backend-module-codeowners
+
+## 0.1.0
+
+### Minor Changes
+
+- b0d0837: Added a new Catalog backend module for the `CodeOwnersProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-codeowners) for more details

--- a/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-codeowners",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The codeowners backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-annotate-scm-slug@0.1.0

### Minor Changes

-   b0d0837: Added a new Catalog backend module for the `AnnotateScmSlugEntityProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug) for more details

## @backstage-community/plugin-catalog-backend-module-codeowners@0.1.0

### Minor Changes

-   b0d0837: Added a new Catalog backend module for the `CodeOwnersProcessor`, see the [`README`](https://github.com/backstage/community-plugins/tree/main/workspaces/catalog/plugins/catalog-backend-module-codeowners) for more details
