### PR TITLE
feat(repo): add per-workspace opt-in Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,19 @@ jobs:
           yarn playwright install --with-deps chromium chrome
           yarn playwright test
 
+      - name: ensure clean working directory
+        run: |
+          if files=$(git ls-files --exclude-standard --others --modified) && [[ -z "$files" ]]; then
+            exit 0
+          else
+            echo ""
+            echo "Working directory has been modified:"
+            echo ""
+            git status --short
+            echo ""
+            exit 1
+          fi
+
       - name: Read codecov flag from bcp.json
         id: bcpCodecov
         run: |
@@ -217,19 +230,6 @@ jobs:
           directory: ./workspaces/${{ matrix.workspaceNodeMatrix.workspace }}/plugins
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-
-      - name: ensure clean working directory
-        run: |
-          if files=$(git ls-files --exclude-standard --others --modified) && [[ -z "$files" ]]; then
-            exit 0
-          else
-            echo ""
-            echo "Working directory has been modified:"
-            echo ""
-            git status --short
-            echo ""
-            exit 1
-          fi
 
   verify:
     name: Workspace ${{ matrix.workspace }}, Verify step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,25 @@ jobs:
           yarn playwright install --with-deps chromium chrome
           yarn playwright test
 
+      - name: Read codecov flag from bcp.json
+        id: bcpCodecov
+        run: |
+          if [ -f bcp.json ]; then
+            CODECOV=$(jq -r '.["codecov"] // "false"' bcp.json)
+            echo "codecov=$CODECOV" >> $GITHUB_OUTPUT
+          else
+            echo "codecov=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload coverage to Codecov
+        if: ${{ steps.bcpCodecov.outputs.codecov == 'true' }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: ${{ matrix.workspaceNodeMatrix.workspace }}
+          directory: ./workspaces/${{ matrix.workspaceNodeMatrix.workspace }}/plugins
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: ensure clean working directory
         run: |
           if files=$(git ls-files --exclude-standard --others --modified) && [[ -z "$files" ]]; then

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -1,0 +1,106 @@
+# Coverage baseline for backstage/community-plugins
+#
+# Runs on push to main and uploads coverage for changed workspaces that
+# have opted in via "codecov": true in their bcp.json. This establishes
+# the per-workspace baselines that Codecov uses to calculate coverage
+# deltas in PRs (via carryforward).
+#
+# PR-level coverage is handled by the upload step in ci.yml; this
+# workflow only covers push events so the two never duplicate work.
+
+name: Coverage Baseline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "workspaces/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect-workspaces:
+    name: Detect changed codecov workspaces
+    runs-on: ubuntu-latest
+    outputs:
+      workspaces: ${{ steps.filter.outputs.workspaces }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Find changed workspaces with codecov enabled
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD | grep '^workspaces/' | cut -d/ -f2 | sort -u)
+          CODECOV_WORKSPACES="[]"
+          for ws in $CHANGED; do
+            BCP="workspaces/$ws/bcp.json"
+            if [ -f "$BCP" ] && [ "$(jq -r '.codecov // false' "$BCP")" = "true" ]; then
+              CODECOV_WORKSPACES=$(echo "$CODECOV_WORKSPACES" | jq -c --arg w "$ws" '. + [$w]')
+            fi
+          done
+          echo "workspaces=$CODECOV_WORKSPACES" >> "$GITHUB_OUTPUT"
+          echo "Codecov workspaces: $CODECOV_WORKSPACES"
+
+  coverage:
+    name: Coverage — ${{ matrix.workspace }}
+    runs-on: ubuntu-latest
+    needs: detect-workspaces
+    if: ${{ needs.detect-workspaces.outputs.workspaces != '[]' }}
+    strategy:
+      matrix:
+        workspace: ${{ fromJSON(needs.detect-workspaces.outputs.workspaces) }}
+      fail-fast: false
+    defaults:
+      run:
+        working-directory: ./workspaces/${{ matrix.workspace }}
+
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=8192
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run tests with coverage
+        # TODO: Remove the Jest 30 detection once all workspaces have migrated to Jest 30
+        run: |
+          if node -e "const p = require('./package.json'); process.exit(p.devDependencies?.jest ? 0 : 1)"; then
+            echo "Using Jest 30"
+            ./node_modules/.bin/backstage-cli repo test --coverage --maxWorkers=3
+          else
+            echo "Using Jest 29 from the Backstage CLI"
+            yarn backstage-cli repo test --coverage --maxWorkers=3
+          fi
+        env:
+          BACKSTAGE_TEST_DISABLE_DOCKER: 1
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          flags: ${{ matrix.workspace }}
+          directory: ./workspaces/${{ matrix.workspace }}/plugins
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Find changed workspaces with codecov enabled
         id: filter
         run: |
-          CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | { grep '^workspaces/' || true; } | cut -d/ -f2 | sort -u)
+          if [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
+            CHANGED=$(git diff --name-only HEAD~1 HEAD | { grep '^workspaces/' || true; } | cut -d/ -f2 | sort -u)
+          else
+            CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | { grep '^workspaces/' || true; } | cut -d/ -f2 | sort -u)
+          fi
           CODECOV_WORKSPACES="[]"
           for ws in $CHANGED; do
             [ -z "$ws" ] && continue
