### PR TITLE
fix(topology): pod status icon and label alignment in pods table

### DIFF
--- a/workspaces/topology/.changeset/thirty-tips-tell.md
+++ b/workspaces/topology/.changeset/thirty-tips-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Fix pod status icon and label alignment in Pods table

--- a/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/TopologyResourcesTabPanel.tsx
@@ -54,8 +54,7 @@ const TranslatedStatus = ({
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-      <Status status={status} iconOnly />
-      <span>{translateFn(status)}</span>
+      <Status status={status} displayStatusText={translateFn(status)} />
     </div>
   );
 };

--- a/workspaces/topology/plugins/topology/src/components/common/StatusIconAndText.tsx
+++ b/workspaces/topology/plugins/topology/src/components/common/StatusIconAndText.tsx
@@ -26,16 +26,18 @@ const DASH = '-';
 
 const useStyles = makeStyles({
   iconAndText: {
-    alignItems: 'baseline',
+    alignItems: 'center',
     display: 'flex',
     fontWeight: 400,
     fontSize: '14px',
+    '& svg': {
+      top: 0,
+    },
   },
 
   flexChild: {
-    flex: ' 0 0 auto',
+    flex: '0 0 auto',
     position: 'relative',
-    top: '0.125em',
   },
 });
 

--- a/workspaces/topology/plugins/topology/tests/utils/topologyHelper.ts
+++ b/workspaces/topology/plugins/topology/tests/utils/topologyHelper.ts
@@ -70,13 +70,16 @@ export class Common {
       - heading "Pods"
       - list:
         - listitem:
-          - text: P test-deployment-645f8d4887-8dmrr ${translations.status.running}
+          - text: P test-deployment-645f8d4887-8dmrr
+          - paragraph: ${translations.status.running}
           - button "view logs": ${translations.common.viewLogs}
         - listitem:
-          - text: P test-deployment-645f8d4887-d77ff ${translations.status.running}
+          - text: P test-deployment-645f8d4887-d77ff
+          - paragraph: ${translations.status.running}
           - button "view logs": ${translations.common.viewLogs}
         - listitem:
-          - text: P test-deployment-645f8d4887-n8644 ${translations.status.running}
+          - text: P test-deployment-645f8d4887-n8644
+          - paragraph: ${translations.status.running}
           - button "view logs": ${translations.common.viewLogs}
       `);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Summary
Fixes alignment of pod status icons and labels in the Topology plugin Pods table.

### Screenshots
#### Without fix
<img width="678" height="695" alt="image" src="https://github.com/user-attachments/assets/8c4eef8a-344b-42fe-ace7-1365caa9110a" />

#### With fix
<img width="735" height="698" alt="image" src="https://github.com/user-attachments/assets/df90e048-025d-4663-907e-27fcd8b62553" />
<img width="551" height="700" alt="image" src="https://github.com/user-attachments/assets/bd325396-0b75-418f-8823-49eb062e2bbd" />
<img width="565" height="735" alt="image" src="https://github.com/user-attachments/assets/37b0064e-1911-4419-ae85-cb5f8f747602" />



<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
