### PR TITLE
Fix/dynatrace mui to bui migration

### DIFF
--- a/workspaces/dynatrace/.changeset/odd-turtles-warn.md
+++ b/workspaces/dynatrace/.changeset/odd-turtles-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-dynatrace': patch
+---
+
+Migrated from Material UI (MUI) to Backstage UI (BUI). Replaced `@material-ui/core` dependency with `@backstage/ui`, updated `Grid` usage in `DynatraceTab` and replaced `Chip` with `Box` and `Text` components in `SyntheticsLocation`.

--- a/workspaces/dynatrace/plugins/dynatrace/package.json
+++ b/workspaces/dynatrace/plugins/dynatrace/package.json
@@ -40,7 +40,7 @@
     "@backstage/catalog-model": "backstage:^",
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
-    "@material-ui/core": "^4.12.2",
+    "@backstage/ui": "backstage:^",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-use": "^17.2.4"
   },

--- a/workspaces/dynatrace/plugins/dynatrace/src/components/DynatraceTab/DynatraceTab.tsx
+++ b/workspaces/dynatrace/plugins/dynatrace/src/components/DynatraceTab/DynatraceTab.tsx
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Grid from '@material-ui/core/Grid';
 import { Page, Content } from '@backstage/core-components';
+import { Grid } from '@backstage/ui';
 import {
   useEntity,
   MissingAnnotationEmptyState,
@@ -43,25 +43,23 @@ export const DynatraceTab = () => {
   return (
     <Page themeId="tool">
       <Content>
-        <Grid container spacing={2}>
-          {dynatraceEntityId ? (
-            <Grid item xs={12} lg={12}>
+        <Grid.Root columns="1" gap="4">
+          {dynatraceEntityId && (
+            <Grid.Item>
               <ProblemsList dynatraceEntityId={dynatraceEntityId} />
-            </Grid>
-          ) : (
-            ''
+            </Grid.Item>
           )}
           {syntheticsIds
             ?.split(/[ ,]/)
             .filter(Boolean)
             .map(id => {
               return (
-                <Grid key={id} item xs={12} lg={12}>
+                <Grid.Item key={id}>
                   <SyntheticsCard syntheticsId={id} />
-                </Grid>
+                </Grid.Item>
               );
             })}
-        </Grid>
+        </Grid.Root>
       </Content>
     </Page>
   );

--- a/workspaces/dynatrace/plugins/dynatrace/src/components/Synthetics/SyntheticsLocation/SyntheticsLocation.tsx
+++ b/workspaces/dynatrace/plugins/dynatrace/src/components/Synthetics/SyntheticsLocation/SyntheticsLocation.tsx
@@ -17,7 +17,7 @@
 import useAsync from 'react-use/esm/useAsync';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import Chip from '@material-ui/core/Chip';
+import { Box, Text } from '@backstage/ui';
 import { dynatraceApiRef } from '../../../api';
 
 type SyntheticsLocationProps = {
@@ -32,17 +32,14 @@ const failedInLastXHours = (timestamp: Date, offset: number): boolean => {
   return timestamp > new Date(new Date().getTime() - 1000 * 60 * 60 * offset);
 };
 
-const chipColor = (timestamp: Date): string => {
+const chipColor = (timestamp: Date): 'danger' | 'warning' | 'success' => {
   if (failedInLastXHours(timestamp, 1)) {
-    return 'salmon';
-  }
-  if (failedInLastXHours(timestamp, 6)) {
-    return 'sandybrown';
+    return 'danger';
   }
   if (failedInLastXHours(timestamp, 24)) {
-    return 'palegoldenrod';
+    return 'warning';
   }
-  return 'lightgreen';
+  return 'success';
 };
 
 export const SyntheticsLocation = (props: SyntheticsLocationProps) => {
@@ -61,14 +58,24 @@ export const SyntheticsLocation = (props: SyntheticsLocationProps) => {
   }
 
   return (
-    <Chip
-      label={`${value?.name}${
-        failedInLastXHours(new Date(lastFailedTimestamp), 24)
-          ? `: failed @ ${lastFailedTimestamp.toLocaleTimeString()}`
-          : ''
-      }`}
-      size="medium"
-      style={{ backgroundColor: chipColor(lastFailedTimestamp) }}
-    />
+    <Box
+      as="span"
+      style={{
+        alignItems: 'center',
+        border: '1px solid var(--bui-border)',
+        borderRadius: '999px',
+        display: 'inline-flex',
+        minHeight: '32px',
+        padding: '0 12px',
+      }}
+    >
+      <Text variant="body-small" color={chipColor(lastFailedTimestamp)}>
+        {`${value?.name}${
+          failedInLastXHours(new Date(lastFailedTimestamp), 24)
+            ? `: failed @ ${lastFailedTimestamp.toLocaleTimeString()}`
+            : ''
+        }`}
+      </Text>
+    </Box>
   );
 };

--- a/workspaces/dynatrace/yarn.lock
+++ b/workspaces/dynatrace/yarn.lock
@@ -364,7 +364,7 @@ __metadata:
     "@backstage/dev-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@material-ui/core": "npm:^4.12.2"
+    "@backstage/ui": "backstage:^"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
@@ -1250,7 +1250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.12.0":
+"@backstage/ui@backstage:^::backstage=1.48.2&npm=0.12.0, @backstage/ui@npm:^0.12.0":
   version: 0.12.0
   resolution: "@backstage/ui@npm:0.12.0"
   dependencies:
@@ -2108,7 +2108,7 @@ __metadata:
     knip: "npm:^5.27.4"
     node-gyp: "npm:^10.0.0"
     prettier: "npm:^2.3.2"
-    typescript: "npm:~5.3.0"
+    typescript: "npm:^5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -19772,13 +19772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.3.0":
-  version: 5.3.3
-  resolution: "typescript@npm:5.3.3"
+"typescript@npm:^5.4.5":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/6e4e6a14a50c222b3d14d4ea2f729e79f972fa536ac1522b91202a9a65af3605c2928c4a790a4a50aa13694d461c479ba92cedaeb1e7b190aadaa4e4b96b8e18
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
   languageName: node
   linkType: hard
 
@@ -19802,13 +19802,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.3.0#optional!builtin<compat/typescript>":
-  version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+"typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c93786fcc9a70718ba1e3819bab56064ead5817004d1b8186f8ca66165f3a2d0100fee91fa64c840dcd45f994ca5d615d8e1f566d39a7470fc1e014dbb4cf15d
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the dynatrace plugin from Material UI (MUI) to Backstage UI (BUI) as part of [#7869](vscode-file://vscode-app/c:/Users/deepthi.ajith/AppData/Local/Programs/Microsoft%20VS%20Code/07ff9d6178/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
