### PR TITLE
github - Fixed `githubDiscussionsSearchResultListItem` to show search results correctly when using the New Frontend System

### DIFF
--- a/workspaces/github/.changeset/eighty-houses-clap.md
+++ b/workspaces/github/.changeset/eighty-houses-clap.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-discussions': patch
+---
+
+Fixed `githubDiscussionsSearchResultListItem` to show search results correctly when using the New Frontend System

--- a/workspaces/github/plugins/github-discussions/src/alpha/plugin.tsx
+++ b/workspaces/github/plugins/github-discussions/src/alpha/plugin.tsx
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-import { GithubDiscussionsDocument } from '@backstage-community/plugin-github-discussions-common';
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import {
   SearchFilterResultTypeBlueprint,
   SearchResultListItemBlueprint,
 } from '@backstage/plugin-search-react/alpha';
 import SpeakerNotesIcon from '@material-ui/icons/SpeakerNotes';
-import { compatWrapper } from '@backstage/core-compat-api';
-
-function isGithubDiscussionsDocument(
-  result: any,
-): result is GithubDiscussionsDocument {
-  return result.entityRef;
-}
 
 /** @alpha */
 export const githubDiscussionsSearchResultListItem =
@@ -39,21 +31,19 @@ export const githubDiscussionsSearchResultListItem =
     },
     factory(originalFactory, { config }) {
       return originalFactory({
+        icon: <SpeakerNotesIcon />,
         predicate: result => result.type === 'github-discussions',
         component: async () => {
           const { GithubDiscussionsSearchResultListItem } = await import(
             '../components/GithubDiscussionsSearchResultListItem'
           );
-          return ({ result, ...rest }) =>
-            compatWrapper(
-              isGithubDiscussionsDocument(result) ? (
-                <GithubDiscussionsSearchResultListItem
-                  {...rest}
-                  {...config}
-                  result={result}
-                />
-              ) : null,
-            );
+          return props => (
+            <GithubDiscussionsSearchResultListItem
+              {...props}
+              result={props.result as any}
+              {...config}
+            />
+          );
         },
       });
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed `githubDiscussionsSearchResultListItem` to show search results correctly when using the New Frontend System

Before:

<img width="1920" height="1049" alt="Screenshot 2026-02-28 at 2 07 43 PM" src="https://github.com/user-attachments/assets/c89ee1bc-13fc-4345-a3ac-808ec6a9cf80" />

After:

<img width="1923" height="1050" alt="Screenshot 2026-02-28 at 2 22 13 PM" src="https://github.com/user-attachments/assets/c59f5c36-4ef0-4854-bee0-8d6f50789f8c" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
