### PR TITLE
fix: normalize Azure pipeline run status output

### DIFF
--- a/workspaces/azure-devops/.changeset/blue-pipelines-return.md
+++ b/workspaces/azure-devops/.changeset/blue-pipelines-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-azure-devops': patch
+---
+
+Normalize `azure:pipeline:run` status outputs to the documented lowercase enum values.

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
@@ -289,6 +289,7 @@ describe('publish:azure', () => {
   it('should output pipelineRunStatus if available', async () => {
     mockPipelineClient.runPipeline.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
+      id: 1,
       result: '1',
     }));
     mockPipelineClient.getRun.mockImplementation(() => ({
@@ -314,11 +315,13 @@ describe('publish:azure', () => {
       'pipelineRunStatus',
       'succeeded',
     );
+    expect(mockPipelineClient.getRun).toHaveBeenCalledWith('project', 1, 1);
   });
 
   it('should output failed pipelineRunStatus without throwing', async () => {
     mockPipelineClient.runPipeline.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
+      id: 1,
     }));
     mockPipelineClient.getRun.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
@@ -341,11 +344,13 @@ describe('publish:azure', () => {
       'pipelineRunStatus',
       'failed',
     );
+    expect(mockPipelineClient.getRun).toHaveBeenCalledWith('project', 1, 1);
   });
 
   it('should output canceled pipelineRunStatus without throwing', async () => {
     mockPipelineClient.runPipeline.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
+      id: 1,
     }));
     mockPipelineClient.getRun.mockImplementation(() => ({
       _links: { web: { href: 'http://pipeline-run-url.com' } },
@@ -368,6 +373,7 @@ describe('publish:azure', () => {
       'pipelineRunStatus',
       'canceled',
     );
+    expect(mockPipelineClient.getRun).toHaveBeenCalledWith('project', 1, 1);
   });
 
   it('should wait when polling is specified', async () => {

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts
@@ -312,7 +312,61 @@ describe('publish:azure', () => {
     );
     expect(mockContext.output).toHaveBeenCalledWith(
       'pipelineRunStatus',
-      'Succeeded',
+      'succeeded',
+    );
+  });
+
+  it('should output failed pipelineRunStatus without throwing', async () => {
+    mockPipelineClient.runPipeline.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+    }));
+    mockPipelineClient.getRun.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+      id: 1,
+      result: RunResult.Failed,
+      state: RunState.Completed,
+    }));
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        host: 'dev.azure.com',
+        organization: 'org',
+        pipelineId: '1',
+        project: 'project',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'pipelineRunStatus',
+      'failed',
+    );
+  });
+
+  it('should output canceled pipelineRunStatus without throwing', async () => {
+    mockPipelineClient.runPipeline.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+    }));
+    mockPipelineClient.getRun.mockImplementation(() => ({
+      _links: { web: { href: 'http://pipeline-run-url.com' } },
+      id: 1,
+      result: RunResult.Canceled,
+      state: RunState.Completed,
+    }));
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        host: 'dev.azure.com',
+        organization: 'org',
+        pipelineId: '1',
+        project: 'project',
+      },
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'pipelineRunStatus',
+      'canceled',
     );
   });
 

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
@@ -24,6 +24,22 @@ import {
   RunResult,
 } from 'azure-devops-node-api/interfaces/PipelinesInterfaces';
 import { getAuthHandler } from './helpers';
+
+const pipelineRunStatusByResult: Record<
+  RunResult,
+  'canceled' | 'failed' | 'succeeded' | 'unknown'
+> = {
+  [RunResult.Canceled]: 'canceled',
+  [RunResult.Failed]: 'failed',
+  [RunResult.Succeeded]: 'succeeded',
+  [RunResult.Unknown]: 'unknown',
+};
+
+function getPipelineRunStatus(result: RunResult | undefined) {
+  return result === undefined
+    ? 'unknown'
+    : pipelineRunStatusByResult[result] ?? 'unknown';
+}
 /**
  * Creates an `azure:pipeline:run` Scaffolder action.
  *
@@ -222,10 +238,7 @@ export function createAzureDevopsRunPipelineAction(options: {
 
       ctx.output('pipelineRunUrl', pipelineRun._links.web.href);
       ctx.output('pipelineRunId', pipelineRun.id!);
-      ctx.output(
-        'pipelineRunStatus',
-        pipelineRun.result ? RunResult[pipelineRun.result] : RunResult.Unknown,
-      );
+      ctx.output('pipelineRunStatus', getPipelineRunStatus(pipelineRun.result));
       ctx.output('pipelineTimeoutExceeded', timeoutExceeded);
       ctx.output('pipelineOutput', pipelineRun.variables);
     },

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts
@@ -25,17 +25,18 @@ import {
 } from 'azure-devops-node-api/interfaces/PipelinesInterfaces';
 import { getAuthHandler } from './helpers';
 
-const pipelineRunStatusByResult: Record<
-  RunResult,
-  'canceled' | 'failed' | 'succeeded' | 'unknown'
-> = {
+type PipelineRunStatus = 'canceled' | 'failed' | 'succeeded' | 'unknown';
+
+const pipelineRunStatusByResult: Record<RunResult, PipelineRunStatus> = {
   [RunResult.Canceled]: 'canceled',
   [RunResult.Failed]: 'failed',
   [RunResult.Succeeded]: 'succeeded',
   [RunResult.Unknown]: 'unknown',
 };
 
-function getPipelineRunStatus(result: RunResult | undefined) {
+function getPipelineRunStatus(
+  result: RunResult | undefined,
+): PipelineRunStatus {
   return result === undefined
     ? 'unknown'
     : pipelineRunStatusByResult[result] ?? 'unknown';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #9119.

`azure:pipeline:run` declares lowercase `pipelineRunStatus` values, but the handler returned Azure enum names such as `Failed` and `Canceled`. This normalizes the output to the documented enum values and adds failed/canceled regression coverage.

This stays scoped to the status-output failure path; it does not add Azure log/error collection.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All commits have a `Signed-off-by` line in the message.

Validation:
- `yarn install --immutable` at repository root -> completed with warnings.
- `yarn install --immutable` in `workspaces/azure-devops` -> completed with warnings.
- `yarn test src/actions/devopsRunPipeline.test.ts --watch=false` in the target package -> 14 passed.
- `yarn lint` in the target package -> passed.
- `yarn prettier --check .changeset/blue-pipelines-return.md plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.ts plugins/scaffolder-backend-module-azure-devops/src/actions/devopsRunPipeline.test.ts` in `workspaces/azure-devops` -> passed.
- `yarn tsc` in `workspaces/azure-devops` -> passed.
- `yarn build` in the target package -> passed.
- `git diff --cached --check` -> passed.
- `git diff --cached | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found.