### PR TITLE
fix(rbac): harden policy validation and error handling across RBAC write paths

### DIFF
--- a/workspaces/rbac/.changeset/olive-shirts-nail.md
+++ b/workspaces/rbac/.changeset/olive-shirts-nail.md
@@ -16,10 +16,10 @@ Compatibility notes:
 
 - Requests/config entries using `permission` values with embedded `"` are now rejected.
 - Conditional policy payloads and conditional YAML ingestion now enforce limits.
+- Conditional `permissionMapping` must list distinct Backstage permission actions (no duplicates); at most one entry per supported action (`create`, `read`, `update`, `delete`, `use`).
 - Plugin ID registration payloads now enforce count/length/duplicate checks.
 - For larger existing payloads, limits are configurable via:
 
-- `permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems`
 - `permission.rbac.validation.conditionalPolicies.maxConditionDepth`
 - `permission.rbac.validation.conditionalPolicies.maxConditionNodeCount`
 - `permission.rbac.validation.conditionalPolicies.maxCriteriaItems`

--- a/workspaces/rbac/.changeset/olive-shirts-nail.md
+++ b/workspaces/rbac/.changeset/olive-shirts-nail.md
@@ -2,13 +2,22 @@
 '@backstage-community/plugin-rbac-backend': patch
 ---
 
-This patch hardens RBAC policy loading and validation to prevent CSV-poisoning failures and improve recovery behavior.
+Hardens RBAC policy handling to prevent Casbin CSV poisoning and improve error visibility.
 
-It now rejects policy permission strings containing double quotes before persistence, rethrows `loadPolicy` failures after audit logging so root causes are surfaced, and parses RBAC CSV input line-by-line with skip-and-warn handling for malformed rows so one invalid line does not block policy file processing.
+Key fixes:
 
-It also improves API validation and error clarity by requiring policy write bodies to be arrays, returning `NotFoundError` when role-scoped policy updates reference missing roles, validating configured default permissions with the same policy validator used by REST writes, failing fast on invalid configured admin entity references, tightening plugin ID payload validation, and aligning ownership filter checks with `IS_OWNER` semantics for default-role handling.
+- Rejects permission policy `permission` values containing `"` before persistence (prevents known CSV parse failures).
+- Rethrows `loadPolicy` failures after audit logging so mutation/read paths surface the root cause instead of secondary errors.
+- Improves policy API request validation and missing-role handling (`400`/`404` where appropriate).
+- Validates default configured permissions/admin refs with the same stricter checks used by runtime write paths.
+- Strengthens conditional and plugin-id payload validation and aligns owner filtering behavior for default roles.
 
-Conditional policy validation and file-ingestion limits are now configurable for safer upgrades in environments with larger policy sets:
+Compatibility notes:
+
+- Requests/config entries using `permission` values with embedded `"` are now rejected.
+- Conditional policy payloads and conditional YAML ingestion now enforce limits.
+- Plugin ID registration payloads now enforce count/length/duplicate checks.
+- For larger existing payloads, limits are configurable via:
 
 - `permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems`
 - `permission.rbac.validation.conditionalPolicies.maxConditionDepth`
@@ -16,3 +25,7 @@ Conditional policy validation and file-ingestion limits are now configurable for
 - `permission.rbac.validation.conditionalPolicies.maxCriteriaItems`
 - `permission.rbac.validation.conditionalPoliciesFile.maxBytes`
 - `permission.rbac.validation.conditionalPoliciesFile.maxDocuments`
+
+Operational note:
+
+- CSV policy files are parsed line-by-line; malformed lines are skipped with warnings instead of aborting the entire file load.

--- a/workspaces/rbac/.changeset/olive-shirts-nail.md
+++ b/workspaces/rbac/.changeset/olive-shirts-nail.md
@@ -2,4 +2,17 @@
 '@backstage-community/plugin-rbac-backend': patch
 ---
 
-Harden RBAC policy handling for Casbin CSV-style persistence: reject permission strings that contain double quotes at validation time; rethrow errors after auditing when a full policy reload fails so root causes are visible; parse the RBAC policy CSV line by line and skip malformed rows with warnings so one bad line no longer prevents the permission backend from starting, with matching skip-and-warn behavior when loading the same file into the temporary policy enforcer.
+This patch hardens RBAC policy loading and validation to prevent CSV-poisoning failures and improve recovery behavior.
+
+It now rejects policy permission strings containing double quotes before persistence, rethrows `loadPolicy` failures after audit logging so root causes are surfaced, and parses RBAC CSV input line-by-line with skip-and-warn handling for malformed rows so one invalid line does not block policy file processing.
+
+It also improves API validation and error clarity by requiring policy write bodies to be arrays, returning `NotFoundError` when role-scoped policy updates reference missing roles, validating configured default permissions with the same policy validator used by REST writes, failing fast on invalid configured admin entity references, tightening plugin ID payload validation, and aligning ownership filter checks with `IS_OWNER` semantics for default-role handling.
+
+Conditional policy validation and file-ingestion limits are now configurable for safer upgrades in environments with larger policy sets:
+
+- `permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems`
+- `permission.rbac.validation.conditionalPolicies.maxConditionDepth`
+- `permission.rbac.validation.conditionalPolicies.maxConditionNodeCount`
+- `permission.rbac.validation.conditionalPolicies.maxCriteriaItems`
+- `permission.rbac.validation.conditionalPoliciesFile.maxBytes`
+- `permission.rbac.validation.conditionalPoliciesFile.maxDocuments`

--- a/workspaces/rbac/.changeset/olive-shirts-nail.md
+++ b/workspaces/rbac/.changeset/olive-shirts-nail.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Harden RBAC policy handling for Casbin CSV-style persistence: reject permission strings that contain double quotes at validation time; rethrow errors after auditing when a full policy reload fails so root causes are visible; parse the RBAC policy CSV line by line and skip malformed rows with warnings so one bad line no longer prevents the permission backend from starting, with matching skip-and-warn behavior when loading the same file into the temporary policy enforcer.

--- a/workspaces/rbac/.gitignore
+++ b/workspaces/rbac/.gitignore
@@ -54,3 +54,6 @@ site
 # E2E test reports
 e2e-test-report*/
 .npmrc
+
+# Local CSV Policy Files
+*.local.csv

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -279,6 +279,38 @@ conditions:
 
 Information about condition policies format you can find in the doc: [Conditional policies documentation](./docs/conditions.md). There is only one difference: yaml format compare to json. But yaml and json are back convertiable.
 
+### Optional validation limits for conditional policies
+
+The RBAC backend now supports configurable limits for conditional policy payload complexity and conditional YAML file ingestion size. Defaults are chosen to be protective while still supporting typical policy definitions.
+
+Use these settings if your environment has larger policy sets and needs temporary tuning during upgrades:
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    validation:
+      conditionalPolicies:
+        maxPermissionMappingItems: 64
+        maxConditionDepth: 12
+        maxConditionNodeCount: 256
+        maxCriteriaItems: 64
+      conditionalPoliciesFile:
+        maxBytes: 1048576
+        maxDocuments: 256
+```
+
+Field descriptions:
+
+- `permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems`: Maximum number of actions in `permissionMapping`.
+- `permission.rbac.validation.conditionalPolicies.maxConditionDepth`: Maximum nesting depth in a conditional criteria tree.
+- `permission.rbac.validation.conditionalPolicies.maxConditionNodeCount`: Maximum number of criteria nodes in a conditional criteria tree.
+- `permission.rbac.validation.conditionalPolicies.maxCriteriaItems`: Maximum number of entries allowed per `allOf`/`anyOf`.
+- `permission.rbac.validation.conditionalPoliciesFile.maxBytes`: Maximum allowed byte size for `conditionalPoliciesFile`.
+- `permission.rbac.validation.conditionalPoliciesFile.maxDocuments`: Maximum number of YAML documents allowed in `conditionalPoliciesFile`.
+
+All values must be positive integers.
+
 ### Configuring Database Storage for policies
 
 The RBAC plugin offers the option to store policies in a database. It supports two database storage options:

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -217,6 +217,19 @@ For more information on the available permissions, refer to the [RBAC permission
 
 We also have a fairly strict validation for permission policies and roles based on the originating role's source information, refer to the [api documentation](./docs/apis.md).
 
+#### Policy validation and compatibility (hardening)
+
+Recent releases tighten validation so malformed or unsafe policy data cannot poison the Casbin store (which uses CSV-shaped persistence for database-backed policies). In practice:
+
+- **`permission` values must not contain double quotes (`"`)** on REST writes, CSV file import, providers, and configured `defaultPermissions.basicPermissions`. Values that previously slipped through could break policy loading; they are now rejected up front. See [API documentation](./docs/apis.md) for the REST contract.
+- **Full policy reload failures are surfaced correctly**: if the enforcer cannot reload policies from storage (for example due to legacy poisoned rows), errors propagate after audit logging instead of leaving a stale model and misleading follow-on errors.
+- **Policy write APIs** expect bodies in the documented shapes (for example, `POST`/`DELETE` `/policies` bodies must be JSON **arrays**). Invalid shapes return `400` with clear messages where applicable.
+- **Configured admins and default permissions** are validated with the same policy rules as runtime writes where relevant, so bad config fails early at startup or sync instead of corrupting storage.
+- **Plugin ID registration** (`POST`/`DELETE` `/plugins/id`) enforces sensible bounds (list size, per-ID length, no duplicates). Very large registrations may need to be split into multiple requests.
+- **CSV policy files** (`policies-csv-file`) are parsed **line by line**. Lines that are syntactically invalid for CSV parsing are **skipped with a warning** so the rest of the file can still be applied; fix or remove bad lines in the file for a fully consistent load. Semantic validation (invalid entity refs, duplicates, source mismatches) continues to skip individual rows with warnings, as before.
+
+For conditional policies and YAML file size limits, use the optional `permission.rbac.validation.*` settings in the section below.
+
 ### Configuring conditional policies via file
 
 The RBAC plugin allows you to import conditional policies from an external file. User can defined conditional policies for roles created with the help of the policies-csv-file. Conditional policies should be defined as object sequences in the YAML format.
@@ -310,6 +323,8 @@ Field descriptions:
 - `permission.rbac.validation.conditionalPoliciesFile.maxDocuments`: Maximum number of YAML documents allowed in `conditionalPoliciesFile`.
 
 All values must be positive integers.
+
+If you already use very large conditional payloads or YAML files, raise these limits in config during upgrade rather than relying on defaults.
 
 ### Configuring Database Storage for policies
 

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -228,7 +228,7 @@ Recent releases tighten validation so malformed or unsafe policy data cannot poi
 - **Plugin ID registration** (`POST`/`DELETE` `/plugins/id`) enforces sensible bounds (list size, per-ID length, no duplicates). Very large registrations may need to be split into multiple requests.
 - **CSV policy files** (`policies-csv-file`) are parsed **line by line**. Lines that are syntactically invalid for CSV parsing are **skipped with a warning** so the rest of the file can still be applied; fix or remove bad lines in the file for a fully consistent load. Semantic validation (invalid entity refs, duplicates, source mismatches) continues to skip individual rows with warnings, as before.
 
-For conditional policies and YAML file size limits, use the optional `permission.rbac.validation.*` settings in the section below.
+- **Conditional policies**: `permissionMapping` must list **distinct** Backstage permission actions only (no duplicates), with at most one entry per supported action (`create`, `read`, `update`, `delete`, `use`). Criteria trees and YAML conditional files still support optional `permission.rbac.validation.*` limits described below.
 
 ### Configuring conditional policies via file
 
@@ -304,7 +304,6 @@ permission:
   rbac:
     validation:
       conditionalPolicies:
-        maxPermissionMappingItems: 64
         maxConditionDepth: 12
         maxConditionNodeCount: 256
         maxCriteriaItems: 64
@@ -315,7 +314,6 @@ permission:
 
 Field descriptions:
 
-- `permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems`: Maximum number of actions in `permissionMapping`.
 - `permission.rbac.validation.conditionalPolicies.maxConditionDepth`: Maximum nesting depth in a conditional criteria tree.
 - `permission.rbac.validation.conditionalPolicies.maxConditionNodeCount`: Maximum number of criteria nodes in a conditional criteria tree.
 - `permission.rbac.validation.conditionalPolicies.maxCriteriaItems`: Maximum number of entries allowed per `allOf`/`anyOf`.

--- a/workspaces/rbac/plugins/rbac-backend/__fixtures__/auditor-test-utils.ts
+++ b/workspaces/rbac/plugins/rbac-backend/__fixtures__/auditor-test-utils.ts
@@ -40,7 +40,18 @@ export function expectAuditorLog(
       expect(succeededEvents[i][0]).toEqual(events[i].success);
     }
     if (events[i].fail) {
-      expect(failedEvents[i][0]).toEqual(events[i].fail);
+      const actual = failedEvents[i][0] as {
+        error: Error;
+        meta?: JsonObject;
+      };
+      const expected = events[i].fail!;
+      const { error: expectedError, ...expectedRest } = expected;
+      const { error: actualError, ...actualRest } = actual;
+      expect(actualError).toMatchObject({
+        name: expectedError.name,
+        message: expectedError.message,
+      });
+      expect(actualRest).toEqual(expectedRest);
     }
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/__fixtures__/data/invalid-csv/malformed-unquoted-quote.csv
+++ b/workspaces/rbac/plugins/rbac-backend/__fixtures__/data/invalid-csv/malformed-unquoted-quote.csv
@@ -1,0 +1,3 @@
+g, user:default/alice, role:default/csv-malformed-test
+p, role:default/csv-malformed-test, catalog-entity"fuzz, read, allow
+p, role:default/csv-malformed-test, catalog-entity, read, allow

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -94,6 +94,45 @@ export interface Config {
           action: 'create' | 'read' | 'update' | 'delete' | 'use';
         }>;
       };
