### PR TITLE
chore(renovate): disable material ui v4 updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,10 +26,15 @@
     {
       "matchManagers": ["npm"],
       "enabled": false,
-      "matchPackageNames": ["@backstage/**"],
+      "matchPackagePatterns": ["^@backstage/"],
       "vulnerabilityAlerts": {
         "enabled": false
       }
+    },
+    {
+      "enabled": false,
+      "matchPackagePatterns": ["^@material-ui/"],
+      "matchUpdateTypes": ["replacement"]
     },
     {
       "matchPackageNames": ["node-fetch"],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed today in Backstage Community SIG, the automated version bumps from Material UI v4 to v5 will never work because the imports would be also needed to change from `@material-ui/` to `@mui/` -- and even that would be not enough.

Examples from the past:

* https://github.com/backstage/community-plugins/pull/5118
* https://github.com/backstage/community-plugins/pull/5210
* https://github.com/backstage/community-plugins/pull/5605
* https://github.com/backstage/community-plugins/pull/5862
* https://github.com/backstage/community-plugins/pull/6674
* https://github.com/backstage/community-plugins/pull/7637
* https://github.com/backstage/community-plugins/pull/7863
* https://github.com/backstage/community-plugins/pull/8450

I kept the last one open with the hope that renovate will close it automaticallty when this PR got merged.

To be transparent: I don't know if there is an option to test this before we merge this.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
