### PR TITLE
feat(analytics-module-newrelic-browser): allow custom endpoint values…

### DIFF
--- a/workspaces/analytics/.changeset/dull-pandas-smell.md
+++ b/workspaces/analytics/.changeset/dull-pandas-smell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-analytics-module-newrelic-browser': patch
+---
+
+Allow custom endpoint values to support internal proxies

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/config.d.ts
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/config.d.ts
@@ -19,10 +19,12 @@ export interface Config {
     analytics?: {
       newRelic: {
         /**
-         * Data ingestion endpoint to use, either bam.eu01.nr-data.net (EU) or bam.nr-data.net (US)
+         * Data ingestion endpoint to use. Standard New Relic endpoints are
+         * bam.nr-data.net (US) or bam.eu01.nr-data.net (EU). A custom endpoint
+         * can also be provided, for example when routing through an internal proxy.
          * @visibility frontend
          */
-        endpoint: 'bam.eu01.nr-data.net' | 'bam.nr-data.net';
+        endpoint: 'bam.eu01.nr-data.net' | 'bam.nr-data.net' | string;
 
         /**
          * New Relic Account ID, e.g. 1234567


### PR DESCRIPTION
… to support internal proxies

## Hey, I just made a Pull Request!

Widened the `endpoint` config type in `config.d.ts` for `@backstage-community/plugin-analytics-module-newrelic-browser` to allow custom endpoint values, and updated the JSDoc comment to reflect this.

```diff
- endpoint: 'bam.eu01.nr-data.net' | 'bam.nr-data.net';
+ endpoint: 'bam.eu01.nr-data.net' | 'bam.nr-data.net' | string;
```

In enterprise environments where direct egress to New Relic is blocked, analytics traffic must be routed through an internal proxy. The previous type prevented this — both as a TypeScript error and as a runtime config validation failure. The known New Relic endpoints are retained in the union for IDE autocomplete hints.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
