### PR TITLE
fix(entity-validation): entity ref humanization

### DIFF
--- a/workspaces/entity-validation/.changeset/beige-roses-smoke.md
+++ b/workspaces/entity-validation/.changeset/beige-roses-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-validation': patch
+---
+
+Fix entity ref creation for missing properties with `humanizeEntityRef`

--- a/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
+++ b/workspaces/entity-validation/plugins/entity-validation/src/components/EntityValidationOutput/EntityResult.tsx
@@ -50,6 +50,13 @@ type EntityResultProps = {
   item: ValidationOutputOk;
 };
 
+const fetchErrorMessages = (response: ValidateEntityResponse) => {
+  if (!response.valid) {
+    return response.errors.map(err => err.message).join('\n\n');
+  }
+  return '';
+};
+
 export const EntityResult = ({
   isFirstError = false,
   item,
@@ -57,21 +64,18 @@ export const EntityResult = ({
   const classes = useStyles();
   const app = useApp();
   const [expanded, setExpanded] = useState(isFirstError);
+  const kind = item?.entity?.kind?.toLocaleLowerCase?.('en-US') ?? '<UNKNOWN>';
+  const entityKey = humanizeEntityRef({
+    kind,
+    namespace: item?.entity?.metadata?.namespace ?? '<UNKNOWN>',
+    name: item?.entity?.metadata?.name ?? '<UNKNOWN>',
+  });
 
-  const Icon = app.getSystemIcon(
-    `kind:${item.entity.kind.toLocaleLowerCase('en-US')}`,
-  ) as typeof SvgIcon;
-
-  const fetchErrorMessages = (response: ValidateEntityResponse) => {
-    if (!response.valid) {
-      return response.errors.map(err => err.message).join('\n\n');
-    }
-    return '';
-  };
+  const Icon = app.getSystemIcon(`kind:${kind}`) as typeof SvgIcon;
 
   return (
     <>
-      <ListItem key={humanizeEntityRef(item.entity)}>
+      <ListItem key={entityKey}>
         <ListItemIcon>
           {Icon && (
             <Icon
@@ -84,7 +88,7 @@ export const EntityResult = ({
           )}
         </ListItemIcon>
         <ListItemText
-          primary={humanizeEntityRef(item.entity)}
+          primary={entityKey}
           onClick={() => setExpanded(!expanded)}
         />
         {!item.response.valid && (


### PR DESCRIPTION
The entity validation plugin doesn't handle entities for validation properly.

Fixes #8216

The `humaizeEntityRef` from `@backstage/plugin-catalog-react` package expects `entitiyRef.kind` & `entityRef.metadata.namespace` to be available, even with the defaults provided, which is why the page breaks when either one of those isn't available. 

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
