### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/calm-panthers-warn.md
+++ b/workspaces/analytics/.changeset/calm-panthers-warn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': patch
----
-
-Removed all unused direct dependencies (Material UI v4, prop-types and react-use)

--- a/workspaces/analytics/.changeset/cyan-fireants-change.md
+++ b/workspaces/analytics/.changeset/cyan-fireants-change.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga4': patch
----
-
-Updated dependency `jest` to `^30.0.0`.

--- a/workspaces/analytics/.changeset/dull-pandas-smell.md
+++ b/workspaces/analytics/.changeset/dull-pandas-smell.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-newrelic-browser': patch
----
-
-Allow custom endpoint values to support internal proxies

--- a/workspaces/analytics/.changeset/lucky-zoos-applaud.md
+++ b/workspaces/analytics/.changeset/lucky-zoos-applaud.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': patch
-'@backstage-community/plugin-analytics-module-matomo': patch
----
-
-Remove unused dev dependencies for @types/node and msw

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.16.1
+
+### Patch Changes
+
+- 6ac83bc: Updated dependency `jest` to `^30.0.0`.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-matomo
 
+## 1.25.1
+
+### Patch Changes
+
+- 6ac83bc: Remove unused dev dependencies for @types/node and msw
+
 ## 1.25.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.16.1
+
+### Patch Changes
+
+- 5416340: Allow custom endpoint values to support internal proxies
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-analytics-provider-segment
 
+## 1.25.1
+
+### Patch Changes
+
+- 6ac83bc: Removed all unused direct dependencies (Material UI v4, prop-types and react-use)
+- 6ac83bc: Remove unused dev dependencies for @types/node and msw
+
 ## 1.25.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga4@0.16.1

### Patch Changes

-   6ac83bc: Updated dependency `jest` to `^30.0.0`.

## @backstage-community/plugin-analytics-module-matomo@1.25.1

### Patch Changes

-   6ac83bc: Remove unused dev dependencies for @types/node and msw

## @backstage-community/plugin-analytics-module-newrelic-browser@0.16.1

### Patch Changes

-   5416340: Allow custom endpoint values to support internal proxies

## @backstage-community/plugin-analytics-provider-segment@1.25.1

### Patch Changes

-   6ac83bc: Removed all unused direct dependencies (Material UI v4, prop-types and react-use)
-   6ac83bc: Remove unused dev dependencies for @types/node and msw
