### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/chubby-nights-rhyme-node.md
+++ b/workspaces/argocd/.changeset/chubby-nights-rhyme-node.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-node': major
----
-
-Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.

--- a/workspaces/argocd/.changeset/chubby-nights-rhyme.md
+++ b/workspaces/argocd/.changeset/chubby-nights-rhyme.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': minor
-'@backstage-community/plugin-argocd-common': minor
-'@backstage-community/plugin-argocd': minor
----
-
-Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.

--- a/workspaces/argocd/.changeset/moody-seas-sip.md
+++ b/workspaces/argocd/.changeset/moody-seas-sip.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-pass namespace to getRevisionDetailsList in DeploymentLifecycle

--- a/workspaces/argocd/.changeset/version-bump-1-48-4.md
+++ b/workspaces/argocd/.changeset/version-bump-1-48-4.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
-'@backstage-community/plugin-argocd-backend': minor
-'@backstage-community/plugin-argocd-common': minor
-'@backstage-community/plugin-argocd-node': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.2.0
+
+### Minor Changes
+
+- 2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
+- c59fa05: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- Updated dependencies [2cde93e]
+- Updated dependencies [2cde93e]
+- Updated dependencies [c59fa05]
+  - @backstage-community/plugin-argocd-node@1.0.0
+  - @backstage-community/plugin-argocd-common@1.14.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.14.0
+
+### Minor Changes
+
+- 2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
+- c59fa05: Backstage version bump to v1.48.4
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
@@ -1,0 +1,17 @@
+# @backstage-community/plugin-argocd-node
+
+## 1.0.0
+
+### Major Changes
+
+- 2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
+
+### Minor Changes
+
+- c59fa05: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- Updated dependencies [2cde93e]
+- Updated dependencies [c59fa05]
+  - @backstage-community/plugin-argocd-common@1.14.0

--- a/workspaces/argocd/plugins/argocd-node/package.json
+++ b/workspaces/argocd/plugins/argocd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-node",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-argocd
 
+## 2.7.0
+
+### Minor Changes
+
+- 2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
+- c59fa05: Backstage version bump to v1.48.4
+
+### Patch Changes
+
+- 9e0c387: pass namespace to getRevisionDetailsList in DeploymentLifecycle
+- Updated dependencies [2cde93e]
+- Updated dependencies [c59fa05]
+  - @backstage-community/plugin-argocd-common@1.14.0
+
 ## 2.6.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd-node@1.0.0

### Major Changes

-   2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.

### Minor Changes

-   c59fa05: Backstage version bump to v1.48.4

### Patch Changes

-   Updated dependencies [2cde93e]
-   Updated dependencies [c59fa05]
    -   @backstage-community/plugin-argocd-common@1.14.0

## @backstage-community/plugin-argocd@2.7.0

### Minor Changes

-   2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
-   c59fa05: Backstage version bump to v1.48.4

### Patch Changes

-   9e0c387: pass namespace to getRevisionDetailsList in DeploymentLifecycle
-   Updated dependencies [2cde93e]
-   Updated dependencies [c59fa05]
    -   @backstage-community/plugin-argocd-common@1.14.0

## @backstage-community/plugin-argocd-backend@1.2.0

### Minor Changes

-   2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
-   c59fa05: Backstage version bump to v1.48.4

### Patch Changes

-   Updated dependencies [2cde93e]
-   Updated dependencies [2cde93e]
-   Updated dependencies [c59fa05]
    -   @backstage-community/plugin-argocd-node@1.0.0
    -   @backstage-community/plugin-argocd-common@1.14.0

## @backstage-community/plugin-argocd-common@1.14.0

### Minor Changes

-   2cde93e: Add additional functionality to the ArgoCDService and move it to a new argocd-node plugin. These new functions will be used in the ArgoCD Scaffolder plugin.
-   c59fa05: Backstage version bump to v1.48.4
