### PR TITLE
Version Packages (gcalendar)

### DIFF
--- a/workspaces/gcalendar/.changeset/renovate-94e2796.md
+++ b/workspaces/gcalendar/.changeset/renovate-94e2796.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-gcalendar': patch
----
-
-Updated dependency `dompurify` to `^3.4.0`.

--- a/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
+++ b/workspaces/gcalendar/plugins/gcalendar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-gcalendar
 
+## 0.19.1
+
+### Patch Changes
+
+- 90d745b: Updated dependency `dompurify` to `^3.4.0`.
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/gcalendar/plugins/gcalendar/package.json
+++ b/workspaces/gcalendar/plugins/gcalendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-gcalendar",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-gcalendar@0.19.1

### Patch Changes

-   90d745b: Updated dependency `dompurify` to `^3.4.0`.
