### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/renovate-48311be.md
+++ b/workspaces/argocd/.changeset/renovate-48311be.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-Updated dependency `@testing-library/react` to `^16.0.0`.
-Updated dependency `@testing-library/dom` to `10.4.1`.
-Updated dependency `@testing-library/jest-dom` to `^6.0.0`.

--- a/workspaces/argocd/.changeset/renovate-5edef33.md
+++ b/workspaces/argocd/.changeset/renovate-5edef33.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd-node': patch
----
-
-Updated dependency `undici` to `^7.24.2`.

--- a/workspaces/argocd/.changeset/renovate-894ecf2.md
+++ b/workspaces/argocd/.changeset/renovate-894ecf2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/argocd/.changeset/version-bump-1-48-5.md
+++ b/workspaces/argocd/.changeset/version-bump-1-48-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd-common': patch
-'@backstage-community/plugin-argocd-node': patch
----
-
-Backstage version bump to v1.48.5

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.2.1
+
+### Patch Changes
+
+- 399031e: Updated dependency `undici` to `^7.24.2`.
+- 8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
+- dc8e24e: Backstage version bump to v1.48.5
+- Updated dependencies [399031e]
+- Updated dependencies [dc8e24e]
+  - @backstage-community/plugin-argocd-node@1.0.1
+  - @backstage-community/plugin-argocd-common@1.14.1
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.14.1
+
+### Patch Changes
+
+- dc8e24e: Backstage version bump to v1.48.5
+
 ## 1.14.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-argocd-node
 
+## 1.0.1
+
+### Patch Changes
+
+- 399031e: Updated dependency `undici` to `^7.24.2`.
+- dc8e24e: Backstage version bump to v1.48.5
+- Updated dependencies [dc8e24e]
+  - @backstage-community/plugin-argocd-common@1.14.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/argocd/plugins/argocd-node/package.json
+++ b/workspaces/argocd/plugins/argocd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd
 
+## 2.7.1
+
+### Patch Changes
+
+- 0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
+  Updated dependency `@testing-library/dom` to `10.4.1`.
+  Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
+- dc8e24e: Backstage version bump to v1.48.5
+- Updated dependencies [dc8e24e]
+  - @backstage-community/plugin-argocd-common@1.14.1
+
 ## 2.7.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.7.1

### Patch Changes

-   0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
    Updated dependency `@testing-library/dom` to `10.4.1`.
    Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
-   dc8e24e: Backstage version bump to v1.48.5
-   Updated dependencies [dc8e24e]
    -   @backstage-community/plugin-argocd-common@1.14.1

## @backstage-community/plugin-argocd-backend@1.2.1

### Patch Changes

-   399031e: Updated dependency `undici` to `^7.24.2`.
-   8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
-   dc8e24e: Backstage version bump to v1.48.5
-   Updated dependencies [399031e]
-   Updated dependencies [dc8e24e]
    -   @backstage-community/plugin-argocd-node@1.0.1
    -   @backstage-community/plugin-argocd-common@1.14.1

## @backstage-community/plugin-argocd-common@1.14.1

### Patch Changes

-   dc8e24e: Backstage version bump to v1.48.5

## @backstage-community/plugin-argocd-node@1.0.1

### Patch Changes

-   399031e: Updated dependency `undici` to `^7.24.2`.
-   dc8e24e: Backstage version bump to v1.48.5
-   Updated dependencies [dc8e24e]
    -   @backstage-community/plugin-argocd-common@1.14.1