+      /**
+       * Optional validation tuning for conditional policies.
+       */
+      validation?: {
+        /**
+         * Limits for conditional policy payload shape and nesting.
+         */
+        conditionalPolicies?: {
+          /**
+           * Maximum number of permission actions in `permissionMapping`.
+           */
+          maxPermissionMappingItems?: number;
+          /**
+           * Maximum nesting depth for conditional criteria trees.
+           */
+          maxConditionDepth?: number;
+          /**
+           * Maximum total number of criteria nodes in a condition tree.
+           */
+          maxConditionNodeCount?: number;
+          /**
+           * Maximum number of items in `allOf`/`anyOf` criteria arrays.
+           */
+          maxCriteriaItems?: number;
+        };
+        /**
+         * Limits for YAML-based conditional policy file ingestion.
+         */
+        conditionalPoliciesFile?: {
+          /**
+           * Maximum size in bytes for the conditional policies YAML file.
+           */
+          maxBytes?: number;
+          /**
+           * Maximum number of YAML documents allowed in the conditional file.
+           */
+          maxDocuments?: number;
+        };
+      };
     };
   };
 }

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -103,10 +103,6 @@ export interface Config {
          */
         conditionalPolicies?: {
           /**
-           * Maximum number of permission actions in `permissionMapping`.
-           */
-          maxPermissionMappingItems?: number;
-          /**
            * Maximum nesting depth for conditional criteria trees.
            */
           maxConditionDepth?: number;

--- a/workspaces/rbac/plugins/rbac-backend/docs/apis.md
+++ b/workspaces/rbac/plugins/rbac-backend/docs/apis.md
@@ -320,6 +320,8 @@ Request parameters:
 | policy          | Policy action for the permission, `create`, `read`, `update`, `delete`, `use` | String |
 | effect          | `allow` or `deny`                                                             | String |
 
+The `permission` string must not contain double quotes (`"`). Embedded quotes are not handled safely in the current Casbin DB persistence path.
+
 body:
 
 ```json

--- a/workspaces/rbac/plugins/rbac-backend/docs/conditions.md
+++ b/workspaces/rbac/plugins/rbac-backend/docs/conditions.md
@@ -14,14 +14,14 @@ The plugin defines the supported condition parameters. API users can retrieve th
 
 The structure of the condition JSON object is as follows:
 
-| Json field        | Description                                                           | Type         |
-| ----------------- | --------------------------------------------------------------------- | ------------ |
-| result            | Always has the value "CONDITIONAL"                                    | String       |
-| roleEntityRef     | String entity reference to the RBAC role ('role:default/dev')         | String       |
-| pluginId          | Corresponding plugin ID (e.g., "catalog")                             | String       |
-| permissionMapping | Array permission actions (['read', 'update', 'delete'])               | String array |
-| resourceType      | Resource type provided by the plugin (e.g., "catalog-entity")         | String       |
-| conditions        | Condition JSON with parameters or array parameters joined by criteria | JSON         |
+| Json field        | Description                                                                                             | Type         |
+| ----------------- | ------------------------------------------------------------------------------------------------------- | ------------ |
+| result            | Always has the value "CONDITIONAL"                                                                      | String       |
+| roleEntityRef     | String entity reference to the RBAC role ('role:default/dev')                                           | String       |
+| pluginId          | Corresponding plugin ID (e.g., "catalog")                                                               | String       |
+| permissionMapping | Distinct Backstage permission actions only (`create`, `read`, `update`, `delete`, `use`); no duplicates | String array |
+| resourceType      | Resource type provided by the plugin (e.g., "catalog-entity")                                           | String       |
+| conditions        | Condition JSON with parameters or array parameters joined by criteria                                   | JSON         |
 
 To get the available conditional rules that can be used to create conditional permission policies, use the GET API request `api/permission/plugins/condition-rules` as seen below.
 

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
@@ -207,5 +207,34 @@ describe('Admin Creation', () => {
       expect(enfRole).not.toContain(oldGroupPolicy);
       expect(enfPermission).toEqual(permissions);
     });
+
+    it('should fail to build admin roles when admin entity reference is invalid', async () => {
+      const invalidConfig = mockServices.rootConfig({
+        data: {
+          permission: {
+            rbac: {
+              admin: {
+                users: [{ name: 'invalid-admin' }],
+              },
+            },
+          },
+        },
+      });
+      const adminUsers =
+        invalidConfig.getOptionalConfigArray('permission.rbac.admin.users') ??
+        [];
+
+      await expect(
+        useAdminsFromConfig(
+          adminUsers,
+          enfDelegate,
+          mockAuditorService,
+          roleMetadataStorageMock,
+          mockClientKnex,
+        ),
+      ).rejects.toThrow(
+        'Invalid admin entity reference \'invalid-admin\': Entity reference "invalid-admin" had missing or empty kind (e.g. did not start with "component:" or similar)',
+      );
+    });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.test.ts
@@ -232,9 +232,11 @@ describe('Admin Creation', () => {
           roleMetadataStorageMock,
           mockClientKnex,
         ),
-      ).rejects.toThrow(
-        'Invalid admin entity reference \'invalid-admin\': Entity reference "invalid-admin" had missing or empty kind (e.g. did not start with "component:" or similar)',
-      );
+      ).rejects.toMatchObject({
+        name: 'InputError',
+        message:
+          'Invalid admin entity reference \'invalid-admin\': Entity reference "invalid-admin" had missing or empty kind (e.g. did not start with "component:" or similar)',
+      });
     });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
@@ -58,7 +58,12 @@ export const useAdminsFromConfig = async (
 
   for (const admin of admins) {
     const entityRef = admin.getString('name').toLocaleLowerCase('en-US');
-    validateEntityReference(entityRef);
+    const validationError = validateEntityReference(entityRef);
+    if (validationError) {
+      throw new Error(
+        `Invalid admin entity reference '${entityRef}': ${validationError.message}`,
+      );
+    }
 
     addedGroupPolicies.set(entityRef, ADMIN_ROLE_NAME);
 

--- a/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/admin-permissions/admin-creation.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AuditorService } from '@backstage/backend-plugin-api';
 import type { Config } from '@backstage/config';
+import { InputError } from '@backstage/errors';
 
 import { Knex } from 'knex';
 
@@ -26,7 +28,6 @@ import {
 import { removeTheDifference } from '../helper';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { validateEntityReference } from '../validation/policies-validation';
-import { AuditorService } from '@backstage/backend-plugin-api';
 
 export const ADMIN_ROLE_NAME = 'role:default/rbac_admin';
 export const ADMIN_ROLE_AUTHOR = 'application configuration';
@@ -60,7 +61,7 @@ export const useAdminsFromConfig = async (
     const entityRef = admin.getString('name').toLocaleLowerCase('en-US');
     const validationError = validateEntityReference(entityRef);
     if (validationError) {
-      throw new Error(
+      throw new InputError(
         `Invalid admin entity reference '${entityRef}': ${validationError.message}`,
       );
     }

--- a/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
@@ -137,7 +137,13 @@ export class DataBaseRoleMetadataStorage implements RoleMetadataStorage {
         return matches(role as RoleMetadata, filter);
       });
       if (this.cachedDefaultRoleMeta) {
-        ownerRoles.push(this.cachedDefaultRoleMeta);
+        const hasDefaultRole = ownerRoles.some(
+          role =>
+            role.roleEntityRef === this.cachedDefaultRoleMeta!.roleEntityRef,
+        );
+        if (!hasDefaultRole) {
+          ownerRoles.push(this.cachedDefaultRoleMeta);
+        }
       }
       return ownerRoles;
     }

--- a/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/role-metadata.ts
@@ -137,12 +137,12 @@ export class DataBaseRoleMetadataStorage implements RoleMetadataStorage {
         return matches(role as RoleMetadata, filter);
       });
       if (this.cachedDefaultRoleMeta) {
+        const cachedDefault = this.cachedDefaultRoleMeta;
         const hasDefaultRole = ownerRoles.some(
-          role =>
-            role.roleEntityRef === this.cachedDefaultRoleMeta!.roleEntityRef,
+          role => role.roleEntityRef === cachedDefault.roleEntityRef,
         );
         if (!hasDefaultRole) {
-          ownerRoles.push(this.cachedDefaultRoleMeta);
+          ownerRoles.push(cachedDefault);
         }
       }
       return ownerRoles;

--- a/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { mockServices } from '@backstage/backend-test-utils';
+import { InputError } from '@backstage/errors';
 
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import {
@@ -59,6 +60,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readRole()).toThrow(InputError);
       expect(() => reader.readRole()).toThrow(
         'Default role is mandatory for defaultPermissions configuration. Please set a valid default role in the configuration.',
       );
@@ -134,6 +136,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readRole()).toThrow(InputError);
       expect(() => reader.readRole()).toThrow(
         "Invalid default role 'invalid-role': Invalid role format",
       );
@@ -160,6 +163,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readPolicies()).toThrow(InputError);
       expect(() => reader.readPolicies()).toThrow(
         "The default role 'role:default/catalog-reader' requires at least one entry in permission.rbac.defaultPermissions.basicPermissions.",
       );
@@ -179,6 +183,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readPolicies()).toThrow(InputError);
       expect(() => reader.readPolicies()).toThrow(
         "The default role 'role:default/catalog-reader' requires at least one entry in permission.rbac.defaultPermissions.basicPermissions.",
       );
@@ -270,6 +275,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readPolicies()).toThrow(InputError);
       expect(() => reader.readPolicies()).toThrow(
         "Invalid action 'invalid-action' for permission 'catalog.entity.read'.",
       );
@@ -294,6 +300,7 @@ describe('DefaultPermissionsReader', () => {
         },
       });
       const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readPolicies()).toThrow(InputError);
       expect(() => reader.readPolicies()).toThrow(
         `Invalid default permission policy for role 'role:default/guest': 'permission' contains double quotes (") which are not supported by the RBAC policy persistence format.`,
       );

--- a/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.test.ts
@@ -274,6 +274,30 @@ describe('DefaultPermissionsReader', () => {
         "Invalid action 'invalid-action' for permission 'catalog.entity.read'.",
       );
     });
+
+    it('throws when default permission is invalid for policy storage', () => {
+      const config = mockServices.rootConfig({
+        data: {
+          permission: {
+            rbac: {
+              defaultPermissions: {
+                defaultRole: 'role:default/guest',
+                basicPermissions: [
+                  {
+                    permission: 'catalog-entity"fuzz',
+                    action: 'read',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      const reader = new DefaultPermissionsReader(config);
+      expect(() => reader.readPolicies()).toThrow(
+        `Invalid default permission policy for role 'role:default/guest': 'permission' contains double quotes (") which are not supported by the RBAC policy persistence format.`,
+      );
+    });
   });
 });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.ts
@@ -30,6 +30,7 @@ import { ADMIN_ROLE_AUTHOR } from '../admin-permissions/admin-creation';
 import {
   validateSource,
   validateEntityReference,
+  validatePolicy,
 } from '../validation/policies-validation';
 
 const DEFAULT_ROLE_DESCRIPTION =
@@ -98,6 +99,15 @@ export class DefaultPermissionsReader {
           policy: action || 'use',
           effect: 'allow',
         };
+      });
+
+      policies.forEach(policy => {
+        const validationError = validatePolicy(policy);
+        if (validationError) {
+          throw new Error(
+            `Invalid default permission policy for role '${role}': ${validationError.message}`,
+          );
+        }
       });
     }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/default-permissions/default-permissions.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Config } from '@backstage/config';
+import { InputError } from '@backstage/errors';
 
 import {
   RoleBasedPolicy,
@@ -51,14 +52,14 @@ export class DefaultPermissionsReader {
       role = defPermissionsConfig.getOptionalString('defaultRole');
 
       if (!role) {
-        throw new Error(
+        throw new InputError(
           'Default role is mandatory for defaultPermissions configuration. Please set a valid default role in the configuration.',
         );
       }
 
       const validationError = validateEntityReference(role, true);
       if (validationError) {
-        throw new Error(
+        throw new InputError(
           `Invalid default role '${role}': ${validationError.message}`,
         );
       }
@@ -78,7 +79,7 @@ export class DefaultPermissionsReader {
       const basicPermissions =
         defPermissionsConfig.getOptionalConfigArray('basicPermissions');
       if (!basicPermissions || basicPermissions.length === 0) {
-        throw new Error(
+        throw new InputError(
           `The default role '${role}' requires at least one entry in permission.rbac.defaultPermissions.basicPermissions.`,
         );
       }
@@ -88,7 +89,7 @@ export class DefaultPermissionsReader {
         const action = permission.getOptionalString('action');
 
         if (action && !isValidPermissionAction(action)) {
-          throw new Error(
+          throw new InputError(
             `Invalid action '${action}' for permission '${permissionName}'.`,
           );
         }
@@ -104,7 +105,7 @@ export class DefaultPermissionsReader {
       policies.forEach(policy => {
         const validationError = validatePolicy(policy);
         if (validationError) {
-          throw new Error(
+          throw new InputError(
             `Invalid default permission policy for role '${role}': ${validationError.message}`,
           );
         }

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.test.ts
@@ -194,6 +194,28 @@ describe('CSVFileWatcher', () => {
   }
 
   describe('parse', () => {
+    test('should skip malformed CSV lines and log a warning', () => {
+      const malformedCsvPath = resolve(
+        __dirname,
+        '../../__fixtures__/data/invalid-csv/malformed-unquoted-quote.csv',
+      );
+      const csvFileWatcher = createCSVFileWatcher(malformedCsvPath);
+      const content = csvFileWatcher.parse();
+      expect(content).toStrictEqual([
+        ['g', 'user:default/alice', 'role:default/csv-malformed-test'],
+        [
+          'p',
+          'role:default/csv-malformed-test',
+          'catalog-entity',
+          'read',
+          'allow',
+        ],
+      ]);
+      expect(mockLoggerService.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/Skipping invalid CSV policy line 2 in/),
+      );
+    });
+
     test('should parse users and groups in lowercase', async () => {
       csvFileName = resolve(
         __dirname,

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/csv-file-watcher.ts
@@ -83,14 +83,38 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
    */
   parse(): string[][] {
     const content = this.getCurrentContents();
-    const data = parse(content, {
+    const lines = content.split(/\r?\n/);
+    const data: string[][] = [];
+    const parseOptions = {
+      delimiter: ',',
       skip_empty_lines: true,
       relax_column_count: true,
       trim: true,
-    });
+    } as const;
 
-    for (const policy of data) {
-      transformPolicyGroupToLowercase(policy);
+    for (let i = 0; i < lines.length; i += 1) {
+      const rawLine = lines[i];
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#')) {
+        continue;
+      }
+      const lineNumber = i + 1;
+      try {
+        const rows = parse(line, parseOptions);
+        const row = rows[0];
+        if (row && row.length > 0) {
+          transformPolicyGroupToLowercase(row);
+          data.push(row);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `Skipping invalid CSV policy line ${lineNumber} in ${this.filePath}: ${message}; line=${line.slice(
+            0,
+            120,
+          )}`,
+        );
+      }
     }
 
     return data;
@@ -115,7 +139,7 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
 
     const tempEnforcer = await newEnforcer(
       newModelFromString(MODEL),
-      new LowercaseFileAdapter(this.filePath),
+      new LowercaseFileAdapter(this.filePath, this.logger),
     );
 
     // Check for any old policies that will need to be removed
@@ -194,7 +218,7 @@ export class CSVFileWatcher extends AbstractFileWatcher<string[][]> {
 
     const tempEnforcer = await newEnforcer(
       newModelFromString(MODEL),
-      new LowercaseFileAdapter(this.filePath!),
+      new LowercaseFileAdapter(this.filePath!, this.logger),
     );
 
     const currentFlatContent = this.currentContent.flatMap(data => {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/lowercase-file-adapter.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/lowercase-file-adapter.ts
@@ -13,9 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { LoggerService } from '@backstage/backend-plugin-api';
+
 import { FileAdapter, Helper, Model, mustGetDefaultFileSystem } from 'casbin';
 
 export class LowercaseFileAdapter extends FileAdapter {
+  constructor(
+    filePath: string,
+    private readonly logger?: LoggerService,
+  ) {
+    super(filePath);
+  }
+
   public async loadPolicy(model: Model): Promise<void> {
     if (!this.filePath) {
       return;
@@ -44,12 +53,25 @@ export class LowercaseFileAdapter extends FileAdapter {
     ).readFileSync(this.filePath);
     const lines = bodyBuf.toString().split('\n');
 
-    lines.forEach((line: string) => {
-      if (!line) {
+    lines.forEach((line: string, index: number) => {
+      const trimmed = line.replace(/\r$/, '').trim();
+      if (!trimmed || trimmed.startsWith('#')) {
         return;
       }
-      const lowercasedLine = this.transformLineToLowercaseGroupsUsers(line);
-      handler(lowercasedLine, model);
+      const lineNumber = index + 1;
+      try {
+        const lowercasedLine =
+          this.transformLineToLowercaseGroupsUsers(trimmed);
+        handler(lowercasedLine, model);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger?.warn(
+          `Skipping invalid policy line ${lineNumber} in ${this.filePath}: ${message}; line=${trimmed.slice(
+            0,
+            120,
+          )}`,
+        );
+      }
     });
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/lowercase-file-adapter.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/lowercase-file-adapter.ts
@@ -65,8 +65,8 @@ export class LowercaseFileAdapter extends FileAdapter {
         handler(lowercasedLine, model);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        this.logger?.warn(
-          `Skipping invalid policy line ${lineNumber} in ${this.filePath}: ${message}; line=${trimmed.slice(
+        this.logger?.debug(
+          `Skipping invalid policy line ${lineNumber} in ${this.filePath} while loading Casbin model: ${message}; line=${trimmed.slice(
             0,
             120,
           )}`,

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -242,6 +242,28 @@ describe('YamlConditionalFileWatcher', () => {
     );
   }
 
+  function createWatcherWithLimits(
+    filePath: string | undefined,
+    maxBytes: number,
+    maxDocuments: number,
+  ): YamlConditinalPoliciesFileWatcher {
+    return new YamlConditinalPoliciesFileWatcher(
+      filePath,
+      false,
+      mockLoggerService,
+      conditionalStorageMock as DataBaseConditionalStorage,
+      mockAuditorService,
+      mockAuthService,
+      pluginMetadataCollectorMock as PluginPermissionMetadataCollector,
+      roleMetadataStorageMock,
+      roleEventEmitterMock,
+      {
+        maxBytes,
+        maxDocuments,
+      },
+    );
+  }
+
   test('handles errors for invalid file paths', async () => {
     const invalidFilePath = 'invalid-file-path.yaml';
     const watcher = createWatcher(invalidFilePath);
@@ -325,6 +347,42 @@ describe('YamlConditionalFileWatcher', () => {
         fail: {
           error: new Error(
             'conditional policies file exceeds maximum of 256 YAML documents',
+          ),
+        },
+      },
+    ]);
+  });
+
+  test('handles error when configured yaml document limit is exceeded', async () => {
+    const watcher = createWatcherWithLimits(csvFileName, 1024 * 1024, 1);
+    const conditionalPolicyDocument = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+    ].join('\n');
+    const yamlDocument = [
+      conditionalPolicyDocument,
+      conditionalPolicyDocument,
+    ].join('\n---\n');
+    jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(yamlDocument);
+
+    await watcher.onChange();
+
+    expectAuditorLog([
+      {
+        event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
+        fail: {
+          error: new Error(
+            'conditional policies file exceeds maximum of 1 YAML documents',
           ),
         },
       },

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -29,7 +29,7 @@ import {
 } from '../database/role-metadata';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
-import { YamlConditinalPoliciesFileWatcher } from './yaml-conditional-file-watcher'; // Adjust the import path as necessary
+import { YamlConditionalPoliciesFileWatcher } from './yaml-conditional-file-watcher';
 import { mockAuditorService } from '../../__fixtures__/mock-utils';
 import { expectAuditorLog } from '../../__fixtures__/auditor-test-utils';
 import {
@@ -228,8 +228,10 @@ describe('YamlConditionalFileWatcher', () => {
     jest.clearAllMocks();
   });
 
-  function createWatcher(filePath?: string): YamlConditinalPoliciesFileWatcher {
-    return new YamlConditinalPoliciesFileWatcher(
+  function createWatcher(
+    filePath?: string,
+  ): YamlConditionalPoliciesFileWatcher {
+    return new YamlConditionalPoliciesFileWatcher(
       filePath,
       false,
       mockLoggerService,
@@ -246,8 +248,8 @@ describe('YamlConditionalFileWatcher', () => {
     filePath: string | undefined,
     maxBytes: number,
     maxDocuments: number,
-  ): YamlConditinalPoliciesFileWatcher {
-    return new YamlConditinalPoliciesFileWatcher(
+  ): YamlConditionalPoliciesFileWatcher {
+    return new YamlConditionalPoliciesFileWatcher(
       filePath,
       false,
       mockLoggerService,

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -275,6 +275,62 @@ describe('YamlConditionalFileWatcher', () => {
     ]);
   });
 
+  test('handles error when yaml conditional policies file exceeds max size', async () => {
+    const watcher = createWatcher(csvFileName);
+    jest
+      .spyOn(watcher, 'getCurrentContents')
+      .mockReturnValue('x'.repeat(1024 * 1024 + 1));
+
+    await watcher.onChange();
+
+    expectAuditorLog([
+      {
+        event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
+        fail: {
+          error: new Error(
+            'conditional policies file exceeds maximum size of 1048576 bytes',
+          ),
+        },
+      },
+    ]);
+  });
+
+  test('handles error when yaml conditional policies exceeds max documents', async () => {
+    const watcher = createWatcher(csvFileName);
+    const conditionalPolicyDocument = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+    ].join('\n');
+    const yamlDocument = Array.from(
+      { length: 257 },
+      () => conditionalPolicyDocument,
+    ).join('\n---\n');
+    jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(yamlDocument);
+
+    await watcher.onChange();
+
+    expectAuditorLog([
+      {
+        event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
+        fail: {
+          error: new Error(
+            'conditional policies file exceeds maximum of 256 YAML documents',
+          ),
+        },
+      },
+    ]);
+  });
+
   test('should handle error on create condition', async () => {
     conditionalStorageMock.filterConditions = jest
       .fn()

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -38,7 +38,7 @@ import {
   RoleConditionalPolicyDecision,
 } from '@backstage-community/plugin-rbac-common';
 import { JsonObject } from '@backstage/types';
-import { NotFoundError } from '@backstage/errors';
+import { InputError, NotFoundError } from '@backstage/errors';
 
 const mockLoggerService = mockServices.logger.mock();
 
@@ -294,7 +294,7 @@ describe('YamlConditionalFileWatcher', () => {
       {
         event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
         fail: {
-          error: new Error(
+          error: new InputError(
             `'roleEntityRef' must be specified in the role condition`,
           ),
         },
@@ -314,7 +314,7 @@ describe('YamlConditionalFileWatcher', () => {
       {
         event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
         fail: {
-          error: new Error(
+          error: new InputError(
             'conditional policies file exceeds maximum size of 1048576 bytes',
           ),
         },
@@ -350,7 +350,7 @@ describe('YamlConditionalFileWatcher', () => {
       {
         event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
         fail: {
-          error: new Error(
+          error: new InputError(
             'conditional policies file exceeds maximum of 256 YAML documents',
           ),
         },
@@ -386,7 +386,7 @@ describe('YamlConditionalFileWatcher', () => {
       {
         event: { eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE },
         fail: {
-          error: new Error(
+          error: new InputError(
             'conditional policies file exceeds maximum of 1 YAML documents',
           ),
         },

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -29,7 +29,10 @@ import {
 } from '../database/role-metadata';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
-import { YamlConditionalPoliciesFileWatcher } from './yaml-conditional-file-watcher';
+import {
+  resolveConditionalPoliciesFileLimits,
+  YamlConditionalPoliciesFileWatcher,
+} from './yaml-conditional-file-watcher';
 import { DEFAULT_CONDITION_VALIDATION_LIMITS } from '../validation/condition-validation';
 import { mockAuditorService } from '../../__fixtures__/mock-utils';
 import { expectAuditorLog } from '../../__fixtures__/auditor-test-utils';
@@ -268,6 +271,48 @@ describe('YamlConditionalFileWatcher', () => {
       },
     );
   }
+
+  describe('conditional policies file limit validation', () => {
+    it('throws InputError when maxBytes is zero', () => {
+      expect(() => createWatcherWithLimits(csvFileName, 0, 256)).toThrow(
+        InputError,
+      );
+      expect(() => createWatcherWithLimits(csvFileName, 0, 256)).toThrow(
+        `'maxBytes' must be a positive integer for conditional policies file validation`,
+      );
+    });
+
+    it('throws InputError when maxDocuments is zero', () => {
+      expect(() => createWatcherWithLimits(csvFileName, 1024, 0)).toThrow(
+        InputError,
+      );
+      expect(() => createWatcherWithLimits(csvFileName, 1024, 0)).toThrow(
+        `'maxDocuments' must be a positive integer for conditional policies file validation`,
+      );
+    });
+
+    it('throws InputError when maxBytes is not an integer', () => {
+      expect(() => createWatcherWithLimits(csvFileName, 1024.5, 10)).toThrow(
+        InputError,
+      );
+    });
+
+    it('includes config key path in InputError when provided', () => {
+      expect(() =>
+        resolveConditionalPoliciesFileLimits(
+          { maxBytes: 0 },
+          {
+            maxBytes:
+              'permission.rbac.validation.conditionalPoliciesFile.maxBytes',
+            maxDocuments:
+              'permission.rbac.validation.conditionalPoliciesFile.maxDocuments',
+          },
+        ),
+      ).toThrow(
+        `'permission.rbac.validation.conditionalPoliciesFile.maxBytes' must be a positive integer for conditional policies file validation`,
+      );
+    });
+  });
 
   test('handles errors for invalid file paths', async () => {
     const invalidFilePath = 'invalid-file-path.yaml';

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -30,6 +30,7 @@ import {
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
 import { YamlConditionalPoliciesFileWatcher } from './yaml-conditional-file-watcher';
+import { DEFAULT_CONDITION_VALIDATION_LIMITS } from '../validation/condition-validation';
 import { mockAuditorService } from '../../__fixtures__/mock-utils';
 import { expectAuditorLog } from '../../__fixtures__/auditor-test-utils';
 import {
@@ -241,6 +242,7 @@ describe('YamlConditionalFileWatcher', () => {
       pluginMetadataCollectorMock as PluginPermissionMetadataCollector,
       roleMetadataStorageMock,
       roleEventEmitterMock,
+      DEFAULT_CONDITION_VALIDATION_LIMITS,
     );
   }
 
@@ -259,6 +261,7 @@ describe('YamlConditionalFileWatcher', () => {
       pluginMetadataCollectorMock as PluginPermissionMetadataCollector,
       roleMetadataStorageMock,
       roleEventEmitterMock,
+      DEFAULT_CONDITION_VALIDATION_LIMITS,
       {
         maxBytes,
         maxDocuments,

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -44,13 +44,23 @@ type ConditionalPoliciesDiff = {
   removedConditions: RoleConditionalPolicyDecision<PermissionAction>[];
 };
 
-const MAX_CONDITIONAL_POLICY_FILE_BYTES = 1024 * 1024;
-const MAX_CONDITIONAL_POLICY_DOCUMENTS = 256;
+export type ConditionalPoliciesFileLimits = {
+  maxBytes: number;
+  maxDocuments: number;
+};
+
+export const DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS: ConditionalPoliciesFileLimits =
+  {
+    maxBytes: 1024 * 1024,
+    maxDocuments: 256,
+  };
 
 export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
   RoleConditionalPolicyDecision<PermissionAction>[]
 > {
   private conditionsDiff: ConditionalPoliciesDiff;
+  private readonly maxFileBytes: number;
+  private readonly maxFileDocuments: number;
 
   constructor(
     filePath: string | undefined,
@@ -62,6 +72,7 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
     private readonly pluginMetadataCollector: PluginPermissionMetadataCollector,
     private readonly roleMetadataStorage: RoleMetadataStorage,
     private readonly roleEventEmitter: RoleEventEmitter<RoleEvents>,
+    limits: Partial<ConditionalPoliciesFileLimits> = {},
   ) {
     super(filePath, allowReload, logger);
 
@@ -69,6 +80,11 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
       addedConditions: [],
       removedConditions: [],
     };
+    this.maxFileBytes =
+      limits.maxBytes ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxBytes;
+    this.maxFileDocuments =
+      limits.maxDocuments ??
+      DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments;
   }
 
   async initialize(): Promise<void> {
@@ -178,9 +194,9 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
   parse(): RoleConditionalPolicyDecision<PermissionAction>[] {
     const fileContents = this.getCurrentContents();
     const fileSizeInBytes = Buffer.byteLength(fileContents, 'utf8');
-    if (fileSizeInBytes > MAX_CONDITIONAL_POLICY_FILE_BYTES) {
+    if (fileSizeInBytes > this.maxFileBytes) {
       throw new InputError(
-        `conditional policies file exceeds maximum size of ${MAX_CONDITIONAL_POLICY_FILE_BYTES} bytes`,
+        `conditional policies file exceeds maximum size of ${this.maxFileBytes} bytes`,
       );
     }
 
@@ -194,9 +210,9 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
       parsedDocuments.push(
         doc as RoleConditionalPolicyDecision<PermissionAction>,
       );
-      if (parsedDocuments.length > MAX_CONDITIONAL_POLICY_DOCUMENTS) {
+      if (parsedDocuments.length > this.maxFileDocuments) {
         throw new InputError(
-          `conditional policies file exceeds maximum of ${MAX_CONDITIONAL_POLICY_DOCUMENTS} YAML documents`,
+          `conditional policies file exceeds maximum of ${this.maxFileDocuments} YAML documents`,
         );
       }
     });

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -55,7 +55,7 @@ export const DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS: ConditionalPoliciesFileLi
     maxDocuments: 256,
   };
 
-export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
+export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   RoleConditionalPolicyDecision<PermissionAction>[]
 > {
   private conditionsDiff: ConditionalPoliciesDiff;

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -18,6 +18,7 @@ import type {
   AuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
 
 import yaml from 'js-yaml';
 import { omit } from 'lodash';
@@ -42,6 +43,9 @@ type ConditionalPoliciesDiff = {
   addedConditions: RoleConditionalPolicyDecision<PermissionAction>[];
   removedConditions: RoleConditionalPolicyDecision<PermissionAction>[];
 };
+
+const MAX_CONDITIONAL_POLICY_FILE_BYTES = 1024 * 1024;
+const MAX_CONDITIONAL_POLICY_DOCUMENTS = 256;
 
 export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
   RoleConditionalPolicyDecision<PermissionAction>[]
@@ -173,17 +177,35 @@ export class YamlConditinalPoliciesFileWatcher extends AbstractFileWatcher<
    */
   parse(): RoleConditionalPolicyDecision<PermissionAction>[] {
     const fileContents = this.getCurrentContents();
-    const data = yaml
-      .loadAll(fileContents)
-      .filter(
-        doc => doc !== null,
-      ) as RoleConditionalPolicyDecision<PermissionAction>[];
+    const fileSizeInBytes = Buffer.byteLength(fileContents, 'utf8');
+    if (fileSizeInBytes > MAX_CONDITIONAL_POLICY_FILE_BYTES) {
+      throw new InputError(
+        `conditional policies file exceeds maximum size of ${MAX_CONDITIONAL_POLICY_FILE_BYTES} bytes`,
+      );
+    }
 
-    for (const condition of data) {
+    const parsedDocuments: RoleConditionalPolicyDecision<PermissionAction>[] =
+      [];
+    yaml.loadAll(fileContents, doc => {
+      if (doc === null) {
+        return;
+      }
+
+      parsedDocuments.push(
+        doc as RoleConditionalPolicyDecision<PermissionAction>,
+      );
+      if (parsedDocuments.length > MAX_CONDITIONAL_POLICY_DOCUMENTS) {
+        throw new InputError(
+          `conditional policies file exceeds maximum of ${MAX_CONDITIONAL_POLICY_DOCUMENTS} YAML documents`,
+        );
+      }
+    });
+
+    for (const condition of parsedDocuments) {
       validateRoleCondition(condition);
     }
 
-    return data;
+    return parsedDocuments;
   }
 
   private async handleFileChanges(): Promise<void> {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -36,7 +36,10 @@ import { RoleMetadataStorage } from '../database/role-metadata';
 import { deepSortEqual, processConditionMapping } from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
-import { validateRoleCondition } from '../validation/condition-validation';
+import {
+  type ConditionValidationLimits,
+  validateRoleCondition,
+} from '../validation/condition-validation';
 import { AbstractFileWatcher } from './file-watcher';
 
 type ConditionalPoliciesDiff = {
@@ -61,6 +64,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   private conditionsDiff: ConditionalPoliciesDiff;
   private readonly maxFileBytes: number;
   private readonly maxFileDocuments: number;
+  private readonly conditionValidationLimits: ConditionValidationLimits;
 
   constructor(
     filePath: string | undefined,
@@ -72,6 +76,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     private readonly pluginMetadataCollector: PluginPermissionMetadataCollector,
     private readonly roleMetadataStorage: RoleMetadataStorage,
     private readonly roleEventEmitter: RoleEventEmitter<RoleEvents>,
+    conditionValidationLimits: ConditionValidationLimits,
     limits: Partial<ConditionalPoliciesFileLimits> = {},
   ) {
     super(filePath, allowReload, logger);
@@ -85,6 +90,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     this.maxFileDocuments =
       limits.maxDocuments ??
       DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments;
+    this.conditionValidationLimits = conditionValidationLimits;
   }
 
   async initialize(): Promise<void> {
@@ -218,7 +224,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     });
 
     for (const condition of parsedDocuments) {
-      validateRoleCondition(condition);
+      validateRoleCondition(condition, this.conditionValidationLimits);
     }
 
     return parsedDocuments;

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -58,6 +58,45 @@ export const DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS: ConditionalPoliciesFileLi
     maxDocuments: 256,
   };
 
+function assertPositiveIntegerConditionalPoliciesFileLimit(
+  value: number,
+  fieldRef: string,
+): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new InputError(
+      `'${fieldRef}' must be a positive integer for conditional policies file validation`,
+    );
+  }
+}
+
+/**
+ * Merges optional overrides with defaults and validates both limits are positive integers.
+ */
+export function resolveConditionalPoliciesFileLimits(
+  partial: Partial<ConditionalPoliciesFileLimits> = {},
+  errorFieldRefs?: {
+    maxBytes: string;
+    maxDocuments: string;
+  },
+): ConditionalPoliciesFileLimits {
+  const resolved: ConditionalPoliciesFileLimits = {
+    maxBytes:
+      partial.maxBytes ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxBytes,
+    maxDocuments:
+      partial.maxDocuments ??
+      DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments,
+  };
+  assertPositiveIntegerConditionalPoliciesFileLimit(
+    resolved.maxBytes,
+    errorFieldRefs?.maxBytes ?? 'maxBytes',
+  );
+  assertPositiveIntegerConditionalPoliciesFileLimit(
+    resolved.maxDocuments,
+    errorFieldRefs?.maxDocuments ?? 'maxDocuments',
+  );
+  return resolved;
+}
+
 export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   RoleConditionalPolicyDecision<PermissionAction>[]
 > {
@@ -85,11 +124,9 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
       addedConditions: [],
       removedConditions: [],
     };
-    this.maxFileBytes =
-      limits.maxBytes ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxBytes;
-    this.maxFileDocuments =
-      limits.maxDocuments ??
-      DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments;
+    const resolvedLimits = resolveConditionalPoliciesFileLimits(limits);
+    this.maxFileBytes = resolvedLimits.maxBytes;
+    this.maxFileDocuments = resolvedLimits.maxDocuments;
     this.conditionValidationLimits = conditionValidationLimits;
   }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -627,7 +627,7 @@ describe('helper.ts', () => {
     const anyOfFilter: RBACFilters = {
       anyOf: [
         {
-          key: 'owner',
+          key: 'owners',
           values: ['user:default/some_user'],
         },
       ],
@@ -636,7 +636,7 @@ describe('helper.ts', () => {
     const allOfFilter: RBACFilters = {
       allOf: [
         {
-          key: 'owner',
+          key: 'owners',
           values: ['user:default/some_user'],
         },
       ],
@@ -644,7 +644,7 @@ describe('helper.ts', () => {
 
     const notFilter: RBACFilters = {
       not: {
-        key: 'owner',
+        key: 'owners',
         values: ['user:default/some_user'],
       },
     };
@@ -687,6 +687,21 @@ describe('helper.ts', () => {
 
     it('shoule return true with not filter where role owner does not match filter owner', () => {
       expect(matches(noMatchedRole, notFilter)).toBeTruthy();
+    });
+
+    it('should return true for default role regardless of owner filters', () => {
+      const defaultRole: RoleMetadata = {
+        isDefault: true,
+      };
+      expect(matches(defaultRole, anyOfFilter)).toBeTruthy();
+    });
+
+    it('should return false for unknown filter keys', () => {
+      const unknownKeyFilter: RBACFilters = {
+        key: 'unknown',
+        values: ['user:default/some_user'],
+      };
+      expect(matches(matchedRole, unknownKeyFilter)).toBeFalsy();
     });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -350,5 +350,18 @@ export const matches = (
     return !matches(role, filters.not);
   }
 
-  return filters.values.includes(role.owner);
+  // Keep filter semantics aligned with the IS_OWNER permission rule.
+  if (role.isDefault) {
+    return true;
+  }
+
+  if (!role.owner) {
+    return false;
+  }
+
+  if (filters.key === 'owners' || filters.key === 'owner') {
+    return filters.values.includes(role.owner);
+  }
+
+  return false;
 };

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -53,9 +53,17 @@ import { replaceAliases } from '../conditional-aliases/alias-resolver';
 import { ConditionalStorage } from '../database/conditional-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
 import { CSVFileWatcher } from '../file-permissions/csv-file-watcher';
-import { YamlConditinalPoliciesFileWatcher } from '../file-permissions/yaml-conditional-file-watcher';
+import {
+  ConditionalPoliciesFileLimits,
+  DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS,
+  YamlConditinalPoliciesFileWatcher,
+} from '../file-permissions/yaml-conditional-file-watcher';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
+import {
+  ConditionValidationLimits,
+  configureConditionValidationLimits,
+} from '../validation/condition-validation';
 
 export class RBACPermissionPolicy implements PermissionPolicy {
   private readonly superUserList?: string[];
@@ -91,6 +99,13 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     const conditionalPoliciesFile = configApi.getOptionalString(
       'permission.rbac.conditionalPoliciesFile',
     );
+
+    const conditionValidationLimits =
+      RBACPermissionPolicy.readConditionValidationLimits(configApi);
+    configureConditionValidationLimits(conditionValidationLimits);
+
+    const conditionalFileLimits =
+      RBACPermissionPolicy.readConditionalFileLimits(configApi);
 
     const preferPermissionPolicy =
       (configApi.getOptionalString(
@@ -142,6 +157,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       pluginMetadataCollector,
       roleMetadataStorage,
       enforcerDelegate,
+      conditionalFileLimits,
     );
     await conditionalFile.initialize();
 
@@ -380,5 +396,57 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       return result;
     }
     return undefined;
+  }
+
+  private static readConditionValidationLimits(
+    configApi: ConfigApi,
+  ): Partial<ConditionValidationLimits> {
+    const limits: Partial<ConditionValidationLimits> = {};
+    const maxPermissionMappingItems = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems',
+    );
+    if (maxPermissionMappingItems !== undefined) {
+      limits.maxPermissionMappingItems = maxPermissionMappingItems;
+    }
+
+    const maxConditionDepth = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPolicies.maxConditionDepth',
+    );
+    if (maxConditionDepth !== undefined) {
+      limits.maxConditionDepth = maxConditionDepth;
+    }
+
+    const maxConditionNodeCount = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPolicies.maxConditionNodeCount',
+    );
+    if (maxConditionNodeCount !== undefined) {
+      limits.maxConditionNodeCount = maxConditionNodeCount;
+    }
+
+    const maxCriteriaItems = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPolicies.maxCriteriaItems',
+    );
+    if (maxCriteriaItems !== undefined) {
+      limits.maxCriteriaItems = maxCriteriaItems;
+    }
+
+    return limits;
+  }
+
+  private static readConditionalFileLimits(
+    configApi: ConfigApi,
+  ): Partial<ConditionalPoliciesFileLimits> {
+    const maxBytes = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPoliciesFile.maxBytes',
+    );
+    const maxDocuments = configApi.getOptionalNumber(
+      'permission.rbac.validation.conditionalPoliciesFile.maxDocuments',
+    );
+
+    return {
+      maxBytes: maxBytes ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxBytes,
+      maxDocuments:
+        maxDocuments ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments,
+    };
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -403,7 +403,6 @@ export class RBACPermissionPolicy implements PermissionPolicy {
   ): Partial<ConditionValidationLimits> {
     const baseKey = 'permission.rbac.validation.conditionalPolicies';
     const limitKeys: (keyof ConditionValidationLimits)[] = [
-      'maxPermissionMappingItems',
       'maxConditionDepth',
       'maxConditionNodeCount',
       'maxCriteriaItems',

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -56,7 +56,7 @@ import { CSVFileWatcher } from '../file-permissions/csv-file-watcher';
 import {
   ConditionalPoliciesFileLimits,
   DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS,
-  YamlConditinalPoliciesFileWatcher,
+  YamlConditionalPoliciesFileWatcher,
 } from '../file-permissions/yaml-conditional-file-watcher';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
@@ -147,7 +147,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     );
     await csvFile.initialize();
 
-    const conditionalFile = new YamlConditinalPoliciesFileWatcher(
+    const conditionalFile = new YamlConditionalPoliciesFileWatcher(
       conditionalPoliciesFile,
       allowReload,
       logger,
@@ -401,35 +401,20 @@ export class RBACPermissionPolicy implements PermissionPolicy {
   private static readConditionValidationLimits(
     configApi: ConfigApi,
   ): Partial<ConditionValidationLimits> {
+    const baseKey = 'permission.rbac.validation.conditionalPolicies';
+    const limitKeys: (keyof ConditionValidationLimits)[] = [
+      'maxPermissionMappingItems',
+      'maxConditionDepth',
+      'maxConditionNodeCount',
+      'maxCriteriaItems',
+    ];
     const limits: Partial<ConditionValidationLimits> = {};
-    const maxPermissionMappingItems = configApi.getOptionalNumber(
-      'permission.rbac.validation.conditionalPolicies.maxPermissionMappingItems',
-    );
-    if (maxPermissionMappingItems !== undefined) {
-      limits.maxPermissionMappingItems = maxPermissionMappingItems;
+    for (const key of limitKeys) {
+      const value = configApi.getOptionalNumber(`${baseKey}.${key}`);
+      if (value !== undefined) {
+        limits[key] = value;
+      }
     }
-
-    const maxConditionDepth = configApi.getOptionalNumber(
-      'permission.rbac.validation.conditionalPolicies.maxConditionDepth',
-    );
-    if (maxConditionDepth !== undefined) {
-      limits.maxConditionDepth = maxConditionDepth;
-    }
-
-    const maxConditionNodeCount = configApi.getOptionalNumber(
-      'permission.rbac.validation.conditionalPolicies.maxConditionNodeCount',
-    );
-    if (maxConditionNodeCount !== undefined) {
-      limits.maxConditionNodeCount = maxConditionNodeCount;
-    }
-
-    const maxCriteriaItems = configApi.getOptionalNumber(
-      'permission.rbac.validation.conditionalPolicies.maxCriteriaItems',
-    );
-    if (maxCriteriaItems !== undefined) {
-      limits.maxCriteriaItems = maxCriteriaItems;
-    }
-
     return limits;
   }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -62,7 +62,8 @@ import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
 import {
   ConditionValidationLimits,
-  configureConditionValidationLimits,
+  readConditionValidationLimitsFromConfig,
+  resolveConditionValidationLimits,
 } from '../validation/condition-validation';
 
 export class RBACPermissionPolicy implements PermissionPolicy {
@@ -79,6 +80,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     knex: Knex,
     pluginMetadataCollector: PluginPermissionMetadataCollector,
     auth: AuthService,
+    conditionValidationLimits?: ConditionValidationLimits,
   ): Promise<RBACPermissionPolicy> {
     const superUserList: string[] = [];
     const adminUsers = configApi.getOptionalConfigArray(
@@ -100,9 +102,11 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       'permission.rbac.conditionalPoliciesFile',
     );
 
-    const conditionValidationLimits =
-      RBACPermissionPolicy.readConditionValidationLimits(configApi);
-    configureConditionValidationLimits(conditionValidationLimits);
+    const resolvedConditionValidationLimits =
+      conditionValidationLimits ??
+      resolveConditionValidationLimits(
+        readConditionValidationLimitsFromConfig(configApi),
+      );
 
     const conditionalFileLimits =
       RBACPermissionPolicy.readConditionalFileLimits(configApi);
@@ -157,6 +161,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       pluginMetadataCollector,
       roleMetadataStorage,
       enforcerDelegate,
+      resolvedConditionValidationLimits,
       conditionalFileLimits,
     );
     await conditionalFile.initialize();
@@ -396,25 +401,6 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       return result;
     }
     return undefined;
-  }
-
-  private static readConditionValidationLimits(
-    configApi: ConfigApi,
-  ): Partial<ConditionValidationLimits> {
-    const baseKey = 'permission.rbac.validation.conditionalPolicies';
-    const limitKeys: (keyof ConditionValidationLimits)[] = [
-      'maxConditionDepth',
-      'maxConditionNodeCount',
-      'maxCriteriaItems',
-    ];
-    const limits: Partial<ConditionValidationLimits> = {};
-    for (const key of limitKeys) {
-      const value = configApi.getOptionalNumber(`${baseKey}.${key}`);
-      if (value !== undefined) {
-        limits[key] = value;
-      }
-    }
-    return limits;
   }
 
   private static readConditionalFileLimits(

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -55,7 +55,7 @@ import { RoleMetadataStorage } from '../database/role-metadata';
 import { CSVFileWatcher } from '../file-permissions/csv-file-watcher';
 import {
   ConditionalPoliciesFileLimits,
-  DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS,
+  resolveConditionalPoliciesFileLimits,
   YamlConditionalPoliciesFileWatcher,
 } from '../file-permissions/yaml-conditional-file-watcher';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
@@ -405,7 +405,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
 
   private static readConditionalFileLimits(
     configApi: ConfigApi,
-  ): Partial<ConditionalPoliciesFileLimits> {
+  ): ConditionalPoliciesFileLimits {
     const maxBytes = configApi.getOptionalNumber(
       'permission.rbac.validation.conditionalPoliciesFile.maxBytes',
     );
@@ -413,10 +413,16 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       'permission.rbac.validation.conditionalPoliciesFile.maxDocuments',
     );
 
-    return {
-      maxBytes: maxBytes ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxBytes,
-      maxDocuments:
-        maxDocuments ?? DEFAULT_CONDITIONAL_POLICIES_FILE_LIMITS.maxDocuments,
-    };
+    return resolveConditionalPoliciesFileLimits(
+      {
+        ...(maxBytes !== undefined ? { maxBytes } : {}),
+        ...(maxDocuments !== undefined ? { maxDocuments } : {}),
+      },
+      {
+        maxBytes: 'permission.rbac.validation.conditionalPoliciesFile.maxBytes',
+        maxDocuments:
+          'permission.rbac.validation.conditionalPoliciesFile.maxDocuments',
+      },
+    );
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.test.ts
@@ -15,7 +15,7 @@
  */
 import { mockServices } from '@backstage/backend-test-utils';
 
-import { Model, newEnforcer, newModelFromString } from 'casbin';
+import { Enforcer, Model, newEnforcer, newModelFromString } from 'casbin';
 import * as Knex from 'knex';
 import { MockClient } from 'knex-mock-client';
 
@@ -31,6 +31,7 @@ import { MODEL } from './permission-model';
 import {
   catalogMock,
   conditionalStorageMock,
+  createEventMock,
   mockAuditorService,
 } from '../../__fixtures__/mock-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
@@ -129,6 +130,8 @@ describe('EnforcerDelegate', () => {
     (roleMetadataStorageMock.updateRoleMetadata as jest.Mock).mockReset();
     (roleMetadataStorageMock.findRoleMetadata as jest.Mock).mockReset();
     (roleMetadataStorageMock.removeRoleMetadata as jest.Mock).mockReset();
+    jest.mocked(createEventMock.fail).mockReset();
+    jest.mocked(createEventMock.success).mockReset();
   });
 
   const knex = Knex.knex({ client: MockClient });
@@ -189,6 +192,27 @@ describe('EnforcerDelegate', () => {
       knex,
     );
   }
+
+  describe('loadPolicy', () => {
+    it('rethrows after auditing a failed enforcer loadPolicy', async () => {
+      const loadErr = new Error('Invalid Closing Quote');
+      const mockEnforcer = {
+        loadPolicy: jest.fn().mockRejectedValue(loadErr),
+      } as unknown as Enforcer;
+
+      const delegate = new EnforcerDelegate(
+        mockEnforcer,
+        mockAuditorService,
+        conditionalStorageMock,
+        roleMetadataStorageMock,
+        knex,
+      );
+
+      await expect(delegate.loadPolicy()).rejects.toThrow(loadErr);
+
+      expect(createEventMock.fail).toHaveBeenCalledWith({ error: loadErr });
+    });
+  });
 
   describe('hasPolicy', () => {
     it('has policy should return false', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/enforcer-delegate.ts
@@ -69,6 +69,7 @@ export class EnforcerDelegate implements RoleEventEmitter<RoleEvents> {
           severityLevel: 'medium',
         });
         await auditorEvent.fail({ error });
+        throw error;
       } finally {
         this.loadPolicyPromise = null;
       }

--- a/workspaces/rbac/plugins/rbac-backend/src/service/permission-definition-routes.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/permission-definition-routes.test.ts
@@ -281,6 +281,20 @@ describe('REST plugin policies metadata API', () => {
     expect(result.body.ids).toContain('scaffolder');
   });
 
+  it('should fail to add plugin ids when ids array is empty', async () => {
+    mockedAuthorize.mockImplementationOnce(async () => [
+      { result: AuthorizeResult.ALLOW },
+    ]);
+
+    const result = await request(app).post('/plugins/id').send({ ids: [] });
+
+    expect(result.statusCode).toBe(400);
+    expect(result.body.error).toEqual({
+      message: `'ids' must contain at least one plugin ID`,
+      name: 'InputError',
+    });
+  });
+
   it('should fail to add more plugin ids, because of ConflictError', async () => {
     mockedAuthorize.mockImplementationOnce(async () => [
       { result: AuthorizeResult.ALLOW },
@@ -374,6 +388,22 @@ describe('REST plugin policies metadata API', () => {
     expect(result.body.ids).toContain('jenkins');
     expect(result.body.ids).toContain('sonarqube');
     expect(result.body.ids).not.toContain('catalog');
+  });
+
+  it('should fail to delete plugin ids with duplicate values', async () => {
+    mockedAuthorizeConditional.mockImplementationOnce(async () => [
+      { result: AuthorizeResult.ALLOW },
+    ]);
+
+    const result = await request(app)
+      .delete('/plugins/id')
+      .send({ ids: ['catalog', 'catalog'] });
+
+    expect(result.statusCode).toBe(400);
+    expect(result.body.error).toEqual({
+      message: `'ids' contains duplicate plugin ID 'catalog'`,
+      name: 'InputError',
+    });
   });
 
   it('should fail to delete plugin id with NotFoundError', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.conditions.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.conditions.test.ts
@@ -52,6 +52,7 @@ import request from 'supertest';
 import { RoleMetadataDao } from '../database/role-metadata';
 import { RBACFilters } from '../permissions/rules';
 import { ExtendablePluginIdProvider } from './extendable-id-provider';
+import { DEFAULT_CONDITION_VALIDATION_LIMITS } from '../validation/condition-validation';
 
 jest.setTimeout(60000);
 
@@ -61,7 +62,11 @@ jest.mock('@backstage/plugin-auth-node', () => ({
 
 const validateRoleConditionMock = jest.fn().mockImplementation();
 jest.mock('../validation/condition-validation', () => {
+  const actual = jest.requireActual(
+    '../validation/condition-validation',
+  ) as typeof import('../validation/condition-validation');
   return {
+    ...actual,
     validateRoleCondition: jest
       .fn()
       .mockImplementation(
@@ -315,6 +320,7 @@ describe('REST policies api with conditions', () => {
       roleMetadataStorageMock,
       permissionDependentPluginStoreMock,
       extendablePluginIdProviderMock as ExtendablePluginIdProvider,
+      DEFAULT_CONDITION_VALIDATION_LIMITS,
       undefined,
     );
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -356,7 +356,7 @@ describe('REST policies API', () => {
       expect(result.statusCode).toBe(400);
       expect(result.body.error).toEqual({
         name: 'InputError',
-        message: `permission policy must be present`,
+        message: `permission policy must be provided as an array`,
       });
     });
 
@@ -997,7 +997,7 @@ describe('REST policies API', () => {
       expect(result.statusCode).toEqual(400);
       expect(result.body.error).toEqual({
         name: 'InputError',
-        message: `permission policy must be present`,
+        message: `permission policy must be provided as an array`,
       });
     });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -360,6 +360,16 @@ describe('REST policies API', () => {
       });
     });
 
+    it('should not be created permission policy - req body must be an array', async () => {
+      const result = await request(app).post('/policies').send({});
+
+      expect(result.statusCode).toBe(400);
+      expect(result.body.error).toEqual({
+        name: 'InputError',
+        message: `permission policy must be provided as an array`,
+      });
+    });
+
     it('should not be created permission policy - entityReference is empty', async () => {
       const result = await request(app).post('/policies').send([{}]);
 
@@ -573,6 +583,42 @@ describe('REST policies API', () => {
         ]);
 
       expect(result.statusCode).toBe(500);
+    });
+
+    it('should fail to create policy for missing role', async () => {
+      roleMetadataStorageMock.findRoleMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === 'role:default/missing-role') {
+              return undefined;
+            }
+            return {
+              source: 'rest',
+              roleEntityRef,
+              modifiedBy,
+            };
+          },
+        );
+
+      const result = await request(app)
+        .post('/policies')
+        .send([
+          {
+            entityReference: 'role:default/missing-role',
+            permission: 'policy-entity',
+            policy: 'delete',
+            effect: 'deny',
+          },
+        ]);
+
+      expect(result.statusCode).toBe(404);
+      expect(result.body.error).toEqual({
+        name: 'NotFoundError',
+        message: `Corresponding role role:default/missing-role was not found`,
+      });
     });
 
     it('should fail to create permission policy - duplication in req body', async () => {
@@ -955,6 +1001,18 @@ describe('REST policies API', () => {
       });
     });
 
+    it('should fail to delete, request body must be an array', async () => {
+      const result = await request(app)
+        .delete('/policies/user/default/permission_admin')
+        .send({});
+
+      expect(result.statusCode).toEqual(400);
+      expect(result.body.error).toEqual({
+        name: 'InputError',
+        message: `permission policy must be provided as an array`,
+      });
+    });
+
     it('should fail to delete, because permission field is absent', async () => {
       const result = await request(app)
         .delete('/policies/user/default/permission_admin')
@@ -1226,6 +1284,50 @@ describe('REST policies API', () => {
       expect(result.body.error).toEqual({
         name: 'InputError',
         message: `'newPolicy' object must be present`,
+      });
+    });
+
+    it('should fail to update policy for missing role', async () => {
+      roleMetadataStorageMock.findRoleMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === 'role:default/missing-role') {
+              return undefined;
+            }
+            return {
+              source: 'rest',
+              roleEntityRef,
+              modifiedBy,
+            };
+          },
+        );
+
+      const result = await request(app)
+        .put('/policies/role/default/missing-role')
+        .send({
+          oldPolicy: [
+            {
+              permission: 'policy-entity',
+              policy: 'read',
+              effect: 'allow',
+            },
+          ],
+          newPolicy: [
+            {
+              permission: 'policy-entity',
+              policy: 'delete',
+              effect: 'allow',
+            },
+          ],
+        });
+
+      expect(result.statusCode).toEqual(404);
+      expect(result.body.error).toEqual({
+        name: 'NotFoundError',
+        message: `Corresponding role role:default/missing-role was not found`,
       });
     });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -3624,6 +3624,23 @@ describe('REST policies API', () => {
       expect(mockHttpAuth.credentials).toHaveBeenCalledTimes(1);
     });
 
+    it('should return 400 when condition validation fails', async () => {
+      validateRoleConditionMock.mockImplementationOnce(() => {
+        throw new InputError(`Invalid condition payload`);
+      });
+
+      const result = await request(app).post('/roles/conditions').send({
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+      });
+
+      expect(result.statusCode).toBe(400);
+      expect(result.body.error).toEqual({
+        name: 'InputError',
+        message: 'Invalid condition payload',
+      });
+    });
+
     it('should create condition with the correct permission name for different resource types but similar actions', async () => {
       conditionalStorageMock.createCondition = jest
         .fn()
@@ -3907,6 +3924,23 @@ describe('REST policies API', () => {
       expect(result.body.error).toEqual({
         message: 'Condition with id 2 was not found',
         name: 'NotFoundError',
+      });
+    });
+
+    it('should return 400 on update when condition validation fails', async () => {
+      validateRoleConditionMock.mockImplementationOnce(() => {
+        throw new InputError(`Invalid condition payload`);
+      });
+
+      const result = await request(app).put('/roles/conditions/1').send({
+        pluginId: 'catalog',
+        roleEntityRef: 'role:default/test',
+      });
+
+      expect(result.statusCode).toBe(400);
+      expect(result.body.error).toEqual({
+        name: 'InputError',
+        message: 'Invalid condition payload',
       });
     });
   });

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -627,6 +627,42 @@ describe('REST policies API', () => {
       });
     });
 
+    it('should fail to create policy for missing role outside default namespace', async () => {
+      roleMetadataStorageMock.findRoleMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === 'role:team/missing-role') {
+              return undefined;
+            }
+            return {
+              source: 'rest',
+              roleEntityRef,
+              modifiedBy,
+            };
+          },
+        );
+
+      const result = await request(app)
+        .post('/policies')
+        .send([
+          {
+            entityReference: 'role:team/missing-role',
+            permission: 'policy-entity',
+            policy: 'delete',
+            effect: 'deny',
+          },
+        ]);
+
+      expect(result.statusCode).toBe(404);
+      expect(result.body.error).toEqual({
+        name: 'NotFoundError',
+        message: `Corresponding role role:team/missing-role was not found`,
+      });
+    });
+
     it('should fail to create permission policy - duplication in req body', async () => {
       const result = await request(app)
         .post('/policies')
@@ -1334,6 +1370,50 @@ describe('REST policies API', () => {
       expect(result.body.error).toEqual({
         name: 'NotFoundError',
         message: `Corresponding role role:default/missing-role was not found`,
+      });
+    });
+
+    it('should fail to update policy for missing role outside default namespace', async () => {
+      roleMetadataStorageMock.findRoleMetadata = jest
+        .fn()
+        .mockImplementation(
+          async (
+            roleEntityRef: string,
+          ): Promise<RoleMetadataDao | undefined> => {
+            if (roleEntityRef === 'role:team/missing-role') {
+              return undefined;
+            }
+            return {
+              source: 'rest',
+              roleEntityRef,
+              modifiedBy,
+            };
+          },
+        );
+
+      const result = await request(app)
+        .put('/policies/role/team/missing-role')
+        .send({
+          oldPolicy: [
+            {
+              permission: 'policy-entity',
+              policy: 'read',
+              effect: 'allow',
+            },
+          ],
+          newPolicy: [
+            {
+              permission: 'policy-entity',
+              policy: 'delete',
+              effect: 'allow',
+            },
+          ],
+        });
+
+      expect(result.statusCode).toEqual(404);
+      expect(result.body.error).toEqual({
+        name: 'NotFoundError',
+        message: `Corresponding role role:team/missing-role was not found`,
       });
     });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.test.ts
@@ -63,6 +63,7 @@ import {
   extendablePluginIdProviderMock,
 } from '../../__fixtures__/mock-utils';
 import { ExtendablePluginIdProvider } from './extendable-id-provider';
+import { DEFAULT_CONDITION_VALIDATION_LIMITS } from '../validation/condition-validation';
 
 jest.setTimeout(60000);
 
@@ -72,7 +73,11 @@ jest.mock('@backstage/plugin-auth-node', () => ({
 
 const validateRoleConditionMock = jest.fn().mockImplementation();
 jest.mock('../validation/condition-validation', () => {
+  const actual = jest.requireActual(
+    '../validation/condition-validation',
+  ) as typeof import('../validation/condition-validation');
   return {
+    ...actual,
     validateRoleCondition: jest
       .fn()
       .mockImplementation(
@@ -259,6 +264,7 @@ describe('REST policies API', () => {
       roleMetadataStorageMock,
       permissionDependentPluginStoreMock,
       extendablePluginIdProviderMock as ExtendablePluginIdProvider,
+      DEFAULT_CONDITION_VALIDATION_LIMITS,
       undefined,
     );
     const router = await server.serve();
@@ -3971,6 +3977,7 @@ describe('REST policies API', () => {
         roleMetadataStorageMock,
         permissionDependentPluginStoreMock,
         extendablePluginIdProviderMock as ExtendablePluginIdProvider,
+        DEFAULT_CONDITION_VALIDATION_LIMITS,
         [providerMock],
       );
       const router = await server.serve();

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -308,10 +308,7 @@ export class PoliciesServer {
 
         const entityRef = this.getEntityReference(request);
 
-        const policyRaw: RoleBasedPolicy[] = request.body;
-        if (isEmpty(policyRaw)) {
-          throw new InputError(`permission policy must be present`); // 400
-        }
+        const policyRaw = this.getPolicyArrayFromBody(request.body);
 
         policyRaw.forEach(element => {
           element.entityReference = entityRef;
@@ -342,24 +339,13 @@ export class PoliciesServer {
           this.options,
         );
 
-        const policyRaw: RoleBasedPolicy[] = request.body;
-
-        if (isEmpty(policyRaw)) {
-          throw new InputError(`permission policy must be present`); // 400
-        }
+        const policyRaw = this.getPolicyArrayFromBody(request.body);
 
         const processedPolicies = await this.processPolicies(
           policyRaw,
           false,
           undefined,
         );
-
-        const entityRef = processedPolicies[0][0];
-        const roleMetadata =
-          await this.roleMetadata.findRoleMetadata(entityRef);
-        if (entityRef.startsWith('role:default') && !roleMetadata) {
-          throw new Error(`Corresponding role ${entityRef} was not found`);
-        }
 
         await this.enforcer.addPolicies(processedPolicies);
 
@@ -435,12 +421,6 @@ export class PoliciesServer {
           'new policy',
           conditionsFilter,
         );
-
-        const roleMetadata =
-          await this.roleMetadata.findRoleMetadata(entityRef);
-        if (entityRef.startsWith('role:default') && !roleMetadata) {
-          throw new Error(`Corresponding role ${entityRef} was not found`);
-        }
 
         await this.enforcer.updatePolicies(
           processedOldPolicy,
@@ -1247,6 +1227,18 @@ export class PoliciesServer {
     );
   }
 
+  getPolicyArrayFromBody(body: unknown): RoleBasedPolicy[] {
+    if (!Array.isArray(body)) {
+      throw new InputError(`permission policy must be provided as an array`);
+    }
+
+    if (isEmpty(body)) {
+      throw new InputError(`permission policy must be present`);
+    }
+
+    return body as RoleBasedPolicy[];
+  }
+
   async processPolicies(
     policyArray: RoleBasedPolicy[],
     isOld?: boolean,
@@ -1269,7 +1261,15 @@ export class PoliciesServer {
         policy.entityReference!,
       );
 
-      if (!metadata || !matches(daoToMetadata(metadata), filter)) {
+      if (!metadata) {
+        if (policy.entityReference?.startsWith('role:default')) {
+          throw new NotFoundError(
+            `Corresponding role ${policy.entityReference} was not found`,
+          );
+        }
+        throw new NotAllowedError(); // 403
+      }
+      if (!matches(daoToMetadata(metadata), filter)) {
         throw new NotAllowedError(); // 403
       }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -21,6 +21,7 @@ import type {
   HttpAuthService,
   PermissionsService,
 } from '@backstage/backend-plugin-api';
+import { parseEntityRef } from '@backstage/catalog-model';
 import {
   ConflictError,
   InputError,
@@ -1272,7 +1273,8 @@ export class PoliciesServer {
       );
 
       if (!metadata) {
-        if (policy.entityReference?.startsWith('role:default')) {
+        const { kind } = parseEntityRef(policy.entityReference!);
+        if (kind === 'role') {
           throw new NotFoundError(
             `Corresponding role ${policy.entityReference} was not found`,
           );

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -65,7 +65,10 @@ import {
   processConditionMapping,
   matches,
 } from '../helper';
-import { validateRoleCondition } from '../validation/condition-validation';
+import {
+  type ConditionValidationLimits,
+  validateRoleCondition,
+} from '../validation/condition-validation';
 import {
   validateEntityReference,
   validatePolicy,
@@ -142,6 +145,7 @@ export class PoliciesServer {
     private readonly roleMetadata: RoleMetadataStorage,
     private readonly extraPluginsIdStorage: PermissionDependentPluginStore,
     private readonly pluginIdProvider: ExtendablePluginIdProvider,
+    private readonly conditionValidationLimits: ConditionValidationLimits,
     private readonly rbacProviders?: RBACProvider[],
   ) {}
 
@@ -863,7 +867,10 @@ export class PoliciesServer {
 
         const roleConditionPolicy: RoleConditionalPolicyDecision<PermissionAction> =
           request.body;
-        validateRoleCondition(roleConditionPolicy);
+        validateRoleCondition(
+          roleConditionPolicy,
+          this.conditionValidationLimits,
+        );
 
         const conditionToCreate = await processConditionMapping(
           roleConditionPolicy,
@@ -1016,7 +1023,10 @@ export class PoliciesServer {
         const roleConditionPolicy: RoleConditionalPolicyDecision<PermissionAction> =
           request.body;
 
-        validateRoleCondition(roleConditionPolicy);
+        validateRoleCondition(
+          roleConditionPolicy,
+          this.conditionValidationLimits,
+        );
 
         const conditionToUpdate = await processConditionMapping(
           roleConditionPolicy,

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
@@ -205,9 +205,12 @@ export class PolicyBuilder {
     });
 
     const isPluginEnabled = env.config.getOptionalBoolean('permission.enabled');
-    const conditionValidationLimits = resolveConditionValidationLimits(
-      readConditionValidationLimitsFromConfig(env.config),
-    );
+    // Invalid permission.rbac.validation.* must not prevent startup when RBAC is off.
+    const conditionValidationLimits = isPluginEnabled
+      ? resolveConditionValidationLimits(
+          readConditionValidationLimitsFromConfig(env.config),
+        )
+      : resolveConditionValidationLimits({});
     if (isPluginEnabled) {
       env.logger.info('RBAC backend plugin was enabled');
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
@@ -58,6 +58,10 @@ import {
   DefaultPermissionsReader,
   DefaultPermissionsSyncher,
 } from '../default-permissions/default-permissions';
+import {
+  readConditionValidationLimitsFromConfig,
+  resolveConditionValidationLimits,
+} from '../validation/condition-validation';
 
 /**
  * @public
@@ -201,6 +205,9 @@ export class PolicyBuilder {
     });
 
     const isPluginEnabled = env.config.getOptionalBoolean('permission.enabled');
+    const conditionValidationLimits = resolveConditionValidationLimits(
+      readConditionValidationLimitsFromConfig(env.config),
+    );
     if (isPluginEnabled) {
       env.logger.info('RBAC backend plugin was enabled');
 
@@ -215,6 +222,7 @@ export class PolicyBuilder {
           databaseClient,
           pluginPermMetaData,
           env.auth,
+          conditionValidationLimits,
         ),
       );
     } else {
@@ -243,6 +251,7 @@ export class PolicyBuilder {
       roleMetadataStorage,
       extraPluginsIdStorage,
       extendablePluginIdProvider,
+      conditionValidationLimits,
       rbacProviders,
     );
     return server.serve();

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
@@ -21,7 +21,11 @@ import type {
   RoleConditionalPolicyDecision,
 } from '@backstage-community/plugin-rbac-common';
 
-import { validateRoleCondition } from './condition-validation';
+import {
+  configureConditionValidationLimits,
+  DEFAULT_CONDITION_VALIDATION_LIMITS,
+  validateRoleCondition,
+} from './condition-validation';
 
 describe('condition-validation', () => {
   describe('validation common fields', () => {
@@ -1053,6 +1057,45 @@ describe('condition-validation', () => {
       expect(() => validateRoleCondition(condition)).toThrow(
         `roleCondition.conditions.anyOf criteria supports at most 64 items`,
       );
+    });
+
+    it('should apply configured validation limits', () => {
+      configureConditionValidationLimits({
+        ...DEFAULT_CONDITION_VALIDATION_LIMITS,
+        maxPermissionMappingItems: 2,
+      });
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read', 'update', 'delete'],
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          resourceType: 'catalog-entity',
+          params: { claims: ['group:default/team-a'] },
+        },
+      };
+
+      expect(() => validateRoleCondition(condition)).toThrow(InputError);
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' can have at most 2 items`,
+      );
+
+      configureConditionValidationLimits(DEFAULT_CONDITION_VALIDATION_LIMITS);
+    });
+
+    it('should fail when configured validation limits are invalid', () => {
+      expect(() =>
+        configureConditionValidationLimits({ maxConditionDepth: 0 }),
+      ).toThrow(InputError);
+      expect(() =>
+        configureConditionValidationLimits({ maxConditionDepth: 0 }),
+      ).toThrow(
+        `'maxConditionDepth' must be a positive integer for conditional policy validation`,
+      );
+
+      configureConditionValidationLimits(DEFAULT_CONDITION_VALIDATION_LIMITS);
     });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { InputError } from '@backstage/errors';
 
 import type {
   PermissionAction,
@@ -983,6 +984,75 @@ describe('condition-validation', () => {
         unexpectedErr = err;
       }
       expect(unexpectedErr).toBeUndefined();
+    });
+  });
+
+  describe('validation limits', () => {
+    it('should fail when permission mapping exceeds max items', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: Array.from({ length: 65 }, () => 'read'),
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          resourceType: 'catalog-entity',
+          params: { claims: ['group:default/team-a'] },
+        },
+      };
+
+      expect(() => validateRoleCondition(condition)).toThrow(InputError);
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' can have at most 64 items`,
+      );
+    });
+
+    it('should fail when criteria depth exceeds max value', () => {
+      let nestedCondition: any = {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: { claims: ['group:default/team-a'] },
+      };
+      for (let i = 0; i < 13; i++) {
+        nestedCondition = { not: nestedCondition };
+      }
+
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
+        conditions: nestedCondition,
+      };
+
+      expect(() => validateRoleCondition(condition)).toThrow(InputError);
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `Conditional criteria depth exceeds maximum of 12`,
+      );
+    });
+
+    it('should fail when criteria array has too many items', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['read'],
+        conditions: {
+          anyOf: Array.from({ length: 65 }, () => ({
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: { claims: ['group:default/team-a'] },
+          })),
+        },
+      };
+
+      expect(() => validateRoleCondition(condition)).toThrow(InputError);
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `roleCondition.conditions.anyOf criteria supports at most 64 items`,
+      );
     });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
@@ -992,13 +992,13 @@ describe('condition-validation', () => {
   });
 
   describe('validation limits', () => {
-    it('should fail when permission mapping exceeds max items', () => {
+    it('should fail when permission mapping has duplicate actions', () => {
       const condition: any = {
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
-        permissionMapping: Array.from({ length: 65 }, () => 'read'),
+        permissionMapping: ['read', 'read'],
         conditions: {
           rule: 'IS_ENTITY_OWNER',
           resourceType: 'catalog-entity',
@@ -1008,8 +1008,45 @@ describe('condition-validation', () => {
 
       expect(() => validateRoleCondition(condition)).toThrow(InputError);
       expect(() => validateRoleCondition(condition)).toThrow(
-        `'permissionMapping' can have at most 64 items`,
+        `'permissionMapping' must not contain duplicate permission action 'read'`,
       );
+    });
+
+    it('should fail when permission mapping exceeds distinct action count', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: Array.from({ length: 6 }, () => 'read'),
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          resourceType: 'catalog-entity',
+          params: { claims: ['group:default/team-a'] },
+        },
+      };
+
+      expect(() => validateRoleCondition(condition)).toThrow(InputError);
+      expect(() => validateRoleCondition(condition)).toThrow(
+        `'permissionMapping' can have at most 5 items (one entry per distinct permission action)`,
+      );
+    });
+
+    it('should accept permission mapping with all distinct supported actions', () => {
+      const condition: any = {
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        roleEntityRef: 'role:default/test',
+        result: AuthorizeResult.CONDITIONAL,
+        permissionMapping: ['create', 'read', 'update', 'delete', 'use'],
+        conditions: {
+          rule: 'IS_ENTITY_OWNER',
+          resourceType: 'catalog-entity',
+          params: { claims: ['group:default/team-a'] },
+        },
+      };
+
+      expect(() => validateRoleCondition(condition)).not.toThrow();
     });
 
     it('should fail when criteria depth exceeds max value', () => {
@@ -1059,27 +1096,41 @@ describe('condition-validation', () => {
       );
     });
 
-    it('should apply configured validation limits', () => {
+    it('should apply configured validation limits for criteria', () => {
       configureConditionValidationLimits({
         ...DEFAULT_CONDITION_VALIDATION_LIMITS,
-        maxPermissionMappingItems: 2,
+        maxCriteriaItems: 2,
       });
       const condition: any = {
         pluginId: 'catalog',
         resourceType: 'catalog-entity',
         roleEntityRef: 'role:default/test',
         result: AuthorizeResult.CONDITIONAL,
-        permissionMapping: ['read', 'update', 'delete'],
+        permissionMapping: ['read'],
         conditions: {
-          rule: 'IS_ENTITY_OWNER',
-          resourceType: 'catalog-entity',
-          params: { claims: ['group:default/team-a'] },
+          anyOf: [
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: { claims: ['group:default/team-a'] },
+            },
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: { claims: ['group:default/team-b'] },
+            },
+            {
+              rule: 'IS_ENTITY_OWNER',
+              resourceType: 'catalog-entity',
+              params: { claims: ['group:default/team-c'] },
+            },
+          ],
         },
       };
 
       expect(() => validateRoleCondition(condition)).toThrow(InputError);
       expect(() => validateRoleCondition(condition)).toThrow(
-        `'permissionMapping' can have at most 2 items`,
+        `roleCondition.conditions.anyOf criteria supports at most 2 items`,
       );
 
       configureConditionValidationLimits(DEFAULT_CONDITION_VALIDATION_LIMITS);

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.test.ts
@@ -22,8 +22,8 @@ import type {
 } from '@backstage-community/plugin-rbac-common';
 
 import {
-  configureConditionValidationLimits,
   DEFAULT_CONDITION_VALIDATION_LIMITS,
+  resolveConditionValidationLimits,
   validateRoleCondition,
 } from './condition-validation';
 
@@ -1097,7 +1097,7 @@ describe('condition-validation', () => {
     });
 
     it('should apply configured validation limits for criteria', () => {
-      configureConditionValidationLimits({
+      const limits = resolveConditionValidationLimits({
         ...DEFAULT_CONDITION_VALIDATION_LIMITS,
         maxCriteriaItems: 2,
       });
@@ -1128,25 +1128,23 @@ describe('condition-validation', () => {
         },
       };
 
-      expect(() => validateRoleCondition(condition)).toThrow(InputError);
-      expect(() => validateRoleCondition(condition)).toThrow(
+      expect(() => validateRoleCondition(condition, limits)).toThrow(
+        InputError,
+      );
+      expect(() => validateRoleCondition(condition, limits)).toThrow(
         `roleCondition.conditions.anyOf criteria supports at most 2 items`,
       );
-
-      configureConditionValidationLimits(DEFAULT_CONDITION_VALIDATION_LIMITS);
     });
 
     it('should fail when configured validation limits are invalid', () => {
       expect(() =>
-        configureConditionValidationLimits({ maxConditionDepth: 0 }),
+        resolveConditionValidationLimits({ maxConditionDepth: 0 }),
       ).toThrow(InputError);
       expect(() =>
-        configureConditionValidationLimits({ maxConditionDepth: 0 }),
+        resolveConditionValidationLimits({ maxConditionDepth: 0 }),
       ).toThrow(
         `'maxConditionDepth' must be a positive integer for conditional policy validation`,
       );
-
-      configureConditionValidationLimits(DEFAULT_CONDITION_VALIDATION_LIMITS);
     });
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
@@ -27,14 +27,62 @@ import type {
 
 import { isPermissionAction } from '../helper';
 
-const MAX_PERMISSION_MAPPING_ITEMS = 64;
-const MAX_CONDITION_DEPTH = 12;
-const MAX_CONDITION_NODE_COUNT = 256;
-const MAX_CRITERIA_ITEMS = 64;
+export type ConditionValidationLimits = {
+  maxPermissionMappingItems: number;
+  maxConditionDepth: number;
+  maxConditionNodeCount: number;
+  maxCriteriaItems: number;
+};
+
+export const DEFAULT_CONDITION_VALIDATION_LIMITS: ConditionValidationLimits = {
+  maxPermissionMappingItems: 64,
+  maxConditionDepth: 12,
+  maxConditionNodeCount: 256,
+  maxCriteriaItems: 64,
+};
+
+let conditionValidationLimits: ConditionValidationLimits = {
+  ...DEFAULT_CONDITION_VALIDATION_LIMITS,
+};
+
+export function configureConditionValidationLimits(
+  limits: Partial<ConditionValidationLimits>,
+): void {
+  const nextLimits = {
+    ...conditionValidationLimits,
+    ...limits,
+  };
+
+  assertPositiveInteger(
+    nextLimits.maxPermissionMappingItems,
+    'maxPermissionMappingItems',
+  );
+  assertPositiveInteger(nextLimits.maxConditionDepth, 'maxConditionDepth');
+  assertPositiveInteger(
+    nextLimits.maxConditionNodeCount,
+    'maxConditionNodeCount',
+  );
+  assertPositiveInteger(nextLimits.maxCriteriaItems, 'maxCriteriaItems');
+
+  conditionValidationLimits = nextLimits;
+}
+
+function getConditionValidationLimits(): ConditionValidationLimits {
+  return conditionValidationLimits;
+}
+
+function assertPositiveInteger(value: number, fieldName: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new InputError(
+      `'${fieldName}' must be a positive integer for conditional policy validation`,
+    );
+  }
+}
 
 export function validateRoleCondition(
   condition: RoleConditionalPolicyDecision<PermissionAction>,
 ) {
+  const limits = getConditionValidationLimits();
   if (!condition.roleEntityRef) {
     throw new InputError(
       `'roleEntityRef' must be specified in the role condition`,
@@ -60,9 +108,9 @@ export function validateRoleCondition(
       `'permissionMapping' must be non empty array in the role condition`,
     );
   }
-  if (condition.permissionMapping.length > MAX_PERMISSION_MAPPING_ITEMS) {
+  if (condition.permissionMapping.length > limits.maxPermissionMappingItems) {
     throw new InputError(
-      `'permissionMapping' can have at most ${MAX_PERMISSION_MAPPING_ITEMS} items`,
+      `'permissionMapping' can have at most ${limits.maxPermissionMappingItems} items`,
     );
   }
   const nonActionValue = condition.permissionMapping.find(
@@ -94,6 +142,7 @@ export function validateRoleCondition(
       'roleCondition.conditions',
       1,
       { nodeCount: 0 },
+      limits,
     );
   }
 }
@@ -111,16 +160,17 @@ function validatePermissionCondition(
   jsonPathLocator: string,
   currentDepth: number,
   state: { nodeCount: number },
+  limits: ConditionValidationLimits,
 ) {
-  if (currentDepth > MAX_CONDITION_DEPTH) {
+  if (currentDepth > limits.maxConditionDepth) {
     throw new InputError(
-      `Conditional criteria depth exceeds maximum of ${MAX_CONDITION_DEPTH}`,
+      `Conditional criteria depth exceeds maximum of ${limits.maxConditionDepth}`,
     );
   }
   state.nodeCount += 1;
-  if (state.nodeCount > MAX_CONDITION_NODE_COUNT) {
+  if (state.nodeCount > limits.maxConditionNodeCount) {
     throw new InputError(
-      `Conditional criteria exceeds maximum of ${MAX_CONDITION_NODE_COUNT} nodes`,
+      `Conditional criteria exceeds maximum of ${limits.maxConditionNodeCount} nodes`,
     );
   }
 
@@ -132,6 +182,7 @@ function validatePermissionCondition(
       `${jsonPathLocator}.not`,
       currentDepth + 1,
       state,
+      limits,
     );
     return;
   }
@@ -145,9 +196,9 @@ function validatePermissionCondition(
         `${jsonPathLocator}.allOf criteria must be non empty array`,
       );
     }
-    if (conditionOrCriteria.allOf.length > MAX_CRITERIA_ITEMS) {
+    if (conditionOrCriteria.allOf.length > limits.maxCriteriaItems) {
       throw new InputError(
-        `${jsonPathLocator}.allOf criteria supports at most ${MAX_CRITERIA_ITEMS} items`,
+        `${jsonPathLocator}.allOf criteria supports at most ${limits.maxCriteriaItems} items`,
       );
     }
     for (const [index, elem] of conditionOrCriteria.allOf.entries()) {
@@ -156,6 +207,7 @@ function validatePermissionCondition(
         `${jsonPathLocator}.allOf[${index}]`,
         currentDepth + 1,
         state,
+        limits,
       );
     }
     return;
@@ -170,9 +222,9 @@ function validatePermissionCondition(
         `${jsonPathLocator}.anyOf criteria must be non empty array`,
       );
     }
-    if (conditionOrCriteria.anyOf.length > MAX_CRITERIA_ITEMS) {
+    if (conditionOrCriteria.anyOf.length > limits.maxCriteriaItems) {
       throw new InputError(
-        `${jsonPathLocator}.anyOf criteria supports at most ${MAX_CRITERIA_ITEMS} items`,
+        `${jsonPathLocator}.anyOf criteria supports at most ${limits.maxCriteriaItems} items`,
       );
     }
     for (const [index, elem] of conditionOrCriteria.anyOf.entries()) {
@@ -181,6 +233,7 @@ function validatePermissionCondition(
         `${jsonPathLocator}.anyOf[${index}]`,
         currentDepth + 1,
         state,
+        limits,
       );
     }
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
@@ -20,22 +20,21 @@ import {
 } from '@backstage/plugin-permission-common';
 import { InputError } from '@backstage/errors';
 
-import type {
-  PermissionAction,
-  RoleConditionalPolicyDecision,
+import {
+  PermissionActionValues,
+  type PermissionAction,
+  type RoleConditionalPolicyDecision,
 } from '@backstage-community/plugin-rbac-common';
 
 import { isPermissionAction } from '../helper';
 
 export type ConditionValidationLimits = {
-  maxPermissionMappingItems: number;
   maxConditionDepth: number;
   maxConditionNodeCount: number;
   maxCriteriaItems: number;
 };
 
 export const DEFAULT_CONDITION_VALIDATION_LIMITS: ConditionValidationLimits = {
-  maxPermissionMappingItems: 64,
   maxConditionDepth: 12,
   maxConditionNodeCount: 256,
   maxCriteriaItems: 64,
@@ -53,10 +52,6 @@ export function configureConditionValidationLimits(
     ...limits,
   };
 
-  assertPositiveInteger(
-    nextLimits.maxPermissionMappingItems,
-    'maxPermissionMappingItems',
-  );
   assertPositiveInteger(nextLimits.maxConditionDepth, 'maxConditionDepth');
   assertPositiveInteger(
     nextLimits.maxConditionNodeCount,
@@ -108,9 +103,10 @@ export function validateRoleCondition(
       `'permissionMapping' must be non empty array in the role condition`,
     );
   }
-  if (condition.permissionMapping.length > limits.maxPermissionMappingItems) {
+  const maxDistinctPermissionActions = PermissionActionValues.length;
+  if (condition.permissionMapping.length > maxDistinctPermissionActions) {
     throw new InputError(
-      `'permissionMapping' can have at most ${limits.maxPermissionMappingItems} items`,
+      `'permissionMapping' can have at most ${maxDistinctPermissionActions} items (one entry per distinct permission action)`,
     );
   }
   const nonActionValue = condition.permissionMapping.find(
@@ -120,6 +116,16 @@ export function validateRoleCondition(
     throw new InputError(
       `'permissionMapping' array contains non action value: '${nonActionValue}'`,
     );
+  }
+
+  const seenActions = new Set<PermissionAction>();
+  for (const action of condition.permissionMapping) {
+    if (seenActions.has(action)) {
+      throw new InputError(
+        `'permissionMapping' must not contain duplicate permission action '${action}'`,
+      );
+    }
+    seenActions.add(action);
   }
 
   if (

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
@@ -18,6 +18,7 @@ import {
   PermissionCriteria,
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
+import { InputError } from '@backstage/errors';
 
 import type {
   PermissionAction,
@@ -26,35 +27,49 @@ import type {
 
 import { isPermissionAction } from '../helper';
 
+const MAX_PERMISSION_MAPPING_ITEMS = 64;
+const MAX_CONDITION_DEPTH = 12;
+const MAX_CONDITION_NODE_COUNT = 256;
+const MAX_CRITERIA_ITEMS = 64;
+
 export function validateRoleCondition(
   condition: RoleConditionalPolicyDecision<PermissionAction>,
 ) {
   if (!condition.roleEntityRef) {
-    throw new Error(`'roleEntityRef' must be specified in the role condition`);
+    throw new InputError(
+      `'roleEntityRef' must be specified in the role condition`,
+    );
   }
   if (!condition.result) {
-    throw new Error(`'result' must be specified in the role condition`);
+    throw new InputError(`'result' must be specified in the role condition`);
   }
   if (!condition.pluginId) {
-    throw new Error(`'pluginId' must be specified in the role condition`);
+    throw new InputError(`'pluginId' must be specified in the role condition`);
   }
   if (!condition.resourceType) {
-    throw new Error(`'resourceType' must be specified in the role condition`);
+    throw new InputError(
+      `'resourceType' must be specified in the role condition`,
+    );
   }
 
   if (
     !condition.permissionMapping ||
     condition.permissionMapping.length === 0
   ) {
-    throw new Error(
+    throw new InputError(
       `'permissionMapping' must be non empty array in the role condition`,
+    );
+  }
+  if (condition.permissionMapping.length > MAX_PERMISSION_MAPPING_ITEMS) {
+    throw new InputError(
+      `'permissionMapping' can have at most ${MAX_PERMISSION_MAPPING_ITEMS} items`,
     );
   }
   const nonActionValue = condition.permissionMapping.find(
     action => !isPermissionAction(action),
   );
   if (nonActionValue) {
-    throw new Error(
+    throw new InputError(
       `'permissionMapping' array contains non action value: '${nonActionValue}'`,
     );
   }
@@ -63,18 +78,22 @@ export function validateRoleCondition(
     condition.resourceType === 'policy-entity' &&
     condition.permissionMapping.includes('create')
   ) {
-    throw new Error(
+    throw new InputError(
       `Conditional policy can not be created for resource type 'policy-entity' with the permission action 'create'`,
     );
   }
 
   if (!condition.conditions) {
-    throw new Error(`'conditions' must be specified in the role condition`);
+    throw new InputError(
+      `'conditions' must be specified in the role condition`,
+    );
   }
   if (condition.conditions) {
     validatePermissionCondition(
       condition.conditions,
       'roleCondition.conditions',
+      1,
+      { nodeCount: 0 },
     );
   }
 }
@@ -90,13 +109,29 @@ function validatePermissionCondition(
     PermissionCondition<string, PermissionRuleParams>
   >,
   jsonPathLocator: string,
+  currentDepth: number,
+  state: { nodeCount: number },
 ) {
+  if (currentDepth > MAX_CONDITION_DEPTH) {
+    throw new InputError(
+      `Conditional criteria depth exceeds maximum of ${MAX_CONDITION_DEPTH}`,
+    );
+  }
+  state.nodeCount += 1;
+  if (state.nodeCount > MAX_CONDITION_NODE_COUNT) {
+    throw new InputError(
+      `Conditional criteria exceeds maximum of ${MAX_CONDITION_NODE_COUNT} nodes`,
+    );
+  }
+
   validateCriteria(conditionOrCriteria, jsonPathLocator);
 
   if ('not' in conditionOrCriteria) {
     validatePermissionCondition(
       conditionOrCriteria.not,
       `${jsonPathLocator}.not`,
+      currentDepth + 1,
+      state,
     );
     return;
   }
@@ -106,12 +141,22 @@ function validatePermissionCondition(
       !Array.isArray(conditionOrCriteria.allOf) ||
       conditionOrCriteria.allOf.length === 0
     ) {
-      throw new Error(
+      throw new InputError(
         `${jsonPathLocator}.allOf criteria must be non empty array`,
       );
     }
+    if (conditionOrCriteria.allOf.length > MAX_CRITERIA_ITEMS) {
+      throw new InputError(
+        `${jsonPathLocator}.allOf criteria supports at most ${MAX_CRITERIA_ITEMS} items`,
+      );
+    }
     for (const [index, elem] of conditionOrCriteria.allOf.entries()) {
-      validatePermissionCondition(elem, `${jsonPathLocator}.allOf[${index}]`);
+      validatePermissionCondition(
+        elem,
+        `${jsonPathLocator}.allOf[${index}]`,
+        currentDepth + 1,
+        state,
+      );
     }
     return;
   }
@@ -121,12 +166,22 @@ function validatePermissionCondition(
       !Array.isArray(conditionOrCriteria.anyOf) ||
       conditionOrCriteria.anyOf.length === 0
     ) {
-      throw new Error(
+      throw new InputError(
         `${jsonPathLocator}.anyOf criteria must be non empty array`,
       );
     }
+    if (conditionOrCriteria.anyOf.length > MAX_CRITERIA_ITEMS) {
+      throw new InputError(
+        `${jsonPathLocator}.anyOf criteria supports at most ${MAX_CRITERIA_ITEMS} items`,
+      );
+    }
     for (const [index, elem] of conditionOrCriteria.anyOf.entries()) {
-      validatePermissionCondition(elem, `${jsonPathLocator}.anyOf[${index}]`);
+      validatePermissionCondition(
+        elem,
+        `${jsonPathLocator}.anyOf[${index}]`,
+        currentDepth + 1,
+        state,
+      );
     }
   }
 }
@@ -143,12 +198,12 @@ function validateRule(
   jsonPathLocator: string,
 ) {
   if (!('resourceType' in conditionOrCriteria)) {
-    throw new Error(
+    throw new InputError(
       `'resourceType' must be specified in the ${jsonPathLocator}.condition`,
     );
   }
   if (!('rule' in conditionOrCriteria)) {
-    throw new Error(
+    throw new InputError(
       `'rule' must be specified in the ${jsonPathLocator}.condition`,
     );
   }
@@ -181,7 +236,7 @@ function validateCriteria(
   }
 
   if (found.length > 1) {
-    throw new Error(
+    throw new InputError(
       `RBAC plugin does not support parallel conditions, consider reworking request to include nested condition criteria. Conditional criteria causing the error ${found}.`,
     );
   } else if (found.length === 0) {
@@ -189,7 +244,7 @@ function validateCriteria(
   }
 
   if (found.length === 1 && 'rule' in conditionOrCriteria) {
-    throw new Error(
+    throw new InputError(
       `RBAC plugin does not support parallel conditions alongside rules, consider reworking request to include nested condition criteria. Conditional criteria causing the error ${found}, 'rule: ${conditionOrCriteria.rule}'.`,
     );
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/condition-validation.ts
@@ -40,16 +40,36 @@ export const DEFAULT_CONDITION_VALIDATION_LIMITS: ConditionValidationLimits = {
   maxCriteriaItems: 64,
 };
 
-let conditionValidationLimits: ConditionValidationLimits = {
-  ...DEFAULT_CONDITION_VALIDATION_LIMITS,
+/** Minimal config surface for reading optional validation limits. */
+export type ConditionValidationLimitsConfig = {
+  getOptionalNumber(key: string): number | undefined;
 };
 
-export function configureConditionValidationLimits(
-  limits: Partial<ConditionValidationLimits>,
-): void {
-  const nextLimits = {
-    ...conditionValidationLimits,
-    ...limits,
+export function readConditionValidationLimitsFromConfig(
+  config: ConditionValidationLimitsConfig,
+): Partial<ConditionValidationLimits> {
+  const baseKey = 'permission.rbac.validation.conditionalPolicies';
+  const limitKeys: (keyof ConditionValidationLimits)[] = [
+    'maxConditionDepth',
+    'maxConditionNodeCount',
+    'maxCriteriaItems',
+  ];
+  const limits: Partial<ConditionValidationLimits> = {};
+  for (const key of limitKeys) {
+    const value = config.getOptionalNumber(`${baseKey}.${key}`);
+    if (value !== undefined) {
+      limits[key] = value;
+    }
+  }
+  return limits;
+}
+
+export function resolveConditionValidationLimits(
+  partial: Partial<ConditionValidationLimits> = {},
+): ConditionValidationLimits {
+  const nextLimits: ConditionValidationLimits = {
+    ...DEFAULT_CONDITION_VALIDATION_LIMITS,
+    ...partial,
   };
 
   assertPositiveInteger(nextLimits.maxConditionDepth, 'maxConditionDepth');
@@ -59,11 +79,7 @@ export function configureConditionValidationLimits(
   );
   assertPositiveInteger(nextLimits.maxCriteriaItems, 'maxCriteriaItems');
 
-  conditionValidationLimits = nextLimits;
-}
-
-function getConditionValidationLimits(): ConditionValidationLimits {
-  return conditionValidationLimits;
+  return nextLimits;
 }
 
 function assertPositiveInteger(value: number, fieldName: string): void {
@@ -76,8 +92,9 @@ function assertPositiveInteger(value: number, fieldName: string): void {
 
 export function validateRoleCondition(
   condition: RoleConditionalPolicyDecision<PermissionAction>,
-) {
-  const limits = getConditionValidationLimits();
+  limits?: Partial<ConditionValidationLimits>,
+): void {
+  const resolvedLimits = resolveConditionValidationLimits(limits ?? {});
   if (!condition.roleEntityRef) {
     throw new InputError(
       `'roleEntityRef' must be specified in the role condition`,
@@ -148,7 +165,7 @@ export function validateRoleCondition(
       'roleCondition.conditions',
       1,
       { nodeCount: 0 },
-      limits,
+      resolvedLimits,
     );
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.test.ts
@@ -41,4 +41,31 @@ describe('validatePermissionDependentPlugin', () => {
       validatePermissionDependentPlugin({ ids: ['plugin-a', 123] } as any),
     ).toThrow(`'ids' must be an array of string plugin ID values`);
   });
+
+  it('throws if ids is an empty array', () => {
+    expect(() => validatePermissionDependentPlugin({ ids: [] })).toThrow(
+      `'ids' must contain at least one plugin ID`,
+    );
+  });
+
+  it('throws if ids contains duplicates', () => {
+    expect(() =>
+      validatePermissionDependentPlugin({ ids: ['plugin-a', 'plugin-a'] }),
+    ).toThrow(`'ids' contains duplicate plugin ID 'plugin-a'`);
+  });
+
+  it('allows plugin ids with varied characters and casing', () => {
+    expect(() =>
+      validatePermissionDependentPlugin({
+        ids: ['Catalog.API', 'catalog/api', 'catalog plugin'],
+      }),
+    ).not.toThrow();
+  });
+
+  it('throws if an id is too long', () => {
+    const longId = 'a'.repeat(65);
+    expect(() => validatePermissionDependentPlugin({ ids: [longId] })).toThrow(
+      `plugin ID '${longId}' must be between 1 and 64 characters`,
+    );
+  });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.test.ts
@@ -30,6 +30,27 @@ describe('validatePermissionDependentPlugin', () => {
     );
   });
 
+  it('throws if plugin body is undefined', () => {
+    expect(() => validatePermissionDependentPlugin(undefined)).toThrow(
+      `'ids' must be specified in the permission dependent plugin`,
+    );
+  });
+
+  it('throws if plugin body is null', () => {
+    expect(() => validatePermissionDependentPlugin(null)).toThrow(
+      `'ids' must be specified in the permission dependent plugin`,
+    );
+  });
+
+  it('throws if plugin body is not an object', () => {
+    expect(() => validatePermissionDependentPlugin('not-json')).toThrow(
+      `'ids' must be specified in the permission dependent plugin`,
+    );
+    expect(() => validatePermissionDependentPlugin(42)).toThrow(
+      `'ids' must be specified in the permission dependent plugin`,
+    );
+  });
+
   it('throws if ids is not an array', () => {
     expect(() =>
       validatePermissionDependentPlugin({ ids: 'plugin-a' } as any),

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 import { PermissionDependentPluginList } from '@backstage-community/plugin-rbac-common';
+import { InputError } from '@backstage/errors';
+
+const MAX_PLUGIN_IDS = 100;
+const MAX_PLUGIN_ID_LENGTH = 64;
 
 export function validatePermissionDependentPlugin(
   plugin: PermissionDependentPluginList,
 ) {
   if (!plugin.ids) {
-    throw new Error(
+    throw new InputError(
       `'ids' must be specified in the permission dependent plugin`,
     );
   }
@@ -27,6 +31,27 @@ export function validatePermissionDependentPlugin(
     !Array.isArray(plugin.ids) ||
     !plugin.ids.every(id => typeof id === 'string')
   ) {
-    throw new Error(`'ids' must be an array of string plugin ID values`);
+    throw new InputError(`'ids' must be an array of string plugin ID values`);
+  }
+  if (plugin.ids.length === 0) {
+    throw new InputError(`'ids' must contain at least one plugin ID`);
+  }
+  if (plugin.ids.length > MAX_PLUGIN_IDS) {
+    throw new InputError(
+      `'ids' can include at most ${MAX_PLUGIN_IDS} plugin IDs`,
+    );
+  }
+
+  const uniqueIds = new Set<string>();
+  for (const id of plugin.ids) {
+    if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
+      throw new InputError(
+        `plugin ID '${id}' must be between 1 and ${MAX_PLUGIN_ID_LENGTH} characters`,
+      );
+    }
+    if (uniqueIds.has(id)) {
+      throw new InputError(`'ids' contains duplicate plugin ID '${id}'`);
+    }
+    uniqueIds.add(id);
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/plugin-validation.ts
@@ -19,31 +19,37 @@ import { InputError } from '@backstage/errors';
 const MAX_PLUGIN_IDS = 100;
 const MAX_PLUGIN_ID_LENGTH = 64;
 
-export function validatePermissionDependentPlugin(
-  plugin: PermissionDependentPluginList,
-) {
-  if (!plugin.ids) {
+export function validatePermissionDependentPlugin(plugin: unknown): void {
+  if (!plugin || typeof plugin !== 'object') {
+    throw new InputError(
+      `'ids' must be specified in the permission dependent plugin`,
+    );
+  }
+
+  const list = plugin as PermissionDependentPluginList;
+
+  if (!list.ids) {
     throw new InputError(
       `'ids' must be specified in the permission dependent plugin`,
     );
   }
   if (
-    !Array.isArray(plugin.ids) ||
-    !plugin.ids.every(id => typeof id === 'string')
+    !Array.isArray(list.ids) ||
+    !list.ids.every(id => typeof id === 'string')
   ) {
     throw new InputError(`'ids' must be an array of string plugin ID values`);
   }
-  if (plugin.ids.length === 0) {
+  if (list.ids.length === 0) {
     throw new InputError(`'ids' must contain at least one plugin ID`);
   }
-  if (plugin.ids.length > MAX_PLUGIN_IDS) {
+  if (list.ids.length > MAX_PLUGIN_IDS) {
     throw new InputError(
       `'ids' can include at most ${MAX_PLUGIN_IDS} plugin IDs`,
     );
   }
 
   const uniqueIds = new Set<string>();
-  for (const id of plugin.ids) {
+  for (const id of list.ids) {
     if (id.length === 0 || id.length > MAX_PLUGIN_ID_LENGTH) {
       throw new InputError(
         `plugin ID '${id}' must be between 1 and ${MAX_PLUGIN_ID_LENGTH} characters`,

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.test.ts
@@ -47,6 +47,18 @@ describe('rest data validation', () => {
       expect(err?.message).toEqual(`'permission' field must not be empty`);
     });
 
+    it('should return an error when permission has embedded double quotes', () => {
+      const policy: RoleBasedPolicy = {
+        entityReference: 'role:default/dev',
+        permission: 'catalog-entity"fuzz',
+        policy: 'read',
+        effect: 'allow',
+      };
+      const err = validatePolicy(policy);
+      expect(err).toBeTruthy();
+      expect(err?.message).toContain(`'permission' contains double quotes (")`);
+    });
+
     it('should return an error when policy is empty', () => {
       const policy: RoleBasedPolicy = {
         entityReference: 'user:default/guest',

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.test.ts
@@ -17,6 +17,7 @@ import type {
   RoleBasedPolicy,
   Source,
 } from '@backstage-community/plugin-rbac-common';
+import { InputError } from '@backstage/errors';
 
 import { RoleMetadataDao } from '../database/role-metadata';
 import {
@@ -55,7 +56,7 @@ describe('rest data validation', () => {
         effect: 'allow',
       };
       const err = validatePolicy(policy);
-      expect(err).toBeTruthy();
+      expect(err).toBeInstanceOf(InputError);
       expect(err?.message).toContain(`'permission' contains double quotes (")`);
     });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { CompoundEntityRef, parseEntityRef } from '@backstage/catalog-model';
-import { NotAllowedError } from '@backstage/errors';
+import { InputError, NotAllowedError } from '@backstage/errors';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 import { Enforcer } from 'casbin';
@@ -79,7 +79,7 @@ export function validatePolicy(policy: RoleBasedPolicy): Error | undefined {
   }
 
   if (permissionContainsUnescapedQuote(policy.permission)) {
-    return new Error(
+    return new InputError(
       `'permission' contains double quotes (") which are not supported by the RBAC policy persistence format.`,
     );
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
@@ -30,6 +30,14 @@ import {
 import { RoleMetadataDao } from '../database/role-metadata';
 
 /**
+ * TypeORM adapter wraps every value in quotes before passing it to Casbin CSV
+ * parser. Unescaped embedded quotes break parsing in that path.
+ */
+function permissionContainsUnescapedQuote(permission: string): boolean {
+  return permission.includes('"');
+}
+
+/**
  * validateSource validates the source to the role that is being modified. This includes comparing the source from the
  * originating role to the source that the modification is coming from.
  * We do this to ensure consistency between permissions and roles and where they are originally defined.
@@ -68,6 +76,12 @@ export function validatePolicy(policy: RoleBasedPolicy): Error | undefined {
 
   if (!policy.permission) {
     return new Error(`'permission' field must not be empty`);
+  }
+
+  if (permissionContainsUnescapedQuote(policy.permission)) {
+    return new Error(
+      `'permission' contains double quotes (") which are not supported by the RBAC policy persistence format.`,
+    );
   }
 
   if (!policy.policy) {

--- a/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/validation/policies-validation.ts
@@ -30,10 +30,11 @@ import {
 import { RoleMetadataDao } from '../database/role-metadata';
 
 /**
- * TypeORM adapter wraps every value in quotes before passing it to Casbin CSV
- * parser. Unescaped embedded quotes break parsing in that path.
+ * Returns whether `permission` contains any double-quote character (`"`).
+ * The RBAC persistence path does not support `"` in this field; any occurrence is
+ * rejected (there is no separate handling for escaped quotes).
  */
-function permissionContainsUnescapedQuote(permission: string): boolean {
+function permissionContainsDoubleQuote(permission: string): boolean {
   return permission.includes('"');
 }
 
@@ -78,7 +79,7 @@ export function validatePolicy(policy: RoleBasedPolicy): Error | undefined {
     return new Error(`'permission' field must not be empty`);
   }
 
-  if (permissionContainsUnescapedQuote(policy.permission)) {
+  if (permissionContainsDoubleQuote(policy.permission)) {
     return new InputError(
       `'permission' contains double quotes (") which are not supported by the RBAC policy persistence format.`,
     );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR hardens RBAC policy ingestion and write paths to prevent Casbin CSV poisoning and reduce confusing failure modes. It rejects unsafe permission values before persistence, rethrows loadPolicy() failures so root causes surface correctly, strengthens API validation/error typing (400/404 vs generic 500), and adds bounded limits for conditional payloads, plugin-id registration payloads, and YAML conditional file ingestion (with config-based tuning).

It also improves resilience for CSV file-based policy loading by skipping malformed lines with warnings instead of aborting the full load, and updates docs/config schema/changelog to describe new validation behavior and compatibility implications.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
