### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/curly-wolves-occur.md
+++ b/workspaces/confluence/.changeset/curly-wolves-occur.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Restore the support for the combination of 'spaces' and 'query' parameters introduced by #4017

--- a/workspaces/confluence/.changeset/many-eggs-lick.md
+++ b/workspaces/confluence/.changeset/many-eggs-lick.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
----
-
-Lowercase the document type passed to the collator factory to prevent OpenSearch invalid_index_name_exception in multi-instance configurations

--- a/workspaces/confluence/.changeset/version-bump-1-48-4.md
+++ b/workspaces/confluence/.changeset/version-bump-1-48-4.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-confluence': patch
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
-'@backstage-community/plugin-techdocs-backend-module-confluence': patch
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-confluence
 
+## 0.14.1
+
+### Patch Changes
+
+- d7ee0fe: Backstage version bump to v1.48.4
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.17.2
+
+### Patch Changes
+
+- 53d1ad6: Restore the support for the combination of 'spaces' and 'query' parameters introduced by #4017
+- ea6b80e: Lowercase the document type passed to the collator factory to prevent OpenSearch invalid_index_name_exception in multi-instance configurations
+- d7ee0fe: Backstage version bump to v1.48.4
+
 ## 0.17.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-techdocs-backend-module-confluence
 
+## 0.2.1
+
+### Patch Changes
+
+- d7ee0fe: Backstage version bump to v1.48.4
+
 ## 0.2.0
 
 ### Minor Changes

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/package.json
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-techdocs-backend-module-confluence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The confluence backend module for the techdocs plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.14.1

### Patch Changes

-   d7ee0fe: Backstage version bump to v1.48.4

## @backstage-community/plugin-search-backend-module-confluence-collator@0.17.2

### Patch Changes

-   53d1ad6: Restore the support for the combination of 'spaces' and 'query' parameters introduced by #4017
-   ea6b80e: Lowercase the document type passed to the collator factory to prevent OpenSearch invalid_index_name_exception in multi-instance configurations
-   d7ee0fe: Backstage version bump to v1.48.4

## @backstage-community/plugin-techdocs-backend-module-confluence@0.2.1

### Patch Changes

-   d7ee0fe: Backstage version bump to v1.48.4
