### PR TITLE
feat(keycloak): add keycloak-focused secure sign-in resolvers

### DIFF
--- a/workspaces/keycloak/.changeset/yellow-beds-shake.md
+++ b/workspaces/keycloak/.changeset/yellow-beds-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-auth-backend-module-keycloak-provider': minor
+---
+
+added `oidcSubClaimMatchingKeycloakUserId` and `ldapUuidMatchingAnnotation` sign-in resolvers

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/README.md
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/README.md
@@ -9,10 +9,12 @@ For an enhanced experience, we recommend using this module alongside the @backst
 - Authentication via the Keycloak OpenID Connect `authorization_code` flow.
 - Automatic discovery of the Keycloak issuer (`/.well-known/openid-configuration`).
 - Refresh token support, including Keycloak's default refresh-token rotation.
-- Three sign-in resolvers out of the box:
+- Sign-in resolvers (configure under `auth.providers.keycloak.<env>.signIn.resolvers`):
   - `emailMatchingUserEntityProfileEmail`
   - `emailLocalPartMatchingUserEntityName`
   - `preferredUsernameMatchingUserEntityName`
+  - `oidcSubClaimMatchingKeycloakUserId` — match catalog users by `keycloak.org/id` using the OIDC `sub` claim
+  - `ldapUuidMatchingAnnotation` — match catalog users by `backstage.io/ldap-uuid`; the LDAP id claim must match in userinfo and the ID token
 - Configurable `additionalScopes` (e.g. `offline_access`, `roles`).
 - RP-initiated Single Logout: revokes the refresh token at Keycloak and returns the Keycloak
   `end_session_endpoint` URL so the browser terminates the Keycloak SSO session.
@@ -96,8 +98,11 @@ auth:
         # prompt: "login"
         signIn:
           resolvers:
-            # See https://backstage.io/docs/auth/identity-resolver for more resolvers.
+            # See "Sign-in resolvers" and "Match users by LDAP UUID" below.
             - resolver: preferredUsernameMatchingUserEntityName
+            # - resolver: oidcSubClaimMatchingKeycloakUserId
+            # - resolver: ldapUuidMatchingAnnotation
+            #   ldapUuidKey: ldap_uuid # optional; default is ldap_uuid
             # Optional: Bypass the catalog check by enabling the `dangerouslyAllowSignInWithoutUserInCatalog` option.
             # - resolver: preferredUsernameMatchingUserEntityName
             #   dangerouslyAllowSignInWithoutUserInCatalog: true
