### PR TITLE
chore(argocd): add e2e tests for multiinstance

### DIFF
--- a/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
@@ -20,7 +20,10 @@ const commonMetadata = {
   labels: {
     'rht-gitops.com/janus-argocd': 'quarkus-app-bootstrap',
   },
-  instance: { name: 'main', url: 'https:/kubernetes.default.svc' },
+  instance: {
+    name: 'main',
+    url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com',
+  },
   name: 'quarkus-app-dev',
 };
 
@@ -338,7 +341,10 @@ export const prodApplication: Application = {
     labels: {
       'rht-gitops.com/janus-argocd': 'quarkus-app-bootstrap',
     },
-    instance: { name: 'main', url: 'https://kubernetes.default.svc' },
+    instance: {
+      name: 'main',
+      url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com',
+    },
     name: 'quarkus-app-prod',
   },
   spec: {
@@ -439,7 +445,7 @@ export const multiSourceArgoApp = {
     },
     instance: {
       name: 'main',
-      url: 'https://kubernetes.default.svc',
+      url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com',
     },
   },
   spec: {

--- a/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/applications.ts
@@ -148,6 +148,16 @@ export const mockApplication: Application = {
   status: commonStatus,
 };
 
+export const mockBasicApplication: Application = {
+  ...mockApplication,
+  metadata: {
+    ...mockApplication.metadata,
+    uid: '0791efe1-164a-48f8-b1ed-11310efa6bef',
+    name: 'basic-app',
+    labels: { 'backstage.io/kubernetes-id': 'basic-app' },
+  },
+};
+
 export const mockQuarkusApplication: Application = {
   metadata: {
     ...commonMetadata,
@@ -197,6 +207,14 @@ export const mockQuarkusApplication: Application = {
         },
       },
     ],
+  },
+};
+
+export const mockQuarkus2Application: Application = {
+  ...mockQuarkusApplication,
+  metadata: {
+    ...mockQuarkusApplication.metadata,
+    uid: '142880cc-931f-48b0-84d0-909b78680f51',
   },
 };
 

