### PR TITLE
chore(bookmarks): run build and unit tests on Node 22 and 24

### DIFF
--- a/workspaces/bookmarks/package.json
+++ b/workspaces/bookmarks/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "20 || 22"
+    "node": "22 || 24"
   },
   "scripts": {
     "start": "backstage-cli repo start",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Switch from Node 20+22 to 22+24 to ensure compatibly with Backstage 1.46+

https://backstage.io/docs/releases/v1.46.0

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
