### PR TITLE
Version Packages (pingidentity)

### DIFF
--- a/workspaces/pingidentity/.changeset/light-seas-sit.md
+++ b/workspaces/pingidentity/.changeset/light-seas-sit.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-auth-backend-module-pingfederate-provider': minor
-'@backstage-community/plugin-catalog-backend-module-pingidentity': minor
----
-
-Added a new PingFederate auth provider.

--- a/workspaces/pingidentity/.changeset/shaggy-timers-buy.md
+++ b/workspaces/pingidentity/.changeset/shaggy-timers-buy.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-auth-backend-module-pingfederate-provider': patch
-'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
----
-
-Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.

--- a/workspaces/pingidentity/.changeset/version-bump-1-51-0.md
+++ b/workspaces/pingidentity/.changeset/version-bump-1-51-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-auth-backend-module-pingfederate-provider': minor
-'@backstage-community/plugin-catalog-backend-module-pingidentity': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @backstage-community/plugin-auth-backend-module-pingfederate-provider
+
+## 0.1.0
+
+### Minor Changes
+
+- 1ae0fc8: Added a new PingFederate auth provider.
+- 881caae: Backstage version bump to v1.51.0
+
+### Patch Changes
+
+- a3f35d7: Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-auth-backend-module-pingfederate-provider",
   "description": "The PingFederate provider backend module for the auth plugin.",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-catalog-backend-module-pingidentity
 
+## 0.12.0
+
+### Minor Changes
+
+- 1ae0fc8: Added a new PingFederate auth provider.
+- 881caae: Backstage version bump to v1.51.0
+
+### Patch Changes
+
+- a3f35d7: Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.
+
 ## 0.11.1
 
 ### Patch Changes

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-pingidentity",
   "description": "The PingOne backend module for the catalog plugin. Ingests organization data (users and groups) from Ping Identity's cloud offering.",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-auth-backend-module-pingfederate-provider@0.1.0

### Minor Changes

-   1ae0fc8: Added a new PingFederate auth provider.
-   881caae: Backstage version bump to v1.51.0

### Patch Changes

-   a3f35d7: Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.

## @backstage-community/plugin-catalog-backend-module-pingidentity@0.12.0

### Minor Changes

-   1ae0fc8: Added a new PingFederate auth provider.
-   881caae: Backstage version bump to v1.51.0

### Patch Changes

-   a3f35d7: Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.
