### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/angry-onions-show.md
+++ b/workspaces/mcp-chat/.changeset/angry-onions-show.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Added support for max_tokens and temperature customization

--- a/workspaces/mcp-chat/.changeset/gold-ends-try.md
+++ b/workspaces/mcp-chat/.changeset/gold-ends-try.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Implement tool-level filtering using plugin configuration

--- a/workspaces/mcp-chat/.changeset/modern-hairs-give.md
+++ b/workspaces/mcp-chat/.changeset/modern-hairs-give.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Add support for configuring MCP tool call timeout

--- a/workspaces/mcp-chat/.changeset/public-insects-hug.md
+++ b/workspaces/mcp-chat/.changeset/public-insects-hug.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': patch
----
-
-Remove allowedTools from public MCPServerConfig API surface and improve disabledTools validation

--- a/workspaces/mcp-chat/.changeset/rude-dingos-throw.md
+++ b/workspaces/mcp-chat/.changeset/rude-dingos-throw.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Added support for O-series and GPT-5 models

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.10.0
+
+### Minor Changes
+
+- 8db17fe: Added support for max_tokens and temperature customization
+- 371fbad: Implement tool-level filtering using plugin configuration
+- 2cb7b1b: Add support for configuring MCP tool call timeout
+- 8db17fe: Added support for O-series and GPT-5 models
+
+### Patch Changes
+
+- 371fbad: Remove allowedTools from public MCPServerConfig API surface and improve disabledTools validation
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat-backend@0.10.0

### Minor Changes

-   8db17fe: Added support for max_tokens and temperature customization
-   371fbad: Implement tool-level filtering using plugin configuration
-   2cb7b1b: Add support for configuring MCP tool call timeout
-   8db17fe: Added support for O-series and GPT-5 models

### Patch Changes

-   371fbad: Remove allowedTools from public MCPServerConfig API surface and improve disabledTools validation
