### PR TITLE
feat(mcp-chat): add support for max_tokens and temperature customization

### DIFF
--- a/workspaces/mcp-chat/.changeset/angry-onions-show.md
+++ b/workspaces/mcp-chat/.changeset/angry-onions-show.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': minor
+---
+
+Added support for max_tokens and temperature customization

--- a/workspaces/mcp-chat/.changeset/rude-dingos-throw.md
+++ b/workspaces/mcp-chat/.changeset/rude-dingos-throw.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': minor
+---
+
+Added support for O-series and GPT-5 models

--- a/workspaces/mcp-chat/README.md
+++ b/workspaces/mcp-chat/README.md
@@ -151,15 +151,31 @@ mcpChat:
       # baseUrl: 'https://custom-openai-compatible-url/v1'
       token: ${OPENAI_API_KEY}
       model: gpt-4o-mini # or gpt-4, gpt-3.5-turbo, etc.
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: claude # Claude provider
       token: ${CLAUDE_API_KEY}
       model: claude-sonnet-4-20250514 # or claude-3-7-sonnet-latest
+      # Optional: Customize max tokens (default: 4096)
+      # maxTokens: 4096
+      # Optional: Customize temperature 0-1
+      # temperature: 0.7
     - id: gemini # Gemini provider
       token: ${GEMINI_API_KEY}
       model: gemini-2.5-flash # or gemini-2.0-pro, etc.
+      # Optional: Customize max tokens (default: 8192)
+      # maxTokens: 8192
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: ollama # Ollama provider
       baseUrl: 'http://localhost:11434'
       model: llama3.1:8b # or any model you have locally
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
 
   # Configure MCP servers
   mcpServers:
