### PR TITLE
feat(tech-insights-maturity): add toggle for compound entity scores.

### DIFF
--- a/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
+++ b/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-tech-insights-maturity': patch
+---
+
+Add a `techInsights.maturity.enableCompoundEntityCheck` config option that lets
+non-Component entities (System, Domain, Group, API, Resource, etc.) have their
+own maturity scorecard. When enabled, the Maturity Summary page additionally
+renders the entity's own scorecard alongside the rollup of its related
+components. Defaults to `false`, preserving existing behavior.

--- a/workspaces/tech-insights/app-config.yaml
+++ b/workspaces/tech-insights/app-config.yaml
@@ -62,6 +62,11 @@ catalog:
         - allow: [User, Group]
 
 techInsights:
+  maturity:
+    # Flip this to true to opt entities (System/Domain/Group/API/Resource) into
+    # having their own maturity scorecard alongside the children rollup on the
+    # Maturity Summary page.
+    enableCompoundEntityCheck: false
   factRetrievers:
     entityOwnershipFactRetriever:
       cadence: '*/15 * * * *'

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/config.d.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/config.d.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  techInsights?: {
+    maturity?: {
+      /**
+       * When enabled (true), maturity checks run directly against any entity
+       * (System, Domain, Group, API, Resource, etc.) so that the entity has
+       * its own maturity score. The Maturity Summary page additionally
+       * renders the entity's own scorecard alongside the rollup of its
+       * related components.
+       *
+       * When disabled (false, default), the existing behavior is preserved:
+       * Component entities are scored individually, while entities that
+       * have related components (System, Domain, Group) aggregate the
+       * results of those components.
+       *
+       * @visibility frontend
+       */
+      enableCompoundEntityCheck?: boolean;
+    };
+  };
+}

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
@@ -42,6 +42,7 @@
     "directory": "workspaces/tech-insights/plugins/tech-insights-maturity"
   },
   "sideEffects": false,
+  "configSchema": "config.d.ts",
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/report.api.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/report.api.md
@@ -56,6 +56,7 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
     catalogApi: CatalogApi;
+    enableCompoundEntityCheck?: boolean;
   });
   // (undocumented)
   readonly catalogApi: CatalogApi;

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.test.ts
@@ -211,22 +211,34 @@ const sdc = new MaturityClient({
   identityApi: mockApis.identity.mock(),
 });
 
