### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-c480fa0.md
+++ b/workspaces/rbac/.changeset/renovate-c480fa0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.5`.

--- a/workspaces/rbac/.changeset/version-bump-1-48-4.md
+++ b/workspaces/rbac/.changeset/version-bump-1-48-4.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': minor
-'@backstage-community/plugin-rbac-backend': minor
-'@backstage-community/plugin-rbac-common': minor
-'@backstage-community/plugin-rbac-node': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.8.0
+
+### Minor Changes
+
+- 843bbe2: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- Updated dependencies [843bbe2]
+  - @backstage-community/plugin-rbac-common@1.24.0
+  - @backstage-community/plugin-rbac-node@1.18.0
+
 ## 7.7.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.7.2",
+  "version": "7.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.24.0
+
+### Minor Changes
+
+- 843bbe2: Backstage version bump to v1.48.4
+
 ## 1.23.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.18.0
+
+### Minor Changes
+
+- 843bbe2: Backstage version bump to v1.48.4
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-rbac
 
+## 1.50.0
+
+### Minor Changes
+
+- 843bbe2: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- d22bce2: Updated dependency `start-server-and-test` to `2.1.5`.
+- Updated dependencies [843bbe2]
+  - @backstage-community/plugin-rbac-common@1.24.0
+
 ## 1.49.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.50.0

### Minor Changes

-   843bbe2: Backstage version bump to v1.48.4

### Patch Changes

-   d22bce2: Updated dependency `start-server-and-test` to `2.1.5`.
-   Updated dependencies [843bbe2]
    -   @backstage-community/plugin-rbac-common@1.24.0

## @backstage-community/plugin-rbac-backend@7.8.0

### Minor Changes

-   843bbe2: Backstage version bump to v1.48.4

### Patch Changes

-   Updated dependencies [843bbe2]
    -   @backstage-community/plugin-rbac-common@1.24.0
    -   @backstage-community/plugin-rbac-node@1.18.0

## @backstage-community/plugin-rbac-common@1.24.0

### Minor Changes

-   843bbe2: Backstage version bump to v1.48.4

## @backstage-community/plugin-rbac-node@1.18.0

### Minor Changes

-   843bbe2: Backstage version bump to v1.48.4
