### PR TITLE
Version Packages (growthbook-flags)

### DIFF
--- a/workspaces/growthbook-flags/.changeset/growthbook-initial-release.md
+++ b/workspaces/growthbook-flags/.changeset/growthbook-initial-release.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-growthbook': minor
-'@backstage-community/plugin-growthbook-backend': minor
-'@backstage-community/plugin-growthbook-common': minor
----
-
-Initial release of the GrowthBook feature flags plugin. See the README for more details.

--- a/workspaces/growthbook-flags/.changeset/renovate-9187fce.md
+++ b/workspaces/growthbook-flags/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-growthbook-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @backstage-community/plugin-growthbook-backend
+
+## 0.1.0
+
+### Minor Changes
+
+- 1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.
+
+### Patch Changes
+
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+- Updated dependencies [1a30776]
+  - @backstage-community/plugin-growthbook-common@0.1.0

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @backstage-community/plugin-growthbook-backend
+
+## 0.1.0
+
+### Minor Changes
+
+- 1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.
+
+### Patch Changes
+
+- Updated dependencies [1a30776]
+  - @backstage-community/plugin-growthbook-common@0.1.0

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-growthbook-backend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage-community/plugin-growthbook-common": "^0.0.0",
+    "@backstage-community/plugin-growthbook-common": "^0.1.0",
     "@backstage/backend-plugin-api": "^1.6.2",
     "@backstage/config": "^1.3.6",
     "express": "^4.17.1"

--- a/workspaces/growthbook-flags/plugins/growthbook-common/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-growthbook-common
+
+## 0.1.0
+
+### Minor Changes
+
+- 1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.

--- a/workspaces/growthbook-flags/plugins/growthbook-common/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-growthbook-common",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Common types for the GrowthBook feature flags plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/growthbook-flags/plugins/growthbook/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @backstage-community/plugin-growthbook
+
+## 0.1.0
+
+### Minor Changes
+
+- 1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.
+
+### Patch Changes
+
+- Updated dependencies [1a30776]
+  - @backstage-community/plugin-growthbook-common@0.1.0

--- a/workspaces/growthbook-flags/plugins/growthbook/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-growthbook",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -44,7 +44,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@backstage-community/plugin-growthbook-common": "^0.0.0",
+    "@backstage-community/plugin-growthbook-common": "^0.1.0",
     "@backstage/catalog-model": "^1.7.6",
     "@backstage/core-compat-api": "^0.5.8",
     "@backstage/core-components": "^0.18.6",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-growthbook@0.1.0

### Minor Changes

-   1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.

### Patch Changes

-   Updated dependencies [1a30776]
    -   @backstage-community/plugin-growthbook-common@0.1.0

## @backstage-community/plugin-growthbook-backend@0.1.0

### Minor Changes

-   1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.

### Patch Changes

-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.
-   Updated dependencies [1a30776]
    -   @backstage-community/plugin-growthbook-common@0.1.0

## @backstage-community/plugin-growthbook-common@0.1.0

### Minor Changes

-   1a30776: Initial release of the GrowthBook feature flags plugin. See the README for more details.
