### PR TITLE
chore(topology): add changeset for Jest 30 migration to trigger release

### DIFF
--- a/workspaces/topology/.changeset/neat-buses-shake.md
+++ b/workspaces/topology/.changeset/neat-buses-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Migrate to Jest 30


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a changeset related to the changes made in https://github.com/backstage/community-plugins/pull/8978 so that a new `topology` version is released supporting Jest 30

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
