### PR TITLE
fix(entity-validation): handle missing kind and metadata without crashing

### DIFF
--- a/workspaces/entity-validation/.changeset/fix-entity-validation-null-safety.md
+++ b/workspaces/entity-validation/.changeset/fix-entity-validation-null-safety.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-validation': patch
+---
+
+Handle missing `kind` and `metadata` without crashing when validating entities. Previously the plugin crashed on entities missing these fields, hiding the underlying validation errors from the user. The plugin now surfaces those errors and labels which field is missing (for example `component:<missing name>`) in the results list.

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
@@ -72,7 +72,7 @@ export const EntityResult = ({
 
   return (
     <>
-      <ListItem key={safeEntityDisplayName(item.entity)}>
+      <ListItem>
         <ListItemIcon>
           {Icon && (
             <Icon

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
@@ -25,7 +25,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import { EntityDisplayName } from '@backstage/plugin-catalog-react';
-import { safeEntityDisplayName, safeEntityKind } from './safeEntityDisplayName';
+import { safeEntityKind } from './safeEntityDisplayName';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { MarkdownContent } from '@backstage/core-components';

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
@@ -25,6 +25,7 @@ import ListItemText from '@material-ui/core/ListItemText';
 import Paper from '@material-ui/core/Paper';
 import { makeStyles } from '@material-ui/core/styles';
 import { EntityDisplayName } from '@backstage/plugin-catalog-react';
+import { safeEntityDisplayName, safeEntityKind } from './safeEntityDisplayName';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import { MarkdownContent } from '@backstage/core-components';
@@ -59,7 +60,7 @@ export const EntityResult = ({
   const [expanded, setExpanded] = useState(isFirstError);
 
   const Icon = app.getSystemIcon(
-    `kind:${item.entity.kind.toLocaleLowerCase('en-US')}`,
+    `kind:${safeEntityKind(item.entity)}`,
   ) as typeof SvgIcon;
 
   const fetchErrorMessages = (response: ValidateEntityResponse) => {
@@ -71,11 +72,7 @@ export const EntityResult = ({
 
   return (
     <>
-      <ListItem
-        key={`${item.entity.kind}:${
-          item.entity.metadata.namespace ?? 'default'
-        }/${item.entity.metadata.name}`}
-      >
+      <ListItem key={safeEntityDisplayName(item.entity)}>
         <ListItemIcon>
           {Icon && (
             <Icon

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityValidationOutput.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityValidationOutput.tsx
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 import { identityApiRef, useApi } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  defaultEntityPresentation,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { safeEntityDisplayName } from './safeEntityDisplayName';
 import List from '@material-ui/core/List';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -43,8 +41,8 @@ const useStyles = makeStyles(theme => ({
 
 function sortResults(items: Array<ValidationOutputOk>) {
   return items.sort((a, b) =>
-    defaultEntityPresentation(a.entity).primaryTitle.localeCompare(
-      defaultEntityPresentation(b.entity).primaryTitle,
+    safeEntityDisplayName(a.entity).localeCompare(
+      safeEntityDisplayName(b.entity),
     ),
   );
 }

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.test.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import { safeEntityDisplayName, safeEntityKind } from './safeEntityDisplayName';
+
+describe('safeEntityDisplayName', () => {
+  it('should return humanized ref for a well-formed entity', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'my-service', namespace: 'default' },
+    } as Entity;
+    expect(safeEntityDisplayName(entity)).toBe('component:my-service');
+  });
+
+  it('should label the missing kind when kind is absent', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      metadata: { name: 'my-service' },
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('<missing kind>:my-service');
+  });
+
+  it('should label the missing name when metadata is null', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: null,
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('component:<missing name>');
+  });
+
+  it('should label the missing name when metadata.name is absent', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {},
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('component:<missing name>');
+  });
+
+  it('should label both fields when metadata is missing entirely', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('<missing kind>:<missing name>');
+  });
+
+  it('should not throw when kind is a non-string (YAML boolean trap)', () => {
+    // YAML 1.1 parses `kind: on` as boolean true
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: true,
+      metadata: { name: 'my-service' },
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('<missing kind>:my-service');
+  });
+
+  it('should not throw when name is a non-string', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 42 },
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    expect(safeEntityDisplayName(entity)).toBe('component:<missing name>');
+  });
+
+  it('should treat empty string kind as missing', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: '',
+      metadata: { name: 'my-service' },
+    } as unknown as Entity;
+    expect(safeEntityDisplayName(entity)).toBe('<missing kind>:my-service');
+  });
+
+  it('should treat empty string name as missing', () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: '' },
+    } as unknown as Entity;
+    expect(safeEntityDisplayName(entity)).toBe('component:<missing name>');
+  });
+
+  it('should not throw when namespace is a non-string (YAML boolean trap)', () => {
+    // YAML 1.1 parses `namespace: on` as boolean true
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'my-service', namespace: true },
+    } as unknown as Entity;
+    expect(() => safeEntityDisplayName(entity)).not.toThrow();
+    // Falls back to non-humanized kind:name format because the
+    // humanizeEntityRef path would crash on the non-string namespace.
+    expect(safeEntityDisplayName(entity)).toBe('component:my-service');
+  });
+});
+
+describe('safeEntityKind', () => {
+  it('should return lowercased kind for a well-formed entity', () => {
+    const entity = { kind: 'Component' } as Entity;
+    expect(safeEntityKind(entity)).toBe('component');
+  });
+
+  it('should return "missing" when kind is absent', () => {
+    const entity = {} as unknown as Entity;
+    expect(safeEntityKind(entity)).toBe('missing');
+  });
+
+  it('should return "missing" when kind is a non-string (YAML boolean trap)', () => {
+    const entity = { kind: true } as unknown as Entity;
+    expect(() => safeEntityKind(entity)).not.toThrow();
+    expect(safeEntityKind(entity)).toBe('missing');
+  });
+});

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.test.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.test.ts
@@ -17,7 +17,7 @@ import { Entity } from '@backstage/catalog-model';
 import { safeEntityDisplayName, safeEntityKind } from './safeEntityDisplayName';
 
 describe('safeEntityDisplayName', () => {
-  it('should return humanized ref for a well-formed entity', () => {
+  it('should return kind:name for a well-formed entity', () => {
     const entity = {
       apiVersion: 'backstage.io/v1alpha1',
       kind: 'Component',
@@ -110,8 +110,6 @@ describe('safeEntityDisplayName', () => {
       metadata: { name: 'my-service', namespace: true },
     } as unknown as Entity;
     expect(() => safeEntityDisplayName(entity)).not.toThrow();
-    // Falls back to non-humanized kind:name format because the
-    // humanizeEntityRef path would crash on the non-string namespace.
     expect(safeEntityDisplayName(entity)).toBe('component:my-service');
   });
 });

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Entity } from '@backstage/catalog-model';
+import { humanizeEntityRef } from '@backstage/plugin-catalog-react';
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isStringOrAbsent(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+/**
+ * Safely produce a display name for an entity, falling back gracefully
+ * when kind or metadata.name are missing or not strings (which would
+ * crash humanizeEntityRef). The fallback labels which field is missing
+ * so the user can tell what is wrong with the entity.
+ *
+ * Non-string values (e.g. YAML 1.1 booleans like `kind: on`) are treated
+ * as missing rather than stringified, since they cannot be safely passed
+ * to humanizeEntityRef and rarely match the intent of the YAML author.
+ */
+export function safeEntityDisplayName(entity: Entity): string {
+  const kind = entity?.kind;
+  const name = entity?.metadata?.name;
+  const namespace = entity?.metadata?.namespace;
+
+  if (
+    isNonEmptyString(kind) &&
+    isNonEmptyString(name) &&
+    isStringOrAbsent(namespace)
+  ) {
+    return humanizeEntityRef(entity);
+  }
+
+  const kindLabel = isNonEmptyString(kind)
+    ? kind.toLocaleLowerCase('en-US')
+    : '<missing kind>';
+  const nameLabel = isNonEmptyString(name) ? name : '<missing name>';
+  return `${kindLabel}:${nameLabel}`;
+}
+
+/**
+ * Safely get the lowercased kind string for an entity, returning
+ * 'missing' when the kind field is not set or not a string.
+ */
+export function safeEntityKind(entity: Entity): string {
+  const kind = entity?.kind;
+  return isNonEmptyString(kind) ? kind.toLocaleLowerCase('en-US') : 'missing';
+}

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.ts
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/safeEntityDisplayName.ts
@@ -14,38 +14,24 @@
  * limitations under the License.
  */
 import { Entity } from '@backstage/catalog-model';
-import { humanizeEntityRef } from '@backstage/plugin-catalog-react';
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
-function isStringOrAbsent(value: unknown): boolean {
-  return value === undefined || value === null || typeof value === 'string';
-}
-
 /**
  * Safely produce a display name for an entity, falling back gracefully
- * when kind or metadata.name are missing or not strings (which would
- * crash humanizeEntityRef). The fallback labels which field is missing
- * so the user can tell what is wrong with the entity.
+ * when kind or metadata.name are missing or not strings. The fallback
+ * labels which field is missing so the user can tell what is wrong with
+ * the entity.
  *
  * Non-string values (e.g. YAML 1.1 booleans like `kind: on`) are treated
- * as missing rather than stringified, since they cannot be safely passed
- * to humanizeEntityRef and rarely match the intent of the YAML author.
+ * as missing rather than stringified, since they rarely match the intent
+ * of the YAML author.
  */
 export function safeEntityDisplayName(entity: Entity): string {
   const kind = entity?.kind;
   const name = entity?.metadata?.name;
-  const namespace = entity?.metadata?.namespace;
-
-  if (
-    isNonEmptyString(kind) &&
-    isNonEmptyString(name) &&
-    isStringOrAbsent(namespace)
-  ) {
-    return humanizeEntityRef(entity);
-  }
 
   const kindLabel = isNonEmptyString(kind)
     ? kind.toLocaleLowerCase('en-US')


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #8216

When validating entities with missing `kind`, missing `metadata.name`, or a non-string value in any of those fields (e.g. the YAML 1.1 boolean trap where `kind: on` parses to `true`), the plugin crashed because `humanizeEntityRef()` and `kind.toLocaleLowerCase()` were called without any checks on the input shape. Instead of showing the validation errors the catalog API already returns, the user saw an unhandled exception.

Added `safeEntityDisplayName` and `safeEntityKind` utility functions that use explicit `typeof` + non-empty-string guards (and a namespace presence check) before calling `humanizeEntityRef`. When any required field is missing or not a string, the functions build a labeled fallback like `component:<missing name>` or `<missing kind>:<missing name>` so the user can tell exactly which field of their entity is broken. Applied the helpers in `EntityResult.tsx` (3 crash points) and `EntityValidationOutput.tsx` (1 crash point in the sort comparator).

### Review feedback addressed in the latest commit

- Replaced the `try/catch` wrapper with explicit value checks, per review.
- Renamed the fallback strings from `"unknown"` / `"<unknown entity>"` to labels that name the missing field, per review.
- Fixed the copyright header on the new files to 2026.
- Added the missing changeset for `@backstage-community/plugin-entity-validation`.
- All commits on the branch are now `Signed-off-by`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
