### PR TITLE
Version Packages (analytics)

### DIFF
--- a/workspaces/analytics/.changeset/version-bump-1-50-3.md
+++ b/workspaces/analytics/.changeset/version-bump-1-50-3.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-analytics-module-ga4': minor
-'@backstage-community/plugin-analytics-module-matomo': minor
-'@backstage-community/plugin-analytics-module-newrelic-browser': minor
-'@backstage-community/plugin-analytics-provider-segment': minor
----
-
-Backstage version bump to v1.50.3

--- a/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-ga4/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-ga4
 
+## 0.19.0
+
+### Minor Changes
+
+- 3fee6eb: Backstage version bump to v1.50.3
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-ga4/package.json
+++ b/workspaces/analytics/plugins/analytics-module-ga4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-ga4",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-matomo/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-matomo
 
+## 1.28.0
+
+### Minor Changes
+
+- 3fee6eb: Backstage version bump to v1.50.3
+
 ## 1.27.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-matomo/package.json
+++ b/workspaces/analytics/plugins/analytics-module-matomo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-matomo",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-module-newrelic-browser
 
+## 0.19.0
+
+### Minor Changes
+
+- 3fee6eb: Backstage version bump to v1.50.3
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
+++ b/workspaces/analytics/plugins/analytics-module-newrelic-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-module-newrelic-browser",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "backstage": {
     "role": "frontend-plugin-module",
     "pluginId": "app",

--- a/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
+++ b/workspaces/analytics/plugins/analytics-provider-segment/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-analytics-provider-segment
 
+## 1.28.0
+
+### Minor Changes
+
+- 3fee6eb: Backstage version bump to v1.50.3
+
 ## 1.27.0
 
 ### Minor Changes

--- a/workspaces/analytics/plugins/analytics-provider-segment/package.json
+++ b/workspaces/analytics/plugins/analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-analytics-provider-segment",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-analytics-module-ga4@0.19.0

### Minor Changes

-   3fee6eb: Backstage version bump to v1.50.3

## @backstage-community/plugin-analytics-module-matomo@1.28.0

### Minor Changes

-   3fee6eb: Backstage version bump to v1.50.3

## @backstage-community/plugin-analytics-module-newrelic-browser@0.19.0

### Minor Changes

-   3fee6eb: Backstage version bump to v1.50.3

## @backstage-community/plugin-analytics-provider-segment@1.28.0

### Minor Changes

-   3fee6eb: Backstage version bump to v1.50.3
