### PR TITLE
Version Packages (npm)

### DIFF
--- a/workspaces/npm/.changeset/healthy-rings-play.md
+++ b/workspaces/npm/.changeset/healthy-rings-play.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-npm': patch
----
-
-Remove any from exported alpha types so that they are now correctly typed.

--- a/workspaces/npm/plugins/npm-backend/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-npm-backend
 
+## 1.21.1
+
+### Patch Changes
+
+- @backstage-community/plugin-npm-common@1.21.1
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-backend/package.json
+++ b/workspaces/npm/plugins/npm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-npm-backend",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm-common/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm-common/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @backstage-community/plugin-npm-common
 
+## 1.21.1
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm-common/package.json
+++ b/workspaces/npm/plugins/npm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm-common",
   "description": "Common functionalities for the npm plugin",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/npm/plugins/npm/CHANGELOG.md
+++ b/workspaces/npm/plugins/npm/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-npm
 
+## 1.21.1
+
+### Patch Changes
+
+- 8833c60: Remove any from exported alpha types so that they are now correctly typed.
+  - @backstage-community/plugin-npm-common@1.21.1
+
 ## 1.21.0
 
 ### Minor Changes

--- a/workspaces/npm/plugins/npm/package.json
+++ b/workspaces/npm/plugins/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-npm",
   "description": "A Backstage plugin that shows meta info and latest versions from a npm registry",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-npm@1.21.1

### Patch Changes

-   8833c60: Remove any from exported alpha types so that they are now correctly typed.
    -   @backstage-community/plugin-npm-common@1.21.1

## @backstage-community/plugin-npm-backend@1.21.1

### Patch Changes

-   @backstage-community/plugin-npm-common@1.21.1

## @backstage-community/plugin-npm-common@1.21.1


