### PR TITLE
fix(argocd): handle issue where trailing slash causes invalid URLS

### DIFF
--- a/workspaces/argocd/.changeset/spotty-bananas-smoke.md
+++ b/workspaces/argocd/.changeset/spotty-bananas-smoke.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-argocd-node': patch
+---
+
+Fixed handling of Argo CD instance URLs configured with a trailing slash; API requests now target paths such as `/api/v1/session` correctly instead of producing invalid double-slash URLs.

--- a/workspaces/argocd/plugins/argocd-node/src/serviceUtils.test.ts
+++ b/workspaces/argocd/plugins/argocd-node/src/serviceUtils.test.ts
@@ -65,6 +65,15 @@ describe('serviceUtils', () => {
         password: undefined,
       } as Instance);
     });
+
+    it('should strip trailing slashes from url', () => {
+      const instanceConfig = new ConfigReader({
+        name: 'test',
+        url: 'https://test.com/',
+      });
+      const result: Instance = toInstance(instanceConfig);
+      expect(result.url).toEqual('https://test.com');
+    });
   });
 
   describe('processFetch', () => {
@@ -107,6 +116,16 @@ describe('serviceUtils', () => {
       expect(url).toEqual(
         'https://test-instance.com/api/v1/applications/test-app?selector=test%3Dtrue&appNamespace=test&project=testing',
       );
+    });
+
+    it('should normalize a trailing slash on the base URL', () => {
+      const url = buildArgoUrl(
+        'https://test-instance.com/',
+        'applications',
+        {},
+      );
+      expect(url).toEqual('https://test-instance.com/api/v1/applications');
+      expect(new URL(url).pathname).not.toMatch(/^\/\//);
     });
   });
 });

--- a/workspaces/argocd/plugins/argocd-node/src/serviceUtils.ts
+++ b/workspaces/argocd/plugins/argocd-node/src/serviceUtils.ts
@@ -22,6 +22,15 @@ import {
 } from '@backstage/errors';
 
 /**
+ * Removes trailing slashes from the configured Argo CD base URL so path joins
+ * do not produce an empty path segment (e.g. `https://host/` + `/api/v1/...`
+ * → `//api/v1/...`), which breaks routing and can yield non-JSON errors such as 405.
+ */
+function normalizeArgoInstanceUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
  * Retrieves an instance by it's name from a list of instances
  *
  * @param {Object} params - The parameters
@@ -51,7 +60,7 @@ export const getInstanceByName = ({
 export const toInstance = (el: Config): Instance => {
   return {
     name: el.getString('name'),
-    url: el.getString('url'),
+    url: normalizeArgoInstanceUrl(el.getString('url')),
     token: el.getOptionalString('token'),
     username: el.getOptionalString('username'),
     password: el.getOptionalString('password'),
@@ -133,7 +142,7 @@ export const buildArgoUrl = (
   path: string,
   params: Record<string, string> = {},
 ): string => {
-  const url = new URL(`${baseUrl}/api/v1/${path}`);
+  const url = new URL(`${normalizeArgoInstanceUrl(baseUrl)}/api/v1/${path}`);
   Object.entries(params).forEach(([key, value]) => {
     if (value) {
       url.searchParams.set(key, value);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PR to fix an issue where trailing slashes for the instance URL in the ArgoCD config would lead to  `Request failed with status 500`.

Example:

Config: `https://argo.example.com/`
Before the fix: `https://argo.example.com//api/v1/session`
After the fix: `https://argo.example.com/api/v1/session`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
