### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/curly-rabbits-start.md
+++ b/workspaces/mcp-chat/.changeset/curly-rabbits-start.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Add Azure OpenAI provider to support newer Azure OpenAI models like `gpt-5.1`.
-
-This provider filters the models returned during the connection test to only show the status of the model of the configured deployment. It also uses `max_completion_tokens` correctly, fixing compatibility with newer models.

--- a/workspaces/mcp-chat/.changeset/dark-ravens-win.md
+++ b/workspaces/mcp-chat/.changeset/dark-ravens-win.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat': patch
----
-
-Updated the list of supported providers in the README

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.11.0
+
+### Minor Changes
+
+- c43e80c: Add Azure OpenAI provider to support newer Azure OpenAI models like `gpt-5.1`.
+
+  This provider filters the models returned during the connection test to only show the status of the model of the configured deployment. It also uses `max_completion_tokens` correctly, fixing compatibility with newer models.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-mcp-chat
 
+## 0.7.1
+
+### Patch Changes
+
+- c43e80c: Updated the list of supported providers in the README
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-mcp-chat",
   "description": "A Backstage plugin that provides a chat interface for interacting with the MCP Servers.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat-backend@0.11.0

### Minor Changes

-   c43e80c: Add Azure OpenAI provider to support newer Azure OpenAI models like `gpt-5.1`.

    This provider filters the models returned during the connection test to only show the status of the model of the configured deployment. It also uses `max_completion_tokens` correctly, fixing compatibility with newer models.

## @backstage-community/plugin-mcp-chat@0.7.1

### Patch Changes

-   c43e80c: Updated the list of supported providers in the README
