### PR TITLE
adding de and es locales to e2e localization tests

### DIFF
--- a/workspaces/acr/playwright.config.ts
+++ b/workspaces/acr/playwright.config.ts
@@ -71,5 +71,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: './plugins/acr/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: './plugins/acr/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/acr/plugins/acr/tests/utils/acrHelper.ts
+++ b/workspaces/acr/plugins/acr/tests/utils/acrHelper.ts
@@ -59,7 +59,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/argocd/playwright.config.ts
+++ b/workspaces/argocd/playwright.config.ts
@@ -68,5 +68,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: './plugins/argocd/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: './plugins/argocd/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
+++ b/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
@@ -106,7 +106,7 @@ test.describe('ArgoCD plugin', () => {
       ];
       for (const col of columns) {
         await expect(
-          argocdPage.getByRole('columnheader', { name: col }),
+          argocdPage.getByRole('columnheader', { name: col, exact: true }),
         ).toBeVisible();
       }
       await runAccessibilityTests(argocdPage);

--- a/workspaces/argocd/plugins/argocd/tests/utils/argocdHelper.ts
+++ b/workspaces/argocd/plugins/argocd/tests/utils/argocdHelper.ts
@@ -66,7 +66,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/argocd/plugins/argocd/tests/utils/translations.ts
+++ b/workspaces/argocd/plugins/argocd/tests/utils/translations.ts
@@ -17,6 +17,8 @@
 // These translation files are not exported by the package, so relative imports are necessary for e2e tests
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { argocdMessages } from '../../src/translations/ref.js';
+import argocdTranslationDe from '../../src/translations/de.js';
+import argocdTranslationEs from '../../src/translations/es.js';
 import argocdTranslationFr from '../../src/translations/fr.js';
 import argocdTranslationIt from '../../src/translations/it.js';
 import argocdTranslationJa from '../../src/translations/ja.js';
@@ -51,6 +53,10 @@ export function getTranslations(locale: string): ArgoCDMessages {
   switch (base) {
     case 'en':
       return argocdMessages;
+    case 'de':
+      return transform(argocdTranslationDe.messages);
+    case 'es':
+      return transform(argocdTranslationEs.messages);
     case 'fr':
       return transform(argocdTranslationFr.messages);
     case 'it':

--- a/workspaces/jfrog-artifactory/playwright.config.ts
+++ b/workspaces/jfrog-artifactory/playwright.config.ts
@@ -70,5 +70,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: 'plugins/jfrog-artifactory/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: 'plugins/jfrog-artifactory/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/tests/utils/helpers.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/tests/utils/helpers.ts
@@ -46,7 +46,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/nexus-repository-manager/playwright.config.ts
+++ b/workspaces/nexus-repository-manager/playwright.config.ts
@@ -70,5 +70,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: 'plugins/nexus-repository-manager/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: 'plugins/nexus-repository-manager/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/tests/utils/helpers.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/tests/utils/helpers.ts
@@ -46,7 +46,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/rbac/playwright.config.ts
+++ b/workspaces/rbac/playwright.config.ts
@@ -67,5 +67,17 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      use: {
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      use: {
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/rbac/plugins/rbac/tests/utils/rbacHelper.ts
+++ b/workspaces/rbac/plugins/rbac/tests/utils/rbacHelper.ts
@@ -88,7 +88,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/servicenow/playwright.config.ts
+++ b/workspaces/servicenow/playwright.config.ts
@@ -72,5 +72,19 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/servicenow/plugins/servicenow/tests/util/helpers.ts
+++ b/workspaces/servicenow/plugins/servicenow/tests/util/helpers.ts
@@ -39,7 +39,8 @@ export class Common {
 
   async switchToLocale(locale: string) {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/tekton/playwright.config.ts
+++ b/workspaces/tekton/playwright.config.ts
@@ -78,5 +78,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: './plugins/tekton/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: './plugins/tekton/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/tekton/plugins/tekton/tests/utils/tektonHelper.ts
+++ b/workspaces/tekton/plugins/tekton/tests/utils/tektonHelper.ts
@@ -40,7 +40,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }

--- a/workspaces/tekton/plugins/tekton/tests/utils/translations.ts
+++ b/workspaces/tekton/plugins/tekton/tests/utils/translations.ts
@@ -17,6 +17,8 @@
 // These translation files are not exported by the package, so relative imports are necessary for e2e tests
 /* eslint-disable @backstage/no-relative-monorepo-imports */
 import { tektonMessages } from '../../src/translations/ref.js';
+import tektonTranslationDe from '../../src/translations/de.js';
+import tektonTranslationEs from '../../src/translations/es.js';
 import tektonTranslationFr from '../../src/translations/fr.js';
 import tektonTranslationIt from '../../src/translations/it.js';
 import tektonTranslationJa from '../../src/translations/ja.js';
@@ -51,6 +53,10 @@ export function getTranslations(locale: string): TektonMessages {
   switch (base) {
     case 'en':
       return tektonMessages;
+    case 'de':
+      return transform(tektonTranslationDe.messages);
+    case 'es':
+      return transform(tektonTranslationEs.messages);
     case 'fr':
       return transform(tektonTranslationFr.messages);
     case 'it':

--- a/workspaces/topology/playwright.config.ts
+++ b/workspaces/topology/playwright.config.ts
@@ -71,5 +71,21 @@ export default defineConfig({
         locale: 'ja',
       },
     },
+    {
+      name: 'de',
+      testDir: './plugins/topology/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'de',
+      },
+    },
+    {
+      name: 'es',
+      testDir: './plugins/topology/tests',
+      use: {
+        channel: 'chrome',
+        locale: 'es',
+      },
+    },
   ],
 });

--- a/workspaces/topology/plugins/topology/tests/utils/topologyHelper.ts
+++ b/workspaces/topology/plugins/topology/tests/utils/topologyHelper.ts
@@ -40,7 +40,8 @@ export class Common {
 
   async switchToLocale(locale: string): Promise<void> {
     if (locale !== 'en') {
-      const localeString = locale === 'ja' ? '日本語' : locale;
+      const names = new Intl.DisplayNames([locale], { type: 'language' });
+      const localeString = names.of(locale) || locale;
       await this.page.getByRole('button', { name: 'Language' }).click();
       await this.page.getByRole('menuitem', { name: localeString }).click();
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added de and es locales to existing localization tests
 
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
