### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/renovate-48311be.md
+++ b/workspaces/quay/.changeset/renovate-48311be.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@testing-library/react` to `^16.0.0`.
-Updated dependency `@testing-library/dom` to `10.4.1`.
-Updated dependency `@testing-library/jest-dom` to `^6.0.0`.

--- a/workspaces/quay/.changeset/renovate-894ecf2.md
+++ b/workspaces/quay/.changeset/renovate-894ecf2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/quay/.changeset/version-bump-1-48-5.md
+++ b/workspaces/quay/.changeset/version-bump-1-48-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
-'@backstage-community/plugin-scaffolder-backend-module-quay': patch
-'@backstage-community/plugin-quay-backend': patch
-'@backstage-community/plugin-quay-common': patch
----
-
-Backstage version bump to v1.48.5

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-quay
 
+## 2.17.1
+
+### Patch Changes
+
+- 46068bd: Backstage version bump to v1.48.5
+
 ## 2.17.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.13.1
+
+### Patch Changes
+
+- 8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
+- 46068bd: Backstage version bump to v1.48.5
+- Updated dependencies [46068bd]
+  - @backstage-community/plugin-quay-common@1.18.1
+
 ## 1.13.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.18.1
+
+### Patch Changes
+
+- 46068bd: Backstage version bump to v1.48.5
+
 ## 1.18.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay
 
+## 1.31.2
+
+### Patch Changes
+
+- 0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
+  Updated dependency `@testing-library/dom` to `10.4.1`.
+  Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
+- 46068bd: Backstage version bump to v1.48.5
+- Updated dependencies [46068bd]
+  - @backstage-community/plugin-quay-common@1.18.1
+
 ## 1.31.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.31.2

### Patch Changes

-   0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
    Updated dependency `@testing-library/dom` to `10.4.1`.
    Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
-   46068bd: Backstage version bump to v1.48.5
-   Updated dependencies [46068bd]
    -   @backstage-community/plugin-quay-common@1.18.1

## @backstage-community/plugin-scaffolder-backend-module-quay@2.17.1

### Patch Changes

-   46068bd: Backstage version bump to v1.48.5

## @backstage-community/plugin-quay-backend@1.13.1

### Patch Changes

-   8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
-   46068bd: Backstage version bump to v1.48.5
-   Updated dependencies [46068bd]
    -   @backstage-community/plugin-quay-common@1.18.1

## @backstage-community/plugin-quay-common@1.18.1

### Patch Changes

-   46068bd: Backstage version bump to v1.48.5
