### PR TITLE
Version Packages (github)

### DIFF
--- a/workspaces/github/.changeset/green-ducks-move.md
+++ b/workspaces/github/.changeset/green-ducks-move.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': major
-'@backstage-community/plugin-github-deployments': major
-'@backstage-community/plugin-github-discussions': major
-'@backstage-community/plugin-github-actions': major
-'@backstage-community/plugin-github-issues': major
----
-
-**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

--- a/workspaces/github/plugins/github-actions/CHANGELOG.md
+++ b/workspaces/github/plugins/github-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-actions
 
+## 1.0.0
+
+### Major Changes
+
+- dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.23.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-actions/package.json
+++ b/workspaces/github/plugins/github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-actions",
-  "version": "0.23.0",
+  "version": "1.0.0",
   "description": "A Backstage plugin that integrates towards GitHub Actions",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/github/plugins/github-deployments/CHANGELOG.md
+++ b/workspaces/github/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-deployments
 
+## 1.0.0
+
+### Major Changes
+
+- dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-deployments/package.json
+++ b/workspaces/github/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-deployments",
-  "version": "0.19.0",
+  "version": "1.0.0",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/github/plugins/github-discussions/CHANGELOG.md
+++ b/workspaces/github/plugins/github-discussions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-discussions
 
+## 1.0.0
+
+### Major Changes
+
+- dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-discussions/package.json
+++ b/workspaces/github/plugins/github-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-discussions",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/github/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-issues
 
+## 1.0.0
+
+### Major Changes
+
+- dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-issues/package.json
+++ b/workspaces/github/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "0.22.0",
+  "version": "1.0.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "github-issues",

--- a/workspaces/github/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/workspaces/github/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-pull-requests-board
 
+## 1.0.0
+
+### Major Changes
+
+- dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-pull-requests-board/package.json
+++ b/workspaces/github/plugins/github-pull-requests-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-pull-requests-board",
-  "version": "0.17.0",
+  "version": "1.0.0",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-actions@1.0.0

### Major Changes

-   dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

## @backstage-community/plugin-github-deployments@1.0.0

### Major Changes

-   dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

## @backstage-community/plugin-github-discussions@1.0.0

### Major Changes

-   dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

## @backstage-community/plugin-github-issues@1.0.0

### Major Changes

-   dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

## @backstage-community/plugin-github-pull-requests-board@1.0.0

### Major Changes

-   dc9bb36: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
