### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/renovate-f40ae4d.md
+++ b/workspaces/rbac/.changeset/renovate-f40ae4d.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Updated dependency `start-server-and-test` to `3.0.2`.

--- a/workspaces/rbac/.changeset/witty-shrimps-bathe.md
+++ b/workspaces/rbac/.changeset/witty-shrimps-bathe.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
-'@backstage-community/plugin-rbac-common': patch
-'@backstage-community/plugin-rbac-node': patch
-'@backstage-community/plugin-rbac-backend': patch
----
-
-Migrate to Jest 30 and fix backend test assertion compatibility

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.12.4
+
+### Patch Changes
+
+- 170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
+- Updated dependencies [170f85d]
+  - @backstage-community/plugin-rbac-common@1.26.1
+  - @backstage-community/plugin-rbac-node@1.20.1
+
 ## 7.12.3
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.12.3",
+  "version": "7.12.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-rbac-common [1.8.2](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-common@1.8.1...@backstage-community/plugin-rbac-common@1.8.2) (2024-08-06)
 
+## 1.26.1
+
+### Patch Changes
+
+- 170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
+
 ## 1.26.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-common/package.json
+++ b/workspaces/rbac/plugins/rbac-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-common",
   "description": "Common functionalities for the rbac-common plugin",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-node/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## @backstage-community/plugin-rbac-node [1.4.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-rbac-node@1.3.1...@backstage-community/plugin-rbac-node@1.4.0) (2024-07-26)
 
+## 1.20.1
+
+### Patch Changes
+
+- 170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
+- Updated dependencies [170f85d]
+  - @backstage-community/plugin-rbac-common@1.26.1
+
 ## 1.20.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac-node/package.json
+++ b/workspaces/rbac/plugins/rbac-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-rbac-node",
   "description": "Node.js library for the rbac plugin",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-rbac
 
+## 1.52.4
+
+### Patch Changes
+
+- a63b0b6: Updated dependency `start-server-and-test` to `3.0.2`.
+- 170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
+- Updated dependencies [170f85d]
+  - @backstage-community/plugin-rbac-common@1.26.1
+
 ## 1.52.3
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.52.3",
+  "version": "1.52.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.52.4

### Patch Changes

-   a63b0b6: Updated dependency `start-server-and-test` to `3.0.2`.
-   170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
-   Updated dependencies [170f85d]
    -   @backstage-community/plugin-rbac-common@1.26.1

## @backstage-community/plugin-rbac-backend@7.12.4

### Patch Changes

-   170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
-   Updated dependencies [170f85d]
    -   @backstage-community/plugin-rbac-common@1.26.1
    -   @backstage-community/plugin-rbac-node@1.20.1

## @backstage-community/plugin-rbac-common@1.26.1

### Patch Changes

-   170f85d: Migrate to Jest 30 and fix backend test assertion compatibility

## @backstage-community/plugin-rbac-node@1.20.1

### Patch Changes

-   170f85d: Migrate to Jest 30 and fix backend test assertion compatibility
-   Updated dependencies [170f85d]
    -   @backstage-community/plugin-rbac-common@1.26.1
