### PR TITLE
Version Packages (kafka)

### DIFF
--- a/workspaces/kafka/.changeset/renovate-5764c28.md
+++ b/workspaces/kafka/.changeset/renovate-5764c28.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-kafka-backend': patch
-'@backstage-community/plugin-kafka': patch
----
-
-Updated dependency `jest-when` to `^4.0.0`.

--- a/workspaces/kafka/.changeset/renovate-9187fce.md
+++ b/workspaces/kafka/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kafka-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-kafka-backend
 
+## 0.11.1
+
+### Patch Changes
+
+- 688b57d: Updated dependency `jest-when` to `^4.0.0`.
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/kafka/plugins/kafka-backend/package.json
+++ b/workspaces/kafka/plugins/kafka-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka-backend",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A Backstage backend plugin that integrates towards Kafka",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/kafka/plugins/kafka/CHANGELOG.md
+++ b/workspaces/kafka/plugins/kafka/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kafka
 
+## 0.12.1
+
+### Patch Changes
+
+- 688b57d: Updated dependency `jest-when` to `^4.0.0`.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/kafka/plugins/kafka/package.json
+++ b/workspaces/kafka/plugins/kafka/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kafka",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A Backstage plugin that integrates towards Kafka",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kafka@0.12.1

### Patch Changes

-   688b57d: Updated dependency `jest-when` to `^4.0.0`.

## @backstage-community/plugin-kafka-backend@0.11.1

### Patch Changes

-   688b57d: Updated dependency `jest-when` to `^4.0.0`.
-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.
