### PR TITLE
feat: add azure openai provider #8402

### DIFF
--- a/workspaces/mcp-chat/.changeset/curly-rabbits-start.md
+++ b/workspaces/mcp-chat/.changeset/curly-rabbits-start.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-mcp-chat-backend': minor
+---
+
+Add Azure OpenAI provider to support newer Azure OpenAI models like `gpt-5.1`.
+
+This provider filters the models returned during the connection test to only show the status of the model of the configured deployment. It also uses `max_completion_tokens` correctly, fixing compatibility with newer models.

--- a/workspaces/mcp-chat/.changeset/dark-ravens-win.md
+++ b/workspaces/mcp-chat/.changeset/dark-ravens-win.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-mcp-chat': patch
+---
+
+Updated the list of supported providers in the README

--- a/workspaces/mcp-chat/README.md
+++ b/workspaces/mcp-chat/README.md
@@ -142,7 +142,7 @@ Add the following configuration to your `app-config.yaml`:
 ```yaml
 mcpChat:
   # Configure AI providers (currently only the first provider is used)
-  # Supported Providers: OpenAI, Gemini, Claude, and Ollama
+  # OpenAI, OpenAI Responses API, Azure OpenAI, Gemini, Claude, Ollama, and LiteLLM
   providers:
     - id: openai # OpenAI provider
       # Optional: Specify a custom baseUrl for OpenAI-compatible endpoints
@@ -155,6 +155,15 @@ mcpChat:
       # maxTokens: 1000
       # Optional: Customize temperature 0-1 (default: 0.7)
       # temperature: 0.7
+    - id: openai-responses # OpenAI Responses API provider (handles MCP internally)
+      baseUrl: 'http://your-responses-api-endpoint.com/v1/openai/v1'
+      model: 'gemini/models/gemini-2.5-flash'
+      token: ${API_TOKEN} # Optional, depends on your API setup
+    - id: azure-openai # Azure OpenAI provider, requires the v1 API endpoint (not the older /openai/deployments/NAME/...?api-version=... format)
+      baseUrl: 'https://your-api-endpoint.openai.azure.com/openai/v1'
+      token: ${AZURE_OPENAI_API_KEY}
+      model: 'gpt-5.1'
+      deploymentName: 'your-deployment-name'
     - id: claude # Claude provider
       token: ${CLAUDE_API_KEY}
       model: claude-sonnet-4-20250514 # or claude-3-7-sonnet-latest
@@ -172,6 +181,14 @@ mcpChat:
     - id: ollama # Ollama provider
       baseUrl: 'http://localhost:11434'
       model: llama3.1:8b # or any model you have locally
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
+    - id: litellm # LiteLLM proxy provider
+      baseUrl: 'http://localhost:4000' # LiteLLM proxy URL
+      token: ${LITELLM_API_KEY} # Optional, depends on your LiteLLM setup
+      model: gpt-4o-mini # Model name configured in LiteLLM
       # Optional: Customize max tokens (default: 1000)
       # maxTokens: 1000
       # Optional: Customize temperature 0-1 (default: 0.7)

--- a/workspaces/mcp-chat/app-config.yaml
+++ b/workspaces/mcp-chat/app-config.yaml
@@ -36,6 +36,15 @@ mcpChat:
       # maxTokens: 1000
       # Optional: Customize temperature 0-1 (default: 0.7)
       # temperature: 0.7
+    - id: azure-openai # Azure OpenAI – deployment-based routing
+      baseUrl: 'https://<resource>.openai.azure.com/openai/v1'
+      token: ${AZURE_OPENAI_API_KEY}
+      model: gpt-5.1
+      deploymentName: my-gpt-5.1-deployment
+      # Optional: Customize max tokens (default: 1000)
+      # maxTokens: 1000
+      # Optional: Customize temperature 0-1 (default: 0.7)
+      # temperature: 0.7
     - id: openai-responses # OpenAI Responses API
       baseUrl: 'http://your-responses-api-endpoint.com/v1/openai/v1'
       model: 'gemini/models/gemini-2.5-flash'

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/README.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/README.md
@@ -229,7 +229,7 @@ Add the following configuration to your `app-config.yaml`:
 ```yaml
 mcpChat:
   # Configure AI providers (currently only the first provider is used)
