### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/version-bump-1-49-2.md
+++ b/workspaces/argocd/.changeset/version-bump-1-49-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
-'@backstage-community/plugin-argocd-backend': minor
-'@backstage-community/plugin-argocd-common': minor
-'@backstage-community/plugin-argocd-node': minor
----
-
-Backstage version bump to v1.49.2

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.3.0
+
+### Minor Changes
+
+- 265995b: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- Updated dependencies [265995b]
+  - @backstage-community/plugin-argocd-common@1.15.0
+  - @backstage-community/plugin-argocd-node@1.1.0
+
 ## 1.2.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.15.0
+
+### Minor Changes
+
+- 265995b: Backstage version bump to v1.49.2
+
 ## 1.14.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd-node
 
+## 1.1.0
+
+### Minor Changes
+
+- 265995b: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- Updated dependencies [265995b]
+  - @backstage-community/plugin-argocd-common@1.15.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd-node/package.json
+++ b/workspaces/argocd/plugins/argocd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-node",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd
 
+## 2.8.0
+
+### Minor Changes
+
+- 265995b: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- Updated dependencies [265995b]
+  - @backstage-community/plugin-argocd-common@1.15.0
+
 ## 2.7.1
 
 ### Patch Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.8.0

### Minor Changes

-   265995b: Backstage version bump to v1.49.2

### Patch Changes

-   Updated dependencies [265995b]
    -   @backstage-community/plugin-argocd-common@1.15.0

## @backstage-community/plugin-argocd-backend@1.3.0

### Minor Changes

-   265995b: Backstage version bump to v1.49.2

### Patch Changes

-   Updated dependencies [265995b]
    -   @backstage-community/plugin-argocd-common@1.15.0
    -   @backstage-community/plugin-argocd-node@1.1.0

## @backstage-community/plugin-argocd-common@1.15.0

### Minor Changes

-   265995b: Backstage version bump to v1.49.2

## @backstage-community/plugin-argocd-node@1.1.0

### Minor Changes

-   265995b: Backstage version bump to v1.49.2

### Patch Changes

-   Updated dependencies [265995b]
    -   @backstage-community/plugin-argocd-common@1.15.0
