### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-5b9d09d.md
+++ b/workspaces/rbac/.changeset/renovate-5b9d09d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `csv-parse` to `^6.0.0`.

--- a/workspaces/rbac/.changeset/renovate-732f4c2.md
+++ b/workspaces/rbac/.changeset/renovate-732f4c2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `@dagrejs/graphlib` to `^4.0.0`.

--- a/workspaces/rbac/.changeset/renovate-a24a263.md
+++ b/workspaces/rbac/.changeset/renovate-a24a263.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `@types/node` to `22.19.17`.

--- a/workspaces/rbac/.changeset/renovate-ebb6055.md
+++ b/workspaces/rbac/.changeset/renovate-ebb6055.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Updated dependency `qs` to `6.15.1`.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.12.2
+
+### Patch Changes
+
+- 39272f8: Updated dependency `csv-parse` to `^6.0.0`.
+- 70e6333: Updated dependency `@dagrejs/graphlib` to `^4.0.0`.
+- a559dfb: Updated dependency `@types/node` to `22.19.17`.
+- 8846adf: Updated dependency `qs` to `6.15.1`.
+
 ## 7.12.1
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rbac
 
+## 1.52.1
+
+### Patch Changes
+
+- a559dfb: Updated dependency `@types/node` to `22.19.17`.
+
 ## 1.52.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.52.0",
+  "version": "1.52.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.52.1

### Patch Changes

-   a559dfb: Updated dependency `@types/node` to `22.19.17`.

## @backstage-community/plugin-rbac-backend@7.12.2

### Patch Changes

-   39272f8: Updated dependency `csv-parse` to `^6.0.0`.
-   70e6333: Updated dependency `@dagrejs/graphlib` to `^4.0.0`.
-   a559dfb: Updated dependency `@types/node` to `22.19.17`.
-   8846adf: Updated dependency `qs` to `6.15.1`.
