### PR TITLE
fix(confluence): restored support of both spaces and query config parameters

### DIFF
--- a/workspaces/confluence/.changeset/curly-wolves-occur.md
+++ b/workspaces/confluence/.changeset/curly-wolves-occur.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Restore the support for the combination of 'spaces' and 'query' parameters introduced by #4017

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.test.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.test.ts
@@ -232,7 +232,7 @@ describe('ConfluenceCollatorFactory', () => {
             token: 'AA',
             email: 'user@example.com',
           },
-          query: 'type = page',
+          query: '() and (type = page)',
         },
       },
     });

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
@@ -289,11 +289,19 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
 
   private async getConfluenceQuery(): Promise<string> {
     const spaceList = await this.getSpacesConfig();
-    const spaceQuery = spaceList.map(s => `space="${s}"`).join(' or ');
-    let query = spaceQuery;
-    const additionalQuery = this.query;
-    if (additionalQuery !== '') {
+    const spaceQuery =
+      spaceList.length > 0
+        ? spaceList.map(s => `space="${s}"`).join(' or ')
+        : '';
+    const additionalQuery = this.query?.trim() ?? '';
+
+    let query = '';
+    if (spaceQuery && additionalQuery) {
       query = `(${spaceQuery}) and (${additionalQuery})`;
+    } else if (spaceQuery) {
+      query = spaceQuery;
+    } else if (additionalQuery) {
+      query = additionalQuery;
     }
     // If no query is provided, default to fetching all pages, blogposts, comments and attachments (which encompasses all content)
     // https://developer.atlassian.com/server/confluence/advanced-searching-using-cql/#type

--- a/workspaces/tech-insights/.changeset/cyan-ducks-mate.md
+++ b/workspaces/tech-insights/.changeset/cyan-ducks-mate.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-maturity': patch
----
-
-Fixed entity page integration instructions


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Restore the accidental feature removal allowing the configuration of both `spaces` and `query` configuration parameters (see #4017)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
