### PR TITLE
fix(dynatrace): remove duplicate catalog-react peer dependency

### DIFF
--- a/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
+++ b/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-dynatrace': patch
 ---
 
-Removed duplicate `@backstage/plugin-catalog-react` peer dependency that caused Portal frontend app validation failures.
+Removed duplicate `@backstage/plugin-catalog-react` peer dependency

--- a/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
+++ b/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-dynatrace': patch
+---
+
+Removed duplicate `@backstage/plugin-catalog-react` peer dependency that caused Portal frontend app validation failures.

--- a/workspaces/dynatrace/plugins/dynatrace/package.json
+++ b/workspaces/dynatrace/plugins/dynatrace/package.json
@@ -75,7 +75,6 @@
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "peerDependencies": {
-    "@backstage/plugin-catalog-react": "^2.1.4",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"

--- a/workspaces/dynatrace/yarn.lock
+++ b/workspaces/dynatrace/yarn.lock
@@ -377,7 +377,6 @@ __metadata:
     react-router-dom: "npm:6.0.0-beta.0 || ^6.3.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
-    "@backstage/plugin-catalog-react": ^2.1.4
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
## Summary
- Removed `@backstage/plugin-catalog-react` from `peerDependencies` in the dynatrace plugin
- The package is already declared in `dependencies` and `devDependencies` via the `backstage:^` protocol
- The hardcoded `^2.1.4` peer dependency caused Portal frontend app validation to fail because yarn.lock resolves it under the `backstage:^` protocol, not the npm version specifier

## Test plan
- [x] Verified `yarn install --mode update-lockfile` succeeds without new errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)