### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/renovate-894ecf2.md
+++ b/workspaces/mcp-chat/.changeset/renovate-894ecf2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/mcp-chat/.changeset/version-bump-1-48-5.md
+++ b/workspaces/mcp-chat/.changeset/version-bump-1-48-5.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat': minor
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Backstage version bump to v1.48.5

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.7.0
+
+### Minor Changes
+
+- 158dbf4: Backstage version bump to v1.48.5
+
+### Patch Changes
+
+- 8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.6.1
 
 ### Patch Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-mcp-chat
 
+## 0.4.0
+
+### Minor Changes
+
+- 158dbf4: Backstage version bump to v1.48.5
+
 ## 0.3.1
 
 ### Patch Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-mcp-chat",
   "description": "A Backstage plugin that provides a chat interface for interacting with the MCP Servers.",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat@0.4.0

### Minor Changes

-   158dbf4: Backstage version bump to v1.48.5

## @backstage-community/plugin-mcp-chat-backend@0.7.0

### Minor Changes

-   158dbf4: Backstage version bump to v1.48.5

### Patch Changes

-   8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
