### PR TITLE
Version Packages (grafana)

### DIFF
--- a/workspaces/grafana/.changeset/grafana-multiple-instances.md
+++ b/workspaces/grafana/.changeset/grafana-multiple-instances.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-grafana': minor
----
-
-Added support for multiple Grafana instances. Organizations with multiple Grafana deployments can now configure them all under the `grafana.hosts` config key and associate entities to specific instances via the `grafana/host-id` annotation. The legacy single-instance `grafana.domain` configuration remains fully supported.

--- a/workspaces/grafana/plugins/grafana/CHANGELOG.md
+++ b/workspaces/grafana/plugins/grafana/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-grafana
 
+## 0.19.0
+
+### Minor Changes
+
+- 25ddfa9: Added support for multiple Grafana instances. Organizations with multiple Grafana deployments can now configure them all under the `grafana.hosts` config key and associate entities to specific instances via the `grafana/host-id` annotation. The legacy single-instance `grafana.domain` configuration remains fully supported.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-grafana",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A Backstage backend plugin that integrates towards Grafana",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-grafana@0.19.0

### Minor Changes

-   25ddfa9: Added support for multiple Grafana instances. Organizations with multiple Grafana deployments can now configure them all under the `grafana.hosts` config key and associate entities to specific instances via the `grafana/host-id` annotation. The legacy single-instance `grafana.domain` configuration remains fully supported.
