### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/renovate-9187fce.md
+++ b/workspaces/playlist/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-playlist-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.26
+
+### Patch Changes
+
+- Updated dependencies [c120454]
+  - @backstage-community/plugin-playlist-backend@0.20.1
+
 ## 0.0.25
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.20.1
+
+### Patch Changes
+
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist-backend@0.20.1

### Patch Changes

-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.

## backend@0.0.26

### Patch Changes

-   Updated dependencies [c120454]
    -   @backstage-community/plugin-playlist-backend@0.20.1
