### PR TITLE
Version Packages (dynatrace)

### DIFF
--- a/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
+++ b/workspaces/dynatrace/.changeset/fix-dynatrace-peer-dep.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-dynatrace': patch
----
-
-Removed duplicate `@backstage/plugin-catalog-react` peer dependency

--- a/workspaces/dynatrace/plugins/dynatrace/CHANGELOG.md
+++ b/workspaces/dynatrace/plugins/dynatrace/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-dynatrace
 
+## 10.19.1
+
+### Patch Changes
+
+- 7922e56: Removed duplicate `@backstage/plugin-catalog-react` peer dependency
+
 ## 10.19.0
 
 ### Minor Changes

--- a/workspaces/dynatrace/plugins/dynatrace/package.json
+++ b/workspaces/dynatrace/plugins/dynatrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-dynatrace",
-  "version": "10.19.0",
+  "version": "10.19.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "dynatrace",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-dynatrace@10.19.1

### Patch Changes

-   7922e56: Removed duplicate `@backstage/plugin-catalog-react` peer dependency
