### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/renovate-48311be.md
+++ b/workspaces/servicenow/.changeset/renovate-48311be.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': patch
----
-
-Updated dependency `@testing-library/react` to `^16.0.0`.
-Updated dependency `@testing-library/dom` to `10.4.1`.
-Updated dependency `@testing-library/jest-dom` to `^6.0.0`.

--- a/workspaces/servicenow/.changeset/renovate-894ecf2.md
+++ b/workspaces/servicenow/.changeset/renovate-894ecf2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/servicenow/.changeset/version-bump-1-49-2.md
+++ b/workspaces/servicenow/.changeset/version-bump-1-49-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
----
-
-Backstage version bump to v1.49.2

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.10.0
+
+### Minor Changes
+
+- a229130: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- 8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
+- Updated dependencies [a229130]
+  - @backstage-community/plugin-servicenow-common@1.9.0
+
 ## 1.9.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-servicenow-common
 
+## 1.9.0
+
+### Minor Changes
+
+- a229130: Backstage version bump to v1.49.2
+
 ## 1.8.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-common/package.json
+++ b/workspaces/servicenow/plugins/servicenow-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-common",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the servicenow plugin",
   "main": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-servicenow
 
+## 1.10.0
+
+### Minor Changes
+
+- a229130: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- 0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
+  Updated dependency `@testing-library/dom` to `10.4.1`.
+  Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
+- Updated dependencies [a229130]
+  - @backstage-community/plugin-servicenow-common@1.9.0
+
 ## 1.9.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.10.0

### Minor Changes

-   a229130: Backstage version bump to v1.49.2

### Patch Changes

-   0467b33: Updated dependency `@testing-library/react` to `^16.0.0`.
    Updated dependency `@testing-library/dom` to `10.4.1`.
    Updated dependency `@testing-library/jest-dom` to `^6.0.0`.
-   Updated dependencies [a229130]
    -   @backstage-community/plugin-servicenow-common@1.9.0

## @backstage-community/plugin-servicenow-backend@1.10.0

### Minor Changes

-   a229130: Backstage version bump to v1.49.2

### Patch Changes

-   8a6b81c: Updated dependency `@types/supertest` to `^7.0.0`.
-   Updated dependencies [a229130]
    -   @backstage-community/plugin-servicenow-common@1.9.0

## @backstage-community/plugin-servicenow-common@1.9.0

### Minor Changes

-   a229130: Backstage version bump to v1.49.2
