### PR TITLE
[tech-insights] Clarify configuring entity tab and overview cards in new frontend system

### DIFF
--- a/workspaces/tech-insights/.changeset/strong-plants-lay.md
+++ b/workspaces/tech-insights/.changeset/strong-plants-lay.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-tech-insights': patch
 ---
 
-Documented how to disable and configure the Tech Insights entity tab and overview card via `app-config.yaml`, and clarified that registering a `TechInsightsScorecardBlueprint` with an `entityFilter` removes the default catch-all scorecard from the Tech Insights tab.
+Documented how to disable and configure the Tech Insights entity tab and overview card via `app-config.yaml`, and clarified that registering any `TechInsightsScorecardBlueprint` extension replaces the built-in fallback scorecard on the Tech Insights tab.

--- a/workspaces/tech-insights/.changeset/strong-plants-lay.md
+++ b/workspaces/tech-insights/.changeset/strong-plants-lay.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+Documented how to disable and configure the Tech Insights entity tab and overview card via `app-config.yaml`, and clarified that registering a `TechInsightsScorecardBlueprint` with an `entityFilter` removes the default catch-all scorecard from the Tech Insights tab.

--- a/workspaces/tech-insights/plugins/tech-insights/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights/README.md
@@ -74,7 +74,7 @@ const techInsightsModule = createFrontendModule({
 
 The Tech Insights entity tab is provided by the `entity-content:tech-insights/scorecards-content` extension. You can configure or disable it from `app-config.yaml` like any other extension in the new frontend system.
 
-To customize the title, description, or which checks are shown by default:
+To customize the tab title or path, and (when no `TechInsightsScorecardBlueprint` extensions are registered) the fallback scorecard's title, description, default checks, and density:
 
 ```yaml
 app:
@@ -87,6 +87,8 @@ app:
           dense: false
 ```
 
+> **Note:** The `description`, `checkIds`, and `dense` config fields only apply to the built-in fallback scorecard that is rendered when no `TechInsightsScorecardBlueprint` extensions are registered. As soon as any scorecard blueprint is registered, scorecard rendering is driven by the blueprint's own `params` (and the matching extension's `config` overrides), and these fallback config fields are ignored. The `title` field continues to control the tab label in either case.
+
 To completely hide the Tech Insights tab from entity pages:
 
 ```yaml
@@ -97,7 +99,7 @@ app:
 
 #### Configuring the Tech Insights overview card via app-config
 
-A scorecard card is also auto-registered on entity overview pages via the `entity-card:tech-insights/scorecards` extension. To disable it:
+A scorecards overview card is also auto-registered on entity overview pages via the `entity-card:tech-insights/scorecards` extension. To disable it:
 
 ```yaml
 app:

--- a/workspaces/tech-insights/plugins/tech-insights/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights/README.md
@@ -58,6 +58,53 @@ const techInsightsModule = createFrontendModule({
 });
 ```
 
+> **Note:** As soon as one or more `TechInsightsScorecardBlueprint` extensions are registered, the default "all checks" scorecard is no longer rendered on the Tech Insights tab. Only scorecards whose `entityFilter` matches the current entity are shown, so entity kinds that do not match any filter will see an empty Tech Insights tab. If you want to keep a generic scorecard alongside kind-specific ones, register an additional scorecard without an `entityFilter` (or with a catch-all filter) to act as the default:
+>
+> ```ts
+> TechInsightsScorecardBlueprint.make({
+>   name: 'default',
+>   params: {
+>     title: 'Scorecards',
+>     // No entityFilter, so this scorecard is shown for every entity.
+>   },
+> }),
+> ```
+
+#### Configuring the Tech Insights tab via app-config
+
+The Tech Insights entity tab is provided by the `entity-content:tech-insights/scorecards-content` extension. You can configure or disable it from `app-config.yaml` like any other extension in the new frontend system.
+
+To customize the title, description, or which checks are shown by default:
+
+```yaml
+app:
+  extensions:
+    - entity-content:tech-insights/scorecards-content:
+        config:
+          title: My Scorecards
+          description: Check compliance status
+          checkIds: ['groupOwnerCheck']
+          dense: false
+```
+
+To completely hide the Tech Insights tab from entity pages:
+
+```yaml
+app:
+  extensions:
+    - entity-content:tech-insights/scorecards-content: false
+```
+
+#### Configuring the Tech Insights overview card via app-config
+
+A scorecard card is also auto-registered on entity overview pages via the `entity-card:tech-insights/scorecards` extension. To disable it:
+
+```yaml
+app:
+  extensions:
+    - entity-card:tech-insights/scorecards: false
+```
+
 ### Integrating with the Legacy Frontend System
 
 The following sections describe how to integrate the plugin with the legacy frontend system.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improves the documentation for the Tech Insights plugin by explaining how to configure or disable the Tech Insights entity tab and overview card using `app-config.yaml`. It also clarifies the behavior when registering custom scorecards and provides examples for common configuration scenarios.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
