### PR TITLE
Version Packages (code-coverage)

### DIFF
--- a/workspaces/code-coverage/.changeset/renovate-56eddd7.md
+++ b/workspaces/code-coverage/.changeset/renovate-56eddd7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Updated dependency `body-parser` to `^2.0.0`.

--- a/workspaces/code-coverage/.changeset/renovate-9187fce.md
+++ b/workspaces/code-coverage/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-code-coverage-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-code-coverage-backend
 
+## 0.16.1
+
+### Patch Changes
+
+- f4dcb75: Updated dependency `body-parser` to `^2.0.0`.
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/code-coverage/plugins/code-coverage-backend/package.json
+++ b/workspaces/code-coverage/plugins/code-coverage-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-code-coverage-backend",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A Backstage backend plugin that helps you keep track of your code coverage",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-code-coverage-backend@0.16.1

### Patch Changes

-   f4dcb75: Updated dependency `body-parser` to `^2.0.0`.
-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.
