### PR TITLE
chore(deps): update dependency @types/supertest to v7, extracted from #7895

### DIFF
--- a/workspaces/argocd/.changeset/renovate-894ecf2.md
+++ b/workspaces/argocd/.changeset/renovate-894ecf2.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-argocd-backend': patch
+---
+
+Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/backend-test-utils": "^1.11.0",
     "@backstage/cli": "^0.35.4",
     "@types/express": "^4.17.6",
-    "@types/supertest": "^6.0.0",
+    "@types/supertest": "^7.0.0",
     "supertest": "^7.0.0"
   },
   "files": [

--- a/workspaces/argocd/yarn.lock
+++ b/workspaces/argocd/yarn.lock
@@ -1390,7 +1390,7 @@ __metadata:
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/plugin-permission-common": "npm:^0.9.6"
     "@types/express": "npm:^4.17.6"
-    "@types/supertest": "npm:^6.0.0"
+    "@types/supertest": "npm:^7.0.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     supertest: "npm:^7.0.0"
@@ -13826,13 +13826,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
+"@types/supertest@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
   dependencies:
     "@types/methods": "npm:^1.1.4"
     "@types/superagent": "npm:^8.1.0"
-  checksum: 10/6ec05eb591c97bc856b0e78c12f5bec10545f3a749688f34232d189797a506d971bc95931718eb57b378d8513f6d2d12462383e6d68455fa72df35c19de6e89e
+  checksum: 10/5a322e29b81033e90ac50ab315d49559b21809ee39b5681ab7386819463e30d68e29c63c946023a1c353e7f13fb3f20d64dcb89d3d8a0fff569450501aff786c
   languageName: node
   linkType: hard
 

--- a/workspaces/mcp-chat/.changeset/renovate-894ecf2.md
+++ b/workspaces/mcp-chat/.changeset/renovate-894ecf2.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': patch
+---
+
+Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -45,7 +45,7 @@
     "@backstage/backend-test-utils": "^1.6.0",
     "@backstage/cli": "^0.33.0",
     "@types/express": "^4.17.6",
-    "@types/supertest": "^6.0.0",
+    "@types/supertest": "^7.0.0",
     "@types/uuid": "^9.0.0",
     "supertest": "^7.0.0"
   },

--- a/workspaces/mcp-chat/yarn.lock
+++ b/workspaces/mcp-chat/yarn.lock
@@ -2519,7 +2519,7 @@ __metadata:
     "@google/generative-ai": "npm:^0.24.1"
     "@modelcontextprotocol/sdk": "npm:^1.25.2"
     "@types/express": "npm:^4.17.6"
-    "@types/supertest": "npm:^6.0.0"
+    "@types/supertest": "npm:^7.0.0"
     "@types/uuid": "npm:^9.0.0"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
@@ -8885,13 +8885,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
+"@types/supertest@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
   dependencies:
     "@types/methods": "npm:^1.1.4"
     "@types/superagent": "npm:^8.1.0"
-  checksum: 10/6ec05eb591c97bc856b0e78c12f5bec10545f3a749688f34232d189797a506d971bc95931718eb57b378d8513f6d2d12462383e6d68455fa72df35c19de6e89e
+  checksum: 10/5a322e29b81033e90ac50ab315d49559b21809ee39b5681ab7386819463e30d68e29c63c946023a1c353e7f13fb3f20d64dcb89d3d8a0fff569450501aff786c
   languageName: node
   linkType: hard
 
@@ -15355,9 +15355,9 @@ __metadata:
   linkType: hard
 
 "hono@npm:^4.11.4":
-  version: 4.12.7
-  resolution: "hono@npm:4.12.7"
-  checksum: 10/fed37e612730491ba9456f8f68f1b8727a5298cd839fff9641a0b7a95b1e8567a05abb819d32621b40988f166b01140cf7d573c9218dee2741004f48e09564d5
+  version: 4.11.8
+  resolution: "hono@npm:4.11.8"
+  checksum: 10/4c741c96087538af1408f2d0075b89caea2ef2436cd4cabe724a0b11d9bf190d38ed084d07f14373376464dc9a9061540a2b8e955f6f44e380da583dbbcb0b04
   languageName: node
   linkType: hard
 

--- a/workspaces/quay/.changeset/renovate-894ecf2.md
+++ b/workspaces/quay/.changeset/renovate-894ecf2.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-quay-backend': patch
+---
+
+Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@backstage/cli": "^0.35.4",
     "@types/express": "^4.17.6",
