### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-48311be.md
+++ b/workspaces/rbac/.changeset/renovate-48311be.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@testing-library/react` to `^16.0.0`.
-Updated dependency `@testing-library/dom` to `10.4.1`.
-Updated dependency `@testing-library/jest-dom` to `^6.0.0`.

--- a/workspaces/rbac/.changeset/renovate-894ecf2.md
+++ b/workspaces/rbac/.changeset/renovate-894ecf2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/rbac/.changeset/violet-walls-sort.md
+++ b/workspaces/rbac/.changeset/violet-walls-sort.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Add support for group reference in superUsers list, using direct membership only

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.9.0
+
+### Minor Changes
+
+- da170a1: Add support for group reference in superUsers list, using direct membership only
+
+### Patch Changes
+
+- 8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 7.8.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.8.0",
+  "version": "7.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-rbac
 
+## 1.50.1
+
+### Patch Changes
+
+- 0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
+  Updated dependency `@testing-library/dom` to `10.4.1`.
+  Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
+
 ## 1.50.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@7.9.0

### Minor Changes

-   da170a1: Add support for group reference in superUsers list, using direct membership only

### Patch Changes

-   8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.

## @backstage-community/plugin-rbac@1.50.1

### Patch Changes

-   0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
    Updated dependency `@testing-library/dom` to `10.4.1`.
    Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
