### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/khaki-insects-search.md
+++ b/workspaces/ocm/.changeset/khaki-insects-search.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
----
-
-Show loading indicator and error panel if needed on the cluster info and cluster resource cards.

--- a/workspaces/ocm/.changeset/loud-rules-taste.md
+++ b/workspaces/ocm/.changeset/loud-rules-taste.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
----
-
-ClusterAvailableResourceCard components returns now a JSX element instead of any but this should be fine in most cases.

--- a/workspaces/ocm/.changeset/nine-garlics-roll.md
+++ b/workspaces/ocm/.changeset/nine-garlics-roll.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
----
-
-Fix crash when cluster entity and cluster resources doesn't match.

--- a/workspaces/ocm/.changeset/renovate-7e24ba8.md
+++ b/workspaces/ocm/.changeset/renovate-7e24ba8.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.30.2`.

--- a/workspaces/ocm/.changeset/renovate-97401f0.md
+++ b/workspaces/ocm/.changeset/renovate-97401f0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/ocm/.changeset/twelve-cougars-mate.md
+++ b/workspaces/ocm/.changeset/twelve-cougars-mate.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm': patch
----
-
-Improve OCM cluster page when an error is displayed and removed unnecessary home plugin dependency.

--- a/workspaces/ocm/.changeset/version-bump-1-48-4.md
+++ b/workspaces/ocm/.changeset/version-bump-1-48-4.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.16.0
+
+### Minor Changes
+
+- 5f6f816: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- fbd59de: Updated dependency `@openapitools/openapi-generator-cli` to `2.30.2`.
+- 5f6f816: Updated dependency `@types/supertest` to `^7.0.0`.
+- Updated dependencies [5f6f816]
+  - @backstage-community/plugin-ocm-common@3.19.0
+
 ## 5.15.1
 
 ### Patch Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.15.1",
+  "version": "5.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.19.0
+
+### Minor Changes
+
+- 5f6f816: Backstage version bump to v1.48.4
+
 ## 3.18.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-ocm
 
+## 5.15.0
+
+### Minor Changes
+
+- 5f6f816: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- 926c09e: Show loading indicator and error panel if needed on the cluster info and cluster resource cards.
+- 13684ea: ClusterAvailableResourceCard components returns now a JSX element instead of any but this should be fine in most cases.
+- 926c09e: Fix crash when cluster entity and cluster resources doesn't match.
+- 926c09e: Improve OCM cluster page when an error is displayed and removed unnecessary home plugin dependency.
+- Updated dependencies [5f6f816]
+  - @backstage-community/plugin-ocm-common@3.19.0
+
 ## 5.14.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.15.0

### Minor Changes

-   5f6f816: Backstage version bump to v1.48.4

### Patch Changes

-   926c09e: Show loading indicator and error panel if needed on the cluster info and cluster resource cards.
-   13684ea: ClusterAvailableResourceCard components returns now a JSX element instead of any but this should be fine in most cases.
-   926c09e: Fix crash when cluster entity and cluster resources doesn't match.
-   926c09e: Improve OCM cluster page when an error is displayed and removed unnecessary home plugin dependency.
-   Updated dependencies [5f6f816]
    -   @backstage-community/plugin-ocm-common@3.19.0

## @backstage-community/plugin-ocm-backend@5.16.0

### Minor Changes

-   5f6f816: Backstage version bump to v1.48.4

### Patch Changes

-   fbd59de: Updated dependency `@openapitools/openapi-generator-cli` to `2.30.2`.
-   5f6f816: Updated dependency `@types/supertest` to `^7.0.0`.
-   Updated dependencies [5f6f816]
    -   @backstage-community/plugin-ocm-common@3.19.0

## @backstage-community/plugin-ocm-common@3.19.0

### Minor Changes

-   5f6f816: Backstage version bump to v1.48.4