-  # Supported Providers: OpenAI, OpenAI Responses API, Gemini, Claude, Ollama, and LiteLLM
+  # Supported Providers: OpenAI, OpenAI Responses API, Azure OpenAI, Gemini, Claude, Ollama, and LiteLLM
   providers:
     - id: openai # OpenAI provider
       token: ${OPENAI_API_KEY}
@@ -242,6 +242,11 @@ mcpChat:
       baseUrl: 'http://your-responses-api-endpoint.com/v1/openai/v1'
       model: 'gemini/models/gemini-2.5-flash'
       token: ${API_TOKEN} # Optional, depends on your API setup
+    - id: azure-openai # Azure OpenAI provider, requires the v1 API endpoint (not the older /openai/deployments/NAME/...?api-version=... format)
+      baseUrl: 'https://your-api-endpoint.openai.azure.com/openai/v1'
+      token: ${AZURE_OPENAI_API_KEY}
+      model: 'gpt-5.1'
+      deploymentName: 'your-deployment-name'
     - id: claude # Claude provider
       token: ${CLAUDE_API_KEY}
       model: claude-sonnet-4-20250514 # or claude-3-7-sonnet-latest

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/config.d.ts
@@ -25,19 +25,34 @@ export interface Config {
       /**
        * Unique identifier for the provider
        * @visibility backend
-       * @enum { 'openai' | 'claude' | 'gemini' | 'ollama' }
+       * @enum { 'openai' | 'openai-responses' | 'azure-openai' | 'claude' | 'gemini' | 'ollama' | 'litellm' }
        */
-      id: 'openai' | 'claude' | 'gemini' | 'ollama';
+      id:
+        | 'openai'
+        | 'openai-responses'
+        | 'azure-openai'
+        | 'claude'
+        | 'gemini'
+        | 'ollama'
+        | 'litellm';
       /**
        * API token for the provider
        * @visibility secret
        */
       token?: string;
       /**
-       * Model name to use for this provider
+       * Model name to use for this provider.
+       * For `azure-openai` this should be the underlying model name (e.g. `gpt-4o-mini`),
+       * used only for capability detection. The actual API calls use `deploymentName`.
        * @visibility backend
        */
       model: string;
+      /**
+       * Azure OpenAI deployment name.
+       * Required for the `azure-openai` provider.
+       * @visibility backend
+       */
+      deploymentName?: string;
       /**
        * Base URL for the provider's API
        * @visibility backend

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/report.api.md
@@ -14,6 +14,21 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 
 // @public
+export class AzureOpenAIProvider extends OpenAIProvider {
+  constructor(config: ProviderConfig);
+  // (undocumented)
+  protected formatRequest(messages: ChatMessage[], tools?: Tool[]): any;
+  // (undocumented)
+  protected get providerName(): string;
+  // (undocumented)
+  testConnection(): Promise<{
+    connected: boolean;
+    models?: string[];
+    error?: string;
+  }>;
+}
+
+// @public
 export class ChatConversationStore {
   static create(
     options: ChatConversationStoreOptions,
@@ -145,6 +160,7 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig;
 
 // @public
 export function getProviderInfo(config: RootConfigService): {
+  deploymentName?: string | undefined;
   provider: string;
   model: string;
   baseURL: string;
@@ -215,6 +231,7 @@ export abstract class LLMProvider {
 export type LLMProviderType =
   | 'openai'
   | 'openai-responses'
+  | 'azure-openai'
   | 'claude'
   | 'gemini'
   | 'ollama'
@@ -346,6 +363,8 @@ export class OpenAIProvider extends LLMProvider {
   // (undocumented)
   protected parseResponse(response: any): ChatResponse;
   // (undocumented)
+  protected get providerName(): string;
+  // (undocumented)
   sendMessage(messages: ChatMessage[], tools?: Tool[]): Promise<ChatResponse>;
   // (undocumented)
   testConnection(): Promise<{
@@ -384,6 +403,7 @@ export class OpenAIResponsesProvider extends LLMProvider {
 export interface ProviderConfig {
   apiKey?: string;
   baseUrl: string;
+  deploymentName?: string;
   logger?: LoggerService;
   maxTokens?: number;
   model: string;

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/index.ts
@@ -28,6 +28,7 @@ export {
   getProviderConfig,
   getProviderInfo,
   OpenAIProvider,
+  AzureOpenAIProvider,
   OpenAIResponsesProvider,
   ClaudeProvider,
   GeminiProvider,

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/azure-openai-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/azure-openai-provider.test.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AzureOpenAIProvider } from './azure-openai-provider';
+import { ProviderConfig, ChatMessage } from '../types';
+
+global.fetch = jest.fn();
+
+const config: ProviderConfig = {
+  type: 'azure-openai',
+  apiKey: 'test-azure-api-key',
+  baseUrl: 'https://my-resource.openai.azure.com/openai/v1',
+  model: 'gpt-4o-mini',
+  deploymentName: 'my-gpt-4o-mini-deployment',
+};
+
+describe('AzureOpenAIProvider', () => {
+  let provider: AzureOpenAIProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
+    provider = new AzureOpenAIProvider(config);
+  });
+
+  describe('constructor', () => {
+    it('should throw when deploymentName is missing', () => {
+      expect(
+        () => new AzureOpenAIProvider({ ...config, deploymentName: undefined }),
+      ).toThrow(/Deployment name is required for the azure-openai provider./);
+    });
+
+    it('should not throw when all required fields are provided', () => {
+      expect(() => new AzureOpenAIProvider(config)).not.toThrow();
+    });
+  });
+
+  describe('formatRequest', () => {
+    const messages: ChatMessage[] = [{ role: 'user', content: 'Hello' }];
+
+    it('should send the deploymentName as the model field in the request body', () => {
+      const request = (provider as any).formatRequest(messages);
+      expect(request.model).toBe('my-gpt-4o-mini-deployment');
+    });
+
+    it('should use the underlying model name for capability detection, not the deployment name', () => {
+      // model = gpt-4o-mini → should use max_tokens (not max_completion_tokens)
+      const request = (provider as any).formatRequest(messages);
+      expect(request.max_tokens).toBeDefined();
+      expect(request.max_completion_tokens).toBeUndefined();
+    });
+
+    it('should use max_completion_tokens when underlying model is o-series', () => {
+      const p = new AzureOpenAIProvider({
+        ...config,
+        model: 'o1-mini',
+        deploymentName: 'my-o1-mini-deployment',
+      });
+      const request = (p as any).formatRequest(messages);
+      expect(request.max_completion_tokens).toBeDefined();
+      expect(request.max_tokens).toBeUndefined();
+      expect(request.model).toBe('my-o1-mini-deployment');
+    });
+
+    it('should use max_completion_tokens when underlying model is gpt-5', () => {
+      const p = new AzureOpenAIProvider({
+        ...config,
+        model: 'gpt-5',
+        deploymentName: 'my-gpt-5-deployment',
+      });
+      const request = (p as any).formatRequest(messages);
+      expect(request.max_completion_tokens).toBeDefined();
+      expect(request.max_tokens).toBeUndefined();
+    });
+
+    it.each([
+      ['o1-mini', 'acme-prod-o1-mini-deployment'],
+      ['gpt-5', 'internal-gpt-5-preview-deploy'],
+    ])(
+      'model field in body should always be the deploymentName (%s / %s)',
+      (model, deploymentName) => {
+        const p = new AzureOpenAIProvider({ ...config, model, deploymentName });
+        const request = (p as any).formatRequest(messages);
+        expect(request.model).toBe(deploymentName);
+      },
+    );
+  });
+
+  describe('testConnection', () => {
+    it('should return connected with the configured model and not all models', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-4o-mini', status: 'succeeded' },
+            { id: 'gpt-5', status: 'succeeded' },
+            { id: 'gpt-5.1', status: 'succeeded' },
+          ],
+        }),
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result).toEqual({
+        connected: true,
+        models: ['gpt-4o-mini'],
+      });
+    });
+
+    it('should return all models and log a warning when configured model is not in the list', async () => {
+      const mockLogger = {
+        warn: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+      };
+      const p = new AzureOpenAIProvider({
+        ...config,
+        logger: mockLogger as any,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-5', status: 'succeeded' },
+            { id: 'gpt-5.1', status: 'succeeded' },
+          ],
+        }),
+      });
+
+      const result = await p.testConnection();
+
+      expect(result).toEqual({
+        connected: true,
+        models: ['gpt-5', 'gpt-5.1'],
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[azure-openai] Configured model "gpt-4o-mini" was not found',
+        ),
+      );
+    });
+
+    it('should log a warning when no models are available', async () => {
+      const mockLogger = {
+        warn: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+      };
+      const p = new AzureOpenAIProvider({
+        ...config,
+        logger: mockLogger as any,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+      const result = await p.testConnection();
+
+      expect(result).toEqual({
+        connected: true,
+        models: [],
+      });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[azure-openai] Configured model "gpt-4o-mini" was not found',
+        ),
+      );
+    });
+
+    it('should say "Azure OpenAI" in 401 error message', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () =>
+          JSON.stringify({ error: { message: 'Unauthorized' } }),
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Azure OpenAI');
+      expect(result.error).toContain('Invalid API key');
+      expect(result.error).not.toBe(
+        'Invalid API key. Please check your OpenAI API key configuration.',
+      );
+    });
+
+    it('should say "Azure OpenAI" in 429 error message', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'Too Many Requests',
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Azure OpenAI');
+      expect(result.error).toContain('Rate limit exceeded');
+    });
+
+    it('should say "Azure OpenAI" in generic API error message', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => '{"error":{"message":"Internal error"}}',
+      });
+
+      const result = await provider.testConnection();
+
+      expect(result.connected).toBe(false);
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should send a message and return the response', async () => {
+      const messages: ChatMessage[] = [{ role: 'user', content: 'Hello!' }];
+
+      const mockResponse = {
+        choices: [{ message: { role: 'assistant', content: 'Hi there!' } }],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await provider.sendMessage(messages);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://my-resource.openai.azure.com/openai/v1/chat/completions',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(result).toEqual(mockResponse);
+
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body,
+      );
+      expect(body.model).toBe('my-gpt-4o-mini-deployment');
+    });
+
+    it('should include tools in the request when provided', async () => {
+      const messages: ChatMessage[] = [
+        { role: 'user', content: 'What is the weather?' },
+      ];
+      const tools = [
+        {
+          type: 'function' as const,
+          function: {
+            name: 'get_weather',
+            description: 'Get weather',
+            parameters: {
+              type: 'object',
+              properties: { location: { type: 'string' } },
+            },
+          },
+        },
+      ];
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [
+            { message: { role: 'assistant', content: null, tool_calls: [] } },
+          ],
+        }),
+      });
+
+      await provider.sendMessage(messages, tools);
+
+      const body = JSON.parse(
+        (global.fetch as jest.Mock).mock.calls[0][1].body,
+      );
+      expect(body.tools).toEqual(tools);
+      expect(body.model).toBe('my-gpt-4o-mini-deployment');
+    });
+
+    it('should throw on API error', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      await expect(
+        provider.sendMessage([{ role: 'user', content: 'Hello' }]),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/azure-openai-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/azure-openai-provider.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OpenAIProvider } from './openai-provider';
+import { ChatMessage, Tool, ProviderConfig } from '../types';
+
+/**
+ * Azure OpenAI Chat Completions API provider.
+ *
+ * @public
+ */
+export class AzureOpenAIProvider extends OpenAIProvider {
+  private readonly deploymentName: string;
+
+  protected get providerName(): string {
+    return 'Azure OpenAI';
+  }
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    if (!config.deploymentName) {
+      throw new Error(
+        'Deployment name is required for the azure-openai provider.',
+      );
+    }
+
+    this.deploymentName = config.deploymentName;
+  }
+
+  async testConnection(): Promise<{
+    connected: boolean;
+    models?: string[];
+    error?: string;
+  }> {
+    const result = await super.testConnection();
+
+    if (result.models) {
+      const hasConfiguredModel = result.models.some(
+        model => model === this.model,
+      );
+      if (!hasConfiguredModel) {
+        this.logger?.warn(
+          `[${this.type}] Configured model "${this.model}" was not found in the available models.`,
+        );
+      } else {
+        result.models = result.models.filter(model => model === this.model);
+      }
+    }
+    return result;
+  }
+
+  protected formatRequest(messages: ChatMessage[], tools?: Tool[]): any {
+    const request = super.formatRequest(messages, tools);
+    request.model = this.deploymentName;
+    return request;
+  }
+}

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/index.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/index.ts
@@ -28,6 +28,7 @@ export {
 // Provider Implementations
 // =============================================================================
 export { OpenAIProvider } from './openai-provider';
+export { AzureOpenAIProvider } from './azure-openai-provider';
 export { OpenAIResponsesProvider } from './openai-responses-provider';
 export { ClaudeProvider } from './claude-provider';
 export { GeminiProvider } from './gemini-provider';

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.test.ts
@@ -133,6 +133,7 @@ describe('OpenAIProvider', () => {
 
       expect(result.connected).toBe(false);
       expect(result.error).toContain('Invalid API key');
+      expect(result.error).toContain('OpenAI');
     });
 
     it('should return error message on 429', async () => {
@@ -146,6 +147,7 @@ describe('OpenAIProvider', () => {
 
       expect(result.connected).toBe(false);
       expect(result.error).toContain('Rate limit exceeded');
+      expect(result.error).toContain('OpenAI');
     });
 
     it('should return error message on 403', async () => {

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/openai-provider.ts
@@ -22,6 +22,10 @@ import { ChatMessage, Tool, ChatResponse } from '../types';
  * @public
  */
 export class OpenAIProvider extends LLMProvider {
+  protected get providerName(): string {
+    return 'OpenAI';
+  }
+
   async sendMessage(
     messages: ChatMessage[],
     tools?: Tool[],
@@ -44,7 +48,7 @@ export class OpenAIProvider extends LLMProvider {
 
       if (!response.ok) {
         const errorText = await response.text();
-        let errorMessage = `OpenAI API error (${response.status})`;
+        let errorMessage = `${this.providerName} API error (${response.status})`;
 
         try {
           const errorData = JSON.parse(errorText);
@@ -61,11 +65,9 @@ export class OpenAIProvider extends LLMProvider {
 
         // Provide user-friendly messages for common errors
         if (response.status === 401) {
-          errorMessage =
-            'Invalid API key. Please check your OpenAI API key configuration.';
+          errorMessage = `Invalid API key. Please check your ${this.providerName} API key configuration.`;
         } else if (response.status === 429) {
-          errorMessage =
-            'Rate limit exceeded. Please try again later or check your OpenAI usage limits.';
+          errorMessage = `Rate limit exceeded. Please try again later or check your ${this.providerName} usage limits.`;
         } else if (response.status === 403) {
           errorMessage =
             'Access forbidden. Please check your API key permissions.';

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.test.ts
@@ -21,6 +21,7 @@ import {
   getProviderInfo,
 } from './provider-factory';
 import { OpenAIProvider } from './openai-provider';
+import { AzureOpenAIProvider } from './azure-openai-provider';
 import { ClaudeProvider } from './claude-provider';
 import { GeminiProvider } from './gemini-provider';
 import { OllamaProvider } from './ollama-provider';
@@ -32,6 +33,7 @@ describe('ProviderFactory', () => {
     it('should create correct provider instances for supported types', () => {
       const testCases = [
         { type: 'openai', expectedClass: OpenAIProvider },
+        { type: 'azure-openai', expectedClass: AzureOpenAIProvider },
         { type: 'claude', expectedClass: ClaudeProvider },
         { type: 'gemini', expectedClass: GeminiProvider },
         { type: 'ollama', expectedClass: OllamaProvider },
@@ -44,6 +46,9 @@ describe('ProviderFactory', () => {
           apiKey: 'test-key',
           baseUrl: 'https://example.com',
           model: 'test-model',
+          ...(type === 'azure-openai'
+            ? { deploymentName: 'test-deployment' }
+            : {}),
           logger: mockServices.logger.mock(),
         };
 
@@ -98,7 +103,7 @@ describe('getProviderConfig', () => {
     mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
 
     expect(() => getProviderConfig(mockConfig)).toThrow(
-      'Unsupported provider id: unsupported. Allowed values are: openai, openai-responses, claude, gemini, ollama, litellm',
+      'Unsupported provider id: unsupported. Allowed values are: openai, openai-responses, azure-openai, claude, gemini, ollama, litellm',
     );
   });
 
@@ -259,6 +264,62 @@ describe('getProviderConfig', () => {
     expect(result.baseUrl).toBe('http://localhost:4000');
     expect(result.type).toBe('litellm');
     expect(result.apiKey).toBeUndefined();
+  });
+
+  it('should configure azure-openai provider with deploymentName', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'azure-openai';
+        if (key === 'model') return 'gpt-5.1';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'token') return 'azure-key';
+        if (key === 'baseUrl')
+          return 'https://myresource.openai.azure.com/openai/v1';
+        if (key === 'deploymentName') return 'my-gpt-5.1-deployment';
+        return undefined;
+      }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    const result = getProviderConfig(mockConfig);
+
+    expect(result).toEqual({
+      type: 'azure-openai',
+      apiKey: 'azure-key',
+      baseUrl: 'https://myresource.openai.azure.com/openai/v1',
+      model: 'gpt-5.1',
+      deploymentName: 'my-gpt-5.1-deployment',
+      maxTokens: undefined,
+      temperature: undefined,
+    });
+  });
+
+  it('should throw error when deploymentName is missing for azure-openai', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'azure-openai';
+        if (key === 'model') return 'gpt-5.1';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'token') return 'azure-key';
+        if (key === 'baseUrl')
+          return 'https://myresource.openai.azure.com/openai/v1';
+        if (key === 'deploymentName') return undefined;
+        return undefined;
+      }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    expect(() => getProviderConfig(mockConfig)).toThrow(
+      'Deployment name is required for the azure-openai provider.',
+    );
   });
 
   it('should throw error when API key is missing for non-Ollama/LiteLLM providers', () => {
@@ -530,5 +591,55 @@ describe('getProviderInfo', () => {
     mockConfig.getOptionalConfigArray.mockReturnValue([]);
 
     expect(() => getProviderInfo(mockConfig)).toThrow();
+  });
+
+  it('should include deploymentName for azure-openai provider', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'azure-openai';
+        if (key === 'model') return 'gpt-4';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl')
+          return 'https://my-resource.openai.azure.com/openai/v1';
+        if (key === 'deploymentName') return 'my-gpt4-deployment';
+        return 'test-key';
+      }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    const result = getProviderInfo(mockConfig);
+
+    expect(result).toEqual({
+      provider: 'azure-openai',
+      model: 'gpt-4',
+      baseURL: 'https://my-resource.openai.azure.com/openai/v1',
+      deploymentName: 'my-gpt4-deployment',
+    });
+  });
+
+  it('should not include deploymentName when not set', () => {
+    const mockProviderConfig = {
+      getString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'id') return 'openai';
+        if (key === 'model') return 'gpt-4';
+        throw new Error(`Unexpected key: ${key}`);
+      }),
+      getOptionalString: jest.fn().mockImplementation((key: string) => {
+        if (key === 'baseUrl') return 'https://api.openai.com/v1';
+        if (key === 'deploymentName') return undefined;
+        return 'test-key';
+      }),
+      getOptionalNumber: jest.fn().mockReturnValue(undefined),
+    } as any;
+
+    mockConfig.getOptionalConfigArray.mockReturnValue([mockProviderConfig]);
+
+    const result = getProviderInfo(mockConfig);
+
+    expect(result).not.toHaveProperty('deploymentName');
   });
 });

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
@@ -25,10 +25,11 @@ import {
   RootConfigService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { AzureOpenAIProvider } from './azure-openai-provider';
 
 /**
  * Factory class for creating LLM provider instances.
- * Supports OpenAI, Claude, Gemini, Ollama, LiteLLM, and OpenAI Responses API.
+ * Supports OpenAI, Azure OpenAI, Claude, Gemini, Ollama, LiteLLM, and OpenAI Responses API.
  *
  * @public
  */
@@ -51,6 +52,9 @@ export class ProviderFactory {
 
       case 'openai-responses':
         return new OpenAIResponsesProvider(configWithLogger);
+
+      case 'azure-openai':
+        return new AzureOpenAIProvider(configWithLogger);
 
       case 'claude':
         return new ClaudeProvider(configWithLogger);
@@ -106,6 +110,7 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
   const allowedProviders = [
     'openai',
     'openai-responses',
+    'azure-openai',
     'claude',
     'gemini',
     'ollama',
@@ -136,6 +141,16 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
       apiKey: token,
       baseUrl: providerConfig.getOptionalString('baseUrl') || '',
       model: model,
+      maxTokens: maxTokens,
+      temperature: temperature,
+    },
+
+    'azure-openai': {
+      type: 'azure-openai',
+      apiKey: token,
+      baseUrl: providerConfig.getOptionalString('baseUrl') || '',
+      model: model,
+      deploymentName: providerConfig.getOptionalString('deploymentName'),
       maxTokens: maxTokens,
       temperature: temperature,
     },
@@ -196,6 +211,11 @@ export function getProviderConfig(config: RootConfigService): ProviderConfig {
   if (!configTemplate.model) {
     throw new Error(`Model is required for provider: ${providerId}`);
   }
+  if (providerId === 'azure-openai' && !configTemplate.deploymentName) {
+    throw new Error(
+      'Deployment name is required for the azure-openai provider.',
+    );
+  }
 
   return configTemplate as ProviderConfig;
 }
@@ -213,5 +233,8 @@ export function getProviderInfo(config: RootConfigService) {
     provider: providerConfig.type,
     model: providerConfig.model,
     baseURL: providerConfig.baseUrl,
+    ...(providerConfig.deploymentName && {
+      deploymentName: providerConfig.deploymentName,
+    }),
   };
 }

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/providers/provider-factory.ts
@@ -21,11 +21,11 @@ import { ClaudeProvider } from './claude-provider';
 import { GeminiProvider } from './gemini-provider';
 import { OllamaProvider } from './ollama-provider';
 import { LiteLLMProvider } from './litellm-provider';
+import { AzureOpenAIProvider } from './azure-openai-provider';
 import {
   RootConfigService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
-import { AzureOpenAIProvider } from './azure-openai-provider';
 
 /**
  * Factory class for creating LLM provider instances.

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/src/types.ts
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/src/types.ts
@@ -50,6 +50,7 @@ export enum MCPServerType {
 export type LLMProviderType =
   | 'openai'
   | 'openai-responses'
+  | 'azure-openai'
   | 'claude'
   | 'gemini'
   | 'ollama'
@@ -207,6 +208,8 @@ export interface ProviderConfig {
   baseUrl: string;
   /** Model identifier to use */
   model: string;
+  /** Azure OpenAI deployment name. Required when using the `azure-openai` provider type. */
+  deploymentName?: string;
   /** Logger for debugging */
   logger?: LoggerService;
   /** Maximum number of tokens to generate (default: 1000 for OpenAI-compatible, 4096 for Claude, 8192 for Gemini) */

--- a/workspaces/mcp-chat/plugins/mcp-chat/README.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat/README.md
@@ -143,7 +143,7 @@ Add the following configuration to your `app-config.yaml`:
 ```yaml
 mcpChat:
   # Configure AI providers (currently only the first provider is used)
-  # Supported Providers: OpenAI, Gemini, Claude, and Ollama
+  # Supported Providers: OpenAI, OpenAI Responses API, Azure OpenAI, Gemini, Claude, Ollama, and LiteLLM
   providers:
     - id: openai # OpenAI provider
       token: ${OPENAI_API_KEY}


### PR DESCRIPTION
## Add Azure OpenAI provider

Closes #8402

Add Azure OpenAI provider to support for newer Azure OpenAI models like `gpt-5.1`.

This provider filters the models returned during the connection test to only show the status of the model of the configured deployment. It also uses `max_completion_tokens` correctly, fixing compatibility with newer models.

<img width="1349" height="775" alt="image" src="https://github.com/user-attachments/assets/bca44a5f-ae05-4538-b81a-1ae778f822c4" />


#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
