### PR TITLE
chore(topology): fix changeset crash and plugin release issue

### DIFF
--- a/workspaces/topology/.changeset/renovate-f948b3a.md
+++ b/workspaces/topology/.changeset/renovate-f948b3a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Updated dependency `@backstage-community/plugin-tekton-react` to `^0.3.0`.

--- a/workspaces/topology/.changeset/update-available-languages.md
+++ b/workspaces/topology/.changeset/update-available-languages.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-acr': patch
+'@backstage-community/plugin-topology': patch
 ---
 
 Translation updated for German and Spanish

--- a/workspaces/topology/.changeset/version-bump-1-48-4.md
+++ b/workspaces/topology/.changeset/version-bump-1-48-4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-Backstage version bump to v1.48.4

--- a/workspaces/topology/.changeset/version-bump-1-48-5.md
+++ b/workspaces/topology/.changeset/version-bump-1-48-5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Backstage version bump to v1.48.5


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The topology package wasn't released for some time due a tiny typo in one of the changesets.

Latest job https://github.com/backstage/community-plugins/actions/runs/23649750442/job/68891230296#logs failed with

<img width="2211" height="747" alt="image" src="https://github.com/user-attachments/assets/3cf77376-617d-4655-b63e-53a473bc0fbf" />

I fixed the typo in one changesets and removed three changesets because there is included in another changesets: `@backstage-community/plugin-tekton-react` to `^0.4.0` and another changeset says "Backstage version bump to v1.49.2". These would be just result in duplicated lines in the same release.

Local validation...

Before:

```
yarn changeset status
🦋  error TypeError: Cannot destructure property 'packageJson' of 'undefined' as it is undefined.
🦋  error     at Object.shouldSkipPackage (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/should-skip-package/dist/changesets-should-skip-package.cjs.js:6:3)
🦋  error     at getRelevantChangesets (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:608:29)
🦋  error     at Object.assembleReleasePlan [as default] (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/assemble-release-plan/dist/changesets-assemble-release-plan.cjs.js:536:30)
🦋  error     at Object.getReleasePlan [as default] (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/get-release-plan/dist/changesets-get-release-plan.cjs.js:71:49)
🦋  error     at async status (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1135:23)
🦋  error     at async run (/home/christoph/git/backstage/community-plugins/workspaces/topology/node_modules/@changesets/cli/dist/changesets-cli.cjs.js:1481:11)
```

With this change:

```
yarn changeset status
Package "backend" must depend on the current version of "app": "0.0.0" vs "link:../app"
🦋  info NO packages to be bumped at patch
🦋  ---
🦋  info Packages to be bumped at minor:
🦋  info 
🦋  - @backstage-community/plugin-topology
🦋  ---
🦋  info NO packages to be bumped at major
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