@@ -68,6 +72,30 @@ jobs:
       CI: true
       NODE_OPTIONS: --max-old-space-size=8192
 
+    services:
+      postgres18:
+        image: postgres:18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432/tcp
+      postgres14:
+        image: postgres:14
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432/tcp
+
     steps:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
@@ -78,7 +106,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 24
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -86,6 +114,7 @@ jobs:
 
       - name: Run tests with coverage
         # TODO: Remove the Jest 30 detection once all workspaces have migrated to Jest 30
+        # NOTE: This block is duplicated from ci.yml — update both if changing
         run: |
           if node -e "const p = require('./package.json'); process.exit(p.devDependencies?.jest ? 0 : 1)"; then
             echo "Using Jest 30"
@@ -96,9 +125,10 @@ jobs:
           fi
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
+          BACKSTAGE_TEST_DATABASE_POSTGRES18_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres18.ports[5432] }}
+          BACKSTAGE_TEST_DATABASE_POSTGRES14_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres14.ports[5432] }}
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -33,15 +33,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Find changed workspaces with codecov enabled
         id: filter
         run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD | grep '^workspaces/' | cut -d/ -f2 | sort -u)
+          CHANGED=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | { grep '^workspaces/' || true; } | cut -d/ -f2 | sort -u)
           CODECOV_WORKSPACES="[]"
           for ws in $CHANGED; do
+            [ -z "$ws" ] && continue
             BCP="workspaces/$ws/bcp.json"
             if [ -f "$BCP" ] && [ "$(jq -r '.codecov // false' "$BCP")" = "true" ]; then
               CODECOV_WORKSPACES=$(echo "$CODECOV_WORKSPACES" | jq -c --arg w "$ws" '. + [$w]')

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,60 @@
+# codecov.yml — per-workspace opt-in coverage for community-plugins
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+        paths:
+          - "workspaces/*/plugins/*/src/**"
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+        paths:
+          - "workspaces/*/plugins/*/src/**"
+
+comment:
+  layout: "header, diff, flags, footer"
+  behavior: default
+  require_changes: true
+  show_carryforward_flags: true
+
+ignore:
+  - "**/node_modules/**"
+  - "**/dist/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/index.ts"
+  - "**/setupTests.*"
+  - "**/playwright.config.ts"
+  - "**/dev/**"
+  - "**/test-utils/**"
+  - "**/__fixtures__/**"
+  - "**/__tests__/**"
+  - "**/__mocks__/**"
+  - "**/examples/**"
+
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: auto
+        threshold: 1%

--- a/codecov.yml
+++ b/codecov.yml
@@ -38,7 +38,6 @@ ignore:
   - "**/*.test.tsx"
   - "**/*.spec.ts"
   - "**/*.spec.tsx"
