### PR TITLE
Version Packages (linguist)

### DIFF
--- a/workspaces/linguist/.changeset/many-planes-relax.md
+++ b/workspaces/linguist/.changeset/many-planes-relax.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-linguist': minor
----
-
-**BREAKING** Backstage UI (BUI) is now required for the Linguist plugin to function
-
-Migrated from Material UI (MUI) to the new Backstage UI (BUI) design system.

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-linguist
 
+## 0.18.0
+
+### Minor Changes
+
+- e23846b: **BREAKING** Backstage UI (BUI) is now required for the Linguist plugin to function
+
+  Migrated from Material UI (MUI) to the new Backstage UI (BUI) design system.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist/package.json
+++ b/workspaces/linguist/plugins/linguist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linguist",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "linguist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linguist@0.18.0

### Minor Changes

-   e23846b: **BREAKING** Backstage UI (BUI) is now required for the Linguist plugin to function

    Migrated from Material UI (MUI) to the new Backstage UI (BUI) design system.
