### PR TITLE
Version Packages (octopus-deploy)

### DIFF
--- a/workspaces/octopus-deploy/.changeset/octopus-deploy-new-frontend-system.md
+++ b/workspaces/octopus-deploy/.changeset/octopus-deploy-new-frontend-system.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-octopus-deploy': minor
----
-
-Add New Frontend System support via a new `./alpha` entry point, exposing `EntityContentBlueprint` for the entity tab, `ApiBlueprint` for the Octopus Deploy API, and `FormFieldBlueprint` for the project group dropdown scaffolder field extension.

--- a/workspaces/octopus-deploy/.changeset/version-bump-1-49-2.md
+++ b/workspaces/octopus-deploy/.changeset/version-bump-1-49-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-octopus-deploy': minor
----
-
-Backstage version bump to v1.49.2

--- a/workspaces/octopus-deploy/.changeset/version-bump-1-50-2.md
+++ b/workspaces/octopus-deploy/.changeset/version-bump-1-50-2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-octopus-deploy': minor
----
-
-Backstage version bump to v1.50.2

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-octopus-deploy
 
+## 0.11.0
+
+### Minor Changes
+
+- 00b064b: Add New Frontend System support via a new `./alpha` entry point, exposing `EntityContentBlueprint` for the entity tab, `ApiBlueprint` for the Octopus Deploy API, and `FormFieldBlueprint` for the project group dropdown scaffolder field extension.
+- fd239c0: Backstage version bump to v1.49.2
+- 30fdca0: Backstage version bump to v1.50.2
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-octopus-deploy
 
+## 0.11.0
+
+### Minor Changes
+
+- fd239c0: Backstage version bump to v1.49.2
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-octopus-deploy
 
+## 0.11.0
+
+### Minor Changes
+
+- fd239c0: Backstage version bump to v1.49.2
+- 30fdca0: Backstage version bump to v1.50.2
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/octopus-deploy/plugins/octopus-deploy/package.json
+++ b/workspaces/octopus-deploy/plugins/octopus-deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-octopus-deploy",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "octopus-deploy",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-octopus-deploy@0.11.0

### Minor Changes

-   00b064b: Add New Frontend System support via a new `./alpha` entry point, exposing `EntityContentBlueprint` for the entity tab, `ApiBlueprint` for the Octopus Deploy API, and `FormFieldBlueprint` for the project group dropdown scaffolder field extension.
-   fd239c0: Backstage version bump to v1.49.2
-   30fdca0: Backstage version bump to v1.50.2
