### PR TITLE
fix(vault): correctly load schedule configuration for token renewal tasks

### DIFF
--- a/workspaces/vault/.changeset/nasty-lamps-compare.md
+++ b/workspaces/vault/.changeset/nasty-lamps-compare.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-vault-backend': patch
+---
+
+Correctly load schedule configuration for token renewal tasks.

--- a/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
@@ -19,6 +19,7 @@ import express from 'express';
 import request from 'supertest';
 import { mockServices } from '@backstage/backend-test-utils';
 import { VaultBuilder } from './VaultBuilder';
+import { SchedulerServiceTaskScheduleDefinition } from '@backstage/backend-plugin-api';
 
 describe('VaultBuilder', () => {
   let app: express.Express;
@@ -93,6 +94,82 @@ describe('VaultBuilder', () => {
       const response = await request(app).get('/v1/secrets//create-url');
 
       expect(response.status).toEqual(404);
+    });
+  });
+
+  describe('enableTokenRenew schedule configuration', () => {
+    const createBuilderWithScheduleConfig = (
+      schedule?: SchedulerServiceTaskScheduleDefinition | boolean,
+    ) => {
+      const runner = jest.fn();
+      const mockScheduler = mockServices.scheduler.mock({
+        createScheduledTaskRunner() {
+          return { run: runner };
+        },
+      });
+
+      const vaultConfig: any = {
+        baseUrl: 'https://vault-server',
+        publicUrl: 'https://vault-server',
+        secretEngine: 'secrets',
+        auth: {
+          type: 'static',
+          secret: '1234567890',
+        },
+      };
+
+      if (schedule) {
+        vaultConfig.schedule = schedule;
+      }
+
+      const builder = VaultBuilder.createBuilder({
+        logger: mockServices.logger.mock(),
+        config: new ConfigReader({ vault: vaultConfig }),
+        scheduler: mockScheduler,
+      });
+
+      return { builder, mockScheduler };
+    };
+
+    it('uses config schedule when vault.schedule is provided', async () => {
+      const { builder, mockScheduler } = createBuilderWithScheduleConfig({
+        scope: 'local',
+        frequency: { minutes: 30 },
+        timeout: { minutes: 15 },
+      });
+      builder.build();
+
+      await builder.enableTokenRenew();
+
+      expect(mockScheduler.createScheduledTaskRunner).toHaveBeenCalledWith({
+        scope: 'local',
+        frequency: { minutes: 30 },
+        timeout: { minutes: 15 },
+      });
+    });
+
+    it('uses default hourly schedule when vault.schedule is not provided', async () => {
+      const { builder, mockScheduler } = createBuilderWithScheduleConfig();
+      builder.build();
+
+      await builder.enableTokenRenew();
+
+      expect(mockScheduler.createScheduledTaskRunner).toHaveBeenCalledWith({
+        frequency: { hours: 1 },
+        timeout: { hours: 1 },
+      });
+    });
+
+    it('uses default hourly schedule when vault.schedule is false', async () => {
+      const { builder, mockScheduler } = createBuilderWithScheduleConfig(false);
+      builder.build();
+
+      await builder.enableTokenRenew();
+
+      expect(mockScheduler.createScheduledTaskRunner).toHaveBeenCalledWith({
+        frequency: { hours: 1 },
+        timeout: { hours: 1 },
+      });
     });
   });
 });

--- a/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
@@ -99,7 +99,7 @@ describe('VaultBuilder', () => {
 
   describe('enableTokenRenew schedule configuration', () => {
     const createBuilderWithScheduleConfig = (
-      schedule?: SchedulerServiceTaskScheduleDefinition | boolean,
+      schedule?: SchedulerServiceTaskScheduleDefinition,
     ) => {
       const runner = jest.fn();
       const mockScheduler = mockServices.scheduler.mock({
@@ -147,18 +147,6 @@ describe('VaultBuilder', () => {
 
     it('uses default hourly schedule when vault.schedule is not provided', async () => {
       const { builder, mockScheduler } = createBuilderWithScheduleConfig();
-      builder.build();
-
-      await builder.enableTokenRenew();
-
-      expect(mockScheduler.createScheduledTaskRunner).toHaveBeenCalledWith({
-        frequency: { hours: 1 },
-        timeout: { hours: 1 },
-      });
-    });
-
-    it('uses default hourly schedule when vault.schedule is false', async () => {
-      const { builder, mockScheduler } = createBuilderWithScheduleConfig(false);
       builder.build();
 
       await builder.enableTokenRenew();

--- a/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.test.ts
@@ -116,11 +116,8 @@ describe('VaultBuilder', () => {
           type: 'static',
           secret: '1234567890',
         },
+        schedule: schedule,
       };
-
-      if (schedule) {
-        vaultConfig.schedule = schedule;
-      }
 
       const builder = VaultBuilder.createBuilder({
         logger: mockServices.logger.mock(),

--- a/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.ts
@@ -147,12 +147,13 @@ export class VaultBuilder {
   }
 
   private getConfigSchedule(): SchedulerServiceTaskScheduleDefinition {
-    const schedule = this.env.config.getOptional<
-      SchedulerServiceTaskScheduleDefinitionConfig | boolean
-    >('vault.schedule');
+    const schedule =
+      this.env.config.getOptional<SchedulerServiceTaskScheduleDefinitionConfig>(
+        'vault.schedule',
+      );
 
     const scheduleCfg =
-      schedule !== undefined && schedule !== false
+      schedule !== undefined
         ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
             this.env.config.getConfig('vault.schedule'),
           )

--- a/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.ts
+++ b/workspaces/vault/plugins/vault-backend/src/service/VaultBuilder.ts
@@ -153,13 +153,13 @@ export class VaultBuilder {
 
     const scheduleCfg =
       schedule !== undefined && schedule !== false
-        ? {
+        ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
+            this.env.config.getConfig('vault.schedule'),
+          )
+        : {
             frequency: { hours: 1 },
             timeout: { hours: 1 },
-          }
-        : readSchedulerServiceTaskScheduleDefinitionFromConfig(
-            this.env.config.getConfig('vault.schedule'),
-          );
+          };
 
     return scheduleCfg;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes how the schedule configuration is loaded from the configuration.

Currently, when present, the `vault.schedule` config is not used and the default is used.
If `vault.schedule` is not present, it will throw when attempting to read it.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] ~Added or updated documentation~
- [X] Tests for new functionality and regression tests for bug fixes
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
