### PR TITLE
Version Packages (report-portal)

### DIFF
--- a/workspaces/report-portal/.changeset/few-needles-jump.md
+++ b/workspaces/report-portal/.changeset/few-needles-jump.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-report-portal': minor
-'@backstage-community/plugin-report-portal': minor
----
-
-Support multiple ReportPortal launches per entity with comma separated launch names and accordion UI

--- a/workspaces/report-portal/plugins/report-portal/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/report-portal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-report-portal
 
+## 1.6.0
+
+### Minor Changes
+
+- f11e6c6: Support multiple ReportPortal launches per entity with comma separated launch names and accordion UI
+
 ## 1.5.1
 
 ### Patch Changes

--- a/workspaces/report-portal/plugins/report-portal/package.json
+++ b/workspaces/report-portal/plugins/report-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-report-portal",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/CHANGELOG.md
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-report-portal
 
+## 1.2.0
+
+### Minor Changes
+
+- f11e6c6: Support multiple ReportPortal launches per entity with comma separated launch names and accordion UI
+
 ## 1.1.3
 
 ### Patch Changes

--- a/workspaces/report-portal/plugins/search-backend-module-report-portal/package.json
+++ b/workspaces/report-portal/plugins/search-backend-module-report-portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-report-portal",
   "description": "The report-portal-collator backend module for the search plugin.",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-report-portal@1.6.0

### Minor Changes

-   f11e6c6: Support multiple ReportPortal launches per entity with comma separated launch names and accordion UI

## @backstage-community/plugin-search-backend-module-report-portal@1.2.0

### Minor Changes

-   f11e6c6: Support multiple ReportPortal launches per entity with comma separated launch names and accordion UI
