### PR TITLE
feat(mcp-chat): add support for toolCallTimeout

### DIFF
--- a/workspaces/mcp-chat/.changeset/modern-hairs-give.md
+++ b/workspaces/mcp-chat/.changeset/modern-hairs-give.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-mcp-chat-backend': minor
 ---
 
-added support for setting tool timeout
+Add support for configuring MCP tool call timeout

--- a/workspaces/mcp-chat/.changeset/modern-hairs-give.md
+++ b/workspaces/mcp-chat/.changeset/modern-hairs-give.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': minor
+---
+
+added support for setting tool timeout

--- a/workspaces/mcp-chat/app-config.yaml
+++ b/workspaces/mcp-chat/app-config.yaml
@@ -26,6 +26,7 @@ integrations:
 
 # --------- MCP Chat Configuration ---------
 mcpChat:
+  toolCallTimeout: 60000
   providers:
     - id: openai
       baseUrl: 'https://any-openai-compatible-url/v1'

--- a/workspaces/mcp-chat/docs/SERVER_CONFIGURATION.md
+++ b/workspaces/mcp-chat/docs/SERVER_CONFIGURATION.md
@@ -168,6 +168,15 @@ mcpServers:
 - **Development**: STDIO servers are ideal for local development and testing
 - **Production**: HTTP servers work better for distributed or cloud deployments
 
+### Tool Call Timeout
+
+By default, MCP tool calls time out after **60 seconds**. For long-running tools (e.g., scaffolder templates that provision infrastructure), increase this with `toolCallTimeout`:
+
+```yaml
+mcpChat:
+  toolCallTimeout: 300000 # 5 minutes, in milliseconds
+```
+
 ---
 
 For additional setup instructions and troubleshooting, refer to the [main README](../README.md).

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
@@ -113,6 +113,13 @@ export interface Config {
       type?: 'stdio' | 'streamable-http'; // Note: Use MCPServerType enum in code
     }>;
     /**
+     * Timeout in milliseconds for MCP tool call requests.
+     * Increase this for long-running tools such as scaffolder templates.
+     * @visibility backend
+     * @default 60000
+     */
+    toolCallTimeout?: number;
+    /**
      * Custom system prompt for the AI assistant
      * @visibility backend
      */

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
@@ -112,6 +112,7 @@ export function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],
   mcpClients: Map<string, Client>,
