### PR TITLE
Version Packages (growthbook-flags)

### DIFF
--- a/workspaces/growthbook-flags/.changeset/wacky-weeks-bow.md
+++ b/workspaces/growthbook-flags/.changeset/wacky-weeks-bow.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-growthbook-backend': patch
-'@backstage-community/plugin-growthbook': patch
----
-
-Use workspace protocol for internal dependency on plugin-growthbook-common

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-growthbook-backend
 
+## 0.1.1
+
+### Patch Changes
+
+- 83c9f32: Use workspace protocol for internal dependency on plugin-growthbook-common
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-growthbook-backend",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/growthbook-flags/plugins/growthbook/CHANGELOG.md
+++ b/workspaces/growthbook-flags/plugins/growthbook/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-growthbook
 
+## 0.1.1
+
+### Patch Changes
+
+- 83c9f32: Use workspace protocol for internal dependency on plugin-growthbook-common
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/growthbook-flags/plugins/growthbook/package.json
+++ b/workspaces/growthbook-flags/plugins/growthbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-growthbook",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-growthbook@0.1.1

### Patch Changes

-   83c9f32: Use workspace protocol for internal dependency on plugin-growthbook-common

## @backstage-community/plugin-growthbook-backend@0.1.1

### Patch Changes

-   83c9f32: Use workspace protocol for internal dependency on plugin-growthbook-common