--- a/workspaces/argocd/plugins/argocd/dev/__data__/config.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/config.ts
@@ -15,19 +15,36 @@
  */
 export const mockArgocdConfig = {
   argocd: {
-    baseUrl: 'https://localhost:8080',
+    baseUrl: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com',
+    appLocatorMethods: [
+      {
+        type: 'config',
+        instances: [
+          {
+            name: 'main',
+            url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com',
+            token: 'fake-jwt-token',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const mockArgocdMultiInstanceConfig = {
+  argocd: {
     appLocatorMethods: [
       {
         type: 'config',
         instances: [
           {
             name: 'argoInstance1',
-            url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com/',
+            url: 'https://test1-openshift-gitops.apps.test.devcluster.openshift.com',
             token: 'fake-jwt-token1',
           },
           {
             name: 'argoInstance2',
-            url: 'https://test-openshift-gitops.apps.test.devcluster.openshift.com/',
+            url: 'https://test2-openshift-gitops.apps.test.devcluster.openshift.com',
             token: 'fake-jwt-token2',
           },
         ],

--- a/workspaces/argocd/plugins/argocd/dev/__data__/devInstanceApplications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/devInstanceApplications.ts
@@ -20,13 +20,13 @@ import {
 } from '@backstage-community/plugin-argocd-common';
 import {
   mockApplication,
-  mockArgocdMultiInstanceConfig,
   mockBasicApplication,
   mockQuarkus2Application,
   mockQuarkusApplication,
   preProdApplication,
   prodApplication,
-} from '.';
+} from './applications';
+import { mockArgocdMultiInstanceConfig } from './config';
 
 const createInstanceApplication = (
   instance: Pick<Instance, 'name' | 'url'>,

--- a/workspaces/argocd/plugins/argocd/dev/__data__/devInstanceApplications.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/devInstanceApplications.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Application,
+  Instance,
+} from '@backstage-community/plugin-argocd-common';
+import {
+  mockApplication,
+  mockArgocdMultiInstanceConfig,
+  mockBasicApplication,
+  mockQuarkus2Application,
+  mockQuarkusApplication,
+  preProdApplication,
+  prodApplication,
+} from '.';
+
+const createInstanceApplication = (
+  instance: Pick<Instance, 'name' | 'url'>,
+  application: Application,
+): Application => {
+  return {
+    ...application,
+    metadata: { ...application.metadata, instance: { ...instance } },
+  };
+};
+
+const argoInstance1Config =
+  mockArgocdMultiInstanceConfig.argocd.appLocatorMethods[0].instances[0];
+
+const argoInstance2Config =
+  mockArgocdMultiInstanceConfig.argocd.appLocatorMethods[0].instances[1];
+
+export const DEV_INSTANCE_APPLICATIONS: Record<string, Application[]> = {
+  main: [
+    mockApplication,
+    preProdApplication,
+    prodApplication,
+    mockQuarkusApplication,
+  ],
+  argoInstance1: [
+    createInstanceApplication(argoInstance1Config, mockApplication),
+    createInstanceApplication(argoInstance1Config, preProdApplication),
+    createInstanceApplication(argoInstance1Config, mockQuarkusApplication),
+  ],
+  argoInstance2: [
+    createInstanceApplication(argoInstance2Config, mockBasicApplication),
+    createInstanceApplication(argoInstance2Config, prodApplication),
+    createInstanceApplication(argoInstance2Config, mockQuarkus2Application),
+  ],
+};

--- a/workspaces/argocd/plugins/argocd/dev/__data__/entity.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/entity.ts
@@ -25,7 +25,7 @@ export const mockEntity: Entity = {
       'argocd/app-selector':
         'rht-gitops.com/janus-argocd=quarkus-app-bootstrap',
       'argocd/project-name': 'project-name',
-      'argocd/instance-name': 'instance-1',
+      'argocd/instance-name': 'main',
       'backstage.io/kubernetes-id': 'quarkus-app',
     },
   },
@@ -33,5 +33,44 @@ export const mockEntity: Entity = {
     lifecycle: 'production',
     type: 'service',
     owner: 'user:guest',
+  },
+};
+
+export const mockArgoMultiInstanceSelectorEntity: Entity = {
+  ...mockEntity,
+  metadata: {
+    name: 'backstage-argocd-multi-selector',
+    description: 'argocd plugin multi-instance selector',
+    annotations: {
+      'argocd/app-selector':
+        'rht-gitops.com/janus-argocd=quarkus-app-bootstrap',
+      'argocd/instance-name': 'argoInstance1,argoInstance2',
+      'backstage.io/kubernetes-id': 'quarkus-app',
+    },
+  },
+};
+
+export const mockArgoMultiInstanceAppNameEntity: Entity = {
+  ...mockEntity,
+  metadata: {
+    name: 'backstage-argocd-multi-app-name',
+    description: 'argocd plugin multi-instance app name',
+    annotations: {
+      'argocd/app-name': 'quarkus-app',
+      'argocd/instance-name': 'argoInstance1,argoInstance2',
+      'backstage.io/kubernetes-id': 'quarkus-app',
+    },
+  },
+};
+
+export const mocArgoOneAppEntity: Entity = {
+  ...mockEntity,
+  metadata: {
+    name: 'backstage-argocd-multi-one-app-name',
+    description: 'argocd plugin multi-instance one app name',
+    annotations: {
+      'argocd/app-name': 'basic-app',
+      'backstage.io/kubernetes-id': 'basic-app',
+    },
   },
 };

--- a/workspaces/argocd/plugins/argocd/dev/__data__/entity.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/entity.ts
@@ -63,7 +63,7 @@ export const mockArgoMultiInstanceAppNameEntity: Entity = {
   },
 };
 
-export const mocArgoOneAppEntity: Entity = {
+export const mockArgoOneAppEntity: Entity = {
   ...mockEntity,
   metadata: {
     name: 'backstage-argocd-multi-one-app-name',

--- a/workspaces/argocd/plugins/argocd/dev/__data__/index.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/index.ts
@@ -15,5 +15,6 @@
  */
 export * from './applications';
 export * from './config';
+export * from './devInstanceApplications';
 export * from './entity';
 export * from './revision';

--- a/workspaces/argocd/plugins/argocd/dev/__data__/revision.ts
+++ b/workspaces/argocd/plugins/argocd/dev/__data__/revision.ts
@@ -22,16 +22,22 @@ export const mockRevision: RevisionInfo = {
   revisionID: '90f9758b7033a4bbb7c33a35ee474d61091644bc',
 };
 
-export const mockRevisionTwo = {
+export const mockRevisionTwo: RevisionInfo = {
   author: 'author-name',
-  date: '2023-10-11T05:28:38Z',
+  date: new Date('2023-10-11T05:28:38Z'),
   message: 'Commit v1.0.0 tag release',
 };
 
-export const mockRevisionThree = {
+export const mockRevisionThree: RevisionInfo = {
   author: 'author-name',
-  date: '2023-10-13T05:28:38Z',
+  date: new Date('2023-10-13T05:28:38Z'),
   message: 'Initial commit',
 };
 
 export const mockRevisions = [mockRevision, mockRevisionTwo, mockRevisionThree];
+
+export const mockIdRevisions: Record<string, RevisionInfo> = {
+  '90f9758b7033a4bbb7c33a35ee474d61091644bc': mockRevision,
+  '80f9758b7033a4bbb7c33a35ee474d61091644bc': mockRevisionTwo,
+  '70f9758b7033a4bbb7c33a35ee474d61091644bc': mockRevisionThree,
+};

--- a/workspaces/argocd/plugins/argocd/dev/index.tsx
+++ b/workspaces/argocd/plugins/argocd/dev/index.tsx
@@ -60,7 +60,7 @@ import {
   mockEntity,
   mockIdRevisions,
   DEV_INSTANCE_APPLICATIONS,
-  mocArgoOneAppEntity,
+  mockArgoOneAppEntity,
 } from './__data__';
 import { mockArgoResources } from './__data__/argoRolloutsObjects';
 import { argocdTranslations } from '../src/translations';
@@ -75,7 +75,7 @@ const getInstanceNameFromUrl = (url: string): string => {
 export class MockArgoCDApiClient implements ArgoCDApi {
   async listApps(options: ListAppsOptions): Promise<{ items: Application[] }> {
     const instanceName = getInstanceNameFromUrl(options.url);
-    let apps = DEV_INSTANCE_APPLICATIONS[instanceName];
+    let apps = DEV_INSTANCE_APPLICATIONS[instanceName] ?? [];
 
     if (options.appSelector) {
       const decodedSelector = decodeURIComponent(options.appSelector);
@@ -100,7 +100,7 @@ export class MockArgoCDApiClient implements ArgoCDApi {
     if (!options.revisionIDs || options.revisionIDs.length < 1) {
       return Promise.resolve([]);
     }
-    const promises: any = [];
+    const promises: Promise<ArgoCDAppDeployRevisionDetails>[] = [];
 
     options.revisionIDs.forEach((revisionID: string) => {
       const application = options.apps.find(app =>
@@ -150,11 +150,19 @@ export class MockArgoCDApiClient implements ArgoCDApi {
   async getApplication(options: GetApplicationOptions): Promise<Application> {
     const instanceName = getInstanceNameFromUrl(options.url);
 
+    if (!DEV_INSTANCE_APPLICATIONS[instanceName]) {
+      throw new Error(
+        `Failed to fetch Application from Instance ${instanceName} : ArgoCD Instance ${instanceName} not found`,
+      );
+    }
+
     const result = DEV_INSTANCE_APPLICATIONS[instanceName].filter(
       app => app.metadata.name === options.appName,
     )[0];
     if (!result) {
-      throw new Error('Application Not Found');
+      throw new Error(
+        `Failed to fetch data, status 403: Insufficient permissions for ArgoCD server`,
+      );
     }
 
     return result;
@@ -176,7 +184,7 @@ export class MockArgoCDApiClient implements ArgoCDApi {
       if (matchingApps.length !== 0) {
         result.push({
           name: instanceName,
-          url: matchingApps[0].spec.destination.server,
+          url: matchingApps[0].metadata.instance.url,
           appName: [options.appName],
           applications: matchingApps,
         });
@@ -455,7 +463,7 @@ createDevApp()
       >
         <EntityProvider
           key="multi-instance-one-app-name"
-          entity={mocArgoOneAppEntity}
+          entity={mockArgoOneAppEntity}
         >
           <Page themeId="service">
             <Header type="component — service" title="basic-app" />

--- a/workspaces/argocd/plugins/argocd/dev/index.tsx
+++ b/workspaces/argocd/plugins/argocd/dev/index.tsx
@@ -15,7 +15,6 @@
  */
 // eslint-disable-next-line
 import '@backstage/ui/css/styles.css';
-import { Entity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { Page, Header, TabbedLayout } from '@backstage/core-components';
@@ -34,99 +33,156 @@ import { Box } from '@material-ui/core';
 import {
   ArgoCDApi,
   argoCDApiRef,
-  ArgoCDInstanceApi,
+  ArgoCDAppDeployRevisionDetails,
+  ArgoCDInstanceApiClient,
   argoCDInstanceApiRef,
   FindApplicationsOptions,
   GetApplicationOptions,
   ListAppsOptions,
   RevisionDetailsListOptions,
   RevisionDetailsOptions,
-  SearchApplicationsOptions,
 } from '../src/api';
 import {
   ArgocdDeploymentLifecycle,
   ArgocdDeploymentSummary,
   argocdPlugin,
 } from '../src/plugin';
-import { Application } from '@backstage-community/plugin-argocd-common';
+import {
+  Application,
+  InstanceApplications,
+} from '@backstage-community/plugin-argocd-common';
 import { customResourceTypes } from '../src/types/resources';
 import {
-  mockApplication,
   mockArgocdConfig,
-  mockQuarkusApplication,
-  mockRevision,
-  mockRevisions,
-  preProdApplication,
-  prodApplication,
+  mockArgocdMultiInstanceConfig,
+  mockArgoMultiInstanceAppNameEntity,
+  mockArgoMultiInstanceSelectorEntity,
+  mockEntity,
+  mockIdRevisions,
+  DEV_INSTANCE_APPLICATIONS,
+  mocArgoOneAppEntity,
 } from './__data__';
 import { mockArgoResources } from './__data__/argoRolloutsObjects';
 import { argocdTranslations } from '../src/translations';
+import { getArgocdInstances } from '../src/hooks/useArgocdConfig';
+import { DeploymentLifecycle } from '../src/components/DeploymentLifeCycle';
+import { DeploymentSummary } from '../src/components/DeploymentSummary';
 
-const mockEntity: Entity = {
-  apiVersion: 'backstage.io/v1alpha1',
-  kind: 'Component',
-  metadata: {
-    name: 'backstage-argocd',
-    description: 'rhtap argocd plugin',
-    annotations: {
-      'argocd/app-selector': 'rht.gitops.com/quarks-app-bootstrap',
-      'backstage.io/kubernetes-id': 'quarkus-app',
-    },
-  },
-  spec: {
-    lifecycle: 'production',
-    type: 'service',
-    owner: 'user:guest',
-  },
+const getInstanceNameFromUrl = (url: string): string => {
+  return url.replace('/argoInstance/', '');
 };
 
 export class MockArgoCDApiClient implements ArgoCDApi {
-  async listApps(_options: ListAppsOptions): Promise<any> {
+  async listApps(options: ListAppsOptions): Promise<{ items: Application[] }> {
+    const instanceName = getInstanceNameFromUrl(options.url);
+    let apps = DEV_INSTANCE_APPLICATIONS[instanceName];
+
+    if (options.appSelector) {
+      const decodedSelector = decodeURIComponent(options.appSelector);
+      const [labelKey, labelValue] = decodedSelector.split('=', 2);
+      apps = apps.filter(app => app.metadata.labels?.[labelKey] === labelValue);
+    }
+
     return {
-      items: [
-        mockApplication,
-        preProdApplication,
-        prodApplication,
-        mockQuarkusApplication,
-      ],
+      items: apps,
     };
   }
 
-  async getRevisionDetails(_options: RevisionDetailsOptions): Promise<any> {
-    return mockRevision;
+  async getRevisionDetails(
+    options: RevisionDetailsOptions,
+  ): Promise<ArgoCDAppDeployRevisionDetails> {
+    return mockIdRevisions[options.revisionID];
   }
+
   async getRevisionDetailsList(
-    _options: RevisionDetailsListOptions,
-  ): Promise<any> {
-    return mockRevisions;
-  }
-  async getApplication(_options: GetApplicationOptions): Promise<Application> {
-    return mockApplication;
+    options: RevisionDetailsListOptions,
+  ): Promise<ArgoCDAppDeployRevisionDetails[]> {
+    if (!options.revisionIDs || options.revisionIDs.length < 1) {
+      return Promise.resolve([]);
+    }
+    const promises: any = [];
+
+    options.revisionIDs.forEach((revisionID: string) => {
+      const application = options.apps.find(app =>
+        app?.status?.history?.find(h => h.revision === revisionID),
+      );
+
+      if (application) {
+        promises.push(
+          this.getRevisionDetails({
+            app: application.metadata.name as string,
+            appNamespace: options.appNamespace,
+            instanceName: application.metadata.instance.name,
+            revisionID,
+          }),
+        );
+      }
+
+      const multiSourceApp = options.apps.find(app => {
+        return app?.status?.history?.find(h => {
+          return h?.revisions?.includes(revisionID);
+        });
+      });
+
+      if (multiSourceApp) {
+        const history = multiSourceApp.status?.history ?? [];
+        const relevantHistories = history.filter(h =>
+          h?.revisions?.includes(revisionID),
+        );
+
+        relevantHistories.forEach(h => {
+          const revisionSourceIndex = h.revisions?.indexOf(revisionID);
+          promises.push(
+            this.getRevisionDetails({
+              app: multiSourceApp.metadata.name as string,
+              appNamespace: options.appNamespace,
+              instanceName: multiSourceApp.metadata.instance.name,
+              revisionID: revisionID,
+              sourceIndex: revisionSourceIndex,
+            }),
+          );
+        });
+      }
+    });
+    return Promise.all(promises);
   }
 
-  async findApplications(_options: FindApplicationsOptions): Promise<any> {
-    return {
-      items: [
-        mockApplication,
-        preProdApplication,
-        prodApplication,
-        mockQuarkusApplication,
-      ],
-    };
-  }
-}
+  async getApplication(options: GetApplicationOptions): Promise<Application> {
+    const instanceName = getInstanceNameFromUrl(options.url);
 
-class MockArgoCDInstanceApiClient implements ArgoCDInstanceApi {
-  async searchApplications(
-    _instanceNames: string[],
-    _options: SearchApplicationsOptions,
-  ): Promise<Application[]> {
-    return [
-      mockApplication,
-      preProdApplication,
-      prodApplication,
-      mockQuarkusApplication,
-    ];
+    const result = DEV_INSTANCE_APPLICATIONS[instanceName].filter(
+      app => app.metadata.name === options.appName,
+    )[0];
+    if (!result) {
+      throw new Error('Application Not Found');
+    }
+
+    return result;
+  }
+
+  async findApplications(
+    options: FindApplicationsOptions,
+  ): Promise<InstanceApplications[]> {
+    const result: InstanceApplications[] = [];
+    for (const [instanceName, apps] of Object.entries(
+      DEV_INSTANCE_APPLICATIONS,
+    )) {
+      const matchingApps = apps.filter(
+        app =>
+          app.metadata.name === options.appName &&
+          app.metadata.name !== undefined,
+      );
+
+      if (matchingApps.length !== 0) {
+        result.push({
+          name: instanceName,
+          url: matchingApps[0].spec.destination.server,
+          appName: [options.appName],
+          applications: matchingApps,
+        });
+      }
+    }
+    return result;
   }
 }
 
@@ -232,6 +288,10 @@ class MockKubernetesClient implements KubernetesApi {
   }
 }
 
+const configApi = new ConfigReader(mockArgocdConfig);
+const multiInstanceConfigApi = new ConfigReader(mockArgocdMultiInstanceConfig);
+const argoCDApi = new MockArgoCDApiClient();
+
 createDevApp()
   .registerPlugin(argocdPlugin)
   .setAvailableLanguages(['en', 'de', 'es', 'fr', 'it', 'ja'])
@@ -241,9 +301,15 @@ createDevApp()
       <TestApiProvider
         apis={[
           [kubernetesApiRef, new MockKubernetesClient(mockArgoResources)],
-          [configApiRef, new ConfigReader(mockArgocdConfig)],
-          [argoCDApiRef, new MockArgoCDApiClient()],
-          [argoCDInstanceApiRef, new MockArgoCDInstanceApiClient()],
+          [configApiRef, configApi],
+          [argoCDApiRef, argoCDApi],
+          [
+            argoCDInstanceApiRef,
+            new ArgoCDInstanceApiClient({
+              argoCDApi,
+              instances: getArgocdInstances(configApi),
+            }),
+          ],
           [permissionApiRef, mockApis.permission()],
           [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
         ]}
@@ -263,9 +329,15 @@ createDevApp()
     element: (
       <TestApiProvider
         apis={[
-          [configApiRef, new ConfigReader(mockArgocdConfig)],
-          [argoCDApiRef, new MockArgoCDApiClient()],
-          [argoCDInstanceApiRef, new MockArgoCDInstanceApiClient()],
+          [configApiRef, configApi],
+          [argoCDApiRef, argoCDApi],
+          [
+            argoCDInstanceApiRef,
+            new ArgoCDInstanceApiClient({
+              argoCDApi,
+              instances: getArgocdInstances(configApi),
+            }),
+          ],
           [permissionApiRef, mockApis.permission()],
           [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
         ]}
@@ -284,5 +356,122 @@ createDevApp()
     ),
     title: 'Summary',
     path: 'argocd/deployment-summary',
+  })
+  .addPage({
+    element: (
+      <TestApiProvider
+        apis={[
+          [kubernetesApiRef, new MockKubernetesClient(mockArgoResources)],
+          [configApiRef, multiInstanceConfigApi],
+          [argoCDApiRef, argoCDApi],
+          [
+            argoCDInstanceApiRef,
+            new ArgoCDInstanceApiClient({
+              argoCDApi,
+              instances: getArgocdInstances(multiInstanceConfigApi),
+            }),
+          ],
+          [permissionApiRef, mockApis.permission()],
+          [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
+        ]}
+      >
+        <EntityProvider
+          key="multi-instance-selector"
+          entity={mockArgoMultiInstanceSelectorEntity}
+        >
+          <Page themeId="service">
+            <Header type="component — service" title="quarkus-app" />
+            <TabbedLayout>
+              <TabbedLayout.Route path="/" title="CI/CD">
+                <>
+                  <DeploymentLifecycle />
+                  <DeploymentSummary />
+                </>
+              </TabbedLayout.Route>
+            </TabbedLayout>
+          </Page>
+        </EntityProvider>
+      </TestApiProvider>
+    ),
+    title: 'Multi Selector',
+    path: 'argocd/multi-instance-selector',
+  })
+  .addPage({
+    element: (
+      <TestApiProvider
+        apis={[
+          [kubernetesApiRef, new MockKubernetesClient(mockArgoResources)],
+          [configApiRef, multiInstanceConfigApi],
+          [argoCDApiRef, argoCDApi],
+          [
+            argoCDInstanceApiRef,
+            new ArgoCDInstanceApiClient({
+              argoCDApi,
+              instances: getArgocdInstances(multiInstanceConfigApi),
+            }),
+          ],
+          [permissionApiRef, mockApis.permission()],
+          [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
+        ]}
+      >
+        <EntityProvider
+          key="multi-instance-app-name"
+          entity={mockArgoMultiInstanceAppNameEntity}
+        >
+          <Page themeId="service">
+            <Header type="component — service" title="quarkus-app" />
+            <TabbedLayout>
+              <TabbedLayout.Route path="/" title="CI/CD">
+                <>
+                  <DeploymentLifecycle />
+                  <DeploymentSummary />
+                </>
+              </TabbedLayout.Route>
+            </TabbedLayout>
+          </Page>
+        </EntityProvider>
+      </TestApiProvider>
+    ),
+    title: 'Multi App Name',
+    path: 'argocd/multi-instance-app-name',
+  })
+  .addPage({
+    element: (
+      <TestApiProvider
+        apis={[
+          [kubernetesApiRef, new MockKubernetesClient(mockArgoResources)],
+          [configApiRef, multiInstanceConfigApi],
+          [argoCDApiRef, argoCDApi],
+          [
+            argoCDInstanceApiRef,
+            new ArgoCDInstanceApiClient({
+              argoCDApi,
+              instances: getArgocdInstances(multiInstanceConfigApi),
+            }),
+          ],
+          [permissionApiRef, mockApis.permission()],
+          [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApiRef],
+        ]}
+      >
+        <EntityProvider
+          key="multi-instance-one-app-name"
+          entity={mocArgoOneAppEntity}
+        >
+          <Page themeId="service">
+            <Header type="component — service" title="basic-app" />
+            <TabbedLayout>
+              <TabbedLayout.Route path="/" title="CI/CD">
+                <>
+                  <DeploymentLifecycle />
+                  <DeploymentSummary />
+                </>
+              </TabbedLayout.Route>
+            </TabbedLayout>
+          </Page>
+        </EntityProvider>
+      </TestApiProvider>
+    ),
+    title: 'Multi One App Name',
+    path: 'argocd/multi-instance-one-app-name',
   })
   .render();

--- a/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
+++ b/workspaces/argocd/plugins/argocd/src/utils/__tests__/utils.test.ts
@@ -70,13 +70,13 @@ describe('Utils', () => {
     });
 
     test('should return the instance name', () => {
-      expect(getInstanceName(mockEntity)).toBe('instance-1');
+      expect(getInstanceName(mockEntity)).toBe('main');
     });
   });
 
   describe('getInstanceNames', () => {
     test('should return the instance name', () => {
-      expect(getInstanceName(mockEntity)).toEqual('instance-1');
+      expect(getInstanceName(mockEntity)).toEqual('main');
     });
 
     test('should return multiple instance names', () => {

--- a/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
+++ b/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
@@ -20,13 +20,19 @@ import { ArgoCDMessages, getTranslations } from './utils/translations';
 import {
   DEV_INSTANCE_APPLICATIONS,
   mockApplication,
+  mockArgocdConfig,
+  mockArgocdMultiInstanceConfig,
   preProdApplication,
   prodApplication,
 } from '../dev/__data__';
 
 import { type Application } from '@backstage-community/plugin-argocd-common';
 import { Common } from './utils/argocdHelper';
-import { verifyAppCard, verifyAppSidebar } from './utils/utils';
+import {
+  getInstanceAppUrl,
+  verifyAppCard,
+  verifyAppSidebar,
+} from './utils/utils';
 
 test.describe('ArgoCD plugin', () => {
   let argocdPage: Page;
@@ -117,6 +123,7 @@ test.describe('ArgoCD plugin', () => {
 
     for (const app of apps) {
       const appName = app.metadata.name;
+      const appUrl = getInstanceAppUrl(app, 'main', mockArgocdConfig);
 
       /* eslint-disable-next-line  no-loop-func */
       test(`Verify ${appName} row`, async () => {
@@ -153,6 +160,10 @@ test.describe('ArgoCD plugin', () => {
             })
             .first(),
         ).toBeVisible();
+        const appLink = row.getByRole('link', {
+          name: appName,
+        });
+        expect(await appLink.getAttribute('href')).toContain(appUrl);
       });
     }
   });
@@ -166,14 +177,22 @@ test.describe('ArgoCD plugin', () => {
       )) {
         for (const app of instanceApps) {
           const appName = app.metadata.name ?? '';
+          const appUrl = getInstanceAppUrl(
+            app,
+            instanceName,
+            mockArgocdMultiInstanceConfig,
+          );
 
           const lifecycleCard = argocdPage
-            .locator('[data-testid$="-card"]')
+            .getByTestId(`${appName}-card`)
             .filter({ hasText: appName })
             .filter({ hasText: instanceName })
             .filter({ hasText: app.spec.destination.server })
             .first();
           await expect(lifecycleCard).toBeVisible();
+          await expect(
+            lifecycleCard.getByTestId(`${appName}-link`),
+          ).toHaveAttribute('href', appUrl);
 
           const summaryRow = argocdPage
             .getByRole('row')
@@ -182,6 +201,10 @@ test.describe('ArgoCD plugin', () => {
             .filter({ hasText: app.spec.destination.server })
             .first();
           await expect(summaryRow).toBeVisible();
+          const appLink = summaryRow.getByRole('link', {
+            name: appName,
+          });
+          expect(await appLink.getAttribute('href')).toContain(appUrl);
         }
       }
     };

--- a/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
+++ b/workspaces/argocd/plugins/argocd/tests/argocd.spec.ts
@@ -15,13 +15,16 @@
  */
 import { expect, Page, test } from '@playwright/test';
 import { runAccessibilityTests } from './utils/accessibility';
-import { getTranslations, ArgoCDMessages } from './utils/translations';
+import { ArgoCDMessages, getTranslations } from './utils/translations';
 
 import {
+  DEV_INSTANCE_APPLICATIONS,
   mockApplication,
   preProdApplication,
   prodApplication,
 } from '../dev/__data__';
+
+import { type Application } from '@backstage-community/plugin-argocd-common';
 import { Common } from './utils/argocdHelper';
 import { verifyAppCard, verifyAppSidebar } from './utils/utils';
 
@@ -152,5 +155,61 @@ test.describe('ArgoCD plugin', () => {
         ).toBeVisible();
       });
     }
+  });
+
+  test.describe('Multiple ArgoCD instances', () => {
+    const verifyInstances = async (
+      expectedAppsByInstance: Record<string, Application[]>,
+    ) => {
+      for (const [instanceName, instanceApps] of Object.entries(
+        expectedAppsByInstance,
+      )) {
+        for (const app of instanceApps) {
+          const appName = app.metadata.name ?? '';
+
+          const lifecycleCard = argocdPage
+            .locator('[data-testid$="-card"]')
+            .filter({ hasText: appName })
+            .filter({ hasText: instanceName })
+            .filter({ hasText: app.spec.destination.server })
+            .first();
+          await expect(lifecycleCard).toBeVisible();
+
+          const summaryRow = argocdPage
+            .getByRole('row')
+            .filter({ hasText: appName })
+            .filter({ hasText: instanceName })
+            .filter({ hasText: app.spec.destination.server })
+            .first();
+          await expect(summaryRow).toBeVisible();
+        }
+      }
+    };
+
+    test('Verify app selector resolves app from all instances', async () => {
+      await argocdPage.goto('/argocd/multi-instance-selector');
+      await verifyInstances({
+        argoInstance1: DEV_INSTANCE_APPLICATIONS.argoInstance1,
+        argoInstance2: [
+          DEV_INSTANCE_APPLICATIONS.argoInstance2[1],
+          DEV_INSTANCE_APPLICATIONS.argoInstance2[2],
+        ],
+      });
+    });
+
+    test('Verify app name resolves app from all instances', async () => {
+      await argocdPage.goto('/argocd/multi-instance-app-name');
+      await verifyInstances({
+        argoInstance1: [DEV_INSTANCE_APPLICATIONS.argoInstance1[2]],
+        argoInstance2: [DEV_INSTANCE_APPLICATIONS.argoInstance2[2]],
+      });
+    });
+
+    test('Verify app name resolves for 1 app across all instances when no instances label in entity', async () => {
+      await argocdPage.goto('/argocd/multi-instance-one-app-name');
+      await verifyInstances({
+        argoInstance2: [DEV_INSTANCE_APPLICATIONS.argoInstance2[0]],
+      });
+    });
   });
 });

--- a/workspaces/argocd/plugins/argocd/tests/utils/utils.ts
+++ b/workspaces/argocd/plugins/argocd/tests/utils/utils.ts
@@ -41,10 +41,17 @@ export const getInstanceAppUrl = (
       ?.find(method => method.type === 'config')
       ?.instances?.find(instance => instance.name === instanceName)?.url ??
     config.argocd?.baseUrl;
+
+  if (!instanceBaseUrl) {
+    throw new Error(
+      `Unable to resolve ArgoCD instance URL for application "${app.metadata.name}" and instance "${instanceName}"`,
+    );
+  }
+
   const appPath = app.metadata.namespace
     ? `/applications/${app.metadata.namespace}/${app.metadata.name}`
     : `/applications/${app.metadata.name}`;
-  return `${instanceBaseUrl ?? ''}${appPath}`;
+  return `${instanceBaseUrl}${appPath}`;
 };
 
 export const verifyHeader = async (

--- a/workspaces/argocd/plugins/argocd/tests/utils/utils.ts
+++ b/workspaces/argocd/plugins/argocd/tests/utils/utils.ts
@@ -19,8 +19,33 @@ import { mockArgocdConfig, mockRevisions } from '../../dev/__data__';
 import {
   Application,
   History,
+  Instance,
 } from '@backstage-community/plugin-argocd-common';
 import type { ArgoCDMessages } from './translations';
+
+export const getInstanceAppUrl = (
+  app: Application,
+  instanceName: string,
+  config: {
+    argocd?: {
+      baseUrl?: string;
+      appLocatorMethods?: Array<{
+        type?: string;
+        instances?: Array<Pick<Instance, 'name' | 'url'>>;
+      }>;
+    };
+  },
+) => {
+  const instanceBaseUrl =
+    config.argocd?.appLocatorMethods
+      ?.find(method => method.type === 'config')
+      ?.instances?.find(instance => instance.name === instanceName)?.url ??
+    config.argocd?.baseUrl;
+  const appPath = app.metadata.namespace
+    ? `/applications/${app.metadata.namespace}/${app.metadata.name}`
+    : `/applications/${app.metadata.name}`;
+  return `${instanceBaseUrl ?? ''}${appPath}`;
+};
 
 export const verifyHeader = async (
   app: Application,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds e2e tests for ArgoCD multiinstance.
Adds 3 new pages to dev app:
  - Multi Selector: for fetching apps from multiple instances by app selector
  - Multi App Name: for fetching apps from multiple instances by app name
  - Multi One App Name: for fetching apps from multiple instances by app name when only 1 app exists, entity doesn't specify `instance-name` label

New pages directly use `DeploymentLifecycle` and `DeploymentSummary` instead of `ArgocdDeploymentLifecycle` and
`ArgocdDeploymentSummary`, as I wanted to show both of these elements in one page to avoid adding 6 pages (Both Argocd* components on 1 page can not be rendered due to error: `Routable element may not contain multiple routable extensions`)

#### Fixes

https://redhat.atlassian.net/browse/RHIDP-9881

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
