### PR TITLE
fix(rbac): expand checkbox click targets to include associated label text

### DIFF
--- a/workspaces/rbac/.changeset/expand-checkbox-click-targets.md
+++ b/workspaces/rbac/.changeset/expand-checkbox-click-targets.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Expanded checkbox click targets in the permission policies form to include the associated label text. Clicking the permission name or policy action text now toggles the corresponding checkbox.

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.test.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+
+import { mockUseLanguage } from '../../test-utils/mockTranslations';
+import { mockTransformedConditionRules } from '../../__fixtures__/mockTransformedConditionRules';
+import * as ConditionsFormRowFields from '../ConditionalAccess/ConditionsFormRowFields';
+import PermissionPoliciesFormNestedRow from './PermissionPoliciesFormNestedRow';
+
+jest.mock('../../hooks/useLanguage', () => ({
+  useLanguage: mockUseLanguage,
+}));
+
+jest.mock('../ConditionalAccess/ConditionsFormRowFields');
+
+describe('PermissionPoliciesFormNestedRow', () => {
+  const spy = jest.spyOn(ConditionsFormRowFields, 'getTextFieldStyles');
+  spy.mockReturnValue({} as any);
+
+  const Table = ({ children }: { children: React.ReactNode }) => (
+    <table>
+      <tbody>{children}</tbody>
+    </table>
+  );
+
+  const baseProps = {
+    plugin: 'catalog',
+    permissionPolicy: {
+      permission: 'catalog.entity.read',
+      isResourced: true,
+      resourceType: 'catalog-entity',
+      actions: ['Read'],
+    },
+    permissionPolicyRowIndex: -1,
+    policies: [
+      { policy: 'Read', effect: 'deny' },
+      { policy: 'Update', effect: 'deny' },
+    ],
+    conditionRulesLength: 2,
+    totalRulesCount: 0,
+    conditionRulesData: mockTransformedConditionRules,
+    conditionsData: undefined,
+    onSelectPermission: jest.fn(),
+    onSelectPolicy: jest.fn(),
+    onRemovePermission: jest.fn(),
+    onAddConditions: jest.fn(),
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onSelectPermission when the permission label text is clicked', () => {
+    render(
+      <Table>
+        <PermissionPoliciesFormNestedRow {...baseProps} />
+      </Table>,
+    );
+
+    fireEvent.click(screen.getByText('catalog.entity.read'));
+
+    expect(baseProps.onSelectPermission).toHaveBeenCalledWith(
+      'catalog',
+      'catalog.entity.read',
+      true,
+      ['Read'],
+      'catalog-entity',
+    );
+  });
+
+  it('calls onRemovePermission when the permission label text is clicked and already selected', () => {
+    const props = { ...baseProps, permissionPolicyRowIndex: 0 };
+    render(
+      <Table>
+        <PermissionPoliciesFormNestedRow {...props} />
+      </Table>,
+    );
+
+    fireEvent.click(screen.getByText('catalog.entity.read'));
+
+    expect(baseProps.onRemovePermission).toHaveBeenCalledWith(0);
+  });
+
+  it('calls onSelectPolicy when a policy label text is clicked', () => {
+    const props = { ...baseProps, permissionPolicyRowIndex: 0 };
+    render(
+      <Table>
+        <PermissionPoliciesFormNestedRow {...props} />
+      </Table>,
+    );
+
+    fireEvent.click(screen.getByText('Read'));
+
+    expect(baseProps.onSelectPolicy).toHaveBeenCalledWith(true, 0, 0);
+  });
+
+  it('does not toggle disabled policy checkboxes when permission is not selected', () => {
+    render(
+      <Table>
+        <PermissionPoliciesFormNestedRow {...baseProps} />
+      </Table>,
+    );
+
+    const readCheckbox = screen.getByRole('checkbox', { name: 'Read' });
+    expect(readCheckbox).toBeDisabled();
+
+    fireEvent.click(screen.getByText('Read'));
+
+    expect(baseProps.onSelectPolicy).not.toHaveBeenCalled();
+  });
+});

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.test.tsx
@@ -109,7 +109,7 @@ describe('PermissionPoliciesFormNestedRow', () => {
     expect(baseProps.onSelectPolicy).toHaveBeenCalledWith(true, 0, 0);
   });
 
