### PR TITLE
fix(repo): use highest instead of newest release in version bump branch name and changelog

### DIFF
--- a/scripts/ci/set-release-name.js
+++ b/scripts/ci/set-release-name.js
@@ -20,6 +20,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import fetch from 'node-fetch';
 import { EOL } from 'os';
+import semver from 'semver';
 
 async function getBackstageVersion(workspace) {
   const rootPath = path.resolve(`workspaces/${workspace}/backstage.json`);
@@ -65,26 +66,13 @@ async function fetchWithRetry(url, retries = 1, delayMs = 60000) {
   return null;
 }
 
-async function getLatestRelease() {
-  return fetchWithRetry(
-    'https://api.github.com/repos/backstage/backstage/releases/latest',
+async function getGitHubReleases() {
+  const releases = await fetchWithRetry(
+    'https://api.github.com/repos/backstage/backstage/releases?per_page=100',
   );
-}
-
-async function getLatestPreRelease() {
-  const json = await fetchWithRetry(
-    'https://api.github.com/repos/backstage/backstage/releases',
+  return releases.filter(
+    release => semver.valid(release.name) && !release.draft,
   );
-
-  const preReleasesOnly = json.filter(release => {
-    return release.prerelease === true;
-  });
-
-  const latestPreRelease = preReleasesOnly.sort((a, b) => {
-    return new Date(b.published_at) - new Date(a.published_at);
-  })[0];
-
-  return latestPreRelease;
 }
 
 async function main() {
@@ -96,10 +84,15 @@ async function main() {
 
   // Get the current Backstage version from the backstage.json file
   const backstageVersion = await getBackstageVersion(workspace);
-  // Get the latest Backstage Release from the GitHub API
-  const latestRelease = await getLatestRelease();
-  // Get the latest Backstage Pre-release from the GitHub API
-  const latestPreRelease = await getLatestPreRelease();
+  // Get the latest Backstage Releases from the GitHub API
+  const gitHubReleases = await getGitHubReleases();
+  // Sort releases by version in descending order to ensure that the
+  // latest release (highest version) is first, regardless of publish date.
+  const orderedReleases = gitHubReleases.sort((a, b) =>
+    semver.compare(b.name, a.name),
+  );
+  const latestRelease = orderedReleases.find(release => !release.prerelease);
+  const latestPreRelease = orderedReleases.find(release => release.prerelease);
 
   console.log(`Current Backstage version is: v${backstageVersion}`);
   console.log(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #8646

The issue includes a detailed information about the timeline and the problem.

Tl;dr: When there is a newer Backstage release that is not from the "latest" minor version it was picked up from the Version bump action for the branch name, PR summary and changeset content while the `yarn backstage-cli versions:bump` command is using the right latest version.

The problem was that `scripts/ci/set-release-name.js` orders the releases by published_at date. This change orders the releases instead with `semver`.

The library was already part of the package.json and used in `scripts/ci/label-aged-renovate-prs.js`.

Local validation works fine:

**Before:**

```
node scripts/ci/set-release-name.js npm main
Current Backstage version is: v1.49.2
Latest Release version is: v1.49.5, published on: 2026-04-17T13:47:45Z
Latest Pre-release version is: v1.50.0-next.2, published on: 2026-04-07T17:49:30Z
```

**After:**

```
node scripts/ci/set-release-name.js npm main
Current Backstage version is: v1.49.2
Latest Release version is: v1.50.1, published on: 2026-04-15T22:26:38Z
Latest Pre-release version is: v1.50.0-next.2, published on: 2026-04-07T17:49:30Z
```

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
