### PR TITLE
growthbook-flags: Use workspace protocol for plugin-growthbook-common dependencies

### DIFF
--- a/workspaces/growthbook-flags/.changeset/wacky-weeks-bow.md
+++ b/workspaces/growthbook-flags/.changeset/wacky-weeks-bow.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-growthbook-backend': patch
+'@backstage-community/plugin-growthbook': patch
+---
+
+Use workspace protocol for internal dependency on plugin-growthbook-common

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
@@ -29,7 +29,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage-community/plugin-growthbook-common": "^0.1.0",
+    "@backstage-community/plugin-growthbook-common": "workspace:^",
     "@backstage/backend-plugin-api": "^1.6.2",
     "@backstage/config": "^1.3.6",
     "express": "^4.17.1"

--- a/workspaces/growthbook-flags/plugins/growthbook/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook/package.json
@@ -44,7 +44,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
-    "@backstage-community/plugin-growthbook-common": "^0.1.0",
+    "@backstage-community/plugin-growthbook-common": "workspace:^",
     "@backstage/catalog-model": "^1.7.6",
     "@backstage/core-compat-api": "^0.5.8",
     "@backstage/core-components": "^0.18.6",

--- a/workspaces/growthbook-flags/yarn.lock
+++ b/workspaces/growthbook-flags/yarn.lock
@@ -1248,7 +1248,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-growthbook-backend@workspace:plugins/growthbook-backend"
   dependencies:
-    "@backstage-community/plugin-growthbook-common": "npm:^0.0.0"
+    "@backstage-community/plugin-growthbook-common": "workspace:^"
     "@backstage/backend-defaults": "npm:^0.7.0"
     "@backstage/backend-plugin-api": "npm:^1.6.2"
     "@backstage/backend-test-utils": "npm:^1.10.4"
@@ -1261,7 +1261,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage-community/plugin-growthbook-common@npm:^0.0.0, @backstage-community/plugin-growthbook-common@workspace:plugins/growthbook-common":
+"@backstage-community/plugin-growthbook-common@workspace:^, @backstage-community/plugin-growthbook-common@workspace:plugins/growthbook-common":
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-growthbook-common@workspace:plugins/growthbook-common"
   dependencies:
@@ -1273,7 +1273,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@backstage-community/plugin-growthbook@workspace:plugins/growthbook"
   dependencies:
-    "@backstage-community/plugin-growthbook-common": "npm:^0.0.0"
+    "@backstage-community/plugin-growthbook-common": "workspace:^"
     "@backstage/catalog-model": "npm:^1.7.6"
     "@backstage/cli": "npm:^0.35.3"
     "@backstage/config": "npm:^1.3.6"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Point `@backstage-community/plugin-growthbook` and `@backstage-community/plugin-growthbook-backend` at `@backstage-community/plugin-growthbook-common` via `workspace:^` as done in other workspaces.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