+  toolCallTimeout?: number,
 ): Promise<ToolExecutionResult>;
 
 // @public

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
@@ -108,6 +108,9 @@ export interface ConversationRecord {
 export function createRouter(options: RouterOptions): Promise<express.Router>;
 
 // @public
+export const DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS = 60000;
+
+// @public
 export function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/index.ts
@@ -108,6 +108,7 @@ export {
   loadServerConfigs,
   executeToolCall,
   findNpxPath,
+  DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS,
 } from './utils';
 
 // =============================================================================

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.test.ts
@@ -199,6 +199,7 @@ describe('MCPClientServiceImpl', () => {
         toolCall,
         expect.any(Array),
         expect.any(Map),
+        expect.any(Number),
       );
     });
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
@@ -70,10 +70,13 @@ export class MCPClientServiceImpl implements MCPClientService {
   private readonly systemPrompt: string;
   private serverConfigs: MCPServerFullConfig[] = [];
   private allowedToolsByServer: Map<string, string[]> = new Map();
+  private readonly toolCallTimeout: number;
 
   constructor(options: Options) {
     this.logger = options.logger;
     this.config = options.config;
+    this.toolCallTimeout =
+      this.config.getOptionalNumber('mcpChat.toolCallTimeout') ?? 60000;
     this.llmProvider = this.initializeLLMProvider();
     this.mcpServers = this.initializeMCPServers();
     this.systemPrompt =
@@ -529,6 +532,7 @@ export class MCPClientServiceImpl implements MCPClientService {
             toolCall,
             this.tools,
             this.mcpClients,
+            this.toolCallTimeout,
           );
           toolResponses.push(toolResponse);
 

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/services/MCPClientServiceImpl.ts
@@ -26,7 +26,12 @@ import {
   getProviderConfig as getConfig,
   getProviderInfo,
 } from '../providers/provider-factory';
-import { executeToolCall, findNpxPath, loadServerConfigs } from '../utils';
+import {
+  executeToolCall,
+  findNpxPath,
+  loadServerConfigs,
+  DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS,
+} from '../utils';
 import { LLMProvider } from '../providers/base-provider';
 import { OpenAIResponsesProvider } from '../providers/openai-responses-provider';
 import { MCPClientService } from './MCPClientService';
@@ -76,7 +81,8 @@ export class MCPClientServiceImpl implements MCPClientService {
     this.logger = options.logger;
     this.config = options.config;
     this.toolCallTimeout =
-      this.config.getOptionalNumber('mcpChat.toolCallTimeout') ?? 60000;
+      this.config.getOptionalNumber('mcpChat.toolCallTimeout') ??
+      DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS;
     this.llmProvider = this.initializeLLMProvider();
     this.mcpServers = this.initializeMCPServers();
     this.systemPrompt =

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.test.ts
@@ -310,6 +310,49 @@ describe('Utils', () => {
 
       expect(() => validateConfig(mockConfig)).not.toThrow();
     });
+
+    it('should throw when toolCallTimeout is 0', () => {
+      const mockConfig = mockServices.rootConfig({
+        data: {
+          mcpChat: {
+            providers: [{ id: 'test' }],
+            toolCallTimeout: 0,
+          },
+        },
+      });
+
+      expect(() => validateConfig(mockConfig)).toThrow(
+        'mcpChat.toolCallTimeout must be a strictly positive number, got: 0',
+      );
+    });
+
+    it('should throw when toolCallTimeout is negative', () => {
+      const mockConfig = mockServices.rootConfig({
+        data: {
+          mcpChat: {
+            providers: [{ id: 'test' }],
+            toolCallTimeout: -1000,
+          },
+        },
+      });
+
+      expect(() => validateConfig(mockConfig)).toThrow(
+        'mcpChat.toolCallTimeout must be a strictly positive number, got: -1000',
+      );
+    });
+
+    it('should pass when toolCallTimeout is a positive number', () => {
+      const mockConfig = mockServices.rootConfig({
+        data: {
+          mcpChat: {
+            providers: [{ id: 'test' }],
+            toolCallTimeout: 30000,
+          },
+        },
+      });
+
+      expect(() => validateConfig(mockConfig)).not.toThrow();
+    });
   });
 
   describe('validateMessages', () => {
@@ -718,6 +761,52 @@ describe('Utils', () => {
         executeToolCall(toolCall, mockTools, mockClients),
       ).rejects.toThrow('Tool execution failed');
     });
+
+    it('should forward the provided toolCallTimeout to client.callTool', async () => {
+      const toolCall = {
+        id: 'call_123',
+        type: 'function' as const,
+        function: {
+          name: 'test_tool',
+          arguments: JSON.stringify({ param: 'value' }),
+        },
+      };
+
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      await executeToolCall(toolCall, mockTools, mockClients, 30000);
+
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        { name: 'test_tool', arguments: { param: 'value' } },
+        undefined,
+        { timeout: 30000 },
+      );
+    });
+
+    it('should use 60000ms as the default timeout when toolCallTimeout is omitted', async () => {
+      const toolCall = {
+        id: 'call_123',
+        type: 'function' as const,
+        function: {
+          name: 'test_tool',
+          arguments: JSON.stringify({ param: 'value' }),
+        },
+      };
+
+      mockClient.callTool.mockResolvedValue({
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      await executeToolCall(toolCall, mockTools, mockClients);
+
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        { name: 'test_tool', arguments: { param: 'value' } },
+        undefined,
+        { timeout: 60000 },
+      );
+    });
   });
 
   describe('validateConfig - systemPrompt validation', () => {
@@ -758,6 +847,7 @@ describe('Utils', () => {
           }
           return undefined;
         }),
+        getOptionalNumber: jest.fn(),
       } as any;
 
       expect(() => validateConfig(mockConfig)).not.toThrow();
@@ -800,6 +890,7 @@ describe('Utils', () => {
           }
           return undefined;
         }),
+        getOptionalNumber: jest.fn(),
       } as any;
 
       expect(() => validateConfig(mockConfig)).not.toThrow();
@@ -842,6 +933,7 @@ describe('Utils', () => {
           }
           return undefined;
         }),