-  it('does not toggle disabled policy checkboxes when permission is not selected', () => {
+  it('auto-selects the permission when a policy checkbox is clicked and permission is not selected', () => {
     render(
       <Table>
         <PermissionPoliciesFormNestedRow {...baseProps} />
@@ -117,10 +117,17 @@ describe('PermissionPoliciesFormNestedRow', () => {
     );
 
     const readCheckbox = screen.getByRole('checkbox', { name: 'Read' });
-    expect(readCheckbox).toBeDisabled();
+    expect(readCheckbox).not.toBeDisabled();
 
     fireEvent.click(screen.getByText('Read'));
 
     expect(baseProps.onSelectPolicy).not.toHaveBeenCalled();
+    expect(baseProps.onSelectPermission).toHaveBeenCalledWith(
+      'catalog',
+      'catalog.entity.read',
+      true,
+      ['Read'],
+      'catalog-entity',
+    );
   });
 });

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.tsx
@@ -15,6 +15,7 @@
  */
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
@@ -87,23 +88,27 @@ const PermissionPoliciesFormNestedRow = ({
               alignItems: 'center',
             }}
           >
-            <Checkbox
-              onChange={e => {
-                if (e.target.checked) {
-                  onSelectPermission(
-                    plugin,
-                    permissionPolicy.permission,
-                    permissionPolicy.isResourced,
-                    permissionPolicy.actions,
-                    permissionPolicy.resourceType,
-                  );
-                } else {
-                  onRemovePermission(permissionPolicyRowIndex);
-                }
-              }}
-              checked={permissionPolicyRowIndex >= 0}
+            <FormControlLabel
+              control={
+                <Checkbox
+                  onChange={e => {
+                    if (e.target.checked) {
+                      onSelectPermission(
+                        plugin,
+                        permissionPolicy.permission,
+                        permissionPolicy.isResourced,
+                        permissionPolicy.actions,
+                        permissionPolicy.resourceType,
+                      );
+                    } else {
+                      onRemovePermission(permissionPolicyRowIndex);
+                    }
+                  }}
+                  checked={permissionPolicyRowIndex >= 0}
+                />
+              }
+              label={permissionPolicy.permission}
             />
-            {permissionPolicy.permission}
             {permissionPolicy.resourceType ? (
               <Tooltip
                 title={t('permissionPolicies.resourceTypeTooltip' as any, {
@@ -132,14 +137,18 @@ const PermissionPoliciesFormNestedRow = ({
               sx={{ display: 'flex', alignItems: 'center' }}
               key={`${permissionPolicy.permission}-${p.policy}`}
             >
-              <Checkbox
-                onChange={(_e, checked) =>
-                  onSelectPolicy(checked, pIndex, permissionPolicyRowIndex)
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    onChange={(_e, checked) =>
+                      onSelectPolicy(checked, pIndex, permissionPolicyRowIndex)
+                    }
+                    checked={p.effect === 'allow'}
+                    disabled={permissionPolicyRowIndex < 0}
+                  />
                 }
-                checked={p.effect === 'allow'}
-                disabled={permissionPolicyRowIndex < 0}
+                label={p.policy}
               />
-              {p.policy}
             </Box>
           ))}
         </TableCell>

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormNestedRow.tsx
@@ -140,11 +140,24 @@ const PermissionPoliciesFormNestedRow = ({
               <FormControlLabel
                 control={
                   <Checkbox
-                    onChange={(_e, checked) =>
-                      onSelectPolicy(checked, pIndex, permissionPolicyRowIndex)
-                    }
+                    onChange={() => {
+                      if (permissionPolicyRowIndex < 0) {
+                        onSelectPermission(
+                          plugin,
+                          permissionPolicy.permission,
+                          permissionPolicy.isResourced,
+                          permissionPolicy.actions,
+                          permissionPolicy.resourceType,
+                        );
+                      } else {
+                        onSelectPolicy(
+                          p.effect !== 'allow',
+                          pIndex,
+                          permissionPolicyRowIndex,
+                        );
+                      }
+                    }}
                     checked={p.effect === 'allow'}
-                    disabled={permissionPolicyRowIndex < 0}
                   />
                 }
                 label={p.policy}

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormRow.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormRow.test.tsx
@@ -91,4 +91,14 @@ describe('PermissionPoliciesFormRow', () => {
 
     expect(getByTestId(/nested-row-catalog/)).toBeInTheDocument();
   });
+
+  it('expands nested row when plugin name text is clicked', () => {
+    const { getByTestId } = render(
+      <PermissionPoliciesFormRow {...mockProps} />,
+    );
+
+    fireEvent.click(screen.getByText('Catalog'));
+
+    expect(getByTestId(/nested-row-catalog/)).toBeInTheDocument();
+  });
 });

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormRow.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/PermissionPoliciesFormRow.tsx
@@ -114,12 +114,17 @@ const PermissionPoliciesFormRow = ({
             display: 'flex',
             alignItems: 'center',
             fontWeight: theme => theme.typography.fontWeightMedium,
+            cursor: 'pointer',
           }}
+          onClick={() => setCurrentOpen(!currentOpen)}
         >
           <IconButton
             aria-label={t('common.expandRow')}
             size="small"
-            onClick={() => setCurrentOpen(!currentOpen)}
+            onClick={e => {
+              e.stopPropagation();
+              setCurrentOpen(!currentOpen);
+            }}
             data-testid={`expand-row-${rowData.plugin}`}
           >
             {currentOpen ? <ArrowDownIcon /> : <ArrowRightIcon />}


### PR DESCRIPTION
## Description
Made changes so that in  `3. Add permission policies` step clicking the label text (permission name or policy action)
toggles the corresponding checkbox. Previously users had to click precisely on the small checkbox control; the adjacent text was not a valid click target.

## UI after changes


https://github.com/user-attachments/assets/b0cf20db-685c-4e01-9019-79cc0e81e7f0



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
