### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/hungry-feet-march.md
+++ b/workspaces/analytics/.changeset/hungry-feet-march.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.
-
-The `alpha` export returns now an `app` module instead of a plugin to be aligned with this changes and Backstage 1.49.

--- a/workspaces/analytics/.changeset/purple-emus-poke.md
+++ b/workspaces/analytics/.changeset/purple-emus-poke.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
-'@backstage-community/plugin-analytics-module-matomo': minor
-'@backstage-community/plugin-analytics-module-ga4': minor
----
-
-Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.18.0
+
+### Minor Changes
+
+- a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-matomo
 
+## 1.27.0
+
+### Minor Changes
+
+- a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.
+
 ## 1.26.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.18.0
+
+### Minor Changes
+
+- a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-analytics-provider-segment
 
+## 1.27.0
+
+### Minor Changes
+
+- a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.
+
+  The `alpha` export returns now an `app` module instead of a plugin to be aligned with this changes and Backstage 1.49.
+
 ## 1.26.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga4@0.18.0

### Minor Changes

-   a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.

## @backstage-community/plugin-analytics-module-matomo@1.27.0

### Minor Changes

-   a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.

## @backstage-community/plugin-analytics-module-newrelic-browser@0.18.0

### Minor Changes

-   a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.

## @backstage-community/plugin-analytics-provider-segment@1.27.0

### Minor Changes

-   a34e621: Migrate `AnalyticsImplementationBlueprint` from `@backstage/frontend-plugin-api` to `@backstage/plugin-app-react`.

    The `alpha` export returns now an `app` module instead of a plugin to be aligned with this changes and Backstage 1.49.
