### PR TITLE
Version Packages (apiiro)

### DIFF
--- a/workspaces/apiiro/.changeset/renovate-59a7dbb.md
+++ b/workspaces/apiiro/.changeset/renovate-59a7dbb.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-apiiro-backend': patch
----
-
-Updated dependency `@types/supertest` to `^6.0.0`.

--- a/workspaces/apiiro/.changeset/renovate-8682ce0.md
+++ b/workspaces/apiiro/.changeset/renovate-8682ce0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-apiiro-backend': patch
----
-
-Updated dependency `supertest` to `7.2.2`.

--- a/workspaces/apiiro/.changeset/version-bump-1-48-2.md
+++ b/workspaces/apiiro/.changeset/version-bump-1-48-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-apiiro': minor
-'@backstage-community/plugin-apiiro-backend': minor
-'@backstage-community/plugin-apiiro-common': minor
-'@backstage-community/plugin-catalog-backend-module-apiiro-entity-processor': minor
----
-
-Backstage version bump to v1.48.2

--- a/workspaces/apiiro/plugins/apiiro-backend/CHANGELOG.md
+++ b/workspaces/apiiro/plugins/apiiro-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-apiiro-backend
 
+## 0.2.0
+
+### Minor Changes
+
+- cd2ccac: Backstage version bump to v1.48.2
+
+### Patch Changes
+
+- b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
+- af998b7: Updated dependency `supertest` to `7.2.2`.
+- Updated dependencies [cd2ccac]
+  - @backstage-community/plugin-apiiro-common@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/apiiro/plugins/apiiro-backend/package.json
+++ b/workspaces/apiiro/plugins/apiiro-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apiiro-backend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/apiiro/plugins/apiiro-common/CHANGELOG.md
+++ b/workspaces/apiiro/plugins/apiiro-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-apiiro-common
 
+## 0.2.0
+
+### Minor Changes
+
+- cd2ccac: Backstage version bump to v1.48.2
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/apiiro/plugins/apiiro-common/package.json
+++ b/workspaces/apiiro/plugins/apiiro-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apiiro-common",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the apiiro plugin",
   "main": "src/index.ts",

--- a/workspaces/apiiro/plugins/apiiro/CHANGELOG.md
+++ b/workspaces/apiiro/plugins/apiiro/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-apiiro
 
+## 0.2.0
+
+### Minor Changes
+
+- cd2ccac: Backstage version bump to v1.48.2
+
+### Patch Changes
+
+- Updated dependencies [cd2ccac]
+  - @backstage-community/plugin-apiiro-common@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/apiiro/plugins/apiiro/package.json
+++ b/workspaces/apiiro/plugins/apiiro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apiiro",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/apiiro/plugins/catalog-backend-module-apiiro-entity-processor/CHANGELOG.md
+++ b/workspaces/apiiro/plugins/catalog-backend-module-apiiro-entity-processor/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-apiiro-entity-processor
 
+## 0.2.0
+
+### Minor Changes
+
+- cd2ccac: Backstage version bump to v1.48.2
+
+### Patch Changes
+
+- Updated dependencies [cd2ccac]
+  - @backstage-community/plugin-apiiro-common@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/apiiro/plugins/catalog-backend-module-apiiro-entity-processor/package.json
+++ b/workspaces/apiiro/plugins/catalog-backend-module-apiiro-entity-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-apiiro-entity-processor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "The apiiro-entity-processor backend module for the catalog plugin.",
   "main": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-apiiro@0.2.0

### Minor Changes

-   cd2ccac: Backstage version bump to v1.48.2

### Patch Changes

-   Updated dependencies [cd2ccac]
    -   @backstage-community/plugin-apiiro-common@0.2.0

## @backstage-community/plugin-apiiro-backend@0.2.0

### Minor Changes

-   cd2ccac: Backstage version bump to v1.48.2

### Patch Changes

-   b133c9d: Updated dependency `@types/supertest` to `^6.0.0`.
-   af998b7: Updated dependency `supertest` to `7.2.2`.
-   Updated dependencies [cd2ccac]
    -   @backstage-community/plugin-apiiro-common@0.2.0

## @backstage-community/plugin-apiiro-common@0.2.0

### Minor Changes

-   cd2ccac: Backstage version bump to v1.48.2

## @backstage-community/plugin-catalog-backend-module-apiiro-entity-processor@0.2.0

### Minor Changes

-   cd2ccac: Backstage version bump to v1.48.2

### Patch Changes

-   Updated dependencies [cd2ccac]
    -   @backstage-community/plugin-apiiro-common@0.2.0
