### PR TITLE
feat(tech-insights-maturity): add groupBy and categoryOrder props to MaturityScorePage

### DIFF
--- a/workspaces/tech-insights/.changeset/add-category-grouping.md
+++ b/workspaces/tech-insights/.changeset/add-category-grouping.md
@@ -1,0 +1,10 @@
+---
+'@backstage-community/plugin-tech-insights-maturity': minor
+---
+
+Add `groupBy` and `categoryOrder` props to `MaturityScorePage`.
+
+By default the component still groups checks by rank tier (Bronze / Silver / Gold).
+Setting `groupBy="category"` groups checks by `metadata.category` instead, with
+optional ordering via `categoryOrder`. This is useful when maturity checks span
+custom pillars rather than the built-in rank tiers.

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/README.md
@@ -140,6 +140,30 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
 );
 ```
 
+## Grouping Checks by Category
+
+By default, the Maturity Scorecards page groups checks by rank tier (Bronze / Silver / Gold). You can switch to category-based grouping using the `groupBy` prop:
+
+```tsx
+<EntityMaturityScorecardContent groupBy="category" />
+```
+
+When `groupBy="category"`, checks are grouped by their `metadata.category` value. Categories with failing checks are automatically expanded.
+
+You can also control the order of categories with `categoryOrder`. Any categories not listed are appended in the order they appear in the data:
+
+```tsx
+<EntityMaturityScorecardContent
+  groupBy="category"
+  categoryOrder={['Security', 'Engineering', 'Documentation']}
+/>
+```
+
+| Prop            | Type                   | Default     | Description                                              |
+| --------------- | ---------------------- | ----------- | -------------------------------------------------------- |
+| `groupBy`       | `'rank' \| 'category'` | `'rank'`    | How to group checks                                      |
+| `categoryOrder` | `string[]`             | `undefined` | Custom category ordering (only for `groupBy="category"`) |
+
 ## Maturity Rank Description
 
 Additionally, you can configure the title and description for the maturity ranks. As default, these values are already set so there is no need to configure unless you want to customize it.

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/report.api.md
@@ -83,6 +83,18 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
 export const MaturityPage: () => JSX_2.Element;
 
 // @public (undocumented)
+export const MaturityScorePage: ({
+  groupBy,
+  categoryOrder,
+}: MaturityScorePageProps) => JSX_2.Element;
+
+// @public
+export interface MaturityScorePageProps {
+  categoryOrder?: string[];
+  groupBy?: 'rank' | 'category';
+}
+
+// @public (undocumented)
 export const techInsightsMaturityPlugin: BackstagePlugin<
   {
     root: RouteRef<undefined>;

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/MaturityScorePage.test.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/MaturityScorePage.test.tsx
@@ -312,4 +312,67 @@ describe('<MaturityScorePage />', () => {
 
     expect(menuBookIcons.length).toBe(checksWithLinks);
   });
+
+  it('groups checks by category when groupBy is category', async () => {
+    const { getAllByText, queryByText } = await renderInTestApp(
+      <TestApiProvider apis={[[maturityApiRef, scoringApi]]}>
+        <EntityProvider entity={entity}>
+          <MaturityScorePage groupBy="category" />
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    // Category names should appear instead of rank chips
+    expect(getAllByText('Operations').length).toBeGreaterThan(0);
+    expect(getAllByText('Ownership').length).toBeGreaterThan(0);
+    expect(queryByText(/Bronze/)).not.toBeInTheDocument();
+    expect(queryByText(/Silver/)).not.toBeInTheDocument();
+  });
+
+  it('respects categoryOrder prop when groupBy is category', async () => {
+    const { container } = await renderInTestApp(
+      <TestApiProvider apis={[[maturityApiRef, scoringApi]]}>
+        <EntityProvider entity={entity}>
+          <MaturityScorePage
+            groupBy="category"
+            categoryOrder={['Ownership', 'Operations']}
+          />
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const chips = container.querySelectorAll('[data-testid^="category-chip-"]');
+    const labels = Array.from(chips).map(el => el.textContent);
+    expect(labels).toEqual(['Ownership', 'Operations']);
+  });
+
+  it('appends unlisted categories after categoryOrder entries', async () => {
+    const { container } = await renderInTestApp(
+      <TestApiProvider apis={[[maturityApiRef, scoringApi]]}>
+        <EntityProvider entity={entity}>
+          <MaturityScorePage groupBy="category" categoryOrder={['Ownership']} />
+        </EntityProvider>
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const chips = container.querySelectorAll('[data-testid^="category-chip-"]');
+    const labels = Array.from(chips).map(el => el.textContent);
+    // Operations is not in categoryOrder, so it is appended after Ownership
+    expect(labels).toEqual(['Ownership', 'Operations']);
+  });
 });

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/MaturityScorePage.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/MaturityScorePage.tsx
@@ -27,7 +27,31 @@ import { Rank } from '@backstage-community/plugin-tech-insights-maturity-common'
 import Box from '@mui/material/Box';
 import { MaturityCheckTable } from './maturityTableRows';
 
-export const MaturityScorePage = () => {
+/**
+ * Props for the MaturityScorePage component.
+ *
+ * @public
+ */
+export interface MaturityScorePageProps {
+  /**
+   * How to group checks in the UI.
+   * - `'rank'` (default): groups by maturity rank tier (Bronze / Silver / Gold).
+   * - `'category'`: groups by `metadata.category` on each check.
+   */
+  groupBy?: 'rank' | 'category';
+  /**
+   * When `groupBy` is `'category'`, an optional ordered list of category names.
+   * Categories not in this list are appended in the order they appear in the data.
+   * Ignored when `groupBy` is `'rank'`.
+   */
+  categoryOrder?: string[];
+}
+
+/** @public */
+export const MaturityScorePage = ({
+  groupBy = 'rank',
+  categoryOrder,
+}: MaturityScorePageProps) => {
   const { entity } = useEntity();
   const api = useApi(maturityApiRef);
 
@@ -72,30 +96,65 @@ export const MaturityScorePage = () => {
           >
             <Box sx={{ flexGrow: 1 }}>
               <Grid item>
-                <MaturityCheckTable
-                  checks={value.checks.filter(
-                    x => x.check.metadata.rank === Rank.Bronze,
-                  )}
-                  facts={value.facts}
-                  category={Rank.Bronze}
-                  rank={value.rank}
-                />
-                <MaturityCheckTable
-                  checks={value.checks.filter(
-                    x => x.check.metadata.rank === Rank.Silver,
-                  )}
-                  facts={value.facts}
-                  category={Rank.Silver}
-                  rank={value.rank}
-                />
-                <MaturityCheckTable
-                  checks={value.checks.filter(
-                    x => x.check.metadata.rank === Rank.Gold,
-                  )}
-                  facts={value.facts}
-                  category={Rank.Gold}
-                  rank={value.rank}
-                />
+                {groupBy === 'category' ? (
+                  (() => {
+                    const derived = [
+                      ...new Set(
+                        value.checks.map(c => c.check.metadata.category),
+                      ),
+                    ];
+                    const ordered = categoryOrder
+                      ? [
+                          ...new Set(categoryOrder),
+                          ...derived.filter(c => !categoryOrder.includes(c)),
+                        ]
+                      : derived;
+                    return ordered
+                      .filter(cat =>
+                        value.checks.some(
+                          x => x.check.metadata.category === cat,
+                        ),
+                      )
+                      .map(cat => (
+                        <MaturityCheckTable
+                          key={cat}
+                          checks={value.checks.filter(
+                            x => x.check.metadata.category === cat,
+                          )}
+                          facts={value.facts}
+                          categoryName={cat}
+                          rank={value.rank}
+                        />
+                      ));
+                  })()
+                ) : (
+                  <>
+                    <MaturityCheckTable
+                      checks={value.checks.filter(
+                        x => x.check.metadata.rank === Rank.Bronze,
+                      )}
+                      facts={value.facts}
+                      category={Rank.Bronze}
+                      rank={value.rank}
+                    />
+                    <MaturityCheckTable
+                      checks={value.checks.filter(
+                        x => x.check.metadata.rank === Rank.Silver,
+                      )}
+                      facts={value.facts}
+                      category={Rank.Silver}
+                      rank={value.rank}
+                    />
+                    <MaturityCheckTable
+                      checks={value.checks.filter(
+                        x => x.check.metadata.rank === Rank.Gold,
+                      )}
+                      facts={value.facts}
+                      category={Rank.Gold}
+                      rank={value.rank}
+                    />
+                  </>
+                )}
               </Grid>
             </Box>
           </Grid>

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export { MaturityScorePage } from './MaturityScorePage';
+export type { MaturityScorePageProps } from './MaturityScorePage';

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/maturityTableRows.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturityScorePage/maturityTableRows.tsx
@@ -40,13 +40,27 @@ import { MaturityRankChip } from '../MaturityRankChip';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import Chip from '@mui/material/Chip';
 
-interface Props {
+interface BaseProps {
   checks: MaturityCheckResult[];
   facts: InsightFacts;
   rank: MaturityRank;
-  category: Rank;
 }
+
+interface RankModeProps extends BaseProps {
+  /** Pass for rank-based grouping (default upstream behavior). */
+  category: Rank;
+  categoryName?: never;
+}
+
+interface CategoryModeProps extends BaseProps {
+  category?: never;
+  /** Pass for category-based grouping (groups by metadata.category). */
+  categoryName: string;
+}
+
+type Props = RankModeProps | CategoryModeProps;
 
 const MaturityCheckTableRow = ({
   checkResult,
@@ -190,14 +204,21 @@ const MaturityCheckTableRow = ({
   );
 };
 
-export const MaturityCheckTable = ({
-  rank,
-  category,
-  checks,
-  facts,
-}: Props) => {
-  // Expand only the next rank Category needed to level up
-  const [expanded, setExpanded] = useState<boolean>(rank.rank + 1 === category);
+export const MaturityCheckTable = (props: Props) => {
+  const { rank, checks, facts } = props;
+
+  const panelId =
+    props.categoryName !== undefined
+      ? `panel-cat-${props.categoryName.replace(/\s+/g, '-').toLowerCase()}`
+      : `panel-rank-${props.category}`;
+
+  // Rank mode: expand the tier the entity needs to reach next
+  // Category mode: expand any category with at least one failing check
+  const [expanded, setExpanded] = useState<boolean>(
+    props.categoryName !== undefined
+      ? checks.some(c => !c.result)
+      : rank.rank + 1 === props.category,
+  );
   if (checks.length === 0) return <></>;
 
   const handleChange = () => (_event: SyntheticEvent, newExpanded: boolean) => {
@@ -214,19 +235,32 @@ export const MaturityCheckTable = ({
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel2-content"
-          id="panel2-header"
+          aria-controls={`${panelId}-content`}
+          id={`${panelId}-header`}
         >
-          <MaturityRankChip
-            value={{ rank: category, isMaxRank: category <= rank.rank }}
-          />
+          {props.categoryName !== undefined ? (
+            <Chip
+              label={props.categoryName}
+              data-testid={`category-chip-${props.categoryName}`}
+              color={checks.every(c => c.result) ? 'success' : 'default'}
+              variant="outlined"
+              sx={{ fontWeight: 600, fontSize: '0.9rem' }}
+            />
+          ) : (
+            <MaturityRankChip
+              value={{
+                rank: props.category,
+                isMaxRank: props.category <= rank.rank,
+              }}
+            />
+          )}
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails id={`${panelId}-content`}>
           <Grid container spacing={1}>
             <Grid item xs={12}>
-              {checks?.map(entry => (
+              {checks?.map((entry, index) => (
                 <MaturityCheckTableRow
-                  key={entry.check.id}
+                  key={`${entry.check.id}-${index}`}
                   updated={facts[entry.check.factIds[0]]?.timestamp}
                   checkResult={entry}
                 />

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/index.ts
@@ -21,4 +21,6 @@ export {
   EntityMaturityRankWidget,
   EntityMaturitySummaryCard,
 } from './plugin';
+export { MaturityScorePage } from './components/MaturityScorePage';
+export type { MaturityScorePageProps } from './components/MaturityScorePage';
 export * from './api';


### PR DESCRIPTION
## What

Add configurable grouping mode to `MaturityScorePage` component via new `groupBy` and `categoryOrder` props.

### New props on `MaturityScorePage`

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `groupBy` | `'rank' \| 'category'` | `'rank'` | How to group checks |
| `categoryOrder` | `string[]` | `undefined` | Custom ordering for category mode |

### Behavior

- **`groupBy='rank'`** (default): Groups by Bronze / Silver / Gold tiers — **identical to current behavior**
- **`groupBy='category'`**: Groups by `metadata.category` on each check. Categories with failing checks auto-expand. Headers show colored `Chip` components (green for all-passing, default for failing).

## Why

The current `MaturityScorePage` only supports rank-based grouping (Bronze/Silver/Gold). Adopters who define maturity checks across custom categories (e.g., Security, Documentation, Operations) have no way to group by those categories in the UI.

This is a common need — maturity models often organize around pillars/domains rather than rank tiers.

## How

- `MaturityScorePage.tsx`: Added `MaturityScorePageProps` interface. When `groupBy='category'`, iterates unique categories (respecting `categoryOrder` if provided) instead of hardcoded rank tiers. Deduplicates `categoryOrder` entries via `Set`.
- `maturityTableRows.tsx`: `Props` is a discriminated union (rank mode vs category mode). Expand logic and header chip rendering are conditional on which prop is provided. Category chips include `data-testid` for stable test targeting.
- `index.ts` / `src/index.ts`: Export `MaturityScorePage` and `MaturityScorePageProps` from package public API.
- `report.api.md`: Updated API report with new exports.
- `README.md`: Added documentation section for category grouping with usage examples and props table.

## Testing

- Existing 2 tests unchanged and pass (default rank mode).
- Added 3 new tests:
  - Verifies category chips appear and rank chips don't when `groupBy='category'`
  - Verifies `categoryOrder` controls chip ordering
  - Verifies unlisted categories are appended after `categoryOrder` entries

## Checklist

- [x] Changeset included (minor)
- [x] `@public` TSDoc on new interface
- [x] Backward compatible — default behavior unchanged
- [x] API report updated
- [x] README documentation added
- [x] Tests use stable `data-testid` selectors
- [x] `categoryOrder` deduplicates input
- [x] Prettier formatted
- [x] DCO signed
