### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/moody-tires-scream.md
+++ b/workspaces/manage/.changeset/moody-tires-scream.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-manage-module-tech-insights': minor
-'@backstage-community/plugin-manage-react': minor
-'@backstage-community/plugin-manage': minor
----
-
-Bump to depend on Backstage 1.48

--- a/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-module-tech-insights/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-manage-module-tech-insights
 
+## 0.8.0
+
+### Minor Changes
+
+- 884e720: Bump to depend on Backstage 1.48
+
+### Patch Changes
+
+- Updated dependencies [884e720]
+  - @backstage-community/plugin-manage-react@2.2.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-module-tech-insights/package.json
+++ b/workspaces/manage/plugins/manage-module-tech-insights/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-module-tech-insights",
   "description": "Manage plugin - Tech Insights module",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage-react/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-manage-react
 
+## 2.2.0
+
+### Minor Changes
+
+- 884e720: Bump to depend on Backstage 1.48
+
 ## 2.1.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-react",
   "description": "Manage plugin - react package",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "backstage": {
     "role": "web-library",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-manage
 
+## 1.2.0
+
+### Minor Changes
+
+- 884e720: Bump to depend on Backstage 1.48
+
+### Patch Changes
+
+- Updated dependencies [884e720]
+  - @backstage-community/plugin-manage-react@2.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage",
   "description": "Manage plugin - Shows a Manage page relevant to the user",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "manage",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage@1.2.0

### Minor Changes

-   884e720: Bump to depend on Backstage 1.48

### Patch Changes

-   Updated dependencies [884e720]
    -   @backstage-community/plugin-manage-react@2.2.0

## @backstage-community/plugin-manage-module-tech-insights@0.8.0

### Minor Changes

-   884e720: Bump to depend on Backstage 1.48

### Patch Changes

-   Updated dependencies [884e720]
    -   @backstage-community/plugin-manage-react@2.2.0

## @backstage-community/plugin-manage-react@2.2.0

### Minor Changes

-   884e720: Bump to depend on Backstage 1.48
