### PR TITLE
repo(tech-insights): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,8 +119,8 @@ yarn.lock                                                               @backsta
 /workspaces/splunk                                                      @backstage/community-plugins-maintainers
 /workspaces/stack-overflow                                              @backstage/community-plugins-maintainers
 /workspaces/stackstorm                                                  @backstage/community-plugins-maintainers
-/workspaces/tech-insights/plugins/tech-insights-maturity                @backstage/community-plugins-maintainers  @xantier @punkle @maicaballangan
-/workspaces/tech-insights                                               @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking @maicaballangan
+/workspaces/tech-insights/plugins/tech-insights-maturity                @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking @maicaballangan
+/workspaces/tech-insights                                               @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking
 /workspaces/tech-radar                                                  @backstage/community-plugins-maintainers
 /workspaces/tekton                                                      @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar 
 /workspaces/todo                                                        @backstage/community-plugins-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,8 +119,8 @@ yarn.lock                                                               @backsta
 /workspaces/splunk                                                      @backstage/community-plugins-maintainers
 /workspaces/stack-overflow                                              @backstage/community-plugins-maintainers
 /workspaces/stackstorm                                                  @backstage/community-plugins-maintainers
-/workspaces/tech-insights                                               @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking
 /workspaces/tech-insights/plugins/tech-insights-maturity                @backstage/community-plugins-maintainers  @xantier @punkle @maicaballangan
+/workspaces/tech-insights                                               @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking @maicaballangan
 /workspaces/tech-radar                                                  @backstage/community-plugins-maintainers
 /workspaces/tekton                                                      @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar 
 /workspaces/todo                                                        @backstage/community-plugins-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

CHANGE: This ensures that @kurtaking can approve tech-insights changes. To me the codeowners file looks like this was intended before.

NEW: It also adds @maicaballangan as a code owner to the complete workspace.

See also https://discord.com/channels/687207715902193673/1496163114725540046

I expect thhat this needs approval / confirmation from @xantier @punkle ?!

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