@@ -137,7 +142,10 @@ For detailed instructions, refer to the official Keycloak documentation on [clie
 
 ### Sign-in resolvers
 
-This module ships three resolvers that you can reference from `signIn.resolvers` above:
+This module ships the following resolvers for `signIn.resolvers` (see also
+[Identity resolver](https://backstage.io/docs/auth/identity-resolver) in the Backstage docs):
+
+**Shared / email / username**
 
 - `emailMatchingUserEntityProfileEmail`: matches the Keycloak `email` claim with a Catalog `User` entity that
   has the same `spec.profile.email`. Throws `NotFoundError` when no entity matches.
@@ -145,12 +153,87 @@ This module ships three resolvers that you can reference from `signIn.resolvers`
   [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the Keycloak `email` claim with a
   Catalog `User` entity whose `metadata.name` is equal to that local part.
 - `preferredUsernameMatchingUserEntityName`: matches the Keycloak `preferred_username` claim with a Catalog
-  `User` entity whose `metadata.name` is equal to that username. Throws when the profile does not contain a
-  `preferred_username`.
+  `User` entity whose `metadata.name` is equal to that username (after the same sanitization as the Keycloak
+  catalog plugin). Throws when the profile does not contain a `preferred_username`.
+
+**Keycloak-specific**
+
+- `oidcSubClaimMatchingKeycloakUserId`: matches the OIDC `sub` from userinfo (cross-checked against the ID
+  token) to the `keycloak.org/id` annotation. Use with the Keycloak catalog module so users carry that
+  annotation.
+
+**LDAP UUID (LDAP user federation)**
+
+- `ldapUuidMatchingAnnotation`: matches a claim from userinfo to the `backstage.io/ldap-uuid` annotation. The
+  same claim must appear on the ID token with the same value. Values are checked as UUID strings.
+
+Optional factory options:
+
+- `dangerouslyAllowSignInWithoutUserInCatalog` (where supported): allow issuing a session when no catalog user
+  matches (discouraged in production).
+- `ldapUuidKey` (LDAP UUID resolvers only): claim name for the directory UUID; default `ldap_uuid`.
 
 If none of the provided resolvers fits your needs, follow the
 [Building Custom Resolvers](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers) guide
 in the Backstage documentation.
+
+### Match users by LDAP UUID (Keycloak)
+
+Use this when Keycloak federates users from LDAP and catalog `User` entities carry `backstage.io/ldap-uuid`
+(from [`@backstage/plugin-catalog-backend-module-ldap`](https://backstage.io/docs/integrations/ldap/introduction)).
+
+You need:
+
+1. Catalog users with the `backstage.io/ldap-uuid` annotation provided by the `@backstage/plugin-catalog-backend-module-ldap` catalog provider.
+2. A Keycloak **client scope** and **mapper** that copies the LDAP unique id into a token claim (default
+   name `ldap_uuid`) on **both** the ID token and userinfo.
+3. `signIn.resolvers` with `ldapUuidMatchingAnnotation`, and `ldapUuidKey` if you use a claim name other than
+   `ldap_uuid`.
+
+#### Keycloak: client scope and mapper
+
+1. **Client scopes** → **Create client scope** (for example `ldap_uuid`).
+2. On that scope → **Mappers** → **User Attribute** or **LDAP Attribute** mapper (depends on your Keycloak
+   version). Example fields:
+   - **User Attribute**: the attribute that stores the LDAP unique id in Keycloak.
+   - **Token Claim Name**: `ldap_uuid` (or your chosen name; set `ldapUuidKey` in `app-config` to match).
+   - **Claim JSON Type**: `String`
+   - **Add to ID token** and **Add to userinfo**: on
+3. **Clients** → your Backstage client → **Client scopes** → add the scope as **Default** (or **Optional**).
+
+This module reads userinfo from Keycloak and checks the ID token from the token response, so the mapper must
+emit the claim in both places.
+
+#### Optional scope on the OAuth request
+
+If the scope is **Optional** on the client, request it with `additionalScopes`:
+
+```yaml
+additionalScopes:
+  - ldap_uuid
+```
+
+#### Backstage: `app-config.yaml`
+
+```yaml
+auth:
+  providers:
+    keycloak:
+      development:
+        clientId: ${AUTH_KEYCLOAK_CLIENT_ID}
+        clientSecret: ${AUTH_KEYCLOAK_CLIENT_SECRET}
+        baseUrl: ${AUTH_KEYCLOAK_BASE_URL}
+        realm: ${AUTH_KEYCLOAK_REALM}
+        signIn:
+          resolvers:
+            - resolver: ldapUuidMatchingAnnotation
+              ldapUuidKey: ldap_uuid # optional; default is ldap_uuid
+```
+
+In production, prefer a **single** sign-in resolver (or a small ordered list you understand) so identity
+matching stays clear.
+
+Restart the Backstage backend after changing Keycloak or `app-config`.
 
 ### Integrating with the Keycloak catalog provider
 
@@ -160,7 +243,9 @@ recommended way to achieve this is to deploy the companion plugin
 synchronises Keycloak users and groups into the catalog on a schedule.
 
 When using that plugin, `preferredUsernameMatchingUserEntityName` is usually the most straightforward
-resolver because the catalog User entity names are generated from the Keycloak username by default.
+resolver because the catalog User entity names are generated from the Keycloak username by default. For
+LDAP-federated identities where the catalog stores `backstage.io/ldap-uuid`, use
+`ldapUuidMatchingAnnotation` instead (see **Match users by LDAP UUID**).
 
 ### Adding the provider to the Backstage frontend
 
@@ -275,10 +360,12 @@ served over TLS in non-local environments.
 
 - **Issuer discovery is performed once per backend start.** If the Keycloak server is unreachable at startup,
   the plugin stays unavailable until the Backstage backend is restarted.
-- **User attributes come from `userinfo`, not the ID Token claims.** The module authenticates users by
-  calling the Keycloak `userinfo` endpoint with the access token rather than trusting the `id_token`
-  payload. CSRF is enforced by the Backstage auth framework via the nonce cookie, and the ID Token `nonce`
-  claim is additionally validated against the nonce embedded in the OAuth state for replay protection.
+- **User attributes for sign-in come primarily from `userinfo`.** The module still obtains the **ID token**
+  string from the token response so resolvers such as `oidcSubClaimMatchingKeycloakUserId` and
+  `ldapUuidMatchingAnnotation` can cross-check claims against the ID token (see implementation in
+  `src/resolvers.ts`). CSRF is enforced by the Backstage auth framework via the nonce cookie, and the ID
+  token `nonce` claim is additionally validated against the nonce embedded in the OAuth state for replay
+  protection.
 - **Self-signed certificates.** If your Keycloak server presents a certificate that the Node runtime does
   not trust, set `NODE_EXTRA_CA_CERTS` to point at your CA bundle. Setting `NODE_TLS_REJECT_UNAUTHORIZED=0`
   disables all TLS validation and is strongly discouraged outside local development.

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/package.json
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "^1.9.0",
     "@backstage/plugin-auth-node": "^0.7.0",
+    "jose": "^5.0.0",
     "openid-client": "^5.6.5",
     "zod": "^3.25.76 || ^4.0.0"
   },

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/report.api.md
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/report.api.md
@@ -55,5 +55,20 @@ export namespace keycloakSignInResolvers {
       }
     | undefined
   >;
+  const oidcSubClaimMatchingKeycloakUserId: SignInResolverFactory<
+    OAuthAuthenticatorResult<UserinfoResponse>,
+    | {
+        dangerouslyAllowSignInWithoutUserInCatalog?: boolean | undefined;
+      }
+    | undefined
+  >;
+  const ldapUuidMatchingAnnotation: SignInResolverFactory<
+    OAuthAuthenticatorResult<UserinfoResponse>,
+    | {
+        dangerouslyAllowSignInWithoutUserInCatalog?: boolean | undefined;
+        ldapUuidKey?: string | undefined;
+      }
+    | undefined
+  >;
 }
 ```

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/src/resolvers.test.ts
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/src/resolvers.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SignJWT } from 'jose';
 import {
   AuthResolverContext,
   commonSignInResolvers,
@@ -30,6 +31,7 @@ const createMockContext = (): jest.Mocked<AuthResolverContext> => ({
 const createInfo = (
   fullProfile: Record<string, unknown>,
   profile: Record<string, unknown> = {},
+  idToken?: string,
 ) =>
   ({
     profile,
@@ -39,9 +41,16 @@ const createInfo = (
         accessToken: 'test-access-token',
         tokenType: 'bearer',
         scope: 'openid profile email',
+        ...(idToken !== undefined ? { idToken } : {}),
       },
     },
   } as any);
+
+const signTestIdToken = async (payload: Record<string, unknown>) => {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .sign(new TextEncoder().encode('unit-test-secret'));
+};
 
 describe('keycloakSignInResolvers', () => {
   describe('preferredUsernameMatchingUserEntityName', () => {
@@ -212,6 +221,216 @@ describe('keycloakSignInResolvers', () => {
       // Act & Assert
       await expect(resolver(info, ctx)).rejects.toThrow(/preferred_username/);
       expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('oidcSubClaimMatchingKeycloakUserId', () => {
+    it('signs in using keycloak.org/id annotation matching userinfo and id token sub', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        keycloakSignInResolvers.oidcSubClaimMatchingKeycloakUserId();
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const idToken = await signTestIdToken({ sub });
+      const info = createInfo({ sub }, {}, idToken);
+
+      const result = await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'keycloak.org/id': sub } },
+        { dangerousEntityRefFallback: undefined },
+      );
+      expect(result).toEqual({ token: 'test-token' });
+    });
+
+    it('throws when sub is missing from userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        keycloakSignInResolvers.oidcSubClaimMatchingKeycloakUserId();
+      const idToken = await signTestIdToken({
+        sub: '9cf51b5d-e066-4ed8-940c-dc6da77f81a5',
+      });
+      const info = createInfo({ preferred_username: 'jdoe' }, {}, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/sub claim/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token is missing', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        keycloakSignInResolvers.oidcSubClaimMatchingKeycloakUserId();
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const info = createInfo({ sub });
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ID token/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token sub does not match userinfo sub', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        keycloakSignInResolvers.oidcSubClaimMatchingKeycloakUserId();
+      const idToken = await signTestIdToken({
+        sub: '11111111-1111-1111-1111-111111111111',
+      });
+      const info = createInfo(
+        { sub: '9cf51b5d-e066-4ed8-940c-dc6da77f81a5' },
+        {},
+        idToken,
+      );
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/does not match/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('passes dangerousEntityRefFallback when enabled', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        keycloakSignInResolvers.oidcSubClaimMatchingKeycloakUserId({
+          dangerouslyAllowSignInWithoutUserInCatalog: true,
+        });
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const idToken = await signTestIdToken({ sub });
+      const info = createInfo({ sub }, {}, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'keycloak.org/id': sub } },
+        {
+          dangerousEntityRefFallback: { entityRef: { name: sub } },
+        },
+      );
+    });
+  });
+
+  describe('ldapUuidMatchingAnnotation', () => {
+    it('signs in using backstage.io/ldap-uuid when userinfo and id token ldap_uuid match', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: ldapUuid,
+      });
+      const info = createInfo({ ldap_uuid: ldapUuid }, {}, idToken);
+
+      const result = await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': ldapUuid } },
+        { dangerousEntityRefFallback: undefined },
+      );
+      expect(result).toEqual({ token: 'test-token' });
+    });
+
+    it('uses ldapUuidKey when provided', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation({
+        ldapUuidKey: 'directory_id',
+      });
+      const uuid = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        directory_id: uuid,
+      });
+      const info = createInfo({ directory_id: uuid }, {}, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': uuid } },
+        { dangerousEntityRefFallback: undefined },
+      );
+    });
+
+    it('throws when the configured claim is missing from userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      });
+      const info = createInfo({ email: 'u@example.com' }, {}, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ldap_uuid/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token claim is not a valid UUID string', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const validUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'not-a-uuid',
+      });
+      const info = createInfo({ ldap_uuid: validUuid }, {}, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/valid UUID string/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token is missing', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const info = createInfo({ ldap_uuid: ldapUuid });
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ID token/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token claim does not match userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: '11111111-1111-1111-1111-111111111111',
+      });
+      const info = createInfo(
+        { ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+        {},
+        idToken,
+      );
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/mismatching UUID/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when userinfo claim is not a valid UUID string', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      });
+      const info = createInfo({ ldap_uuid: 'not-a-uuid' }, {}, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/valid UUID string/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('passes dangerousEntityRefFallback when enabled', async () => {
+      const ctx = createMockContext();
+      const resolver = keycloakSignInResolvers.ldapUuidMatchingAnnotation({
+        dangerouslyAllowSignInWithoutUserInCatalog: true,
+      });
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: ldapUuid,
+      });
+      const info = createInfo({ ldap_uuid: ldapUuid }, {}, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': ldapUuid } },
+        {
+          dangerousEntityRefFallback: { entityRef: { name: ldapUuid } },
+        },
+      );
     });
   });
 

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/src/resolvers.ts
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/src/resolvers.ts
@@ -13,14 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { decodeJwt } from 'jose';
 import { z } from 'zod/v3';
 import {
+  AuthResolverContext,
   commonSignInResolvers,
   createSignInResolverFactory,
   OAuthAuthenticatorResult,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { UserinfoResponse } from 'openid-client';
+
+/** Annotation defined by `@backstage-community/plugin-catalog-backend-module-keycloak`. */
+const KEYCLOAK_ID_ANNOTATION = 'keycloak.org/id';
+
+/** Annotation defined by `@backstage/plugin-catalog-backend-module-ldap`. */
+const LDAP_UUID_ANNOTATION = 'backstage.io/ldap-uuid';
 
 /**
  * Sign-in resolvers for the Keycloak auth provider.
@@ -82,4 +90,141 @@ export namespace keycloakSignInResolvers {
         };
       },
     });
+
+  /**
+   * Looks up the catalog User whose `keycloak.org/id` annotation matches the OIDC
+   * `sub` claim from Keycloak userinfo.
+   *
+   * The ID token `sub` must match userinfo `sub` before the user is accepted.
+   * Pair this resolver with the Keycloak catalog module so User entities carry
+   * the same `keycloak.org/id` value as Keycloak's subject identifier.
+   */
+  export const oidcSubClaimMatchingKeycloakUserId = createSignInResolverFactory(
+    {
+      optionsSchema: z
+        .object({
+          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        })
+        .optional(),
+      create(options = {}) {
+        return async (
+          info: SignInInfo<OAuthAuthenticatorResult<UserinfoResponse>>,
+          ctx: AuthResolverContext,
+        ) => {
+          const sub = info.result.fullProfile.sub?.trim();
+          if (!sub) {
+            throw new Error(
+              'Login failed, Keycloak userinfo does not contain a non-empty sub claim',
+            );
+          }
+
+          const idToken = info.result.session.idToken;
+          if (!idToken) {
+            throw new Error(
+              'Login failed, Keycloak did not return an ID token, which is required to verify the sub claim',
+            );
+          }
+
+          const subFromIdToken = decodeJwt(idToken).sub;
+          if (subFromIdToken !== sub) {
+            throw new Error(
+              'Login failed, Keycloak ID token sub claim does not match the userinfo sub claim',
+            );
+          }
+
+          return ctx.signInWithCatalogUser(
+            {
+              annotations: { [KEYCLOAK_ID_ANNOTATION]: sub },
+            },
+            {
+              dangerousEntityRefFallback:
+                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                  ? { entityRef: { name: sub } }
+                  : undefined,
+            },
+          );
+        };
+      },
+    },
+  );
+
+  /**
+   * A resolver that looks up the user using an LDAP UUID from Keycloak.
+   *
+   * Retrieves the LDAP UUID claim from the OIDC UserInfo response and matches it
+   * against the `backstage.io/ldap-uuid` annotation on catalog User entities.
+   *
+   *
+   * **Requires Keycloak LDAP UUID Configuration:**
+   * Keycloak must be configured to expose the LDAP UUID attribute in both
+   * the ID token and UserInfo endpoint.
+   *
+   * **Configuration Options:**
+   * - `ldapUuidKey` (optional): The claim name containing the LDAP UUID (default: 'ldap_uuid')
+   */
+  export const ldapUuidMatchingAnnotation = createSignInResolverFactory({
+    optionsSchema: z
+      .object({
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        ldapUuidKey: z.string().optional(),
+      })
+      .optional(),
+    create(options = {}) {
+      return async (
+        info: SignInInfo<OAuthAuthenticatorResult<UserinfoResponse>>,
+        ctx,
+      ) => {
+        const uuidKey = options?.ldapUuidKey ?? 'ldap_uuid';
+        const userinfo = info.result.fullProfile as Record<string, unknown>;
+        const uuid = userinfo[uuidKey];
+        if (!uuid) {
+          throw new Error(
+            `Keycloak UserInfo response is missing the '${uuidKey}' claim. ` +
+              `Keycloak must be configured to expose the LDAP UUID attribute in the OIDC Policy. ` +
+              `Please contact your system administrator for assistance.`,
+          );
+        }
+        const uuidFromUserinfo = z.string().uuid().safeParse(uuid);
+        if (!uuidFromUserinfo.success) {
+          throw new Error(
+            `UUID in Keycloak UserInfo response for claim '${uuidKey}' must be a valid UUID string. Please contact your system administrator for assistance.`,
+          );
+        }
+
+        const idToken = info.result.session.idToken;
+        if (!idToken) {
+          throw new Error(
+            `ID token is missing from Keycloak response. Please contact your system administrator for assistance.`,
+          );
+        }
+
+        const uuidFromIdToken = z
+          .string()
+          .uuid()
+          .safeParse(decodeJwt(idToken)?.[uuidKey]);
+        if (!uuidFromIdToken.success) {
+          throw new Error(
+            `UUID in Keycloak ID token for claim '${uuidKey}' must be a valid UUID string. Please contact your system administrator for assistance.`,
+          );
+        }
+        if (uuidFromUserinfo.data !== uuidFromIdToken.data) {
+          throw new Error(
+            `There was a problem verifying your identity with Keycloak due to mismatching UUID. Please contact your system administrator for assistance.`,
+          );
+        }
+
+        return ctx.signInWithCatalogUser(
+          {
+            annotations: { [LDAP_UUID_ANNOTATION]: uuidFromUserinfo.data },
+          },
+          {
+            dangerousEntityRefFallback:
+              options?.dangerouslyAllowSignInWithoutUserInCatalog
+                ? { entityRef: { name: uuidFromUserinfo.data } }
+                : undefined,
+          },
+        );
+      };
+    },
+  });
 }

--- a/workspaces/keycloak/yarn.lock
+++ b/workspaces/keycloak/yarn.lock
@@ -1565,6 +1565,7 @@ __metadata:
     "@backstage/cli": "npm:^0.36.0"
     "@backstage/plugin-auth-node": "npm:^0.7.0"
     "@types/express": "npm:^5.0.6"
+    jose: "npm:^5.0.0"
     openid-client: "npm:^5.6.5"
     zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added two secure Keycloak-focused sign-in resolvers that resolve users using immutable identifiers (like the OIDC sub claim and LDAP UUID). They provide a more secure way to resolver users compared to matching on email or username which users can change to help reduce risk of impersonation.

- `oidcSubClaimMatchingKeycloakUserId`: Resolves users via the `keycloak.org/id` annotation from the Keycloak catalog provider using OIDC sub from `userinfo`, verified to match with the ID token sub claim.
- `ldapUuidMatchingAnnotation`: Resolves users via `backstage.io/ldap-uuid` using a configurable claim (default `ldap_uuid`), with UUID validation and `userinfo/ID-token` check

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
