### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/version-bump-1-48-4.md
+++ b/workspaces/adr/.changeset/version-bump-1-48-4.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-adr': patch
-'@backstage-community/plugin-adr-backend': patch
-'@backstage-community/plugin-adr-common': patch
-'@backstage-community/search-backend-module-adr': patch
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.19.1
+
+### Patch Changes
+
+- 91887fc: Backstage version bump to v1.48.4
+- Updated dependencies [91887fc]
+  - @backstage-community/plugin-adr-common@0.17.1
+  - @backstage-community/search-backend-module-adr@0.16.1
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/adr/plugins/adr-common/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-common
 
+## 0.17.1
+
+### Patch Changes
+
+- 91887fc: Backstage version bump to v1.48.4
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-common/package.json
+++ b/workspaces/adr/plugins/adr-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-common",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Common functionalities for the adr plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.21.1
+
+### Patch Changes
+
+- 91887fc: Backstage version bump to v1.48.4
+- Updated dependencies [91887fc]
+  - @backstage-community/plugin-adr-common@0.17.1
+
 ## 0.21.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",

--- a/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/search-backend-module-adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/search-backend-module-adr
 
+## 0.16.1
+
+### Patch Changes
+
+- 91887fc: Backstage version bump to v1.48.4
+- Updated dependencies [91887fc]
+  - @backstage-community/plugin-adr-common@0.17.1
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/search-backend-module-adr/package.json
+++ b/workspaces/adr/plugins/search-backend-module-adr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/search-backend-module-adr",
   "description": "The adr backend module for the search plugin.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.21.1

### Patch Changes

-   91887fc: Backstage version bump to v1.48.4
-   Updated dependencies [91887fc]
    -   @backstage-community/plugin-adr-common@0.17.1

## @backstage-community/plugin-adr-backend@0.19.1

### Patch Changes

-   91887fc: Backstage version bump to v1.48.4
-   Updated dependencies [91887fc]
    -   @backstage-community/plugin-adr-common@0.17.1
    -   @backstage-community/search-backend-module-adr@0.16.1

## @backstage-community/plugin-adr-common@0.17.1

### Patch Changes

-   91887fc: Backstage version bump to v1.48.4

## @backstage-community/search-backend-module-adr@0.16.1

### Patch Changes

-   91887fc: Backstage version bump to v1.48.4
-   Updated dependencies [91887fc]
    -   @backstage-community/plugin-adr-common@0.17.1
