### PR TITLE
chore(repo/entity-feedback): remove workspace-specific changeset and update entity-feedback changelog

### DIFF
--- a/.changeset/feedback-notification-links.md
+++ b/.changeset/feedback-notification-links.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': patch
-'@backstage-community/plugin-entity-feedback': patch
-'@backstage-community/plugin-entity-feedback-common': patch
----
-
-Add clickable link to feedback notifications. When entity owners receive notifications about new feedback, the notification now includes a link to navigate directly to the entity page. The entity URL is derived from the frontend routing configuration using the same logic as `EntityRefLink`, ensuring it always matches the actual routes configured in the app without requiring additional backend configuration.

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Patch Changes
 
+- c92a717: Add clickable link to feedback notifications. When entity owners receive notifications about new feedback, the notification now includes a link to navigate directly to the entity page. The entity URL is derived from the frontend routing configuration using the same logic as `EntityRefLink`, ensuring it always matches the actual routes configured in the app without requiring additional backend configuration.
 - Updated dependencies [227f90a]
   - @backstage-community/plugin-entity-feedback-common@0.13.0
 

--- a/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-common/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - 227f90a: Backstage version bump to v1.47.2
 
+### Patch Changes
+
+- c92a717: Add clickable link to feedback notifications. When entity owners receive notifications about new feedback, the notification now includes a link to navigate directly to the entity page. The entity URL is derived from the frontend routing configuration using the same logic as `EntityRefLink`, ensuring it always matches the actual routes configured in the app without requiring additional backend configuration.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Patch Changes
 
+- c92a717: Add clickable link to feedback notifications. When entity owners receive notifications about new feedback, the notification now includes a link to navigate directly to the entity page. The entity URL is derived from the frontend routing configuration using the same logic as `EntityRefLink`, ensuring it always matches the actual routes configured in the app without requiring additional backend configuration.
 - Updated dependencies [227f90a]
   - @backstage-community/plugin-entity-feedback-common@0.13.0
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Nothing to add, cleaning up `.changeset` folder in repo root and added the changelog to the already released changelog.

Origin PR #6611 -- see also #8353 for the other existing changeset

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
