### PR TITLE
chore(tech-insights): remove unused uuid and @types/uuid dependency

### DIFF
--- a/workspaces/tech-insights/.changeset/fair-buttons-worry.md
+++ b/workspaces/tech-insights/.changeset/fair-buttons-worry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+---
+
+Remove unused uuid (and @types/uuid) dependency

--- a/workspaces/tech-insights/.prettierignore
+++ b/workspaces/tech-insights/.prettierignore
@@ -1,5 +1,6 @@
 dist
 dist-types
 coverage
+knip-report.md
 .vscode
 .eslintrc.js

--- a/workspaces/tech-insights/bcp.json
+++ b/workspaces/tech-insights/bcp.json
@@ -1,5 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false,
+  "knipReports": true,
   "listDeprecations": true
 }

--- a/workspaces/tech-insights/packages/app/knip-report.md
+++ b/workspaces/tech-insights/packages/app/knip-report.md
@@ -2,17 +2,18 @@
 
 ## Unused dependencies (3)
 
-| Name         | Location     | Severity |
-| :----------- | :----------- | :------- |
-| react-router | package.json | error    |
-| react-use    | package.json | error    |
-| history      | package.json | error    |
+| Name         | Location          | Severity |
+| :----------- | :---------------- | :------- |
+| react-router | package.json:51:6 | error    |
+| react-use    | package.json:53:6 | error    |
+| history      | package.json:48:6 | error    |
 
 ## Unused devDependencies (4)
 
-| Name                        | Location     | Severity |
-| :-------------------------- | :----------- | :------- |
-| @testing-library/user-event | package.json | error    |
-| @backstage/test-utils       | package.json | error    |
-| @testing-library/dom        | package.json | error    |
-| cross-env                   | package.json | error    |
+| Name                        | Location          | Severity |
+| :-------------------------- | :---------------- | :------- |
+| @testing-library/user-event | package.json:61:6 | error    |
+| @backstage/test-utils       | package.json:56:6 | error    |
+| @testing-library/dom        | package.json:58:6 | error    |
+| cross-env                   | package.json:63:6 | error    |
+

--- a/workspaces/tech-insights/packages/backend/knip-report.md
+++ b/workspaces/tech-insights/packages/backend/knip-report.md
@@ -1,27 +1,25 @@
 # Knip report
 
-## Unused dependencies (12)
+## Unused dependencies (10)
 
-| Name                                                  | Location     | Severity |
-| :---------------------------------------------------- | :----------- | :------- |
-| @backstage/plugin-auth-backend-module-github-provider | package.json | error    |
-| @backstage/plugin-search-backend-node                 | package.json | error    |
-| @backstage/plugin-permission-common                   | package.json | error    |
-| @backstage/plugin-permission-node                     | package.json | error    |
-| @backstage/plugin-auth-node                           | package.json | error    |
-| @backstage/config                                     | package.json | error    |
-| better-sqlite3                                        | package.json | error    |
-| dockerode                                             | package.json | error    |
-| node-gyp                                              | package.json | error    |
-| winston                                               | package.json | error    |
-| app                                                   | package.json | error    |
-| pg                                                    | package.json | error    |
+| Name                                                  | Location          | Severity |
+| :---------------------------------------------------- | :---------------- | :------- |
+| @backstage/plugin-auth-backend-module-github-provider | package.json:34:6 | error    |
+| @backstage/plugin-search-backend-node                 | package.json:47:6 | error    |
+| @backstage/plugin-permission-common                   | package.json:41:6 | error    |
+| @backstage/plugin-permission-node                     | package.json:42:6 | error    |
+| @backstage/plugin-auth-node                           | package.json:36:6 | error    |
+| @backstage/config                                     | package.json:31:6 | error    |
+| node-gyp                                              | package.json:51:6 | error    |
+| winston                                               | package.json:53:6 | error    |
+| app                                                   | package.json:49:6 | error    |
+| pg                                                    | package.json:52:6 | error    |
 
