### PR TITLE
fix(announcements): ensure banner is always on top by setting zIndex

### DIFF
--- a/workspaces/announcements/.changeset/lemon-pillows-kneel.md
+++ b/workspaces/announcements/.changeset/lemon-pillows-kneel.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Ensure that Announcement banner is always on top of the page. It fixes the issue where the banner could be hidden behind existing page content.

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -54,6 +54,7 @@ const floatingStyle: React.CSSProperties = {
   top: 20,
   left: '50%',
   transform: 'translateX(-50%)',
+  zIndex: 9999,
 };
 
 const externalLinkIconStyle: React.CSSProperties = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change fixes #8155 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
