### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/gorgeous-books-attend.md
+++ b/workspaces/azure-devops/.changeset/gorgeous-books-attend.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-backend': minor
-'@backstage-community/plugin-azure-devops-common': minor
-'@backstage-community/plugin-azure-devops': minor
----
-
-Added multi-org support to the Azure Pull Request Dashboard Page

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.29.0
+
+### Minor Changes
+
+- 7067acc: Added multi-org support to the Azure Pull Request Dashboard Page
+
+### Patch Changes
+
+- Updated dependencies [7067acc]
+  - @backstage-community/plugin-azure-devops-common@0.23.0
+
 ## 0.28.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.23.0
+
+### Minor Changes
+
+- 7067acc: Added multi-org support to the Azure Pull Request Dashboard Page
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.31.0
+
+### Minor Changes
+
+- 7067acc: Added multi-org support to the Azure Pull Request Dashboard Page
+
+### Patch Changes
+
+- Updated dependencies [7067acc]
+  - @backstage-community/plugin-azure-devops-common@0.23.0
+
 ## 0.30.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.19.1
+
+### Patch Changes
+
+- Updated dependencies [7067acc]
+  - @backstage-community/plugin-azure-devops-common@0.23.0
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.31.0

### Minor Changes

-   7067acc: Added multi-org support to the Azure Pull Request Dashboard Page

### Patch Changes

-   Updated dependencies [7067acc]
    -   @backstage-community/plugin-azure-devops-common@0.23.0

## @backstage-community/plugin-azure-devops-backend@0.29.0

### Minor Changes

-   7067acc: Added multi-org support to the Azure Pull Request Dashboard Page

### Patch Changes

-   Updated dependencies [7067acc]
    -   @backstage-community/plugin-azure-devops-common@0.23.0

## @backstage-community/plugin-azure-devops-common@0.23.0

### Minor Changes

-   7067acc: Added multi-org support to the Azure Pull Request Dashboard Page

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.19.1

### Patch Changes

-   Updated dependencies [7067acc]
    -   @backstage-community/plugin-azure-devops-common@0.23.0
