### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/eleven-ghosts-play.md
+++ b/workspaces/topology/.changeset/eleven-ghosts-play.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Add (already used) Material UI v4 and mobx-react dependency to resolve linter issues.

--- a/workspaces/topology/.changeset/renovate-3c0371e.md
+++ b/workspaces/topology/.changeset/renovate-3c0371e.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Updated dependency `@backstage-community/plugin-tekton-react` to `^0.4.0`.

--- a/workspaces/topology/.changeset/update-available-languages.md
+++ b/workspaces/topology/.changeset/update-available-languages.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Translation updated for German and Spanish

--- a/workspaces/topology/.changeset/version-bump-1-49-2.md
+++ b/workspaces/topology/.changeset/version-bump-1-49-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-Backstage version bump to v1.49.2

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-topology
 
+## 2.12.0
+
+### Minor Changes
+
+- 9deb41e: Backstage version bump to v1.49.2
+
+### Patch Changes
+
+- 29fd2da: Add (already used) Material UI v4 and mobx-react dependency to resolve linter issues.
+- 9c24b43: Updated dependency `@backstage-community/plugin-tekton-react` to `^0.4.0`.
+- 1d15595: Translation updated for German and Spanish
+
 ## 2.11.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.12.0

### Minor Changes

-   9deb41e: Backstage version bump to v1.49.2

### Patch Changes

-   29fd2da: Add (already used) Material UI v4 and mobx-react dependency to resolve linter issues.
-   9c24b43: Updated dependency `@backstage-community/plugin-tekton-react` to `^0.4.0`.
-   1d15595: Translation updated for German and Spanish