-## Unused devDependencies (4)
+## Unused devDependencies (3)
 
-| Name                             | Location     | Severity |
-| :------------------------------- | :----------- | :------- |
-| @types/express-serve-static-core | package.json | error    |
-| @types/dockerode                 | package.json | error    |
-| @types/express                   | package.json | error    |
-| @types/luxon                     | package.json | error    |
+| Name                             | Location          | Severity |
+| :------------------------------- | :---------------- | :------- |
+| @types/express-serve-static-core | package.json:58:6 | error    |
+| @types/express                   | package.json:57:6 | error    |
+| @types/luxon                     | package.json:59:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/knip-report.md
@@ -2,7 +2,8 @@
 
 ## Unused dependencies (2)
 
-| Name             | Location     | Severity |
-| :--------------- | :----------- | :------- |
-| @backstage/types | package.json | error    |
-| luxon            | package.json | error    |
+| Name             | Location          | Severity |
+| :--------------- | :---------------- | :------- |
+| @backstage/types | package.json:49:6 | error    |
+| luxon            | package.json:53:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights-backend/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/knip-report.md
@@ -1,15 +1,14 @@
 # Knip report
 
-## Unused dependencies (2)
+## Unused dependencies (1)
 
-| Name | Location     | Severity |
-| :--- | :----------- | :------- |
-| uuid | package.json | error    |
-| yn   | package.json | error    |
+| Name | Location          | Severity |
+| :- | :---------------- | :------- |
+| yn | package.json:71:6 | error    |
 
-## Unused devDependencies (2)
+## Unused devDependencies (1)
 
-| Name            | Location     | Severity |
-| :-------------- | :----------- | :------- |
-| wait-for-expect | package.json | error    |
-| @types/uuid     | package.json | error    |
+| Name            | Location          | Severity |
+| :-------------- | :---------------- | :------- |
+| wait-for-expect | package.json:79:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -68,7 +68,6 @@
     "luxon": "^3.0.0",
     "p-limit": "^3.1.0",
     "semver": "^7.5.3",
-    "uuid": "^9.0.0",
     "yn": "^4.0.0"
   },
   "devDependencies": {
@@ -76,7 +75,6 @@
     "@types/lodash": "^4.14.151",
     "@types/semver": "^7.3.8",
     "@types/supertest": "^7.0.0",
-    "@types/uuid": "^10.0.0",
     "supertest": "^7.0.0",
     "wait-for-expect": "^4.0.0"
   },

--- a/workspaces/tech-insights/plugins/tech-insights-common/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-common/knip-report.md
@@ -1,1 +1,2 @@
 # Knip report
+

--- a/workspaces/tech-insights/plugins/tech-insights-maturity-common/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity-common/knip-report.md
@@ -2,7 +2,8 @@
 
 ## Unused dependencies (2)
 
-| Name                  | Location     | Severity |
-| :-------------------- | :----------- | :------- |
-| @backstage/repo-tools | package.json | error    |
-| msw                   | package.json | error    |
+| Name                  | Location          | Severity |
+| :-------------------- | :---------------- | :------- |
+| @backstage/repo-tools | package.json:56:6 | error    |
+| msw                   | package.json:57:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/knip-report.md
@@ -1,19 +1,15 @@
 # Knip report
 
-## Unused dependencies (5)
+## Unused dependencies (2)
 
-| Name                  | Location     | Severity |
-| :-------------------- | :----------- | :------- |
-| @backstage/repo-tools | package.json | error    |
-| @material-ui/icons    | package.json | error    |
-| @material-ui/lab      | package.json | error    |
-| @types/d3-scale       | package.json | error    |
-| @types/d3-shape       | package.json | error    |
+| Name            | Location          | Severity |
+| :-------------- | :---------------- | :------- |
+| @types/d3-scale | package.json:69:6 | error    |
+| @types/d3-shape | package.json:70:6 | error    |
 
