### PR TITLE
Version Packages (azure-sites)

### DIFF
--- a/workspaces/azure-sites/.changeset/renovate-9187fce.md
+++ b/workspaces/azure-sites/.changeset/renovate-9187fce.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-sites-backend': patch
----
-
-Updated dependency `@types/supertest` to `^7.0.0`.

--- a/workspaces/azure-sites/.changeset/version-bump-1-47-2.md
+++ b/workspaces/azure-sites/.changeset/version-bump-1-47-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-sites': minor
-'@backstage-community/plugin-azure-sites-backend': minor
-'@backstage-community/plugin-azure-sites-common': minor
----
-
-Backstage version bump to v1.47.2

--- a/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-azure-sites-backend
 
+## 0.16.0
+
+### Minor Changes
+
+- 07f3ff6: Backstage version bump to v1.47.2
+
+### Patch Changes
+
+- c120454: Updated dependency `@types/supertest` to `^7.0.0`.
+- Updated dependencies [07f3ff6]
+  - @backstage-community/plugin-azure-sites-common@0.13.0
+
 ## 0.15.0
 
 ### Minor Changes

--- a/workspaces/azure-sites/plugins/azure-sites-backend/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-backend",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-sites-common
 
+## 0.13.0
+
+### Minor Changes
+
+- 07f3ff6: Backstage version bump to v1.47.2
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/azure-sites/plugins/azure-sites-common/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites-common",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Common functionalities for the azure plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
+++ b/workspaces/azure-sites/plugins/azure-sites/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-azure-sites
 
+## 0.13.0
+
+### Minor Changes
+
+- 07f3ff6: Backstage version bump to v1.47.2
+
+### Patch Changes
+
+- Updated dependencies [07f3ff6]
+  - @backstage-community/plugin-azure-sites-common@0.13.0
+
 ## 0.12.0
 
 ### Minor Changes

--- a/workspaces/azure-sites/plugins/azure-sites/package.json
+++ b/workspaces/azure-sites/plugins/azure-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-sites",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-sites",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-sites@0.13.0

### Minor Changes

-   07f3ff6: Backstage version bump to v1.47.2

### Patch Changes

-   Updated dependencies [07f3ff6]
    -   @backstage-community/plugin-azure-sites-common@0.13.0

## @backstage-community/plugin-azure-sites-backend@0.16.0

### Minor Changes

-   07f3ff6: Backstage version bump to v1.47.2

### Patch Changes

-   c120454: Updated dependency `@types/supertest` to `^7.0.0`.
-   Updated dependencies [07f3ff6]
    -   @backstage-community/plugin-azure-sites-common@0.13.0

## @backstage-community/plugin-azure-sites-common@0.13.0

### Minor Changes

-   07f3ff6: Backstage version bump to v1.47.2