+const sdcWithCompoundChecks = new MaturityClient({
+  catalogApi: mockCatalogApi as CatalogApi,
+  discoveryApi: mockApis.discovery.mock(),
+  identityApi: mockApis.identity.mock(),
+  enableCompoundEntityCheck: true,
+});
+
 describe('MaturityClient', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('getMaturityRank', () => {
-    it('generates a  maturity rank for a given component', async () => {
+    it('generates a maturity rank for a given component', async () => {
       const expected: MaturityRank = {
         rank: Rank.Silver,
         isMaxRank: false,
       };
       jest.spyOn(sdc, 'runChecks').mockResolvedValue(checkResults);
 
-      expect(await sdc.getMaturityRank(mockSystem)).toMatchObject(expected);
+      expect(await sdc.getMaturityRank(entity)).toMatchObject(expected);
     });
   });
 
   describe('getMaturityScore', () => {
-    jest.spyOn(sdc, 'runChecks').mockResolvedValue(checkResults);
     it('generates a maturity score for a given component', async () => {
+      jest.spyOn(sdc, 'runChecks').mockResolvedValue(checkResults);
+
       const score = await sdc.getMaturityScore(entity);
       expect(score.checks).toEqual(checkResults); // Ownership and Operations
       expect(score.rank.rank).toEqual(2); // Silver
@@ -236,10 +248,28 @@ describe('MaturityClient', () => {
   });
 
   describe('getMaturitySummary', () => {
-    jest.spyOn(sdc, 'runBulkChecks').mockResolvedValue(bulkCheckResult);
+    it('aggregates maturity summary across child components for a system by default', async () => {
+      const runBulkSpy = jest
+        .spyOn(sdc, 'runBulkChecks')
+        .mockResolvedValue(bulkCheckResult);
+      const runChecksSpy = jest.spyOn(sdc, 'runChecks');
 
-    it('generates a maturity summary for a given system', async () => {
       expect(await sdc.getMaturitySummary(mockSystem)).toEqual(maturitySummary);
+      expect(runBulkSpy).toHaveBeenCalled();
+      expect(runChecksSpy).not.toHaveBeenCalled();
+    });
+
+    it('runs checks directly against the system when enableCompoundEntityCheck is true', async () => {
+      const runChecksSpy = jest
+        .spyOn(sdcWithCompoundChecks, 'runChecks')
+        .mockResolvedValue(checkResults);
+      const runBulkSpy = jest.spyOn(sdcWithCompoundChecks, 'runBulkChecks');
+
+      expect(
+        await sdcWithCompoundChecks.getMaturitySummary(mockSystem),
+      ).toEqual(maturitySummary);
+      expect(runChecksSpy).toHaveBeenCalled();
+      expect(runBulkSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/api/MaturityClient.ts
@@ -47,14 +47,24 @@ const SDF = new ScoringDataFormatter();
  */
 export class MaturityClient extends TechInsightsClient implements MaturityApi {
   readonly catalogApi: CatalogApi;
+  private readonly enableCompoundEntityCheck: boolean;
 
   constructor(options: {
     discoveryApi: DiscoveryApi;
     identityApi: IdentityApi;
     catalogApi: CatalogApi;
+    /**
+     * When true, runs maturity checks directly against any entity (including
+     * System / Domain / Group / API / Resource), in addition to the existing
+     * behavior that aggregates child component results for entities that
+     * have related components. Defaults to false to preserve existing
+     * behavior.
+     */
+    enableCompoundEntityCheck?: boolean;
   }) {
     super(options);
     this.catalogApi = options.catalogApi;
+    this.enableCompoundEntityCheck = options.enableCompoundEntityCheck ?? false;
   }
 
   public async getMaturityRank(entity: Entity): Promise<MaturityRank> {
@@ -115,7 +125,7 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
   private async getCheckResults(
     entity: Entity,
   ): Promise<MaturityCheckResult[]> {
-    if (isComponentEntity(entity)) {
+    if (this.enableCompoundEntityCheck || isComponentEntity(entity)) {
       return (await this.runChecks(
         getCompoundEntityRef(entity),
       )) as MaturityCheckResult[];
@@ -123,23 +133,6 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
 
     const entities = await this.getRelatedComponents(entity);
     return await this.getGroupCheckResults(entities);
-  }
-
-  private async getBulkCheckResults(entities: CompoundEntityRef[]) {
-    const bulkResponse = await this.runBulkChecks(entities);
-    return Promise.all(
-      bulkResponse.map(async x => {
-        const checks = x.results as MaturityCheckResult[];
-        const rank = SDF.getMaturityRank(checks);
-
-        return {
-          entity: x.entity,
-          rank: rank.rank,
-          isMaxRank: rank.isMaxRank,
-          checks,
-        };
-      }),
-    );
   }
 
   private async getGroupCheckResults(
@@ -161,6 +154,23 @@ export class MaturityClient extends TechInsightsClient implements MaturityApi {
     }
 
     return results;
+  }
+
+  private async getBulkCheckResults(entities: CompoundEntityRef[]) {
+    const bulkResponse = await this.runBulkChecks(entities);
+    return Promise.all(
+      bulkResponse.map(async x => {
+        const checks = x.results as MaturityCheckResult[];
+        const rank = SDF.getMaturityRank(checks);
+
+        return {
+          entity: x.entity,
+          rank: rank.rank,
+          isMaxRank: rank.isMaxRank,
+          checks,
+        };
+      }),
+    );
   }
 
   private async getRelatedComponents(

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturitySummaryPage/MaturitySummaryPage.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/components/MaturitySummaryPage/MaturitySummaryPage.tsx
@@ -15,7 +15,7 @@
  */
 import useAsyncRetry from 'react-use/lib/useAsync';
 
-import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import { useEntity, useRelatedEntities } from '@backstage/plugin-catalog-react';
 import { EmptyState, Progress } from '@backstage/core-components';
 import Alert from '@mui/material/Alert';
@@ -24,10 +24,17 @@ import { MaturityRankInfoCard } from '../MaturityRankInfoCard';
 import { MaturitySummaryTable } from '../MaturitySummaryTable';
 import { getSubEntityFilter } from '../../helpers/utils';
 import { maturityApiRef } from '../../api';
+import { MaturityScorePage } from '../MaturityScorePage';
 
 export const MaturitySummaryPage = () => {
   const { entity } = useEntity();
   const { entities } = useRelatedEntities(entity, getSubEntityFilter(entity));
+
+  const configApi = useApi(configApiRef);
+  const enableCompoundEntityCheck =
+    configApi.getOptionalBoolean(
+      'techInsights.maturity.enableCompoundEntityCheck',
+    ) ?? false;
 
   const api = useApi(maturityApiRef);
   const { value, loading, error } = useAsyncRetry(
@@ -41,6 +48,19 @@ export const MaturitySummaryPage = () => {
     return <Alert severity="error">{error.message}</Alert>;
   } else if (!value) {
     return <EmptyState missing="info" title="No information to display" />;
+  }
+
+  if (enableCompoundEntityCheck) {
+    return (
+      <Grid container spacing={1}>
+        <Grid item xs={12}>
+          <MaturityScorePage />
+        </Grid>
+        <Grid item xs={12}>
+          {entities && <MaturitySummaryTable entities={entities} />}
+        </Grid>
+      </Grid>
+    );
   }
 
   return (

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/src/plugin.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/src/plugin.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import {
+  configApiRef,
   createApiFactory,
   createComponentExtension,
   createPlugin,
@@ -39,14 +40,19 @@ export const techInsightsMaturityPlugin = createPlugin({
       api: maturityApiRef,
       deps: {
         catalogApi: catalogApiRef,
+        configApi: configApiRef,
         discoveryApi: discoveryApiRef,
         identityApi: identityApiRef,
       },
-      factory: ({ catalogApi, discoveryApi, identityApi }) =>
+      factory: ({ catalogApi, configApi, discoveryApi, identityApi }) =>
         new MaturityClient({
           catalogApi,
           discoveryApi,
           identityApi,
+          enableCompoundEntityCheck:
+            configApi.getOptionalBoolean(
+              'techInsights.maturity.enableCompoundEntityCheck',
+            ) ?? false,
         }),
     }),
   ],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the tech-insights-maturity plugin with a new config option that, when enabled, allows compound entities to have their own score (like other entities) in addition to the 'rollup' score the currently show.

This is a update from https://github.com/backstage/community-plugins/pull/7564, which was closed due to inactivity. This should resolve the requested changes made in that MR.

For transparency: I used Claude Opus 4.7 to help me generate these changes and test them.

I ran this locally, and when the flag is enabled in app-config, the maturity tab shows both the compound entity's maturity and it's children's maturity:

<img width="1648" height="885" alt="image" src="https://github.com/user-attachments/assets/fd2190c1-963d-4c7e-904b-82c16bd1a881" />

**NOTE**: When the flag is enabled, the tech-insights-maturity scorecard that shows on the Overview tab for a compound entity (System, Domain, Group) will show only the entity's own scores; one must go to the Maturity tab to see the child entity scores. I think this is reasonable (it keeps the compound entity's overview experience consistent with other entities), but I want to be sure it's called out.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