-## Unused devDependencies (3)
+## Unused devDependencies (1)
 
-| Name                        | Location     | Severity |
-| :-------------------------- | :----------- | :------- |
-| @testing-library/user-event | package.json | error    |
-| @backstage/core-app-api     | package.json | error    |
-| msw                         | package.json | error    |
+| Name | Location          | Severity |
+| :-- | :---------------- | :------- |
+| msw | package.json:85:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights-node/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-node/knip-report.md
@@ -1,1 +1,2 @@
 # Knip report
+

--- a/workspaces/tech-insights/plugins/tech-insights-react/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-react/knip-report.md
@@ -1,14 +1,16 @@
 # Knip report
 
-## Unused dependencies (1)
+## Unused dependencies (2)
 
-| Name             | Location     | Severity |
-| :--------------- | :----------- | :------- |
-| @backstage/types | package.json | error    |
+| Name                            | Location          | Severity |
+| :------------------------------ | :---------------- | :------- |
+| @backstage/plugin-catalog-react | package.json:60:6 | error    |
+| @backstage/types                | package.json:61:6 | error    |
 
 ## Unused devDependencies (2)
 
-| Name                   | Location     | Severity |
-| :--------------------- | :----------- | :------- |
-| @testing-library/react | package.json | error    |
-| @backstage/test-utils  | package.json | error    |
+| Name                   | Location          | Severity |
+| :--------------------- | :---------------- | :------- |
+| @testing-library/react | package.json:74:6 | error    |
+| @backstage/test-utils  | package.json:72:6 | error    |
+

--- a/workspaces/tech-insights/plugins/tech-insights/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights/knip-report.md
@@ -2,15 +2,15 @@
 
 ## Unused dependencies (2)
 
-| Name              | Location     | Severity |
-| :---------------- | :----------- | :------- |
-| @backstage/errors | package.json | error    |
-| @backstage/types  | package.json | error    |
+| Name              | Location          | Severity |
+| :---------------- | :---------------- | :------- |
+| @backstage/errors | package.json:64:6 | error    |
+| @backstage/types  | package.json:68:6 | error    |
 
-## Unused devDependencies (3)
+## Unused devDependencies (2)
 
-| Name                   | Location     | Severity |
-| :--------------------- | :----------- | :------- |
-| @testing-library/react | package.json | error    |
-| @testing-library/dom   | package.json | error    |
-| canvas                 | package.json | error    |
+| Name                   | Location          | Severity |
+| :--------------------- | :---------------- | :------- |
+| @testing-library/react | package.json:83:6 | error    |
+| @testing-library/dom   | package.json:81:6 | error    |
+

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -1936,7 +1936,6 @@ __metadata:
     "@types/luxon": "npm:^3.0.0"
     "@types/semver": "npm:^7.3.8"
     "@types/supertest": "npm:^7.0.0"
-    "@types/uuid": "npm:^10.0.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
@@ -1945,7 +1944,6 @@ __metadata:
     p-limit: "npm:^3.1.0"
     semver: "npm:^7.5.3"
     supertest: "npm:^7.0.0"
-    uuid: "npm:^9.0.0"
     wait-for-expect: "npm:^4.0.0"
     yn: "npm:^4.0.0"
   languageName: unknown
@@ -12181,13 +12179,6 @@ __metadata:
   version: 0.0.6
   resolution: "@types/use-sync-external-store@npm:0.0.6"
   checksum: 10/a95ce330668501ad9b1c5b7f2b14872ad201e552a0e567787b8f1588b22c7040c7c3d80f142cbb9f92d13c4ea41c46af57a20f2af4edf27f224d352abcfe4049
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: 10/e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi @xantier @punkle @maicaballangan,

from time to time I try to check and cleanup old PRs, this time I saw #7789 and saw that your plugin is actually not using the uuid library. (I found it just in the knip report, not in the source code.)

To this PR removes it from tech-insights, updates the knip-reports and enables the automated knip-report checks in bcp.json.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
