### PR TITLE
Version Packages (confluence)

### DIFF
--- a/workspaces/confluence/.changeset/grumpy-shirts-think.md
+++ b/workspaces/confluence/.changeset/grumpy-shirts-think.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-confluence-collator': patch
-'@backstage-community/plugin-techdocs-backend-module-confluence': patch
-'@backstage-community/plugin-confluence': patch
----
-
-Improved README with clearer configuration docs and cross-references between plugins.

--- a/workspaces/confluence/.changeset/version-bump-1-50-3.md
+++ b/workspaces/confluence/.changeset/version-bump-1-50-3.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-confluence': minor
-'@backstage-community/plugin-search-backend-module-confluence-collator': minor
-'@backstage-community/plugin-techdocs-backend-module-confluence': minor
----
-
-Backstage version bump to v1.50.3

--- a/workspaces/confluence/.changeset/version-bump-1-51-0.md
+++ b/workspaces/confluence/.changeset/version-bump-1-51-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-confluence': minor
-'@backstage-community/plugin-search-backend-module-confluence-collator': minor
-'@backstage-community/plugin-techdocs-backend-module-confluence': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/confluence/.changeset/version-bump-1-52-0.md
+++ b/workspaces/confluence/.changeset/version-bump-1-52-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-confluence': minor
-'@backstage-community/plugin-search-backend-module-confluence-collator': minor
-'@backstage-community/plugin-techdocs-backend-module-confluence': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/confluence/plugins/confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/confluence/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-confluence
 
+## 0.15.0
+
+### Minor Changes
+
+- 7aeeb74: Backstage version bump to v1.50.3
+- f224db5: Backstage version bump to v1.51.0
+- 8f26fd1: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 44b51c2: Improved README with clearer configuration docs and cross-references between plugins.
+
 ## 0.14.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/confluence/package.json
+++ b/workspaces/confluence/plugins/confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-confluence",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-search-backend-module-confluence-collator
 
+## 0.18.0
+
+### Minor Changes
+
+- 7aeeb74: Backstage version bump to v1.50.3
+- f224db5: Backstage version bump to v1.51.0
+- 8f26fd1: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 44b51c2: Improved README with clearer configuration docs and cross-references between plugins.
+
 ## 0.17.2
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-confluence-collator",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "The confluence-collator backend module for the search plugin.",
   "backstage": {
     "role": "backend-plugin-module",

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/CHANGELOG.md
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-techdocs-backend-module-confluence
 
+## 0.3.0
+
+### Minor Changes
+
+- 7aeeb74: Backstage version bump to v1.50.3
+- f224db5: Backstage version bump to v1.51.0
+- 8f26fd1: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 44b51c2: Improved README with clearer configuration docs and cross-references between plugins.
+
 ## 0.2.1
 
 ### Patch Changes

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/package.json
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-techdocs-backend-module-confluence",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "The confluence backend module for the techdocs plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-confluence@0.15.0

### Minor Changes

-   7aeeb74: Backstage version bump to v1.50.3
-   f224db5: Backstage version bump to v1.51.0
-   8f26fd1: Backstage version bump to v1.52.0

### Patch Changes

-   44b51c2: Improved README with clearer configuration docs and cross-references between plugins.

## @backstage-community/plugin-search-backend-module-confluence-collator@0.18.0

### Minor Changes

-   7aeeb74: Backstage version bump to v1.50.3
-   f224db5: Backstage version bump to v1.51.0
-   8f26fd1: Backstage version bump to v1.52.0

### Patch Changes

-   44b51c2: Improved README with clearer configuration docs and cross-references between plugins.

## @backstage-community/plugin-techdocs-backend-module-confluence@0.3.0

### Minor Changes

-   7aeeb74: Backstage version bump to v1.50.3
-   f224db5: Backstage version bump to v1.51.0
-   8f26fd1: Backstage version bump to v1.52.0

### Patch Changes

-   44b51c2: Improved README with clearer configuration docs and cross-references between plugins.
