### PR TITLE
chore(codeowners): update argocd and quay codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ yarn.lock                                                               @backsta
 /workspaces/apache-airflow                                              @backstage/community-plugins-maintainers
 /workspaces/apiiro                                                      @backstage/community-plugins-maintainers  @hetsaliya-crestdata @zuberc-cds @IgalKreich @shaim-apiiro
 /workspaces/apollo-explorer                                             @backstage/community-plugins-maintainers
-/workspaces/argocd                                                      @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar 
+/workspaces/argocd                                                      @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar @dzemanov
 /workspaces/azure-devops                                                @backstage/community-plugins-maintainers  @awanlin
 /workspaces/azure-resources                                             @backstage/community-plugins-maintainers  @sarabadu
 /workspaces/azure-sites                                                 @backstage/community-plugins-maintainers  @deepan10 @sarabadu
@@ -99,7 +99,7 @@ yarn.lock                                                               @backsta
 /workspaces/pingidentity                                                @backstage/community-plugins-maintainers  @jessicajhee @AndrienkoAleksandr @dzemanov @lholmquist @PatAKnight @djanickova
 /workspaces/playlist                                                    @backstage/community-plugins-maintainers  @kuangp
 /workspaces/puppetdb                                                    @backstage/community-plugins-maintainers
-/workspaces/quay                                                        @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar 
+/workspaces/quay                                                        @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar @dzemanov
 /workspaces/rbac                                                        @backstage/community-plugins-maintainers  @AndrienkoAleksandr @christoph-jerolimov @debsmita1 @divyanshiGupta @PatAKnight @dzemanov @jrichter1 @HusneShabbir @karthikjeeyar @rohitkrai03 @djanickova
 /workspaces/repo-tools                                                  @backstage/community-plugins-maintainers
 /workspaces/report-portal                                               @backstage/community-plugins-maintainers  @yashoswalyo @deshmukhmayur @riginoommen


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adding myself as codeowner for `argocd` and `quay` workspaces.

Some contributions:
- argocd
  - https://github.com/backstage/community-plugins/pull/6469
  - https://github.com/backstage/community-plugins/pull/7031
  - https://github.com/backstage/community-plugins/pull/7640
  - https://github.com/backstage/community-plugins/pull/7631
  - https://github.com/backstage/community-plugins/pull/6752
- quay
  - https://github.com/backstage/community-plugins/pull/7560
  - https://github.com/backstage/community-plugins/pull/6295
  - https://github.com/backstage/community-plugins/pull/3486
  - https://github.com/backstage/community-plugins/pull/3118
  - https://github.com/backstage/community-plugins/pull/2949

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
