### PR TITLE
azure-storage-explorer: fix stylings in example-app

### DIFF
--- a/workspaces/azure-storage-explorer/packages/app/package.json
+++ b/workspaces/azure-storage-explorer/packages/app/package.json
@@ -43,6 +43,7 @@
     "@backstage/plugin-techdocs-react": "backstage:^",
     "@backstage/plugin-user-settings": "backstage:^",
     "@backstage/theme": "backstage:^",
+    "@backstage/ui": "backstage:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "react": "^18.0.2",

--- a/workspaces/azure-storage-explorer/packages/app/src/index.tsx
+++ b/workspaces/azure-storage-explorer/packages/app/src/index.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import '@backstage/cli/asset-types';
+import '@backstage/ui';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 

--- a/workspaces/azure-storage-explorer/yarn.lock
+++ b/workspaces/azure-storage-explorer/yarn.lock
@@ -3973,6 +3973,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/ui@backstage:^::backstage=1.45.1&npm=0.9.0":
+  version: 0.9.1
+  resolution: "@backstage/ui@npm:0.9.1"
+  dependencies:
+    "@remixicon/react": "npm:^4.6.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    react-aria-components: "npm:^1.13.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/a600bf5df2955f5cf279a792a44196df4737f190a88b7d77fc88940a175ae5dd7ef6f388a4a075428e1da63e2db87711c55e70860f95037e429de85b88e667e5
+  languageName: node
+  linkType: hard
+
 "@backstage/ui@npm:^0.9.0":
   version: 0.9.0
   resolution: "@backstage/ui@npm:0.9.0"
@@ -14124,6 +14144,7 @@ __metadata:
     "@backstage/plugin-user-settings": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@backstage/theme": "backstage:^"
+    "@backstage/ui": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@playwright/test": "npm:^1.32.3"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The CSS was missing some stylings

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
