### PR TITLE
Version Packages (flux)

### DIFF
--- a/workspaces/flux/.changeset/fresh-oranges-warn.md
+++ b/workspaces/flux/.changeset/fresh-oranges-warn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-flux': minor
----
-
-migrate components from material-ui to backstage-ui (mui to bui)

--- a/workspaces/flux/.changeset/migrate-mui-to-bui.md
+++ b/workspaces/flux/.changeset/migrate-mui-to-bui.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-flux': patch
----
-
-Migrated from Material-UI to Backstage UI (BUI). Replaced `makeStyles` with CSS Modules, updated component imports to use BUI components (`Text`, `Flex`, `ButtonIcon`, `Tooltip`), and replaced Material-UI icons with Remix icons.

--- a/workspaces/flux/plugins/flux/CHANGELOG.md
+++ b/workspaces/flux/plugins/flux/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-flux
 
+## 0.3.0
+
+### Minor Changes
+
+- c54c209: migrate components from material-ui to backstage-ui (mui to bui)
+
+### Patch Changes
+
+- c54c209: Migrated from Material-UI to Backstage UI (BUI). Replaced `makeStyles` with CSS Modules, updated component imports to use BUI components (`Text`, `Flex`, `ButtonIcon`, `Tooltip`), and replaced Material-UI icons with Remix icons.
+
 ## 0.2.2
 
 ### Patch Changes

--- a/workspaces/flux/plugins/flux/package.json
+++ b/workspaces/flux/plugins/flux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-flux",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-flux@0.3.0

### Minor Changes

-   c54c209: migrate components from material-ui to backstage-ui (mui to bui)

### Patch Changes

-   c54c209: Migrated from Material-UI to Backstage UI (BUI). Replaced `makeStyles` with CSS Modules, updated component imports to use BUI components (`Text`, `Flex`, `ButtonIcon`, `Tooltip`), and replaced Material-UI icons with Remix icons.
