### PR TITLE
fix(report-portal): fix accordion summary spacing on newer MUI versions

### DIFF
--- a/workspaces/report-portal/.changeset/metal-windows-share.md
+++ b/workspaces/report-portal/.changeset/metal-windows-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-report-portal': patch
+---
+
+Fix accordion summary spacing for launch name and count on newer MUI versions

--- a/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalOverviewCard/ReportPortalOverviewCard.tsx
+++ b/workspaces/report-portal/plugins/report-portal/src/components/ReportPortalOverviewCard/ReportPortalOverviewCard.tsx
@@ -253,7 +253,7 @@ const MultiLaunchCard = (props: {
                 <Typography
                   variant="body2"
                   component="span"
-                  style={{ whiteSpace: 'nowrap', marginLeft: 'auto' }}
+                  style={{ whiteSpace: 'nowrap', marginLeft: '16px' }}
                 >
                   {total} (
                   <Typography


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- `marginLeft: 'auto'` on the accordion summary count doesn't work reliably when combined with `flexGrow: 1` on newer MUI versions (e.g., 5.18.0), causing the launch name and count to render without spacing
- Replaced with explicit `marginLeft: '16px'` which works consistently across MUI versions

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