@@ -209,6 +225,34 @@ mcpChat:
       prompt: 'Describe the "example-app" microservice in our Backstage catalog'
       category: Catalog
 ```
+
+### Provider Response Configuration
+
+You can customize the response generation behavior for each provider using optional `maxTokens` and `temperature` settings.
+
+#### Max Tokens
+
+Controls the maximum number of tokens (words/characters) the AI can generate in a single response.
+
+**Default Values:**
+
+- OpenAI/LiteLLM: 1000 tokens
+- Claude: 4096 tokens
+- Gemini: 8192 tokens
+- Ollama: 1000 tokens
+
+**When to Adjust:**
+
+- Increase for detailed explanations or long-form responses
+- Decrease to save costs or enforce brevity
+
+#### Temperature
+
+Controls randomness in responses (0-1 scale). Default: 0.7
+
+- **0.0-0.3**: Focused, deterministic responses (best for factual queries)
+- **0.4-0.7**: Balanced (default for general use)
+- **0.8-1.0**: Creative, diverse responses (best for brainstorming)
 
 For more advanced MCP server configuration examples (including STDIO, Streamable HTTP, custom scripts, and arguments), see [SERVER_CONFIGURATION](docs/SERVER_CONFIGURATION.md).
 

--- a/workspaces/mcp-chat/app-config.yaml
+++ b/workspaces/mcp-chat/app-config.yaml
@@ -31,6 +31,10 @@ mcpChat:
       baseUrl: 'https://any-openai-compatible-url/v1'
       token: ${OPENAI_API_KEY}
       model: gpt-4o-mini
+      # Optional: Customize max tokens (default: 1000 for OpenAI)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: openai-responses # OpenAI Responses API
       baseUrl: 'http://your-responses-api-endpoint.com/v1/openai/v1'
       model: 'gemini/models/gemini-2.5-flash'
@@ -38,16 +42,32 @@ mcpChat:
     - id: gemini
       token: ${GEMINI_API_KEY}
       model: gemini-2.5-flash
+      # Optional: Customize max tokens (default: 8192 for Gemini)
+      # maxTokens: 8192
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: claude
       token: ${CLAUDE_API_KEY}
       model: claude-sonnet-4-20250514
+      # Optional: Customize max tokens (default: 4096 for Claude)
+      # maxTokens: 4096
+      # Optional: Customize temperature 0-1 (default: not set, uses Claude API default)
+      # temperature: 0.8
     - id: ollama
       baseUrl: 'http://localhost:11434'
       model: llama3.1:8b
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: litellm
       baseUrl: 'http://localhost:4000'
       token: ${LITELLM_API_KEY}
       model: gpt-4o-mini
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
   mcpServers:
     - id: brave-search-server
       name: Brave Search Server

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/README.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/README.md
@@ -234,6 +234,10 @@ mcpChat:
     - id: openai # OpenAI provider
       token: ${OPENAI_API_KEY}
       model: gpt-4o-mini # or gpt-4, gpt-3.5-turbo, etc.
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: openai-responses # OpenAI Responses API provider (handles MCP internally)
       baseUrl: 'http://your-responses-api-endpoint.com/v1/openai/v1'
       model: 'gemini/models/gemini-2.5-flash'
@@ -241,16 +245,32 @@ mcpChat:
     - id: claude # Claude provider
       token: ${CLAUDE_API_KEY}
       model: claude-sonnet-4-20250514 # or claude-3-7-sonnet-latest
+      # Optional: Customize max tokens (default: 4096)
+      # maxTokens: 4096
+      # Optional: Customize temperature 0-1
+      # temperature: 0.7
     - id: gemini # Gemini provider
       token: ${GEMINI_API_KEY}
       model: gemini-2.5-flash # or gemini-2.0-pro, etc.
+      # Optional: Customize max tokens (default: 8192)
+      # maxTokens: 8192
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: ollama # Ollama provider
       baseUrl: 'http://localhost:11434'
       model: llama3.1:8b # or any model you have locally
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: litellm # LiteLLM proxy provider
       baseUrl: 'http://localhost:4000' # LiteLLM proxy URL
       token: ${LITELLM_API_KEY} # Optional, depends on your LiteLLM setup
       model: gpt-4o-mini # Model name configured in LiteLLM
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
 
   # Configure MCP servers
   mcpServers:
@@ -344,6 +364,70 @@ systemPrompt: 'You are a security-focused DevOps assistant. Always consider secu
 - Mention specific domains or expertise when relevant
 - Include instructions about response format if needed
 - The system prompt affects all AI interactions in the plugin
+
+### Provider Response Configuration
+
+You can customize the response generation behavior for each provider using optional `maxTokens` and `temperature` settings.
+
+#### Max Tokens
+
+The `maxTokens` setting controls the maximum number of tokens (words/characters) the AI can generate in a single response.
+
+**Default Values by Provider:**
+
+- **OpenAI/LiteLLM**: 1000 tokens
+- **Claude**: 4096 tokens
+- **Gemini**: 8192 tokens
+- **Ollama**: 1000 tokens (via `num_predict` option)
+
+**Example Configuration:**
+
+```yaml
+providers:
+  - id: openai
+    token: ${OPENAI_API_KEY}
+    model: gpt-4o-mini
+    maxTokens: 2000 # Generate up to 2000 tokens
+```
+
+**When to Adjust:**
+
+- Increase for long-form responses or detailed explanations
+- Decrease to save costs or enforce concise responses
+- Consider your model's context window limits
+
+#### Temperature
+
+The `temperature` setting controls randomness in responses (0-1 scale):
+
+**Default Value:** 0.7 (for most providers)
+
+- **Lower values (0.0-0.3)**: More focused, deterministic, consistent responses
+- **Medium values (0.4-0.7)**: Balanced creativity and consistency (default)
+- **Higher values (0.8-1.0)**: More creative, diverse, and random responses
+
+**Example Configuration:**
+
+```yaml
+providers:
+  - id: claude
+    token: ${CLAUDE_API_KEY}
+    model: claude-sonnet-4-20250514
+    temperature: 0.3 # More deterministic responses
+
+  - id: gemini
+    token: ${GEMINI_API_KEY}
+    model: gemini-2.5-flash
+    temperature: 0.9 # More creative responses
+```
+
+**When to Adjust:**
+
+- Use **lower temperature** for factual queries, code generation, data analysis
+- Use **higher temperature** for brainstorming, creative writing, exploration
+- Keep **default (0.7)** for general-purpose assistant behavior
+
+**Note:** Claude provider supports temperature but doesn't set a default value, relying on the API's own defaults unless explicitly configured.
 
 For more advanced MCP server configuration examples (including STDIO, Streamable HTTP, custom scripts, and arguments), see [SERVER_CONFIGURATION](../../docs/SERVER_CONFIGURATION.md).
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
@@ -43,6 +43,16 @@ export interface Config {
        * @visibility backend
        */
       baseUrl?: string;
+      /**
+       * Maximum number of tokens to generate in the response
+       * @visibility backend
+       */
+      maxTokens?: number;
+      /**
+       * Sampling temperature for the model
+       * @visibility backend
+       */
+      temperature?: number;
     }>;
     /**
      * MCP (Model Context Protocol) servers configuration

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
@@ -183,6 +183,8 @@ export abstract class LLMProvider {
   // (undocumented)
   protected makeRequest(endpoint: string, body: any): Promise<any>;
   // (undocumented)
+  protected maxTokens?: number;
+  // (undocumented)
   protected model: string;
   // (undocumented)
   protected abstract parseResponse(response: any): ChatResponse;
@@ -191,6 +193,8 @@ export abstract class LLMProvider {
     messages: ChatMessage[],
     tools?: Tool[],
   ): Promise<ChatResponse>;
+  // (undocumented)
+  protected temperature?: number;
   // (undocumented)
   abstract testConnection(): Promise<{
     connected: boolean;
@@ -377,7 +381,9 @@ export interface ProviderConfig {
   apiKey?: string;
   baseUrl: string;
   logger?: LoggerService;
+  maxTokens?: number;
   model: string;
+  temperature?: number;
   type: string;
 }
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/base-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/base-provider.ts
@@ -29,6 +29,8 @@ export abstract class LLMProvider {
   protected model: string;
   protected type: string;
   protected logger?: LoggerService;
+  protected maxTokens?: number;
+  protected temperature?: number;
 
   constructor(config: ProviderConfig) {
     this.apiKey = config.apiKey;
@@ -36,6 +38,8 @@ export abstract class LLMProvider {
     this.model = config.model;
     this.type = config.type;
     this.logger = config.logger;
+    this.maxTokens = config.maxTokens;
+    this.temperature = config.temperature;
   }
 
   abstract sendMessage(

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/claude-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/claude-provider.ts
@@ -117,9 +117,13 @@ export class ClaudeProvider extends LLMProvider {
 
     const request: any = {
       model: this.model,
-      max_tokens: 4096,
+      max_tokens: this.maxTokens ?? 4096,
       messages: claudeMessages,
     };
+
+    if (this.temperature !== undefined) {
+      request.temperature = this.temperature;
+    }
 
     if (tools && tools.length > 0) {
       request.tools = this.convertToAnthropicTools(tools);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/gemini-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/gemini-provider.ts
@@ -48,8 +48,8 @@ export class GeminiProvider extends LLMProvider {
 
     this.genAI = new GoogleGenAI({ apiKey: this.apiKey });
     this.baseModelConfig = {
-      temperature: 0.7,
-      maxOutputTokens: 8192,
+      temperature: this.temperature ?? 0.7,
+      maxOutputTokens: this.maxTokens ?? 8192,
       safetySettings: [
         {
           category: HarmCategory.HARM_CATEGORY_HARASSMENT,

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/litellm-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/litellm-provider.ts
@@ -161,8 +161,8 @@ export class LiteLLMProvider extends LLMProvider {
     const request: any = {
       model: this.model,
       messages,
-      max_tokens: 1000,
-      temperature: 0.7,
+      max_tokens: this.maxTokens ?? 1000,
+      temperature: this.temperature ?? 0.7,
     };
 
     if (tools && tools.length > 0) {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/ollama-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/ollama-provider.test.ts
@@ -87,6 +87,11 @@ describe('OllamaProvider', () => {
   });
 
   describe('sendMessage', () => {
+    const defaultChatOptions = {
+      model: 'llama2',
+      options: { temperature: 0.7, num_predict: 1000 },
+    };
+
     it('should send simple message without tools', async () => {
       const messages: ChatMessage[] = [
         { role: 'user', content: 'Hello, how are you?' },
@@ -109,7 +114,7 @@ describe('OllamaProvider', () => {
       const result = await provider.sendMessage(messages);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'user',
@@ -153,7 +158,7 @@ describe('OllamaProvider', () => {
       await provider.sendMessage(messages);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'user',
@@ -211,7 +216,7 @@ describe('OllamaProvider', () => {
       const result = await provider.sendMessage(messages, tools);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'user',
@@ -263,7 +268,7 @@ describe('OllamaProvider', () => {
       await provider.sendMessage(messages);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'assistant',
@@ -315,7 +320,7 @@ describe('OllamaProvider', () => {
       await provider.sendMessage(messages);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'assistant',
@@ -358,7 +363,7 @@ describe('OllamaProvider', () => {
       await provider.sendMessage(messages);
 
       expect(mockOllama.chat).toHaveBeenCalledWith({
-        model: 'llama2',
+        ...defaultChatOptions,
         messages: [
           {
             role: 'tool',

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/ollama-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/ollama-provider.ts
@@ -72,6 +72,10 @@ export class OllamaProvider extends LLMProvider {
         model: this.model,
         messages: ollamaMessages,
         tools: tools,
+        options: {
+          temperature: this.temperature ?? 0.7,
+          num_predict: this.maxTokens ?? 1000,
+        },
       });
       const duration = Date.now() - startTime;
 
@@ -141,8 +145,8 @@ export class OllamaProvider extends LLMProvider {
     const request: any = {
       model: this.model,
       messages,
-      max_tokens: 1000,
-      temperature: 0.7,
+      max_tokens: this.maxTokens ?? 1000,
+      temperature: this.temperature ?? 0.7,
     };
 
     if (tools && tools.length > 0) {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OpenAIProvider } from './openai-provider';
+import { ProviderConfig, ChatMessage, Tool } from '../types';
+
+global.fetch = jest.fn();
+
+describe('OpenAIProvider', () => {
+  let provider: OpenAIProvider;
+
+  const config: ProviderConfig = {
+    type: 'openai',
+    apiKey: 'test-api-key',
+    baseUrl: 'https://api.openai.com/v1',
+    model: 'gpt-4o-mini',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
+    provider = new OpenAIProvider(config);
+  });
+
+  describe('sendMessage', () => {
+    it('should send a message and return the response', async () => {
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hello!' }];
+
+      const mockResponse = {
+        choices: [{ message: { role: 'assistant', content: 'Hi there!' } }],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.sendMessage(messages);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/chat/completions',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should include tools in the request when provided', async () => {
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'What is the weather?' },
+      ];
+      const tools: Tool[] = [
+        {
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            description: 'Get weather',
+            parameters: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+            },
+          },
+        },
+      ];
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [
+            { message: { role: 'assistant', content: null, tool_calls: [] } },
+          ],
+        }),
+      });
+
+      await provider.sendMessage(messages, tools);
+
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body,
+      );
+      expect(body.tools).toEqual(tools);
+    });
+
+    it('should throw on API error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      await expect(
+        provider.sendMessage([{ role: 'user', content: 'Hello' }]),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('testConnection', () => {
+    it('should return connected with models on success', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [{ id: 'gpt-4o' }, { id: 'gpt-4o-mini' }] }),
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({
+        connected: true,
+        models: ['gpt-4o', 'gpt-4o-mini'],
+      });
+    });
+
+    it('should return error message on 401', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () =>
+          JSON.stringify({ error: { message: 'Unauthorized' } }),
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Invalid API key');
+    });
+
+    it('should return error message on 429', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'Too Many Requests',
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Rate limit exceeded');
+    });
+
+    it('should return error message on 403', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: async () => 'Forbidden',
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Access forbidden');
+    });
+
+    it('should handle network errors', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+
+    it('should handle non-Error exceptions', async () => {
+      (global.fetch as jest.Mock).mockRejectedValueOnce('string error');
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toBe('Unknown error');
+    });
+  });
+
+  describe('getHeaders', () => {
+    it('should include Authorization header when API key is set', () => {
+      const headers = (provider as any).getHeaders();
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-api-key',
+      });
+    });
+
+    it('should omit Authorization header when no API key', () => {
+      const p = new OpenAIProvider({ ...config, apiKey: undefined });
+      const headers = (p as any).getHeaders();
+      expect(headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('formatRequest', () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'Hello' }];
+
+    it.each([
+      ['gpt-4o-mini', 'max_tokens'],
+      ['gpt-4o', 'max_tokens'],
+      ['gpt-4', 'max_tokens'],
+      ['gpt-3.5-turbo', 'max_tokens'],
+      ['o1', 'max_completion_tokens'],
+      ['o1-mini', 'max_completion_tokens'],
+      ['o1-preview', 'max_completion_tokens'],
+      ['o3-mini', 'max_completion_tokens'],
+      ['o4-mini', 'max_completion_tokens'],
+      ['gpt-5', 'max_completion_tokens'],
+      ['gpt-5.2', 'max_completion_tokens'],
+    ])('model %s should use %s', (model, expectedParam) => {
+      const p = new OpenAIProvider({ ...config, model });
+      const request = (p as any).formatRequest(messages);
+
+      expect(request[expectedParam]).toBeDefined();
+      const unexpectedParam =
+        expectedParam === 'max_tokens' ? 'max_completion_tokens' : 'max_tokens';
+      expect(request[unexpectedParam]).toBeUndefined();
+    });
+
+    it.each([
+      [undefined, 1000],
+      [4096, 4096],
+      [512, 512],
+    ])('maxTokens config %s should result in %d', (maxTokens, expected) => {
+      const p = new OpenAIProvider({ ...config, maxTokens });
+      const request = (p as any).formatRequest(messages);
+      expect(request.max_tokens).toBe(expected);
+    });
+
+    it.each([
+      [undefined, 0.7],
+      [0.2, 0.2],
+      [0, 0],
+      [1, 1],
+    ])('temperature config %s should result in %s', (temperature, expected) => {
+      const p = new OpenAIProvider({ ...config, temperature });
+      const request = (p as any).formatRequest(messages);
+      expect(request.temperature).toBe(expected);
+    });
+
+    it('should not include tools when array is empty', () => {
+      const request = (provider as any).formatRequest(messages, []);
+      expect(request.tools).toBeUndefined();
+    });
+  });
+
+  describe('parseResponse', () => {
+    it('should return the response as-is', () => {
+      const response = {
+        choices: [{ message: { role: 'assistant', content: 'Hello' } }],
+      };
+      expect((provider as any).parseResponse(response)).toEqual(response);
+    });
+  });
+});

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
@@ -245,6 +245,24 @@ describe('OpenAIProvider', () => {
       expect(request.temperature).toBe(expected);
     });
 
+    it.each(['o1', 'o1-mini', 'o3-mini', 'o4-mini', 'gpt-5', 'gpt-5.2'])(
+      'model %s should NOT include temperature',
+      model => {
+        const p = new OpenAIProvider({ ...config, model, temperature: 0.5 });
+        const request = (p as any).formatRequest(messages);
+        expect(request.temperature).toBeUndefined();
+      },
+    );
+
+    it.each(['gpt-4o-mini', 'gpt-4o', 'gpt-4', 'gpt-3.5-turbo'])(
+      'model %s should include temperature',
+      model => {
+        const p = new OpenAIProvider({ ...config, model, temperature: 0.5 });
+        const request = (p as any).formatRequest(messages);
+        expect(request.temperature).toBe(0.5);
+      },
+    );
+
     it('should not include tools when array is empty', () => {
       const request = (provider as any).formatRequest(messages, []);
       expect(request.tools).toBeUndefined();

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
@@ -105,10 +105,15 @@ export class OpenAIProvider extends LLMProvider {
   }
 
   protected formatRequest(messages: ChatMessage[], tools?: Tool[]): any {
+    const maxTokens = this.maxTokens ?? 1000;
+    const useMaxCompletionTokens = /^(o[0-9]|gpt-5)/.test(this.model);
+
     const request: any = {
       model: this.model,
       messages,
-      max_tokens: this.maxTokens ?? 1000,
+      ...(useMaxCompletionTokens
+        ? { max_completion_tokens: maxTokens }
+        : { max_tokens: maxTokens }),
       temperature: this.temperature ?? 0.7,
     };
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
@@ -108,8 +108,8 @@ export class OpenAIProvider extends LLMProvider {
     const request: any = {
       model: this.model,
       messages,
-      max_tokens: 1000,
-      temperature: 0.7,
+      max_tokens: this.maxTokens ?? 1000,
+      temperature: this.temperature ?? 0.7,
     };
 
     if (tools && tools.length > 0) {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
@@ -114,8 +114,12 @@ export class OpenAIProvider extends LLMProvider {
       ...(useMaxCompletionTokens
         ? { max_completion_tokens: maxTokens }
         : { max_tokens: maxTokens }),
-      temperature: this.temperature ?? 0.7,
     };
+
+    // O-series and GPT-5 models do not support the temperature parameter
+    if (!useMaxCompletionTokens) {
+      request.temperature = this.temperature ?? 0.7;
+    }
 
     if (tools && tools.length > 0) {
       request.tools = tools;

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-responses-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-responses-provider.test.ts
@@ -854,6 +854,51 @@ describe('OpenAIResponsesProvider', () => {
     });
   });
 
+  describe('maxTokens and temperature in formatRequest', () => {
+    it('should include max_output_tokens when maxTokens is configured', () => {
+      const p = new OpenAIResponsesProvider({ ...config, maxTokens: 4096 });
+      p.setMcpServerConfigs(mockMCPServerFullConfigs);
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const request = (p as any).formatRequest(messages);
+      expect(request.max_output_tokens).toBe(4096);
+    });
+
+    it('should not include max_output_tokens when maxTokens is not configured', () => {
+      const request = (provider as any).formatRequest([
+        { role: 'user', content: 'test' },
+      ]);
+      expect(request.max_output_tokens).toBeUndefined();
+    });
+
+    it('should include temperature when configured', () => {
+      const p = new OpenAIResponsesProvider({ ...config, temperature: 0.3 });
+      p.setMcpServerConfigs(mockMCPServerFullConfigs);
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const request = (p as any).formatRequest(messages);
+      expect(request.temperature).toBe(0.3);
+    });
+
+    it('should not include temperature when not configured', () => {
+      const request = (provider as any).formatRequest([
+        { role: 'user', content: 'test' },
+      ]);
+      expect(request.temperature).toBeUndefined();
+    });
+
+    it('should include both max_output_tokens and temperature when both configured', () => {
+      const p = new OpenAIResponsesProvider({
+        ...config,
+        maxTokens: 2048,
+        temperature: 0.5,
+      });
+      p.setMcpServerConfigs(mockMCPServerFullConfigs);
+      const messages: ChatMessage[] = [{ role: 'user', content: 'test' }];
+      const request = (p as any).formatRequest(messages);
+      expect(request.max_output_tokens).toBe(2048);
+      expect(request.temperature).toBe(0.5);
+    });
+  });
+
   describe('getHeaders', () => {
     it('should include authorization header when API key is provided', () => {
       const headers = (provider as any).getHeaders();

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-responses-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-responses-provider.ts
@@ -175,6 +175,14 @@ export class OpenAIResponsesProvider extends LLMProvider {
       request.instructions = instructions;
     }
 
+    if (this.maxTokens !== undefined) {
+      request.max_output_tokens = this.maxTokens;
+    }
+
+    if (this.temperature !== undefined) {
+      request.temperature = this.temperature;
+    }
+
     return request;
   }
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-config.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-config.test.ts
@@ -218,7 +218,7 @@ describe('Provider maxTokens and temperature configuration', () => {
       ];
 
       providers.forEach(
-        ({ name, instance, expectedMaxTokens, expectedTemperature }) => {
+        ({ instance, expectedMaxTokens, expectedTemperature }) => {
           const request = (instance as any).formatRequest(testMessages);
           expect(request.max_tokens).toBe(expectedMaxTokens);
           expect(request.temperature).toBe(expectedTemperature);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-config.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-config.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OpenAIProvider } from './openai-provider';
+import { ClaudeProvider } from './claude-provider';
+import { GeminiProvider } from './gemini-provider';
+import { LiteLLMProvider } from './litellm-provider';
+import { OllamaProvider } from './ollama-provider';
+import { ChatMessage } from '../types';
+
+describe('Provider maxTokens and temperature configuration', () => {
+  const testMessages: ChatMessage[] = [
+    { role: 'user', content: 'Hello, how are you?' },
+  ];
+
+  describe('OpenAIProvider', () => {
+    it('should use custom maxTokens and temperature in requests', () => {
+      const provider = new OpenAIProvider({
+        type: 'openai',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4',
+        maxTokens: 2000,
+        temperature: 0.3,
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(2000);
+      expect(request.temperature).toBe(0.3);
+      expect(request.model).toBe('gpt-4');
+    });
+
+    it('should use default values when not specified', () => {
+      const provider = new OpenAIProvider({
+        type: 'openai',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-4',
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(1000); // Default
+      expect(request.temperature).toBe(0.7); // Default
+    });
+  });
+
+  describe('ClaudeProvider', () => {
+    it('should use custom maxTokens and temperature in requests', () => {
+      const provider = new ClaudeProvider({
+        type: 'claude',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.anthropic.com/v1',
+        model: 'claude-3',
+        maxTokens: 2048,
+        temperature: 0.9,
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(2048);
+      expect(request.temperature).toBe(0.9);
+    });
+
+    it('should use default maxTokens when not specified', () => {
+      const provider = new ClaudeProvider({
+        type: 'claude',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.anthropic.com/v1',
+        model: 'claude-3',
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(4096); // Default
+      // Temperature is not set by default for Claude
+      expect(request.temperature).toBeUndefined();
+    });
+  });
+
+  describe('GeminiProvider', () => {
+    it('should use custom maxTokens and temperature', () => {
+      const provider = new GeminiProvider({
+        type: 'gemini',
+        apiKey: 'test-key',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        model: 'gemini-pro',
+        maxTokens: 4096,
+        temperature: 0.8,
+      });
+
+      // Check that the values are stored in the model config
+      expect((provider as any).maxTokens).toBe(4096);
+      expect((provider as any).temperature).toBe(0.8);
+    });
+
+    it('should use defaults when not specified', () => {
+      const provider = new GeminiProvider({
+        type: 'gemini',
+        apiKey: 'test-key',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        model: 'gemini-pro',
+      });
+
+      expect((provider as any).maxTokens).toBeUndefined();
+      expect((provider as any).temperature).toBeUndefined();
+    });
+  });
+
+  describe('LiteLLMProvider', () => {
+    it('should use custom maxTokens and temperature in requests', () => {
+      const provider = new LiteLLMProvider({
+        type: 'litellm',
+        apiKey: 'test-key',
+        baseUrl: 'http://localhost:4000',
+        model: 'gpt-4',
+        maxTokens: 1500,
+        temperature: 0.4,
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(1500);
+      expect(request.temperature).toBe(0.4);
+    });
+
+    it('should use defaults when not specified', () => {
+      const provider = new LiteLLMProvider({
+        type: 'litellm',
+        apiKey: 'test-key',
+        baseUrl: 'http://localhost:4000',
+        model: 'gpt-4',
+      });
+
+      const request = (provider as any).formatRequest(testMessages);
+
+      expect(request.max_tokens).toBe(1000); // Default
+      expect(request.temperature).toBe(0.7); // Default
+    });
+  });
+
+  describe('OllamaProvider', () => {
+    it('should use custom maxTokens and temperature in options', () => {
+      const provider = new OllamaProvider({
+        type: 'ollama',
+        baseUrl: 'http://localhost:11434',
+        model: 'llama2',
+        maxTokens: 1500,
+        temperature: 0.6,
+      });
+
+      expect((provider as any).maxTokens).toBe(1500);
+      expect((provider as any).temperature).toBe(0.6);
+    });
+
+    it('should use defaults when not specified', () => {
+      const provider = new OllamaProvider({
+        type: 'ollama',
+        baseUrl: 'http://localhost:11434',
+        model: 'llama2',
+      });
+
+      expect((provider as any).maxTokens).toBeUndefined();
+      expect((provider as any).temperature).toBeUndefined();
+    });
+  });
+
+  describe('Provider defaults comparison', () => {
+    it('should have correct default values for each provider type', () => {
+      const providers = [
+        {
+          name: 'OpenAI',
+          instance: new OpenAIProvider({
+            type: 'openai',
+            apiKey: 'test',
+            baseUrl: 'https://api.openai.com/v1',
+            model: 'gpt-4',
+          }),
+          expectedMaxTokens: 1000,
+          expectedTemperature: 0.7,
+        },
+        {
+          name: 'Claude',
+          instance: new ClaudeProvider({
+            type: 'claude',
+            apiKey: 'test',
+            baseUrl: 'https://api.anthropic.com/v1',
+            model: 'claude-3',
+          }),
+          expectedMaxTokens: 4096,
+          expectedTemperature: undefined,
+        },
+        {
+          name: 'LiteLLM',
+          instance: new LiteLLMProvider({
+            type: 'litellm',
+            apiKey: 'test',
+            baseUrl: 'http://localhost:4000',
+            model: 'gpt-4',
+          }),
+          expectedMaxTokens: 1000,
+          expectedTemperature: 0.7,
+        },
+      ];
+
+      providers.forEach(
+        ({ name, instance, expectedMaxTokens, expectedTemperature }) => {
+          const request = (instance as any).formatRequest(testMessages);
+          expect(request.max_tokens).toBe(expectedMaxTokens);
+          expect(request.temperature).toBe(expectedTemperature);
+        },
+      );
+    });
+  });
+});

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
@@ -92,6 +92,7 @@ describe('getProviderConfig', () => {
         if (key === 'baseUrl') return undefined;
         return 'test-key';
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -122,6 +123,7 @@ describe('getProviderConfig', () => {
           if (key === 'baseUrl') return undefined;
           return 'test-key';
         }),
+        getOptionalNumber: jest.fn().mockReturnValue(undefined),
       } as any;
 
       mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -158,6 +160,7 @@ describe('getProviderConfig', () => {
           if (key === 'baseUrl') return customBaseUrl;
           return undefined;
         }),
+        getOptionalNumber: jest.fn().mockReturnValue(undefined),
       } as any;
 
       mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -190,6 +193,7 @@ describe('getProviderConfig', () => {
           if (key === 'baseUrl') return customBaseUrl;
           return undefined;
         }),
+        getOptionalNumber: jest.fn().mockReturnValue(undefined),
       } as any;
 
       mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -222,6 +226,7 @@ describe('getProviderConfig', () => {
           if (key === 'baseUrl') return customBaseUrl;
           return undefined;
         }),
+        getOptionalNumber: jest.fn().mockReturnValue(undefined),
       } as any;
 
       mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -245,6 +250,7 @@ describe('getProviderConfig', () => {
         if (key === 'baseUrl') return 'http://localhost:4000';
         return undefined;
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -263,6 +269,7 @@ describe('getProviderConfig', () => {
         throw new Error(`Unexpected key: ${key}`);
       }),
       getOptionalString: jest.fn().mockReturnValue(undefined),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -283,6 +290,7 @@ describe('getProviderConfig', () => {
         if (key === 'baseUrl') return undefined;
         return 'first-key';
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     const mockProviderConfig2 = {
@@ -295,6 +303,7 @@ describe('getProviderConfig', () => {
         if (key === 'baseUrl') return undefined;
         return 'second-key';
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([
@@ -323,6 +332,7 @@ describe('getProviderConfig', () => {
         if (key === 'baseUrl') return undefined;
         return 'test-key';
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
@@ -330,6 +340,89 @@ describe('getProviderConfig', () => {
     expect(() => getProviderConfig(mockConfig)).toThrow(
       'Model is required for provider: openai',
     );
+  });
+
+  it('should read maxTokens and temperature from config for OpenAI', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'openai';
+        if (key === 'model') return 'gpt-4';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        if (key === 'token') return 'test-key';
+        return undefined;
+      }),
+      getOptionalNumber: jest.fn().mockImplementation((key: string) => {
+        if (key === 'maxTokens') return 2000;
+        if (key === 'temperature') return 0.5;
+        return undefined;
+      }),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    const result = getProviderConfig(mockConfig);
+
+    expect(result.maxTokens).toBe(2000);
+    expect(result.temperature).toBe(0.5);
+  });
+
+  it('should handle undefined maxTokens and temperature', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'openai';
+        if (key === 'model') return 'gpt-4';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return undefined;
+        if (key === 'token') return 'test-key';
+        return undefined;
+      }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    const result = getProviderConfig(mockConfig);
+
+    expect(result.maxTokens).toBeUndefined();
+    expect(result.temperature).toBeUndefined();
+  });
+
+  it('should pass maxTokens and temperature to all provider types', () => {
+    const providerTypes = ['openai', 'claude', 'gemini', 'ollama', 'litellm'];
+
+    providerTypes.forEach(providerId => {
+      const mockProviderConfig = {
+        getString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'id') return providerId;
+          if (key === 'model') return 'test-model';
+          throw new Error(`Unexpected key: ${key}`);
+        }),
+        getOptionalString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'token')
+            return providerId === 'ollama' ? undefined : 'test-key';
+          if (key === 'baseUrl') return undefined;
+          return undefined;
+        }),
+        getOptionalNumber: jest.fn().mockImplementation((key: string) => {
+          if (key === 'maxTokens') return 1500;
+          if (key === 'temperature') return 0.3;
+          return undefined;
+        }),
+      } as any;
+
+      mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+      const result = getProviderConfig(mockConfig);
+
+      expect(result.maxTokens).toBe(1500);
+      expect(result.temperature).toBe(0.3);
+      expect(result.type).toBe(providerId);
+    });
   });
 });
 
@@ -351,6 +444,7 @@ describe('getProviderInfo', () => {
         if (key === 'baseUrl') return 'https://api.openai.com/v1';
         return 'test-key';
       }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
     } as any;
 
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
@@ -424,6 +424,74 @@ describe('getProviderConfig', () => {
       expect(result.type).toBe(providerId);
     });
   });
+
+  it.each([0, -1, -100, 1.5, 3.14])(
+    'should throw on invalid maxTokens: %s',
+    invalidValue => {
+      const mockProviderConfig = {
+        getString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'id') return 'openai';
+          if (key === 'model') return 'gpt-4';
+          throw new Error(`Unexpected key: ${key}`);
+        }),
+        getOptionalString: jest.fn().mockReturnValue('test-key'),
+        getOptionalNumber: jest.fn().mockImplementation((key: string) => {
+          if (key === 'maxTokens') return invalidValue;
+          return undefined;
+        }),
+      } as any;
+      mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+      expect(() => getProviderConfig(mockConfig)).toThrow(
+        /Invalid maxTokens value/,
+      );
+    },
+  );
+
+  it.each([-1, -0.1, 2.1, 3, 100])(
+    'should throw on invalid temperature: %s',
+    invalidValue => {
+      const mockProviderConfig = {
+        getString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'id') return 'openai';
+          if (key === 'model') return 'gpt-4';
+          throw new Error(`Unexpected key: ${key}`);
+        }),
+        getOptionalString: jest.fn().mockReturnValue('test-key'),
+        getOptionalNumber: jest.fn().mockImplementation((key: string) => {
+          if (key === 'temperature') return invalidValue;
+          return undefined;
+        }),
+      } as any;
+      mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+      expect(() => getProviderConfig(mockConfig)).toThrow(
+        /Invalid temperature value/,
+      );
+    },
+  );
+
+  it.each([0, 0.5, 1, 1.5, 2])(
+    'should accept valid temperature: %s',
+    validValue => {
+      const mockProviderConfig = {
+        getString: jest.fn().mockImplementation((key: string) => {
+          if (key === 'id') return 'openai';
+          if (key === 'model') return 'gpt-4';
+          throw new Error(`Unexpected key: ${key}`);
+        }),
+        getOptionalString: jest.fn().mockReturnValue('test-key'),
+        getOptionalNumber: jest.fn().mockImplementation((key: string) => {
+          if (key === 'temperature') return validValue;
+          return undefined;
+        }),
+      } as any;
+      mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+      const result = getProviderConfig(mockConfig);
+      expect(result.temperature).toBe(validValue);
+    },
+  );
 });
 
 describe('getProviderInfo', () => {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
@@ -86,6 +86,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
   const providerId = providerConfig.getString('id');
   const token = providerConfig.getOptionalString('token');
   const model = providerConfig.getString('model');
+  const maxTokens = providerConfig.getOptionalNumber('maxTokens');
+  const temperature = providerConfig.getOptionalNumber('temperature');
 
   const allowedProviders = [
     'openai',
@@ -111,6 +113,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
         providerConfig.getOptionalString('baseUrl') ||
         'https://api.openai.com/v1',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
 
     'openai-responses': {
@@ -118,6 +122,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       apiKey: token,
       baseUrl: providerConfig.getOptionalString('baseUrl') || '',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
 
     claude: {
@@ -125,6 +131,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       apiKey: token,
       baseUrl: 'https://api.anthropic.com/v1',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
 
     gemini: {
@@ -132,6 +140,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       apiKey: token,
       baseUrl: 'https://generativelanguage.googleapis.com',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
 
     ollama: {
@@ -140,6 +150,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       baseUrl:
         providerConfig.getOptionalString('baseUrl') || 'http://localhost:11434',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
 
     litellm: {
@@ -148,6 +160,8 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       baseUrl:
         providerConfig.getOptionalString('baseUrl') || 'http://localhost:4000',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
     },
   };
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
@@ -89,6 +89,20 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
   const maxTokens = providerConfig.getOptionalNumber('maxTokens');
   const temperature = providerConfig.getOptionalNumber('temperature');
 
+  if (
+    maxTokens !== undefined &&
+    (maxTokens <= 0 || !Number.isInteger(maxTokens))
+  ) {
+    throw new Error(
+      `Invalid maxTokens value: ${maxTokens}. Must be a positive integer.`,
+    );
+  }
+  if (temperature !== undefined && (temperature < 0 || temperature > 2)) {
+    throw new Error(
+      `Invalid temperature value: ${temperature}. Must be between 0 and 2.`,
+    );
+  }
+
   const allowedProviders = [
     'openai',
     'openai-responses',

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/types.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/types.ts
@@ -209,6 +209,10 @@ export interface ProviderConfig {
   model: string;
   /** Logger for debugging */
   logger?: LoggerService;
+  /** Maximum number of tokens to generate (default: 1000 for OpenAI-compatible, 4096 for Claude, 8192 for Gemini) */
+  maxTokens?: number;
+  /** Temperature for response randomness, between 0 and 1 (default: 0.7) */
+  temperature?: number;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds support for `max_tokens` and `temperature` customization on each provider:

```yaml
mcpChat:
  providers:
    - id: openai
      baseUrl: 'https://any-openai-compatible-url/v1'
      token: ${OPENAI_API_KEY}
      model: gpt-4o-mini
      maxTokens: 8192
      temperature: 0.5
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [-] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