+        getOptionalNumber: jest.fn(),
       } as any;
 
       expect(() => validateConfig(mockConfig)).toThrow(
@@ -886,6 +978,7 @@ describe('Utils', () => {
           }
           return undefined;
         }),
+        getOptionalNumber: jest.fn(),
       } as any;
 
       expect(() => validateConfig(mockConfig)).toThrow(
@@ -930,6 +1023,7 @@ describe('Utils', () => {
           }
           return undefined;
         }),
+        getOptionalNumber: jest.fn(),
       } as any;
 
       expect(() => validateConfig(mockConfig)).toThrow(

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
@@ -145,7 +145,7 @@ export async function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],
   mcpClients: Map<string, Client>,
-  toolCallTimeout: number = 60000,
+  toolCallTimeout: number,
 ): Promise<ToolExecutionResult> {
   const toolName = toolCall.function.name;
   const toolArgs = JSON.parse(toolCall.function.arguments || '{}');
@@ -260,6 +260,14 @@ export const validateConfig = (config: RootConfigService) => {
         );
       }
     }
+  }
+
+  // Validate toolCallTimeout if present
+  const toolCallTimeout = config.getOptionalNumber('mcpChat.toolCallTimeout');
+  if (toolCallTimeout !== undefined && toolCallTimeout <= 0) {
+    throw new Error(
+      `mcpChat.toolCallTimeout must be a strictly positive number, got: ${toolCallTimeout}`,
+    );
   }
 
   // Validate systemPrompt if present

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
@@ -28,6 +28,9 @@ import {
 } from './types';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
+/** Default timeout in milliseconds for MCP tool call requests. */
+export const DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS = 60000;
+
 /**
  * Loads MCP server configurations from Backstage config.
  * Reads from the `mcpChat.mcpServers` configuration section.
@@ -138,6 +141,7 @@ export async function findNpxPath(): Promise<string> {
  * @param toolCall - The tool call from the LLM containing function name and arguments
  * @param tools - List of available tools with their server IDs
  * @param mcpClients - Map of server IDs to MCP client instances
+ * @param toolCallTimeout - Timeout for the tool call to complete (default: 60000, unit: ms)
  * @returns Promise resolving to the tool execution result
  * @public
  */
@@ -145,7 +149,7 @@ export async function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],
   mcpClients: Map<string, Client>,
-  toolCallTimeout: number = 60000,
+  toolCallTimeout: number = DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS,
 ): Promise<ToolExecutionResult> {
   const toolName = toolCall.function.name;
   const toolArgs = JSON.parse(toolCall.function.arguments || '{}');

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
@@ -145,6 +145,7 @@ export async function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],
   mcpClients: Map<string, Client>,
+  toolCallTimeout: number = 60000,
 ): Promise<ToolExecutionResult> {
   const toolName = toolCall.function.name;
   const toolArgs = JSON.parse(toolCall.function.arguments || '{}');
@@ -160,10 +161,14 @@ export async function executeToolCall(
     throw new Error(`Client for server '${tool.serverId}' not found`);
   }
 
-  const result = await client.callTool({
-    name: toolName,
-    arguments: toolArgs,
-  });
+  const result = await client.callTool(
+    {
+      name: toolName,
+      arguments: toolArgs,
+    },
+    undefined,
+    { timeout: toolCallTimeout },
+  );
 
   // Extract and format the result content properly
   let formattedResult: string;

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
@@ -28,7 +28,10 @@ import {
 } from './types';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
-/** Default timeout in milliseconds for MCP tool call requests. */
+/**
+ * Default timeout in milliseconds for MCP tool call requests.
+ * @public
+ */
 export const DEFAULT_MCP_TOOL_CALL_TIMEOUT_MS = 60000;
 
 /**

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/utils.ts
@@ -145,7 +145,7 @@ export async function executeToolCall(
   toolCall: ToolCall,
   tools: ServerTool[],
   mcpClients: Map<string, Client>,
-  toolCallTimeout: number,
+  toolCallTimeout: number = 60000,
 ): Promise<ToolExecutionResult> {
   const toolName = toolCall.function.name;
   const toolArgs = JSON.parse(toolCall.function.arguments || '{}');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

I added support to extend tool call timeout. This is useful when you trigger long actions such as scaffolding. The default is the previous value of 60s.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [-] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