-    "@types/supertest": "^6.0.0",
+    "@types/supertest": "^7.0.0",
     "supertest": "^7.0.0"
   },
   "files": [

--- a/workspaces/quay/yarn.lock
+++ b/workspaces/quay/yarn.lock
@@ -1387,7 +1387,7 @@ __metadata:
     "@backstage/config": "npm:^1.3.6"
     "@backstage/plugin-permission-common": "npm:^0.9.6"
     "@types/express": "npm:^4.17.6"
-    "@types/supertest": "npm:^6.0.0"
+    "@types/supertest": "npm:^7.0.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     supertest: "npm:^7.0.0"
@@ -13224,13 +13224,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
+"@types/supertest@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
   dependencies:
     "@types/methods": "npm:^1.1.4"
     "@types/superagent": "npm:^8.1.0"
-  checksum: 10/6ec05eb591c97bc856b0e78c12f5bec10545f3a749688f34232d189797a506d971bc95931718eb57b378d8513f6d2d12462383e6d68455fa72df35c19de6e89e
+  checksum: 10/5a322e29b81033e90ac50ab315d49559b21809ee39b5681ab7386819463e30d68e29c63c946023a1c353e7f13fb3f20d64dcb89d3d8a0fff569450501aff786c
   languageName: node
   linkType: hard
 

--- a/workspaces/rbac/.changeset/renovate-894ecf2.md
+++ b/workspaces/rbac/.changeset/renovate-894ecf2.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -69,7 +69,7 @@
     "@types/knex": "^0.16.1",
     "@types/lodash": "^4.14.151",
     "@types/node": "22.19.11",
-    "@types/supertest": "6.0.3",
+    "@types/supertest": "7.2.0",
     "knex-mock-client": "3.0.2",
     "msw": "1.3.5",
     "qs": "6.14.1",

--- a/workspaces/rbac/yarn.lock
+++ b/workspaces/rbac/yarn.lock
@@ -1426,7 +1426,7 @@ __metadata:
     "@types/knex": "npm:^0.16.1"
     "@types/lodash": "npm:^4.14.151"
     "@types/node": "npm:22.19.11"
-    "@types/supertest": "npm:6.0.3"
+    "@types/supertest": "npm:7.2.0"
     casbin: "npm:^5.27.1"
     chokidar: "npm:^3.6.0"
     csv-parse: "npm:^5.5.5"
@@ -13438,13 +13438,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:6.0.3":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
+"@types/supertest@npm:7.2.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
   dependencies:
     "@types/methods": "npm:^1.1.4"
     "@types/superagent": "npm:^8.1.0"
-  checksum: 10/6ec05eb591c97bc856b0e78c12f5bec10545f3a749688f34232d189797a506d971bc95931718eb57b378d8513f6d2d12462383e6d68455fa72df35c19de6e89e
+  checksum: 10/5a322e29b81033e90ac50ab315d49559b21809ee39b5681ab7386819463e30d68e29c63c946023a1c353e7f13fb3f20d64dcb89d3d8a0fff569450501aff786c
   languageName: node
   linkType: hard
 

--- a/workspaces/servicenow/.changeset/renovate-894ecf2.md
+++ b/workspaces/servicenow/.changeset/renovate-894ecf2.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-servicenow-backend': patch
+---
+
+Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -51,7 +51,7 @@
     "@types/express": "^4.17.6",
     "@types/qs": "^6",
     "@types/simple-oauth2": "^5",
-    "@types/supertest": "^6.0.0",
+    "@types/supertest": "^7.0.0",
     "qs": "^6.14.0",
     "supertest": "^7.0.0"
   },

--- a/workspaces/servicenow/yarn.lock
+++ b/workspaces/servicenow/yarn.lock
@@ -1256,7 +1256,7 @@ __metadata:
     "@types/express": "npm:^4.17.6"
     "@types/qs": "npm:^6"
     "@types/simple-oauth2": "npm:^5"
-    "@types/supertest": "npm:^6.0.0"
+    "@types/supertest": "npm:^7.0.0"
     axios: "npm:^1.9.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -9620,13 +9620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/supertest@npm:^6.0.0":
-  version: 6.0.3
-  resolution: "@types/supertest@npm:6.0.3"
+"@types/supertest@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
   dependencies:
     "@types/methods": "npm:^1.1.4"
     "@types/superagent": "npm:^8.1.0"
-  checksum: 10/6ec05eb591c97bc856b0e78c12f5bec10545f3a749688f34232d189797a506d971bc95931718eb57b378d8513f6d2d12462383e6d68455fa72df35c19de6e89e
+  checksum: 10/5a322e29b81033e90ac50ab315d49559b21809ee39b5681ab7386819463e30d68e29c63c946023a1c353e7f13fb3f20d64dcb89d3d8a0fff569450501aff786c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Extracts some `@types/supertest` updates from #7895 for argocd, mcp-chat, quay, rbac and servicenow where I can poke people. This will make the other PR even easier to review.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
