### PR TITLE
fix(argocd): add --server-side --force-conflicts to kubectl to fix #7968

### DIFF
--- a/workspaces/argocd/scripts/start-argocd.sh
+++ b/workspaces/argocd/scripts/start-argocd.sh
@@ -10,7 +10,7 @@ kubectl create namespace argocd || echo "Namespace argocd already exists"
 kubectl create namespace demo-apps || echo "Namespace demo-apps already exists"
 
 echo "=== Installing ArgoCD ==="
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 
 echo "=== Waiting for ArgoCD pods to exist ==="
 # Wait until at least one pod exists


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This small change aligns the test script `scripts/start-argocd.sh` with the off. Argo CD getting started section on https://argo-cd.readthedocs.io/en/stable/ to resolve #7968

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
