### PR TITLE
kiali: fix 'occured' -> 'occurred' in KChart error message

### DIFF
--- a/workspaces/kiali/.changeset/kchart-occured-fix.md
+++ b/workspaces/kiali/.changeset/kchart-occured-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-kiali': patch
+---
+
+Fix typo `occured` -> `occurred` in KChart error message.

--- a/workspaces/kiali/plugins/kiali/src/components/Charts/KChart.tsx
+++ b/workspaces/kiali/plugins/kiali/src/components/Charts/KChart.tsx
@@ -241,7 +241,7 @@ export class KChart<T extends LineInfo> extends React.Component<
             </Icon>
           )}
           <EmptyStateBody className={emptyStyle}>
-            An error occured while fetching this metric:
+            An error occurred while fetching this metric:
             <p>
               <i>{this.props.chart.error}</i>
             </p>


### PR DESCRIPTION
Error message in `workspaces/kiali/plugins/kiali/src/components/Charts/KChart.tsx` line 244 reads `An error occured while fetching this metric`. User-visible in the Backstage UI. Fixed to `occurred`. String-literal-only change.