### PR TITLE
fix(rbac): improve role creation form UI text consistency and accuracy

### DIFF
--- a/workspaces/rbac/.changeset/rbac-ui-text-improvements.md
+++ b/workspaces/rbac/.changeset/rbac-ui-text-improvements.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Fix RBAC role creation form UI text consistency and accuracy

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
@@ -76,7 +76,7 @@ const rbacTranslationDe = createTranslationMessages({
     'roleForm.titles.createRole': 'Rolle erstellen',
     'roleForm.titles.editRole': 'Rolle bearbeiten',
     'roleForm.titles.nameAndDescription':
-      'Name und Beschreibung der Rolle eingeben',
+      'Name, Beschreibung und Eigentümer der Rolle eingeben',
     'roleForm.titles.usersAndGroups': 'Benutzer und Gruppen hinzufügen',
     'roleForm.titles.permissionPolicies': 'Berechtigungsrichtlinien hinzufügen',
     'roleForm.review.reviewAndCreate': 'Überprüfen und erstellen',
@@ -95,7 +95,7 @@ const rbacTranslationDe = createTranslationMessages({
     'roleForm.fields.name.helperText': 'Geben Sie den Namen der Rolle ein',
     'roleForm.fields.description.label': 'Beschreibung',
     'roleForm.fields.description.helperText':
-      'Geben Sie eine kurze Beschreibung der Rolle ein (Zweck der Rolle)',
+      'Optional: Geben Sie eine kurze Beschreibung der Rolle ein (Zweck der Rolle)',
     'roleForm.fields.owner.label': 'Eigentümer',
     'roleForm.fields.owner.helperText':
       'Optional: Geben Sie einen Benutzer oder eine Gruppe ein, der bzw. die die Berechtigung haben soll, diese Rolle zu bearbeiten und zusätzliche Rollen zu erstellen. Im nächsten Schritt legen Sie fest, welchen Benutzern sie ihre Rollen zuweisen können und auf welche Plugins sie Zugriff erteilen können. Wird hier keine Angabe gemacht, wird bei der Erstellung automatisch der Autor zugewiesen.',

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/es.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/es.ts
@@ -75,7 +75,7 @@ const rbacTranslationEs = createTranslationMessages({
     'roleForm.titles.createRole': 'Crear rol',
     'roleForm.titles.editRole': 'Modificar rol',
     'roleForm.titles.nameAndDescription':
-      'Ingresar el nombre y la descripción del rol',
+      'Ingresar el nombre, la descripción y el propietario del rol',
     'roleForm.titles.usersAndGroups': 'Agregar usuarios y grupos',
     'roleForm.titles.permissionPolicies': 'Agregar políticas de permisos',
     'roleForm.review.reviewAndCreate': 'Revisar y crear',
@@ -94,7 +94,7 @@ const rbacTranslationEs = createTranslationMessages({
     'roleForm.fields.name.helperText': 'Ingresar el nombre del rol',
     'roleForm.fields.description.label': 'Descripción',
     'roleForm.fields.description.helperText':
-      'Ingrese una breve descripción sobre el rol (el propósito del rol)',
+      'Opcional: Ingrese una breve descripción sobre el rol (el propósito del rol)',
     'roleForm.fields.owner.label': 'Propietario',
     'roleForm.fields.owner.helperText':
       'Opcional: Ingrese un usuario o grupo que tenga permiso para modificar este rol y crear roles adicionales. En el siguiente paso, especifique a qué usuarios pueden asignar sus roles y a qué complementos pueden conceder acceso. Si se deja en blanco, se asigna automáticamente el autor en el momento de la creación.',

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
@@ -100,7 +100,7 @@ const rbacTranslationFr = createTranslationMessages({
     'roleForm.fields.name.helperText': 'Entrez le nom du rôle',
     'roleForm.fields.description.label': 'Description',
     'roleForm.fields.description.helperText':
-      'Facultatif : saisissez une brève description du rôle (le but du rôle)',
+      'Facultatif : saisissez une brève description du rôle (le but du rôle)',
     'roleForm.fields.owner.label': 'Propriétaire',
     'roleForm.fields.owner.helperText':
       "Facultatif : saisissez un utilisateur ou un groupe qui sera autorisé à modifier ce rôle et à créer des rôles supplémentaires. À l’étape suivante, spécifiez les utilisateurs auxquels ils peuvent attribuer leurs rôles et les plugins auxquels ils peuvent accorder l’accès. Si laissé vide, attribue automatiquement l'auteur lors de la création.",

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
@@ -80,7 +80,7 @@ const rbacTranslationFr = createTranslationMessages({
     'roleForm.titles.createRole': 'Créer un rôle',
     'roleForm.titles.editRole': 'Modifier le rôle',
     'roleForm.titles.nameAndDescription':
-      'Entrez le nom et la description du rôle',
+      'Entrez le nom, la description et le propriétaire du rôle',
     'roleForm.titles.usersAndGroups': 'Ajouter des utilisateurs et des groupes',
     'roleForm.titles.permissionPolicies':
       "Ajouter des politiques d'autorisation",
@@ -100,7 +100,7 @@ const rbacTranslationFr = createTranslationMessages({
     'roleForm.fields.name.helperText': 'Entrez le nom du rôle',
     'roleForm.fields.description.label': 'Description',
     'roleForm.fields.description.helperText':
-      'Saisissez une brève description du rôle (le but du rôle)',
+      'Facultatif : saisissez une brève description du rôle (le but du rôle)',
     'roleForm.fields.owner.label': 'Propriétaire',
     'roleForm.fields.owner.helperText':
       "Facultatif : saisissez un utilisateur ou un groupe qui sera autorisé à modifier ce rôle et à créer des rôles supplémentaires. À l’étape suivante, spécifiez les utilisateurs auxquels ils peuvent attribuer leurs rôles et les plugins auxquels ils peuvent accorder l’accès. Si laissé vide, attribue automatiquement l'auteur lors de la création.",

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/it.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/it.ts
@@ -78,7 +78,7 @@ const rbacTranslationIt = createTranslationMessages({
     'roleForm.titles.createRole': 'Crea ruolo',
     'roleForm.titles.editRole': 'Modifica ruolo',
     'roleForm.titles.nameAndDescription':
-      'Inserire il nome e la descrizione del ruolo',
+      'Inserire il nome, la descrizione e il proprietario del ruolo',
     'roleForm.titles.usersAndGroups': 'Aggiungi utenti e gruppi',
     'roleForm.titles.permissionPolicies': 'Aggiungi criteri di autorizzazione',
     'roleForm.review.reviewAndCreate': 'Rivedi e crea',
@@ -97,7 +97,7 @@ const rbacTranslationIt = createTranslationMessages({
     'roleForm.fields.name.helperText': 'Inserire il nome del ruolo',
     'roleForm.fields.description.label': 'Descrizione',
     'roleForm.fields.description.helperText':
-      'Inserire una breve descrizione del ruolo (finalità del ruolo)',
+      'Facoltativo: inserire una breve descrizione del ruolo (finalità del ruolo)',
     'roleForm.fields.owner.label': 'Proprietario',
     'roleForm.fields.owner.helperText':
       "Facoltativo: inserire un utente o un gruppo che avrà l'autorizzazione a modificare questo ruolo e a creare ruoli aggiuntivi. Nel passaggio successivo, specificare quali utenti possono assegnare ai loro ruoli e a quali plugin possono concedere l'accesso. Se vuoto, l'autore viene assegnato automaticamente al momento della creazione.",

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/ja.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/ja.ts
@@ -73,7 +73,7 @@ const rbacTranslationJa = createTranslationMessages({
     'roleForm.titles.createRole': 'ロールの作成',
     'roleForm.titles.editRole': 'ロールの編集',
     'roleForm.titles.nameAndDescription':
-      'ロールの名前と説明を入力してください',
+      'ロールの名前、説明、および所有者を入力してください',
     'roleForm.titles.usersAndGroups': 'ユーザーとグループの追加',
     'roleForm.titles.permissionPolicies': '権限ポリシーの追加',
     'roleForm.review.reviewAndCreate': '確認および作成',
@@ -90,7 +90,7 @@ const rbacTranslationJa = createTranslationMessages({
     'roleForm.fields.name.helperText': 'ロールの名前を入力してください',
     'roleForm.fields.description.label': '説明',
     'roleForm.fields.description.helperText':
-      'ロールについての簡単な説明を入力してください (ロールの目的)',
+      '任意: ロールについての簡単な説明を入力してください (ロールの目的)',
     'roleForm.fields.owner.label': '所有者',
     'roleForm.fields.owner.helperText':
       '任意: このロールを編集する権限と追加のロールを作成する権限を持つユーザーまたはグループを入力してください。どのユーザーを自分のロールに割り当て可能にするか、どのプラグインへのアクセスを許可するかは、次のステップで設定します。空白のままにすると、作成時に作成者が自動的に割り当てられます。',

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/ref.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/ref.ts
@@ -78,7 +78,7 @@ export const rbacMessages = {
     titles: {
       createRole: 'Create Role',
       editRole: 'Edit Role',
-      nameAndDescription: 'Enter name and description of role',
+      nameAndDescription: 'Enter name, description, and owner of role',
       usersAndGroups: 'Add users and groups',
       permissionPolicies: 'Add permission policies',
     },
@@ -104,7 +104,7 @@ export const rbacMessages = {
       description: {
         label: 'Description',
         helperText:
-          'Enter a brief description about the role (The purpose of the role)',
+          'Optional: Enter a brief description about the role (the purpose of the role)',
       },
       owner: {
         label: 'Owner',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-2946

This addresses UI inconsistencies in the RBAC role creation form where:
1. The step title mentioned "name and description" but the form also includes owner field
2. Description field lacked "Optional:" prefix while Owner field had it

-------------

-----BEFORE----

<img width="1522" height="477" alt="image" src="https://github.com/user-attachments/assets/707bb5ba-88fd-474c-ae5e-5c5d3fd9aa5d" />

-------------


----AFTER----

<img width="1493" height="908" alt="Screenshot 2026-04-21 at 11 52 14 AM" src="https://github.com/user-attachments/assets/dfafa041-1497-4b3d-b5d0-3ec55ed2220e" />

-------------

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
