### PR TITLE
scaffolder-backend-module-azure-devops: Actually stage removed files for deletion

### DIFF
--- a/workspaces/azure-devops/.changeset/smooth-swans-pay.md
+++ b/workspaces/azure-devops/.changeset/smooth-swans-pay.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
+---
+
+Use `isomorphic-git` in `devopsRepoPush` to actually stage removed files for deletion

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/package.json
@@ -45,6 +45,7 @@
     "@backstage/integration": "backstage:^",
     "@backstage/plugin-scaffolder-node": "backstage:^",
     "azure-devops-node-api": "^15.0.0",
+    "isomorphic-git": "^1.23.0",
     "yaml": "^2.6.0"
   },
   "devDependencies": {

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRepoPush.test.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRepoPush.test.ts
@@ -24,9 +24,15 @@ jest.mock('@backstage/plugin-scaffolder-node', () => ({
   addFiles: jest.fn(),
 }));
 
+jest.mock('isomorphic-git', () => ({
+  statusMatrix: jest.fn().mockResolvedValue([]),
+  remove: jest.fn().mockResolvedValue(undefined),
+}));
+
 import { createAzureDevOpsPushRepoAction } from './devopsRepoPush';
 
 const { commitAndPushBranch } = require('@backstage/plugin-scaffolder-node');
+const isomorphicGit = require('isomorphic-git');
 
 describe('createAzureDevOpsPushRepoAction', () => {
   const config = new ConfigReader({
@@ -133,6 +139,30 @@ describe('createAzureDevOpsPushRepoAction', () => {
         commitMessage: 'Initial commit',
         gitAuthorInfo: { name: 'Default Name', email: 'default@email.com' },
       }),
+    );
+  });
+
+  it('stages deleted files', async () => {
+    getCredentialsMock.mockResolvedValue(undefined);
+    isomorphicGit.statusMatrix.mockResolvedValue([
+      ['deleted-file.txt', 1, 0, 1],
+      ['modified-file.txt', 1, 2, 1],
+      ['new-file.txt', 0, 2, 0],
+    ]);
+    const ctx = createMockActionContext({
+      workspacePath,
+      input: { remoteUrl, token: 'tok' },
+    });
+    await action.handler(ctx);
+    expect(isomorphicGit.remove).toHaveBeenCalledTimes(1);
+    expect(isomorphicGit.remove).toHaveBeenCalledWith(
+      expect.objectContaining({ filepath: 'deleted-file.txt' }),
+    );
+    expect(isomorphicGit.remove).not.toHaveBeenCalledWith(
+      expect.objectContaining({ filepath: 'modified-file.txt' }),
+    );
+    expect(isomorphicGit.remove).not.toHaveBeenCalledWith(
+      expect.objectContaining({ filepath: 'created-file.txt' }),
     );
   });
 

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRepoPush.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRepoPush.ts
@@ -23,6 +23,8 @@ import {
 } from '@backstage/plugin-scaffolder-node';
 import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
 import { getGitCredentials } from './helpers';
+import git from 'isomorphic-git';
+import * as fs from 'fs';
 
 export const createAzureDevOpsPushRepoAction = (options: {
   integrations: ScmIntegrationRegistry;
@@ -100,6 +102,13 @@ export const createAzureDevOpsPushRepoAction = (options: {
         integrations,
         remoteUrl,
         ctx.input.token,
+      );
+
+      const statusMatrix = await git.statusMatrix({ fs, dir: sourcePath });
+      await Promise.all(
+        statusMatrix
+          .filter(([, head, workdir]) => head !== 0 && workdir === 0)
+          .map(([filepath]) => git.remove({ fs, dir: sourcePath, filepath })),
       );
 
       await addFiles({

--- a/workspaces/azure-devops/yarn.lock
+++ b/workspaces/azure-devops/yarn.lock
@@ -1483,6 +1483,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "backstage:^"
     "@backstage/plugin-scaffolder-node-test-utils": "backstage:^"
     azure-devops-node-api: "npm:^15.0.0"
+    isomorphic-git: "npm:^1.23.0"
     yaml: "npm:^2.6.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #7898 

Using `isomorphic-git` we now check which files are tracked in `HEAD` but absent from the working directory. Next `remove()` is called explicitly for these files.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
