### PR TITLE
feat: update GitHub issues API to support fetching issues by repository host

### DIFF
--- a/workspaces/github/.changeset/twelve-donuts-knock.md
+++ b/workspaces/github/.changeset/twelve-donuts-knock.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-issues': minor
+---
+
+allows github issues plugin to work with multiple github instances and solves crash when group was not an entity managed by a github url

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -131,43 +131,93 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/yo.yo'),
         ],
         10,
-        'github.com',
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
       expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
     });
 
-    it('should only fetch data for entities hosted in the same GitHub instance as is entity location', async () => {
+    it('should fetch data for repositories grouped by GitHub host', async () => {
       await api.fetchIssuesByRepoFromGithub(
         [
           entityRepository('mrwolny/yo-yo'),
           entityRepository('mrwolny/yoyo'),
           entityRepository('mrwolny/yo.yo'),
-          entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
+          entityRepository('mrwolny/another-repo', 'enterprise.github.com'),
         ],
         10,
-        'github.com',
       );
 
-      expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
-      expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
+      expect(mockGraphQLQuery).toHaveBeenCalledTimes(2);
+      expect(mockGraphQLQuery).toHaveBeenNthCalledWith(1, getFragment());
+      expect(mockGraphQLQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(
+          'anotherrepo: repository(name: "another-repo", owner: "mrwolny")',
+        ),
+      );
     });
 
-    it("should only fetch data for entities hosted in the same GitHub instance as the plugin's first config if no config matches", async () => {
+    it('should merge issues from repositories across different GitHub hosts', async () => {
+      mockGraphQLQuery
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            yoyo: {
+              issues: {
+                totalCount: 1,
+                edges: [],
+              },
+            },
+          }),
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            anotherrepo: {
+              issues: {
+                totalCount: 2,
+                edges: [],
+              },
+            },
+          }),
+        );
+
+      const data = await api.fetchIssuesByRepoFromGithub(
+        [
+          entityRepository('mrwolny/yo-yo'),
+          entityRepository('mrwolny/another-repo', 'enterprise.github.com'),
+        ],
+        10,
+      );
+
+      expect(data).toEqual({
+        'mrwolny/yo-yo': {
+          issues: {
+            totalCount: 1,
+            edges: [],
+          },
+        },
+        'mrwolny/another-repo': {
+          issues: {
+            totalCount: 2,
+            edges: [],
+          },
+        },
+      });
+    });
+
+    it('should ignore repositories without hostname', async () => {
       await api.fetchIssuesByRepoFromGithub(
         [
           entityRepository('mrwolny/yo-yo'),
-          entityRepository('mrwolny/yoyo'),
-          entityRepository('mrwolny/yo.yo'),
-          entityRepository('mrwolny/another-repo', 'enterprise.github.com'), // This one should be filtered out
+          {
+            name: 'mrwolny/no-hostname',
+            locationHostname: '',
+          },
         ],
         10,
-        'enterprise.github.com',
       );
 
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
-      expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
     });
 
     it('should call Github API with the correct filterBy and orderBy clauses', async () => {
@@ -178,7 +228,6 @@ describe('githubIssuesApi', () => {
           entityRepository('mrwolny/yo.yo'),
         ],
         10,
-        'github.com',
         {
           filterBy: {
             labels: ['bug'],
@@ -290,7 +339,6 @@ describe('githubIssuesApi', () => {
     const data = await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/yo-yo'), entityRepository('mrwolny/notfound')],
       10,
-      'github.com',
     );
 
     expect(data).toEqual({
@@ -361,7 +409,6 @@ describe('githubIssuesApi', () => {
     const data = await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/notfound')],
       10,
-      'github.com',
     );
 
     expect(data).toEqual({});
@@ -403,7 +450,6 @@ describe('githubIssuesApi', () => {
     await api.fetchIssuesByRepoFromGithub(
       [entityRepository('mrwolny/notfound')],
       10,
-      'github.com',
     );
 
     expect(mockErrorApi.post).toHaveBeenCalledTimes(1);

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -133,13 +133,13 @@ export const githubIssuesApi = (
     });
 
     const baseUrl = githubIntegrationConfig?.apiBaseUrl;
-    return { octokit: new Octokit({ auth: token, baseUrl }), host };
+    return { octokit: new Octokit({ auth: token, baseUrl }) };
   };
 
-  const fetchIssuesByRepoFromGithub = async (
+  const fetchIssuesByRepoFromHost = async (
+    hostname: string,
     repos: Array<Repository>,
     itemsPerRepo: number,
-    hostname: string,
     {
       filterBy,
       orderBy = {
@@ -148,35 +148,29 @@ export const githubIssuesApi = (
       },
     }: GithubIssuesByRepoOptions = {},
   ): Promise<IssuesByRepo> => {
-    const { octokit, host } = await getOctokit(hostname);
+    const { octokit } = await getOctokit(hostname);
     const safeNames: Array<string> = [];
-    const repositories = repos
-      // only tries to fetch issues from repositories that are hosted on the same GitHub instance as the octokit
-      .filter(repo => repo.locationHostname === host)
-      .map(repo => {
-        const [owner, name] = repo.name.split('/');
+    const repositories = repos.map(repo => {
+      const [owner, name] = repo.name.split('/');
 
-        const safeNameRegex = /-|\./gi;
-        let safeName = name.replace(safeNameRegex, '');
+      const safeNameRegex = /-|\./gi;
+      let safeName = name.replace(safeNameRegex, '');
 
-        while (safeNames.includes(safeName)) {
-          safeName += 'x';
-        }
+      while (safeNames.includes(safeName)) {
+        safeName += 'x';
+      }
 
-        safeNames.push(safeName);
+      safeNames.push(safeName);
 
-        return {
-          safeName,
-          name,
-          owner,
-        };
-      });
+      return {
+        safeName,
+        name,
+        owner,
+      };
+    });
 
     let issuesByRepo: IssuesByRepo = {};
     try {
-      if (repositories.length === 0) {
-        throw new Error(`No repositories found for ${host}`);
-      }
       issuesByRepo = await octokit.graphql(
         createIssueByRepoQuery(repositories, itemsPerRepo, {
           filterBy,
@@ -198,6 +192,37 @@ export const githubIssuesApi = (
 
       return acc;
     }, {} as IssuesByRepo);
+  };
+
+  const fetchIssuesByRepoFromGithub = async (
+    repos: Array<Repository>,
+    itemsPerRepo: number,
+    options: GithubIssuesByRepoOptions = {},
+  ): Promise<IssuesByRepo> => {
+    const reposByHost = repos.reduce<Record<string, Array<Repository>>>(
+      (acc, repo) => {
+        if (!repo.locationHostname) {
+          return acc;
+        }
+
+        acc[repo.locationHostname] = acc[repo.locationHostname] ?? [];
+        acc[repo.locationHostname].push(repo);
+
+        return acc;
+      },
+      {},
+    );
+
+    const issuesByRepoByHost = await Promise.all(
+      Object.entries(reposByHost).map(([hostname, hostRepos]) =>
+        fetchIssuesByRepoFromHost(hostname, hostRepos, itemsPerRepo, options),
+      ),
+    );
+
+    return issuesByRepoByHost.reduce(
+      (acc, issuesByRepo) => ({ ...acc, ...issuesByRepo }),
+      {},
+    );
   };
 
   return { fetchIssuesByRepoFromGithub };

--- a/workspaces/github/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
+++ b/workspaces/github/plugins/github-issues/src/hooks/useGetIssuesByRepoFromGithub.ts
@@ -21,8 +21,6 @@ import {
   githubIssuesApiRef,
   GithubIssuesByRepoOptions,
 } from '../api';
-import { useEntity } from '@backstage/plugin-catalog-react';
-import { getHostnameFromEntity } from './useEntityGithubRepositories';
 
 export const useGetIssuesByRepoFromGithub = (
   repos: Array<Repository>,
@@ -30,8 +28,6 @@ export const useGetIssuesByRepoFromGithub = (
   options?: GithubIssuesByRepoOptions,
 ) => {
   const githubIssuesApi = useApi(githubIssuesApiRef);
-  const { entity } = useEntity();
-  const hostname = getHostnameFromEntity(entity);
 
   const {
     value: issues,
@@ -42,7 +38,6 @@ export const useGetIssuesByRepoFromGithub = (
       return await githubIssuesApi.fetchIssuesByRepoFromGithub(
         repos,
         itemsPerRepo,
-        hostname,
         options,
       );
     }


### PR DESCRIPTION


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Problem

1. Not all groups are (github groups), some are manually created groups and they don't have locations that are valid URLs. WHen this is the case, the application crashes when trying to parse the hostname from the URL.
2. A Group can own Github Repositories across multiple github hosts

By moving the hostname discovery from the Group to the Repo (and splitting the query into one per github host) we solve both problems.

This allows groups that are not synced from Github to still use the plugin + adds a new feature that allows you to see all of your issues across multiple github instances.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
