### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/strange-ladybugs-attend.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/strange-ladybugs-attend.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
----
-
-Bump pinned dependencies to resolve to backstage 1.49.3 instead of backstage 1.45.3

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 2.14.1
+
+### Patch Changes
+
+- 10451e9: Bump pinned dependencies to resolve to backstage 1.49.3 instead of backstage 1.45.3
+
 ## 2.14.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@2.14.1

### Patch Changes

-   10451e9: Bump pinned dependencies to resolve to backstage 1.49.3 instead of backstage 1.45.3
