### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/spotty-dragons-laugh.md
+++ b/workspaces/cicd-statistics/.changeset/spotty-dragons-laugh.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics-module-gitlab': patch
----
-
-Updated dependency `@gitbeaker/rest` to `^43.0.0`.
-Replaced deprecated `@gitbeaker/browser` with `@gitbeaker/rest`

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.15.2
+
+### Patch Changes
+
+- 9e7b674: Updated dependency `@gitbeaker/rest` to `^43.0.0`.
+  Replaced deprecated `@gitbeaker/browser` with `@gitbeaker/rest`
+
 ## 0.15.1
 
 ### Patch Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.15.2

### Patch Changes

-   9e7b674: Updated dependency `@gitbeaker/rest` to `^43.0.0`.
    Replaced deprecated `@gitbeaker/browser` with `@gitbeaker/rest`
