### PR TITLE
feat(sonarqube): register actions for getting code quality

### DIFF
--- a/workspaces/sonarqube/.changeset/empty-apples-wash.md
+++ b/workspaces/sonarqube/.changeset/empty-apples-wash.md
@@ -1,0 +1,10 @@
+---
+'@backstage-community/plugin-sonarqube-backend': patch
+---
+
+Added actions for SonarQube code quality data.
+
+Registered two actions that expose SonarQube backend capabilities via MCP and scaffolder templates:
+
+- `sonarqube:get-findings` — return all SonarQube measures (bugs, coverage, code smells, etc.) for a catalog entity
+- `sonarqube:get-quality-gate` — return the quality gate status and key metrics summary for a catalog entity

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetFindingsAction.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetFindingsAction.test.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { InputError, NotFoundError } from '@backstage/errors';
+import { createGetFindingsAction } from './createGetFindingsAction';
+import {
+  SonarqubeInfoProvider,
+  SonarqubeFindings,
+} from '../service/sonarqubeInfoProvider';
+
+const mockEntity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+    annotations: { 'sonarqube.org/project-key': 'com.example:my-service' },
+  },
+  spec: { type: 'service', lifecycle: 'production' },
+};
+
+const mockFindings: SonarqubeFindings = {
+  analysisDate: '2024-01-15T10:30:00+0000',
+  measures: [
+    { metric: 'alert_status', value: 'OK' },
+    { metric: 'bugs', value: '3' },
+    { metric: 'coverage', value: '82.5' },
+  ],
+};
+
+describe('createGetFindingsAction', () => {
+  let mockActionsRegistry: { register: jest.Mock };
+  let mockInfoProvider: jest.Mocked<SonarqubeInfoProvider>;
+  let mockCatalog: { getEntityByRef: jest.Mock };
+
+  beforeEach(() => {
+    mockActionsRegistry = { register: jest.fn() };
+
+    mockInfoProvider = {
+      getFindings: jest.fn().mockResolvedValue(mockFindings),
+      getBaseUrl: jest
+        .fn()
+        .mockReturnValue({ baseUrl: 'https://sonarqube.example.com' }),
+    } as any;
+
+    mockCatalog = {
+      getEntityByRef: jest.fn().mockResolvedValue(mockEntity),
+    };
+
+    createGetFindingsAction({
+      actionsRegistry: mockActionsRegistry as any,
+      sonarqubeInfoProvider: mockInfoProvider,
+      catalog: mockCatalog as any,
+    });
+  });
+
+  it('registers the sonarqube:get-findings action', () => {
+    expect(mockActionsRegistry.register).toHaveBeenCalledTimes(1);
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    expect(reg.name).toBe('sonarqube:get-findings');
+    expect(reg.attributes.readOnly).toBe(true);
+    expect(reg.attributes.destructive).toBe(false);
+    expect(reg.attributes.idempotent).toBe(true);
+  });
+
+  it('returns findings for a catalog entity', async () => {
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    const result = await reg.action({
+      input: { name: 'my-service', kind: 'Component', namespace: 'default' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
+      { kind: 'Component', namespace: 'default', name: 'my-service' },
+      { credentials },
+    );
+    expect(mockInfoProvider.getFindings).toHaveBeenCalledWith({
+      componentKey: 'com.example:my-service',
+      instanceName: undefined,
+    });
+    expect(result.output.componentKey).toBe('com.example:my-service');
+    expect(result.output.analysisDate).toBe('2024-01-15T10:30:00+0000');
+    expect(result.output.measures).toEqual(mockFindings.measures);
+  });
+
+  it('applies default kind and namespace', async () => {
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await reg.action({
+      input: { name: 'my-service' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
+      { kind: 'Component', namespace: 'default', name: 'my-service' },
+      { credentials },
+    );
+  });
+
+  it('parses instanceName/projectKey annotation format', async () => {
+    mockCatalog.getEntityByRef.mockResolvedValue({
+      ...mockEntity,
+      metadata: {
+        ...mockEntity.metadata,
+        annotations: {
+          'sonarqube.org/project-key': 'my-instance/com.example:my-service',
+        },
+      },
+    });
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await reg.action({
+      input: { name: 'my-service' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(mockInfoProvider.getFindings).toHaveBeenCalledWith({
+      componentKey: 'com.example:my-service',
+      instanceName: 'my-instance',
+    });
+  });
+
+  it('returns empty measures when findings are undefined', async () => {
+    mockInfoProvider.getFindings.mockResolvedValue(undefined);
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    const result = await reg.action({
+      input: { name: 'my-service' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(result.output.measures).toEqual([]);
+    expect(result.output.analysisDate).toBeNull();
+  });
+
+  it('throws NotFoundError when entity does not exist', async () => {
+    mockCatalog.getEntityByRef.mockResolvedValue(undefined);
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await expect(
+      reg.action({
+        input: { name: 'unknown-service' },
+        credentials,
+        logger: mockServices.logger.mock(),
+      }),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('throws InputError when annotation is missing', async () => {
+    mockCatalog.getEntityByRef.mockResolvedValue({
+      ...mockEntity,
+      metadata: { ...mockEntity.metadata, annotations: {} },
+    });
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await expect(
+      reg.action({
+        input: { name: 'my-service' },
+        credentials,
+        logger: mockServices.logger.mock(),
+      }),
+    ).rejects.toThrow(InputError);
+  });
+});

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetFindingsAction.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetFindingsAction.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { InputError, NotFoundError } from '@backstage/errors';
+import { SonarqubeInfoProvider } from '../service/sonarqubeInfoProvider';
+
+const SONARQUBE_ANNOTATION = 'sonarqube.org/project-key';
+
+async function resolveComponentKey(
+  entityRef: { kind: string; namespace: string; name: string },
+  catalog: CatalogService,
+  credentials: BackstageCredentials,
+): Promise<{ componentKey: string; instanceName: string | undefined }> {
+  const entity = await catalog.getEntityByRef(entityRef, { credentials });
+  if (!entity) {
+    throw new NotFoundError(
+      `Entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name} not found`,
+    );
+  }
+
+  const annotation = entity.metadata.annotations?.[SONARQUBE_ANNOTATION];
+  if (!annotation) {
+    throw new InputError(
+      `Entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name} is missing the "${SONARQUBE_ANNOTATION}" annotation`,
+    );
+  }
+
+  // Annotation format is either "projectKey" or "instanceName/projectKey"
+  const separatorIndex = annotation.indexOf('/');
+  const instanceName =
+    separatorIndex > -1 ? annotation.substring(0, separatorIndex) : undefined;
+  const componentKey =
+    separatorIndex > -1 ? annotation.substring(separatorIndex + 1) : annotation;
+
+  return { componentKey, instanceName };
+}
+
+/**
+ * Registers the `sonarqube:get-findings` action with the ActionsRegistryService.
+ *
+ * @public
+ */
+export function createGetFindingsAction(options: {
+  actionsRegistry: ActionsRegistryService;
+  sonarqubeInfoProvider: SonarqubeInfoProvider;
+  catalog: CatalogService;
+}) {
+  const { actionsRegistry, sonarqubeInfoProvider, catalog } = options;
+
+  actionsRegistry.register({
+    name: 'sonarqube:get-findings',
+    title: 'Get SonarQube Findings',
+    description: `
+Returns all SonarQube measures (findings) for a Backstage catalog entity.
+
+The entity must have the \`sonarqube.org/project-key\` annotation. The annotation
+value is either:
+- \`projectKey\` — uses the default SonarQube instance
+- \`instanceName/projectKey\` — uses a named SonarQube instance from config
+
+## Metrics returned
+
+The following metrics are returned when available on the SonarQube instance:
+
+| Metric | Description |
+|---|---|
+| \`alert_status\` | Quality gate status: \`OK\`, \`WARN\`, or \`ERROR\` |
+| \`bugs\` | Number of reliability bugs |
+| \`reliability_rating\` | Reliability rating (A=1.0, B=2.0, C=3.0, D=4.0, E=5.0) |
+| \`vulnerabilities\` | Number of security vulnerabilities |
+| \`security_rating\` | Security rating (A–E) |
+| \`security_hotspots_reviewed\` | Percentage of security hotspots reviewed |
+| \`security_review_rating\` | Security review rating (A–E) |
+| \`code_smells\` | Number of maintainability code smells |
+| \`sqale_rating\` | Maintainability rating (A–E) |
+| \`coverage\` | Code coverage percentage |
+| \`duplicated_lines_density\` | Percentage of duplicated lines |
+
+## When to use
+
+Use this action to assess the overall code quality of a service before a release,
+as part of a security review workflow, or to identify the most critical quality issues.
+For a quick pass/fail check use \`sonarqube:get-quality-gate\`.
+`,
+    attributes: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+    },
+    schema: {
+      input: z =>
+        z.object({
+          name: z.string().describe('The name of the catalog entity.'),
+          kind: z
+            .string()
+            .optional()
+            .describe(
+              'The kind of the catalog entity, e.g. "Component". Defaults to "Component" if omitted.',
+            ),
+          namespace: z
+            .string()
+            .optional()
+            .describe(
+              'The namespace of the catalog entity. Defaults to "default" if omitted.',
+            ),
+        }),
+      output: z =>
+        z.object({
+          componentKey: z
+            .string()
+            .describe('The SonarQube project/component key.'),
+          instanceUrl: z
+            .string()
+            .describe('URL of the SonarQube instance for building deep links.'),
+          analysisDate: z
+            .string()
+            .nullable()
+            .describe(
+              'ISO 8601 timestamp of the last analysis, or null if no analysis has run.',
+            ),
+          measures: z
+            .array(
+              z.object({
+                metric: z
+                  .string()
+                  .describe(
+                    'Metric key (e.g. "alert_status", "bugs", "coverage").',
+                  ),
+                value: z.string().describe('String value of the metric.'),
+              }),
+            )
+            .describe('List of all returned SonarQube measures.'),
+        }),
+    },
+    action: async ({ input, credentials, logger }) => {
+      const entityRef = {
+        kind: input.kind ?? 'Component',
+        namespace: input.namespace ?? 'default',
+        name: input.name,
+      };
+
+      logger.info(
+        `Fetching SonarQube findings for entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name}`,
+      );
+
+      const { componentKey, instanceName } = await resolveComponentKey(
+        entityRef,
+        catalog,
+        credentials,
+      );
+
+      const [findings, { baseUrl, externalBaseUrl }] = await Promise.all([
+        sonarqubeInfoProvider.getFindings({ componentKey, instanceName }),
+        Promise.resolve(sonarqubeInfoProvider.getBaseUrl({ instanceName })),
+      ]);
+
+      return {
+        output: {
+          componentKey,
+          instanceUrl: externalBaseUrl || baseUrl,
+          analysisDate: findings?.analysisDate ?? null,
+          measures: findings?.measures ?? [],
+        },
+      };
+    },
+  });
+}

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetQualityGateAction.test.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetQualityGateAction.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { InputError, NotFoundError } from '@backstage/errors';
+import { createGetQualityGateAction } from './createGetQualityGateAction';
+import {
+  SonarqubeInfoProvider,
+  SonarqubeFindings,
+} from '../service/sonarqubeInfoProvider';
+
+const mockEntity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+    annotations: { 'sonarqube.org/project-key': 'com.example:my-service' },
+  },
+  spec: { type: 'service', lifecycle: 'production' },
+};
+
+const mockFindings: SonarqubeFindings = {
+  analysisDate: '2024-01-15T10:30:00+0000',
+  measures: [
+    { metric: 'alert_status', value: 'ERROR' },
+    { metric: 'bugs', value: '5' },
+    { metric: 'vulnerabilities', value: '2' },
+    { metric: 'code_smells', value: '14' },
+    { metric: 'coverage', value: '75.0' },
+    { metric: 'duplicated_lines_density', value: '3.1' },
+  ],
+};
+
+describe('createGetQualityGateAction', () => {
+  let mockActionsRegistry: { register: jest.Mock };
+  let mockInfoProvider: jest.Mocked<SonarqubeInfoProvider>;
+  let mockCatalog: { getEntityByRef: jest.Mock };
+
+  beforeEach(() => {
+    mockActionsRegistry = { register: jest.fn() };
+
+    mockInfoProvider = {
+      getFindings: jest.fn().mockResolvedValue(mockFindings),
+      getBaseUrl: jest.fn().mockReturnValue({
+        baseUrl: 'https://sonarqube.example.com',
+        externalBaseUrl: 'https://sonarqube-public.example.com',
+      }),
+    } as any;
+
+    mockCatalog = {
+      getEntityByRef: jest.fn().mockResolvedValue(mockEntity),
+    };
+
+    createGetQualityGateAction({
+      actionsRegistry: mockActionsRegistry as any,
+      sonarqubeInfoProvider: mockInfoProvider,
+      catalog: mockCatalog as any,
+    });
+  });
+
+  it('registers the sonarqube:get-quality-gate action', () => {
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    expect(reg.name).toBe('sonarqube:get-quality-gate');
+    expect(reg.attributes.readOnly).toBe(true);
+  });
+
+  it('returns quality gate status and key metrics', async () => {
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    const result = await reg.action({
+      input: { name: 'my-service' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(result.output).toMatchObject({
+      componentKey: 'com.example:my-service',
+      qualityGateStatus: 'ERROR',
+      analysisDate: '2024-01-15T10:30:00+0000',
+      bugs: '5',
+      vulnerabilities: '2',
+      codeSmells: '14',
+      coverage: '75.0',
+      duplicatedLinesDensity: '3.1',
+    });
+    // Should prefer externalBaseUrl over baseUrl
+    expect(result.output.projectUrl).toContain('sonarqube-public.example.com');
+    expect(result.output.projectUrl).toContain(
+      encodeURIComponent('com.example:my-service'),
+    );
+  });
+
+  it('returns NONE quality gate status when findings are absent', async () => {
+    mockInfoProvider.getFindings.mockResolvedValue(undefined);
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    const result = await reg.action({
+      input: { name: 'my-service' },
+      credentials,
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(result.output.qualityGateStatus).toBe('NONE');
+    expect(result.output.bugs).toBeNull();
+  });
+
+  it('throws NotFoundError when entity is missing', async () => {
+    mockCatalog.getEntityByRef.mockResolvedValue(undefined);
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await expect(
+      reg.action({
+        input: { name: 'ghost-service' },
+        credentials,
+        logger: mockServices.logger.mock(),
+      }),
+    ).rejects.toThrow(NotFoundError);
+  });
+
+  it('throws InputError when annotation is missing', async () => {
+    mockCatalog.getEntityByRef.mockResolvedValue({
+      ...mockEntity,
+      metadata: { ...mockEntity.metadata, annotations: {} },
+    });
+    const reg = mockActionsRegistry.register.mock.calls[0][0];
+    const credentials = mockCredentials.user();
+
+    await expect(
+      reg.action({
+        input: { name: 'my-service' },
+        credentials,
+        logger: mockServices.logger.mock(),
+      }),
+    ).rejects.toThrow(InputError);
+  });
+});

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetQualityGateAction.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/createGetQualityGateAction.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { InputError, NotFoundError } from '@backstage/errors';
+import { SonarqubeInfoProvider } from '../service/sonarqubeInfoProvider';
+
+const SONARQUBE_ANNOTATION = 'sonarqube.org/project-key';
+
+async function resolveComponentKey(
+  entityRef: { kind: string; namespace: string; name: string },
+  catalog: CatalogService,
+  credentials: BackstageCredentials,
+): Promise<{ componentKey: string; instanceName: string | undefined }> {
+  const entity = await catalog.getEntityByRef(entityRef, { credentials });
+  if (!entity) {
+    throw new NotFoundError(
+      `Entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name} not found`,
+    );
+  }
+
+  const annotation = entity.metadata.annotations?.[SONARQUBE_ANNOTATION];
+  if (!annotation) {
+    throw new InputError(
+      `Entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name} is missing the "${SONARQUBE_ANNOTATION}" annotation`,
+    );
+  }
+
+  const separatorIndex = annotation.indexOf('/');
+  const instanceName =
+    separatorIndex > -1 ? annotation.substring(0, separatorIndex) : undefined;
+  const componentKey =
+    separatorIndex > -1 ? annotation.substring(separatorIndex + 1) : annotation;
+
+  return { componentKey, instanceName };
+}
+
+/**
+ * Registers the `sonarqube:get-quality-gate` action with the ActionsRegistryService.
+ *
+ * @public
+ */
+export function createGetQualityGateAction(options: {
+  actionsRegistry: ActionsRegistryService;
+  sonarqubeInfoProvider: SonarqubeInfoProvider;
+  catalog: CatalogService;
+}) {
+  const { actionsRegistry, sonarqubeInfoProvider, catalog } = options;
+
+  actionsRegistry.register({
+    name: 'sonarqube:get-quality-gate',
+    title: 'Get SonarQube Quality Gate Status',
+    description: `
+Returns the quality gate status and key code quality metrics for a Backstage catalog entity.
+
+The entity must have the \`sonarqube.org/project-key\` annotation.
+
+## Quality gate status values
+
+- \`OK\` — all quality gate conditions are met
+- \`WARN\` — some conditions produce warnings
+- \`ERROR\` — one or more conditions are failing (build should be blocked)
+- \`NONE\` — no analysis has been run yet
+
+## When to use
+
+Use this action for a quick pass/fail check on a service's code quality. This is ideal
+for pre-deployment checks, PR review context, or any workflow where you need a concise
+quality status without the full metrics breakdown.
+
+For detailed metric values use \`sonarqube:get-findings\`.
+`,
+    attributes: {
+      readOnly: true,
+      destructive: false,
+      idempotent: true,
+    },
+    schema: {
+      input: z =>
+        z.object({
+          name: z.string().describe('The name of the catalog entity.'),
+          kind: z
+            .string()
+            .optional()
+            .describe(
+              'The kind of the catalog entity, e.g. "Component". Defaults to "Component" if omitted.',
+            ),
+          namespace: z
+            .string()
+            .optional()
+            .describe(
+              'The namespace of the catalog entity. Defaults to "default" if omitted.',
+            ),
+        }),
+      output: z =>
+        z.object({
+          componentKey: z
+            .string()
+            .describe('The SonarQube project/component key.'),
+          qualityGateStatus: z
+            .string()
+            .describe(
+              'Quality gate status: "OK", "WARN", "ERROR", or "NONE" if no analysis has run.',
+            ),
+          analysisDate: z
+            .string()
+            .nullable()
+            .describe(
+              'ISO 8601 timestamp of the last analysis, or null if no analysis has run.',
+            ),
+          bugs: z
+            .string()
+            .nullable()
+            .describe('Number of reliability bugs, or null if not available.'),
+          vulnerabilities: z
+            .string()
+            .nullable()
+            .describe(
+              'Number of security vulnerabilities, or null if not available.',
+            ),
+          codeSmells: z
+            .string()
+            .nullable()
+            .describe(
+              'Number of maintainability code smells, or null if not available.',
+            ),
+          coverage: z
+            .string()
+            .nullable()
+            .describe(
+              'Code coverage percentage (0–100), or null if not available.',
+            ),
+          duplicatedLinesDensity: z
+            .string()
+            .nullable()
+            .describe(
+              'Percentage of duplicated lines (0–100), or null if not available.',
+            ),
+          projectUrl: z
+            .string()
+            .describe('Direct URL to the project in the SonarQube instance.'),
+        }),
+    },
+    action: async ({ input, credentials, logger }) => {
+      const entityRef = {
+        kind: input.kind ?? 'Component',
+        namespace: input.namespace ?? 'default',
+        name: input.name,
+      };
+
+      logger.info(
+        `Fetching SonarQube quality gate for entity ${entityRef.kind}:${entityRef.namespace}/${entityRef.name}`,
+      );
+
+      const { componentKey, instanceName } = await resolveComponentKey(
+        entityRef,
+        catalog,
+        credentials,
+      );
+
+      const [findings, { baseUrl, externalBaseUrl }] = await Promise.all([
+        sonarqubeInfoProvider.getFindings({ componentKey, instanceName }),
+        Promise.resolve(sonarqubeInfoProvider.getBaseUrl({ instanceName })),
+      ]);
+
+      const instanceUrl = externalBaseUrl || baseUrl;
+
+      const getMeasure = (metric: string): string | null =>
+        findings?.measures.find(m => m.metric === metric)?.value ?? null;
+
+      return {
+        output: {
+          componentKey,
+          qualityGateStatus: getMeasure('alert_status') ?? 'NONE',
+          analysisDate: findings?.analysisDate ?? null,
+          bugs: getMeasure('bugs'),
+          vulnerabilities: getMeasure('vulnerabilities'),
+          codeSmells: getMeasure('code_smells'),
+          coverage: getMeasure('coverage'),
+          duplicatedLinesDensity: getMeasure('duplicated_lines_density'),
+          projectUrl: `${instanceUrl}/dashboard?id=${encodeURIComponent(
+            componentKey,
+          )}`,
+        },
+      };
+    },
+  });
+}

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/index.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/actions/index.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { SonarqubeInfoProvider } from '../service/sonarqubeInfoProvider';
+import { createGetFindingsAction } from './createGetFindingsAction';
+import { createGetQualityGateAction } from './createGetQualityGateAction';
+
+export { createGetFindingsAction } from './createGetFindingsAction';
+export { createGetQualityGateAction } from './createGetQualityGateAction';
+
+/**
+ * Registers all SonarQube actions with the ActionsRegistryService.
+ *
+ * @public
+ */
+export function createSonarqubeActions(options: {
+  actionsRegistry: ActionsRegistryService;
+  sonarqubeInfoProvider: SonarqubeInfoProvider;
+  catalog: CatalogService;
+}) {
+  createGetFindingsAction(options);
+  createGetQualityGateAction(options);
+}

--- a/workspaces/sonarqube/plugins/sonarqube-backend/src/plugin.ts
+++ b/workspaces/sonarqube/plugins/sonarqube-backend/src/plugin.ts
@@ -18,10 +18,12 @@ import {
   coreServices,
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
+import { actionsRegistryServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { DefaultSonarqubeInfoProvider } from './service/sonarqubeInfoProvider';
 import { createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
+import { createSonarqubeActions } from './actions';
 
 /**
  * Sonarqube backend plugin
@@ -38,8 +40,19 @@ export const sonarqubePlugin = createBackendPlugin({
         httpRouter: coreServices.httpRouter,
         httpAuth: coreServices.httpAuth,
         catalog: catalogServiceRef,
+        actionsRegistry: actionsRegistryServiceRef,
       },
-      async init({ logger, config, httpRouter, httpAuth, catalog }) {
+      async init({
+        logger,
+        config,
+        httpRouter,
+        httpAuth,
+        catalog,
+        actionsRegistry,
+      }) {
+        const sonarqubeInfoProvider =
+          DefaultSonarqubeInfoProvider.fromConfig(config);
+
         const router = await createRouter({
           /**
            * Logger for logging purposes
@@ -48,8 +61,7 @@ export const sonarqubePlugin = createBackendPlugin({
           /**
            * Info provider to be able to get all necessary information for the APIs
            */
-          sonarqubeInfoProvider:
-            DefaultSonarqubeInfoProvider.fromConfig(config),
+          sonarqubeInfoProvider,
           catalog,
           httpAuth,
         });
@@ -58,6 +70,12 @@ export const sonarqubePlugin = createBackendPlugin({
         router.use(factory.error());
 
         httpRouter.use(router);
+
+        createSonarqubeActions({
+          actionsRegistry,
+          sonarqubeInfoProvider,
+          catalog,
+        });
       },
     });
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds two new actions to get quality status from sonarqube for entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
