### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/version-bump-1-48-5.md
+++ b/workspaces/rbac/.changeset/version-bump-1-48-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac-common': patch
-'@backstage-community/plugin-rbac-node': patch
----
-
-Backstage version bump to v1.48.5

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.9.1
+
+### Patch Changes
+
+- d737494: Backstage version bump to v1.48.5
+- Updated dependencies [d737494]
+  - @backstage-community/plugin-rbac-common@1.24.1
+  - @backstage-community/plugin-rbac-node@1.18.1
+
 ## 7.9.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.24.1
+
+### Patch Changes
+
+- d737494: Backstage version bump to v1.48.5
+
 ## 1.24.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.18.1
+
+### Patch Changes
+
+- d737494: Backstage version bump to v1.48.5
+
 ## 1.18.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-rbac
 
+## 1.50.2
+
+### Patch Changes
+
+- d737494: Backstage version bump to v1.48.5
+- Updated dependencies [d737494]
+  - @backstage-community/plugin-rbac-common@1.24.1
+
 ## 1.50.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.50.2

### Patch Changes

-   d737494: Backstage version bump to v1.48.5
-   Updated dependencies [d737494]
    -   @backstage-community/plugin-rbac-common@1.24.1

## @backstage-community/plugin-rbac-backend@7.9.1

### Patch Changes

-   d737494: Backstage version bump to v1.48.5
-   Updated dependencies [d737494]
    -   @backstage-community/plugin-rbac-common@1.24.1
    -   @backstage-community/plugin-rbac-node@1.18.1

## @backstage-community/plugin-rbac-common@1.24.1

### Patch Changes

-   d737494: Backstage version bump to v1.48.5

## @backstage-community/plugin-rbac-node@1.18.1

### Patch Changes

-   d737494: Backstage version bump to v1.48.5
