### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/renovate-7b9d339.md
+++ b/workspaces/quay/.changeset/renovate-7b9d339.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `filesize` to `^11.0.0`.

--- a/workspaces/quay/.changeset/renovate-c480fa0.md
+++ b/workspaces/quay/.changeset/renovate-c480fa0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `start-server-and-test` to `2.1.5`.

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-quay
 
+## 1.31.1
+
+### Patch Changes
+
+- da31305: Updated dependency `filesize` to `^11.0.0`.
+- d22bce2: Updated dependency `start-server-and-test` to `2.1.5`.
+
 ## 1.31.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.31.1

### Patch Changes

-   da31305: Updated dependency `filesize` to `^11.0.0`.
-   d22bce2: Updated dependency `start-server-and-test` to `2.1.5`.
