### PR TITLE
Version Packages (manage)

### DIFF
--- a/workspaces/manage/.changeset/giant-turtles-change.md
+++ b/workspaces/manage/.changeset/giant-turtles-change.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage-react': patch
----
-
-Use 'manage.kinds' config for deciding what kinds to use

--- a/workspaces/manage/.changeset/red-geckos-invite.md
+++ b/workspaces/manage/.changeset/red-geckos-invite.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-manage': minor
----
-
-The page header is now replaced with the new BUI page header instead of MUI (only in NFS)

--- a/workspaces/manage/plugins/manage-react/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-manage-react
 
+## 2.2.1
+
+### Patch Changes
+
+- 57d32c5: Use 'manage.kinds' config for deciding what kinds to use
+
 ## 2.2.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage-react/package.json
+++ b/workspaces/manage/plugins/manage-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage-react",
   "description": "Manage plugin - react package",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "backstage": {
     "role": "web-library",
     "pluginId": "manage",

--- a/workspaces/manage/plugins/manage/CHANGELOG.md
+++ b/workspaces/manage/plugins/manage/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-manage
 
+## 1.3.0
+
+### Minor Changes
+
+- 57d32c5: The page header is now replaced with the new BUI page header instead of MUI (only in NFS)
+
+### Patch Changes
+
+- Updated dependencies [57d32c5]
+  - @backstage-community/plugin-manage-react@2.2.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/manage/plugins/manage/package.json
+++ b/workspaces/manage/plugins/manage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-manage",
   "description": "Manage plugin - Shows a Manage page relevant to the user",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "manage",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-manage@1.3.0

### Minor Changes

-   57d32c5: The page header is now replaced with the new BUI page header instead of MUI (only in NFS)

### Patch Changes

-   Updated dependencies [57d32c5]
    -   @backstage-community/plugin-manage-react@2.2.1

## @backstage-community/plugin-manage-react@2.2.1

### Patch Changes

-   57d32c5: Use 'manage.kinds' config for deciding what kinds to use
