### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/lemon-pillows-kneel.md
+++ b/workspaces/announcements/.changeset/lemon-pillows-kneel.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Ensure that Announcement banner is always on top of the page. It fixes the issue where the banner could be hidden behind existing page content.

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements
 
+## 2.5.1
+
+### Patch Changes
+
+- c4d2f14: Ensure that Announcement banner is always on top of the page. It fixes the issue where the banner could be hidden behind existing page content.
+
 ## 2.5.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@2.5.1

### Patch Changes

-   c4d2f14: Ensure that Announcement banner is always on top of the page. It fixes the issue where the banner could be hidden behind existing page content.
