### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-38b6c9f.md
+++ b/workspaces/ocm/.changeset/renovate-38b6c9f.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.31.0`.

--- a/workspaces/ocm/.changeset/renovate-fe89caa.md
+++ b/workspaces/ocm/.changeset/renovate-fe89caa.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.31.1`.

--- a/workspaces/ocm/.changeset/version-bump-1-50-2.md
+++ b/workspaces/ocm/.changeset/version-bump-1-50-2.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.50.2

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.18.0
+
+### Minor Changes
+
+- a6cd71c: Backstage version bump to v1.50.2
+
+### Patch Changes
+
+- ad24d78: Updated dependency `@openapitools/openapi-generator-cli` to `2.31.0`.
+- f450326: Updated dependency `@openapitools/openapi-generator-cli` to `2.31.1`.
+- Updated dependencies [a6cd71c]
+  - @backstage-community/plugin-ocm-common@3.21.0
+
 ## 5.17.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.21.0
+
+### Minor Changes
+
+- a6cd71c: Backstage version bump to v1.50.2
+
 ## 3.20.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-ocm
 
+## 5.17.0
+
+### Minor Changes
+
+- a6cd71c: Backstage version bump to v1.50.2
+
+### Patch Changes
+
+- Updated dependencies [a6cd71c]
+  - @backstage-community/plugin-ocm-common@3.21.0
+
 ## 5.16.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.16.0",
+  "version": "5.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.17.0

### Minor Changes

-   a6cd71c: Backstage version bump to v1.50.2

### Patch Changes

-   Updated dependencies [a6cd71c]
    -   @backstage-community/plugin-ocm-common@3.21.0

## @backstage-community/plugin-ocm-backend@5.18.0

### Minor Changes

-   a6cd71c: Backstage version bump to v1.50.2

### Patch Changes

-   ad24d78: Updated dependency `@openapitools/openapi-generator-cli` to `2.31.0`.
-   f450326: Updated dependency `@openapitools/openapi-generator-cli` to `2.31.1`.
-   Updated dependencies [a6cd71c]
    -   @backstage-community/plugin-ocm-common@3.21.0

## @backstage-community/plugin-ocm-common@3.21.0

### Minor Changes

-   a6cd71c: Backstage version bump to v1.50.2
