### PR TITLE
Version Packages (rollbar)

### DIFF
--- a/workspaces/rollbar/.changeset/renovate-9187fce.md
+++ b/workspaces/rollbar/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rollbar-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rollbar-backend
 
+## 0.12.1
+
+### Patch Changes
+
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/rollbar/plugins/rollbar-backend/package.json
+++ b/workspaces/rollbar/plugins/rollbar-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rollbar-backend",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A Backstage backend plugin that integrates towards Rollbar",
   "backstage": {
     "role": "backend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rollbar-backend@0.12.1

### Patch Changes

-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.
