### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/hip-rice-pump.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/hip-rice-pump.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Bump axios to 1.16.0 to include different security fixes.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-2788e38.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-2788e38.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.97.1`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-9f78a5a.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-9f78a5a.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.95.0`.

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.15.1
+
+### Patch Changes
+
+- 85f6e69: Bump axios to 1.16.0 to include different security fixes.
+- 24acada: Updated dependency `@hey-api/openapi-ts` to `0.97.1`.
+- e9a32f2: Updated dependency `@hey-api/openapi-ts` to `0.95.0`.
+
 ## 2.15.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.15.1
+
+### Patch Changes
+
+- e9a32f2: Updated dependency `@hey-api/openapi-ts` to `0.95.0`.
+
 ## 2.15.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.15.1

### Patch Changes

-   85f6e69: Bump axios to 1.16.0 to include different security fixes.
-   24acada: Updated dependency `@hey-api/openapi-ts` to `0.97.1`.
-   e9a32f2: Updated dependency `@hey-api/openapi-ts` to `0.95.0`.
