### PR TITLE
fix(scaffolder-backend-module-azure-devops): mask secret parameters in logs

### DIFF
--- a/workspaces/azure-devops/.changeset/six-trees-beg.md
+++ b/workspaces/azure-devops/.changeset/six-trees-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
+---
+
+fix: mask secret parameters in logs for Azure DevOps pipeline actions

--- a/workspaces/azure-devops/.changeset/six-trees-beg.md
+++ b/workspaces/azure-devops/.changeset/six-trees-beg.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
 ---
 
-fix: mask secret parameters in logs for Azure DevOps pipeline actions
+Removed logging of `templateParameters` when executing `azure:pipeline:run`

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
@@ -178,7 +178,7 @@ describe('publish:azure', () => {
     );
   });
 
-  it('should not log secret values in template parameters', async () => {
+  it('should not log template parameter values to prevent secret exposure', async () => {
     mockPipelineClient.runPipeline.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
     }));
@@ -218,17 +218,12 @@ describe('publish:azure', () => {
 
     const allLogs = logMessages.join(' ');
 
-    // Verify parameter keys are logged
-    expect(allLogs).toContain('normalParam');
-    expect(allLogs).toContain('secretKV');
-
-    // Verify secret values are NOT logged
+    // Verify that template parameter values are NOT logged at all
     expect(allLogs).not.toContain(secretValue);
     expect(allLogs).not.toContain('my-super-secret-password-123');
     expect(allLogs).not.toContain('visible-value');
-
-    // Verify masked values are present in debug logs
-    expect(allLogs).toContain('*****');
+    expect(allLogs).not.toContain('normalParam');
+    expect(allLogs).not.toContain('secretKV');
   });
 
   it('should use branch branch if provided', async () => {

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
@@ -178,6 +178,59 @@ describe('publish:azure', () => {
     );
   });
 
+  it('should not log secret values in template parameters', async () => {
+    mockPipelineClient.runPipeline.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+    }));
+    mockPipelineClient.getRun.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+    }));
+
+    const logMessages: string[] = [];
+    const mockLogger = {
+      info: (msg: string) => logMessages.push(msg),
+      debug: (msg: string, obj?: any) => {
+        logMessages.push(msg);
+        if (obj) logMessages.push(JSON.stringify(obj));
+      },
+      warn: (msg: string) => logMessages.push(msg),
+      error: (msg: string) => logMessages.push(msg),
+    };
+
+    const secretValue = 'my-super-secret-password-123';
+    const templateParameters = {
+      normalParam: 'visible-value',
+      secretKV: secretValue,
+    };
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        host: 'dev.azure.com',
+        organization: 'org',
+        pipelineId: '1',
+        project: 'project',
+        token: 'input-token',
+        templateParameters,
+      },
+      logger: mockLogger as any,
+    });
+
+    const allLogs = logMessages.join(' ');
+
+    // Verify parameter keys are logged
+    expect(allLogs).toContain('normalParam');
+    expect(allLogs).toContain('secretKV');
+
+    // Verify secret values are NOT logged
+    expect(allLogs).not.toContain(secretValue);
+    expect(allLogs).not.toContain('my-super-secret-password-123');
+    expect(allLogs).not.toContain('visible-value');
+
+    // Verify masked values are present in debug logs
+    expect(allLogs).toContain('*****');
+  });
+
   it('should use branch branch if provided', async () => {
     mockPipelineClient.runPipeline.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
@@ -152,30 +152,8 @@ export function createAzureDevopsRunPipelineAction(options: {
 
       // Add template parameters to RunPipelineParameters if available
       if (templateParameters) {
-        // Log the template parameter keys only (values may contain secrets)
-        ctx.logger.info(
-          `Template parameters provided: ${Object.keys(templateParameters).join(
-            ', ',
-          )}`,
-        );
         createOptions.templateParameters = templateParameters;
       }
-
-      // Log the createOptions object in a readable format (masking template parameter values)
-      const createOptionsForLogging = {
-        ...createOptions,
-        ...(createOptions.templateParameters && {
-          templateParameters: Object.fromEntries(
-            Object.keys(createOptions.templateParameters).map(key => [
-              key,
-              '*****',
-            ]),
-          ),
-        }),
-      };
-      ctx.logger.debug('Create options for running the pipeline:', {
-        RunPipelineParameters: JSON.stringify(createOptionsForLogging, null, 2),
-      });
 
       const pipelineIdAsInt = parseInt(pipelineId, 10);
 

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
@@ -152,16 +152,29 @@ export function createAzureDevopsRunPipelineAction(options: {
 
       // Add template parameters to RunPipelineParameters if available
       if (templateParameters) {
-        // Log the templateParameters if available
+        // Log the template parameter keys only (values may contain secrets)
         ctx.logger.info(
-          `Template parameters: ${JSON.stringify(templateParameters, null, 2)}`,
+          `Template parameters provided: ${Object.keys(templateParameters).join(
+            ', ',
+          )}`,
         );
         createOptions.templateParameters = templateParameters;
       }
 
-      // Log the createOptions object in a readable format
+      // Log the createOptions object in a readable format (masking template parameter values)
+      const createOptionsForLogging = {
+        ...createOptions,
+        ...(createOptions.templateParameters && {
+          templateParameters: Object.fromEntries(
+            Object.keys(createOptions.templateParameters).map(key => [
+              key,
+              '*****',
+            ]),
+          ),
+        }),
+      };
       ctx.logger.debug('Create options for running the pipeline:', {
-        RunPipelineParameters: JSON.stringify(createOptions, null, 2),
+        RunPipelineParameters: JSON.stringify(createOptionsForLogging, null, 2),
       });
 
       const pipelineIdAsInt = parseInt(pipelineId, 10);


### PR DESCRIPTION
Fixes #8904

Template parameters defined as secrets were being exposed in plain text when running `azure:pipeline:run`. This PR removes any logs of `templateParameters`
