### PR TITLE
Version Packages (acs)

### DIFF
--- a/workspaces/acs/.changeset/renovate-247e322.md
+++ b/workspaces/acs/.changeset/renovate-247e322.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@apollo/client` to `^4.0.0`.

--- a/workspaces/acs/.changeset/renovate-fa9cf8b.md
+++ b/workspaces/acs/.changeset/renovate-fa9cf8b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': patch
----
-
-Updated dependency `@patternfly/react-topology` to `6.4.0`.

--- a/workspaces/acs/.changeset/version-bump-1-49-4.md
+++ b/workspaces/acs/.changeset/version-bump-1-49-4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acs': minor
----
-
-Backstage version bump to v1.49.4

--- a/workspaces/acs/plugins/acs/CHANGELOG.md
+++ b/workspaces/acs/plugins/acs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-acs
 
+## 0.1.2
+
+### Patch Changes
+
+- f99931a: Updated dependency `@apollo/client` to `^4.0.0`.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/acs/plugins/acs/CHANGELOG.md
+++ b/workspaces/acs/plugins/acs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-acs
 
+## 0.2.0
+
+### Minor Changes
+
+- 54e5879: Backstage version bump to v1.49.4
+
+### Patch Changes
+
+- f99931a: Updated dependency `@apollo/client` to `^4.0.0`.
+- 9881304: Updated dependency `@patternfly/react-topology` to `6.4.0`.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/acs/plugins/acs/CHANGELOG.md
+++ b/workspaces/acs/plugins/acs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-acs
 
+## 0.1.2
+
+### Patch Changes
+
+- f99931a: Updated dependency `@apollo/client` to `^4.0.0`.
+- 9881304: Updated dependency `@patternfly/react-topology` to `6.4.0`.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/workspaces/acs/plugins/acs/package.json
+++ b/workspaces/acs/plugins/acs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-acs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/acs/plugins/acs/package.json
+++ b/workspaces/acs/plugins/acs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-acs",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acs@0.2.0

### Minor Changes

-   54e5879: Backstage version bump to v1.49.4

### Patch Changes

-   f99931a: Updated dependency `@apollo/client` to `^4.0.0`.
-   9881304: Updated dependency `@patternfly/react-topology` to `6.4.0`.
