### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/version-bump-1-48-4.md
+++ b/workspaces/quay/.changeset/version-bump-1-48-4.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-quay
 
+## 2.17.0
+
+### Minor Changes
+
+- c9adc64: Backstage version bump to v1.48.4
+
 ## 2.16.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.13.0
+
+### Minor Changes
+
+- c9adc64: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- Updated dependencies [c9adc64]
+  - @backstage-community/plugin-quay-common@1.18.0
+
 ## 1.12.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.18.0
+
+### Minor Changes
+
+- c9adc64: Backstage version bump to v1.48.4
+
 ## 1.17.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay
 
+## 1.31.0
+
+### Minor Changes
+
+- c9adc64: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- Updated dependencies [c9adc64]
+  - @backstage-community/plugin-quay-common@1.18.0
+
 ## 1.30.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.31.0

### Minor Changes

-   c9adc64: Backstage version bump to v1.48.4

### Patch Changes

-   Updated dependencies [c9adc64]
    -   @backstage-community/plugin-quay-common@1.18.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.17.0

### Minor Changes

-   c9adc64: Backstage version bump to v1.48.4

## @backstage-community/plugin-quay-backend@1.13.0

### Minor Changes

-   c9adc64: Backstage version bump to v1.48.4

### Patch Changes

-   Updated dependencies [c9adc64]
    -   @backstage-community/plugin-quay-common@1.18.0

## @backstage-community/plugin-quay-common@1.18.0

### Minor Changes

-   c9adc64: Backstage version bump to v1.48.4
