### PR TITLE
Version Packages (keycloak)

### DIFF
--- a/workspaces/keycloak/.changeset/renovate-ab512f4.md
+++ b/workspaces/keycloak/.changeset/renovate-ab512f4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Updated dependency `@types/lodash` to `4.17.24`.

--- a/workspaces/keycloak/.changeset/renovate-c58dced.md
+++ b/workspaces/keycloak/.changeset/renovate-c58dced.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': patch
----
-
-Updated dependency `@keycloak/keycloak-admin-client` to `26.5.6`.

--- a/workspaces/keycloak/.changeset/version-bump-1-48-4.md
+++ b/workspaces/keycloak/.changeset/version-bump-1-48-4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-keycloak': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-keycloak
 
+## 3.18.0
+
+### Minor Changes
+
+- e8105de: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- 95eca61: Updated dependency `@types/lodash` to `4.17.24`.
+- f788dc3: Updated dependency `@keycloak/keycloak-admin-client` to `26.5.6`.
+
 ## 3.17.2
 
 ### Patch Changes

--- a/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/catalog-backend-module-keycloak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-keycloak",
-  "version": "3.17.2",
+  "version": "3.18.0",
   "description": "A Backend backend plugin for Keycloak",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-keycloak@3.18.0

### Minor Changes

-   e8105de: Backstage version bump to v1.48.4

### Patch Changes

-   95eca61: Updated dependency `@types/lodash` to `4.17.24`.
-   f788dc3: Updated dependency `@keycloak/keycloak-admin-client` to `26.5.6`.
