### PR TITLE
Updated `mui-to-bui.js` to filter out the packages folder

### DIFF
--- a/scripts/mui-to-bui.js
+++ b/scripts/mui-to-bui.js
@@ -50,11 +50,12 @@ const CONFIG = {
     'build',
     '.git',
     'coverage',
+    'packages',
     '.yarn',
   ],
 
   // Excluded workspaces (same as list-workspaces.js)
-  excludedWorkspaces: ['.claude', 'noop', 'repo-tools'],
+  excludedWorkspaces: ['noop', 'repo-tools'],
 
   // MUI import patterns to track
   muiPatterns: {
@@ -146,6 +147,7 @@ class CommunityPluginsMigrationAnalyzer {
       .readdirSync(workspacesDir, { withFileTypes: true })
       .filter(dirent => dirent.isDirectory())
       .map(dirent => dirent.name)
+      .filter(name => !name.startsWith('.'))
       .filter(name => !CONFIG.excludedWorkspaces.includes(name))
       .sort();
 

--- a/scripts/mui-to-bui.js
+++ b/scripts/mui-to-bui.js
@@ -54,7 +54,7 @@ const CONFIG = {
   ],
 
   // Excluded workspaces (same as list-workspaces.js)
-  excludedWorkspaces: ['noop', 'repo-tools'],
+  excludedWorkspaces: ['.claude', 'noop', 'repo-tools'],
 
   // MUI import patterns to track
   muiPatterns: {
@@ -244,12 +244,8 @@ class CommunityPluginsMigrationAnalyzer {
 
     // Find all relevant files in the workspace
     const files = [];
-    const packagesDir = path.join(workspacePath, 'packages');
     const pluginsDir = path.join(workspacePath, 'plugins');
 
-    if (fs.existsSync(packagesDir)) {
-      files.push(...this.findRelevantFiles(packagesDir));
-    }
     if (fs.existsSync(pluginsDir)) {
       files.push(...this.findRelevantFiles(pluginsDir));
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated `mui-to-bui.js` to filter out the packages folder, this should get us a bit better results as that folder does not contain code that actually ships.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
