### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/dry-cars-hang.md
+++ b/workspaces/mcp-chat/.changeset/dry-cars-hang.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Migrating away from deprecated @google/generative-ai npm package to new @google/genai for gemini provider

--- a/workspaces/mcp-chat/.changeset/short-wasps-fly.md
+++ b/workspaces/mcp-chat/.changeset/short-wasps-fly.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Added support for debugging LLM calls

--- a/workspaces/mcp-chat/.changeset/version-bump-1-49-2.md
+++ b/workspaces/mcp-chat/.changeset/version-bump-1-49-2.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat': minor
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Backstage version bump to v1.49.2
-
-Updated `uuid` and `@types/uuid` to ^11.0.0, `@backstage/plugin-catalog-node` to ^2.1.0, and deduplicated yarn.lock

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.8.0
+
+### Minor Changes
+
+- 1b22981: Migrating away from deprecated @google/generative-ai npm package to new @google/genai for gemini provider
+- a81325a: Added support for debugging LLM calls
+- 3e01b82: Backstage version bump to v1.49.2
+
+  Updated `uuid` and `@types/uuid` to ^11.0.0, `@backstage/plugin-catalog-node` to ^2.1.0, and deduplicated yarn.lock
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-mcp-chat
 
+## 0.6.0
+
+### Minor Changes
+
+- 3e01b82: Backstage version bump to v1.49.2
+
+  Updated `uuid` and `@types/uuid` to ^11.0.0, `@backstage/plugin-catalog-node` to ^2.1.0, and deduplicated yarn.lock
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-mcp-chat",
   "description": "A Backstage plugin that provides a chat interface for interacting with the MCP Servers.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat@0.6.0

### Minor Changes

-   3e01b82: Backstage version bump to v1.49.2

    Updated `uuid` and `@types/uuid` to ^11.0.0, `@backstage/plugin-catalog-node` to ^2.1.0, and deduplicated yarn.lock

## @backstage-community/plugin-mcp-chat-backend@0.8.0

### Minor Changes

-   1b22981: Migrating away from deprecated @google/generative-ai npm package to new @google/genai for gemini provider
-   a81325a: Added support for debugging LLM calls
-   3e01b82: Backstage version bump to v1.49.2

    Updated `uuid` and `@types/uuid` to ^11.0.0, `@backstage/plugin-catalog-node` to ^2.1.0, and deduplicated yarn.lock
