### PR TITLE
lowercase document type for OpenSearch index campatibility

### DIFF
--- a/workspaces/confluence/.changeset/many-eggs-lick.md
+++ b/workspaces/confluence/.changeset/many-eggs-lick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Lowercase the document type passed to the collator factory to prevent OpenSearch invalid_index_name_exception in multi-instance configurations

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/module.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/module.ts
@@ -102,7 +102,7 @@ export const searchModuleConfluenceCollator = createBackendModule({
               config,
               { logger },
               actualInstanceKey,
-              collatorKey,
+              collatorKey.toLowerCase(),
             ),
           });
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->


### Context — How Backstage Search Uses the Document Type

fix: lowercase document type for OpenSearch index compatibility

Backstage's search architecture uses the `DocumentCollatorFactory.type` property as a **document type identifier**. How this identifier is consumed depends on the search engine backend:

| Search Engine | How `type` is used | Case restriction? |
|---|---|---|
| **Lunr** (Backstage default) | In-memory key to group/filter documents | None |
| **OpenSearch / Elasticsearch** | Actual **index name** (e.g., `{type}-index_{timestamp}`) | **Must be lowercase** |
| **Postgres** (`pg`) | Document type column in the search table | None |

Organizations that use **OpenSearch or Elasticsearch** as their Backstage search backend (instead of the default Lunr) hit this bug because the document type flows directly into the index name, and [OpenSearch requires all index names to be lowercase](https://opensearch.org/docs/latest/api-reference/index-apis/create-index/).

### Problem

In multi-instance Confluence configurations, the `collatorKey` is constructed with `toUpperCase()` on the first character of the instance key:

```typescript
const collatorKey = `confluence${actualInstanceKey.charAt(0).toUpperCase()}${actualInstanceKey.slice(1)}`;
// e.g., instance key "iso" → collatorKey "confluenceIso"
```

This `collatorKey` is passed as the document `type` to `ConfluenceCollatorFactory`, which becomes the OpenSearch index name. OpenSearch rejects any index name containing uppercase characters, causing cascading failures:

1. **Index creation fails** — `invalid_index_name_exception`
2. **Document collation fails** — collator cannot write documents to the rejected index
3. **Index cleanup fails** — the index never existed, so cleanup throws `index_not_found_exception`

#### Errors observed (Splunk, dev environment)

```json
{"level":"error","reason":"Invalid index name [confluenceIso-index_1772258804332], must be lowercase","type":"invalid_index_name_exception","status":400}
```
```json
{"documentType":"confluenceIso","level":"error","message":"Collating documents for confluenceIso failed"}
```
```json
{"documentType":"confluenceIso","level":"error","message":"Unable to clean up elastic index confluenceIso-index_1772258804332","type":"index_not_found_exception"}
```

### Fix

Apply `.toLowerCase()` to the document type before passing it to the collator factory:

```diff
 factory: ConfluenceCollatorFactory.fromConfig(
   config,
   { logger },
   actualInstanceKey,
-  collatorKey,
+  collatorKey.toLowerCase(),
 ),
```

The camelCase `collatorKey` is **still used unchanged** for the `app-config.yaml` schedule config path lookup (`search.collators.${collatorKey}.schedule`), preserving backward compatibility with existing configuration files.

### Backward Compatibility

| Concern | Impact |
|---|---|
| **Single-instance users** | ✅ Zero impact — default type `'confluence'` is already lowercase |
| **`app-config.yaml` schedule paths** | ✅ No change — still uses camelCase `collatorKey` |
| **Lunr (default search engine)** | ✅ No impact — no case restriction on document type |
| **OpenSearch / Elasticsearch** | ✅ Fixes `invalid_index_name_exception` |
| **Postgres search** | ✅ No impact — no case restriction |
| **Frontend search tabs (multi-instance)** | ⚠️ Must match lowercase type — but the uppercase type was **never functional** (OpenSearch rejected it), so no working setup is broken |

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
