### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/stale-lizards-sip.md
+++ b/workspaces/azure-devops/.changeset/stale-lizards-sip.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-**DEPRECATED** This change marks the `AzurePullRequestsIcon` as deprecated, use `RiGitPullRequestLine` from `@remixicon/react` instead.
-
-Migrated Material UI Icons to Remix Icons, also fixed a bug in `AzureDevOpsWikiArticleSearchResultListItem` to filter on the correct `result.type`

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.28.1
+
+### Patch Changes
+
+- 8d3c162: **DEPRECATED** This change marks the `AzurePullRequestsIcon` as deprecated, use `RiGitPullRequestLine` from `@remixicon/react` instead.
+
+  Migrated Material UI Icons to Remix Icons, also fixed a bug in `AzureDevOpsWikiArticleSearchResultListItem` to filter on the correct `result.type`
+
 ## 0.28.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.28.1

### Patch Changes

-   8d3c162: **DEPRECATED** This change marks the `AzurePullRequestsIcon` as deprecated, use `RiGitPullRequestLine` from `@remixicon/react` instead.

    Migrated Material UI Icons to Remix Icons, also fixed a bug in `AzureDevOpsWikiArticleSearchResultListItem` to filter on the correct `result.type`