-  - "**/index.ts"
   - "**/setupTests.*"
   - "**/playwright.config.ts"
   - "**/dev/**"

--- a/docs/plugin-maintainers-guide.md
+++ b/docs/plugin-maintainers-guide.md
@@ -16,6 +16,7 @@
   - [Opt-in to Knip Reports Check](#opt-in-to-knip-reports-check)
   - [Opt-in to List Deprecations Check](#opt-in-to-list-deprecations-check)
   - [Opt-in to Playwright UI Check](#opt-in-to-playwright-ui-check)
+  - [Opt-in to Code Coverage](#opt-in-to-code-coverage)
   - [Maintaining and patching an older release line](#maintaining-and-patching-an-older-release-line)
     - [Patching an older release](#patching-an-older-release)
   - [FAQ](#faq)
@@ -167,6 +168,19 @@ Test file selection is based solely on the config file. Launching the plugin can
 Note that since there is no per-plugin configuration for the workflow, there is no place to store secrets for the CI, in case any communication with external services is required. For the sake of consistency, we recommend testing using static data for the dev pages, or [mocking](https://playwright.dev/docs/mock#mock-api-requests) any external APIs during as part of the tests themselves.
 
 For a working example, check out the [quay](/workspaces/quay/) workspace. In particular, the [config](/workspaces/quay/playwright.config.ts) file, and the [tests](/workspaces/quay/plugins/quay/tests/) might be of interest.
+
+## Opt-in to Code Coverage
+
+Plugin owners can opt into having test coverage data uploaded to [Codecov](https://app.codecov.io/gh/backstage/community-plugins) by adding `"codecov": true` to their `bcp.json` file in the root of their workspace (`workspaces/${WORKSPACE}/bcp.json`).
+
+When enabled:
+
+- The CI workflow uploads coverage data from your workspace's plugin test suite to Codecov on each PR
+- A baseline workflow uploads coverage on push to `main` so that Codecov can calculate coverage deltas on subsequent PRs
+- Codecov posts an informational comment on PRs where coverage changed, showing which files gained or lost coverage
+- Coverage status checks are **informational only** — they will never block a PR from merging
+
+No changes to your test configuration are needed. The existing `backstage-cli repo test --coverage` command already produces the coverage data that Codecov consumes.
 
 ## Maintaining and patching an older release line
 

--- a/workspaces/rbac/bcp.json
+++ b/workspaces/rbac/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "playwrightTests": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As discussed in Tuesday's SIG, this PR adds Codecov integration to the CI pipeline, allowing workspace maintainers to opt in to test coverage reporting by setting `"codecov": true` in their `bcp.json`. 

 ### Changes                                                                                                                                                                            
                                                                                                                                                                                        
 - **`codecov.yml`** — Codecov configuration with informational-only status checks (never blocks PRs), a `flag_management.default_rules` block so new workspaces are automatically      
 configured on first upload, and an ignore list to exclude test files, barrel files, dev harness, and fixtures from coverage metrics.                                                   
 - **`.github/workflows/coverage-baseline.yml`** — New workflow that runs on push to `main` for changed workspaces with `"codecov": true`. This seeds the per-workspace baselines that Codecov uses to calculate coverage deltas on PRs. Only runs for workspaces modified in the push (not all opted-in workspaces) so it scales without impacting CI concurrency.         
 - **`.github/workflows/ci.yml`** — Added two steps after the test step: reads the `"codecov"` flag from `bcp.json` and uploads coverage if enabled.                                    
 - **`workspaces/rbac/bcp.json`** — Enabled `"codecov": true` as the pilot workspace.                                                                                                   
 - **`docs/plugin-maintainers-guide.md`** — Added "Opt-in to Code Coverage" section documenting how to enable Codecov and what to expect.
 
### Admin Requirements 

Before this PR will function correctly, `CODECOV_TOKEN` must be added as a repository secret. This can be found at https://app.codecov.io/gh/backstage/community-plugins/new

Edit: It appears I now have access to add repo secrets, so I can move ahead with this once the PR is merged. No further action will be required by admins.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
