### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/clean-humans-glow.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/clean-humans-glow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
----
-
-Updated dependency `@gitbeaker/rest` to `^43.0.0`.

--- a/workspaces/scaffolder-relation-processor/.changeset/version-bump-1-48-4.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/version-bump-1-48-4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 2.13.0
+
+### Minor Changes
+
+- 495ad08: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- 9e7b674: Updated dependency `@gitbeaker/rest` to `^43.0.0`.
+
 ## 2.12.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@2.13.0

### Minor Changes

-   495ad08: Backstage version bump to v1.48.4

### Patch Changes

-   9e7b674: Updated dependency `@gitbeaker/rest` to `^43.0.0`.
