### PR TITLE
fix(announcements-backend): use absolute URL in notification link

### DIFF
--- a/workspaces/announcements/.changeset/fix-notification-absolute-url.md
+++ b/workspaces/announcements/.changeset/fix-notification-absolute-url.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-backend': patch
+---
+
+Fixed notification link being a relative URL, which caused Slack Block Kit button validation to fail with `invalid_attachments`. The link is now prefixed with `app.baseUrl` from config when available.

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -308,7 +308,11 @@ export async function createRouter(
             const announcementNotificationsEnabled =
               req.body?.sendNotification === true;
             if (announcementNotificationsEnabled) {
-              await sendAnnouncementNotification(announcement, notifications, config);
+              await sendAnnouncementNotification(
+                announcement,
+                notifications,
+                config,
+              );
             }
           }
         }
@@ -409,7 +413,11 @@ export async function createRouter(
         const announcementNotificationsEnabled =
           req.body?.sendNotification === true;
         if (announcementNotificationsEnabled) {
-          await sendAnnouncementNotification(announcement, notifications, config);
+          await sendAnnouncementNotification(
+            announcement,
+            notifications,
+            config,
+          );
         }
       }
 

--- a/workspaces/announcements/plugins/announcements-backend/src/router.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/router.ts
@@ -308,7 +308,7 @@ export async function createRouter(
             const announcementNotificationsEnabled =
               req.body?.sendNotification === true;
             if (announcementNotificationsEnabled) {
-              await sendAnnouncementNotification(announcement, notifications);
+              await sendAnnouncementNotification(announcement, notifications, config);
             }
           }
         }
@@ -409,7 +409,7 @@ export async function createRouter(
         const announcementNotificationsEnabled =
           req.body?.sendNotification === true;
         if (announcementNotificationsEnabled) {
-          await sendAnnouncementNotification(announcement, notifications);
+          await sendAnnouncementNotification(announcement, notifications, config);
         }
       }
 

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.test.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mockServices } from '@backstage/backend-test-utils';
+import { DateTime } from 'luxon';
+import { sendAnnouncementNotification } from './announcementNotification';
+import { AnnouncementModel } from './model';
+
+const mockAnnouncement: AnnouncementModel = {
+  id: 'test-id',
+  title: 'Test Announcement',
+  excerpt: 'Test excerpt',
+  body: 'Test body',
+  publisher: 'user:default/test',
+  active: true,
+  created_at: DateTime.fromISO('2024-01-01T00:00:00.000Z'),
+  start_at: DateTime.fromISO('2024-01-01T00:00:00.000Z'),
+  updated_at: DateTime.fromISO('2024-01-01T00:00:00.000Z'),
+};
+
+describe('sendAnnouncementNotification', () => {
+  const mockNotifications = {
+    send: jest.fn().mockResolvedValue(undefined),
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does nothing when notifications service is not provided', async () => {
+    await sendAnnouncementNotification(mockAnnouncement);
+
+    expect(mockNotifications.send).not.toHaveBeenCalled();
+  });
+
+  it('sends notification with absolute URL when config provides app.baseUrl', async () => {
+    const config = mockServices.rootConfig({
+      data: { app: { baseUrl: 'https://backstage.example.com' } },
+    });
+
+    await sendAnnouncementNotification(
+      mockAnnouncement,
+      mockNotifications,
+      config,
+    );
+
+    expect(mockNotifications.send).toHaveBeenCalledWith({
+      recipients: { type: 'broadcast' },
+      payload: {
+        title: `New Announcement "${mockAnnouncement.title}"`,
+        description: mockAnnouncement.excerpt,
+        link: `https://backstage.example.com/announcements/view/${mockAnnouncement.id}`,
+      },
+    });
+  });
+
+  it('sends notification with relative URL when config is not provided', async () => {
+    await sendAnnouncementNotification(mockAnnouncement, mockNotifications);
+
+    expect(mockNotifications.send).toHaveBeenCalledWith({
+      recipients: { type: 'broadcast' },
+      payload: {
+        title: `New Announcement "${mockAnnouncement.title}"`,
+        description: mockAnnouncement.excerpt,
+        link: `/announcements/view/${mockAnnouncement.id}`,
+      },
+    });
+  });
+
+  it('sends notification with relative URL when app.baseUrl is not set in config', async () => {
+    const config = mockServices.rootConfig({ data: {} });
+
+    await sendAnnouncementNotification(
+      mockAnnouncement,
+      mockNotifications,
+      config,
+    );
+
+    expect(mockNotifications.send).toHaveBeenCalledWith({
+      recipients: { type: 'broadcast' },
+      payload: {
+        title: `New Announcement "${mockAnnouncement.title}"`,
+        description: mockAnnouncement.excerpt,
+        link: `/announcements/view/${mockAnnouncement.id}`,
+      },
+    });
+  });
+});

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
@@ -26,10 +26,7 @@ export const sendAnnouncementNotification = async (
     return;
   }
 
-  const appBaseUrl = config?.getOptionalString('app.baseUrl') ?? '';
-  const link = appBaseUrl
-    ? `${appBaseUrl}/announcements/view/${announcement.id}`
-    : `/announcements/view/${announcement.id}`;
+  const link = `${config?.getOptionalString('app.baseUrl') ?? ''}/announcements/view/${announcement.id}`;
 
   await notifications.send({
     recipients: {

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { NotificationService } from '@backstage/plugin-notifications-node';
 import { AnnouncementModel } from './model';
 
 export const sendAnnouncementNotification = async (
   announcement: AnnouncementModel,
   notifications?: NotificationService,
+  config?: RootConfigService,
 ) => {
   if (!notifications) {
     return;
   }
+
+  const appBaseUrl = config?.getOptionalString('app.baseUrl') ?? '';
+  const link = appBaseUrl
+    ? `${appBaseUrl}/announcements/view/${announcement.id}`
+    : `/announcements/view/${announcement.id}`;
 
   await notifications.send({
     recipients: {
@@ -31,7 +38,7 @@ export const sendAnnouncementNotification = async (
     payload: {
       title: `New Announcement "${announcement.title}"`,
       description: announcement.excerpt,
-      link: `/announcements/view/${announcement.id}`,
+      link,
     },
   });
 };

--- a/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
+++ b/workspaces/announcements/plugins/announcements-backend/src/service/announcementNotification.ts
@@ -26,7 +26,9 @@ export const sendAnnouncementNotification = async (
     return;
   }
 
-  const link = `${config?.getOptionalString('app.baseUrl') ?? ''}/announcements/view/${announcement.id}`;
+  const link = `${
+    config?.getOptionalString('app.baseUrl') ?? ''
+  }/announcements/view/${announcement.id}`;
 
   await notifications.send({
     recipients: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #8470

When `@backstage/plugin-notifications-backend-module-slack` forwards announcement notifications to Slack, the link is placed into a Block Kit button `url` field. Slack requires absolute URLs there, the relative path (`/announcements/view/<id>`) that was being built caused `invalid_attachments` errors and silently dropped every notification.

This fix reads `app.baseUrl` from the root config and prepends it to the notification link. It falls back to the relative path when config is not provided, so existing setups without Slack are unaffected.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
