### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/renovate-9187fce.md
+++ b/workspaces/linkerd/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-linkerd-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.29
+
+### Patch Changes
+
+- Updated dependencies [c120454]
+  - @backstage-community/plugin-linkerd-backend@0.18.1
+
 ## 0.0.28
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.18.1
+
+### Patch Changes
+
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd-backend@0.18.1

### Patch Changes

-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.

## backend@0.0.29

### Patch Changes

-   Updated dependencies [c120454]
    -   @backstage-community/plugin-linkerd-backend@0.18.1
