### PR TITLE
add techInsightsFactInsertService for fact insertion in backend plugins

### DIFF
--- a/workspaces/tech-insights/.changeset/curvy-spies-tan.md
+++ b/workspaces/tech-insights/.changeset/curvy-spies-tan.md
@@ -1,0 +1,8 @@
+---
+'@backstage-community/plugin-tech-insights-backend': minor
+'@backstage-community/plugin-tech-insights-node': minor
+---
+
+Add `techInsightsFactInsertServiceRef` and `techInsightsFactInsertServiceFactory`,
+a plugin-scoped service for inserting facts and fact schemas directly into the
+tech insights store from external backend modules.

--- a/workspaces/tech-insights/packages/backend/package.json
+++ b/workspaces/tech-insights/packages/backend/package.json
@@ -35,6 +35,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^",
     "@backstage/plugin-auth-node": "backstage:^",
     "@backstage/plugin-catalog-backend": "backstage:^",
+    "@backstage/plugin-catalog-backend-module-incremental-ingestion": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
     "@backstage/plugin-permission-backend": "backstage:^",
     "@backstage/plugin-permission-backend-module-allow-all-policy": "backstage:^",

--- a/workspaces/tech-insights/packages/backend/src/index.ts
+++ b/workspaces/tech-insights/packages/backend/src/index.ts
@@ -56,6 +56,16 @@ backend.add(import('@backstage/plugin-search-backend-module-techdocs'));
 // Tech insights
 backend.add(import('@backstage-community/plugin-tech-insights-backend'));
 
+// Demonstrates inserting facts from an incremental entity provider via
+// `techInsightsFactInsertServiceRef`. The local file at
+// `./plugins/incrementalFactExample.ts` bundles both the `tech-insights`
+// capture module and the `catalog` ingestion module via
+// `createBackendFeatureLoader`, so a single `backend.add` is sufficient.
+backend.add(
+  import('@backstage/plugin-catalog-backend-module-incremental-ingestion'),
+);
+backend.add(import('./plugins/incrementalFactExample'));
+
 // This will register JsonRulesEngineFactCheckerFactory by configuration and overwrite all programmatically registration
 // backend.add(import('@backstage-community/plugin-tech-insights-backend-module-jsonfc'));
 

--- a/workspaces/tech-insights/packages/backend/src/plugins/incrementalFactExample.ts
+++ b/workspaces/tech-insights/packages/backend/src/plugins/incrementalFactExample.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Example showing how to insert tech insights facts from an incremental
+ * entity provider via `techInsightsFactInsertServiceRef`, without
+ * registering a `FactRetriever`.
+ *
+ * This is example backend code, not a published plugin — see the
+ * "Inserting facts from an external module" section of the
+ * `plugin-tech-insights-backend` README for the same pattern presented as
+ * copy-paste documentation.
+ */
+
+import {
+  coreServices,
+  createBackendFeatureLoader,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import {
+  incrementalIngestionProvidersExtensionPoint,
+  type EntityIteratorResult,
+} from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
+import { CatalogClient } from '@backstage/catalog-client';
+import type { Entity } from '@backstage/catalog-model';
+import {
+  techInsightsFactInsertServiceRef,
+  type TechInsightsFactInsertService,
+} from '@backstage-community/plugin-tech-insights-node';
+
+/**
+ * Identifier and version of the example fact source. The pair must be
+ * stable so that `insertFactSchema` is idempotent across restarts.
+ *
+ * Intentionally not suffixed `-fact-retriever` — the whole point of this
+ * example is that facts are written *without* registering a `FactRetriever`.
+ */
+const EXAMPLE_FACT_ID = 'example-incremental-facts';
+const EXAMPLE_FACT_VERSION = '0.1.0';
+
+/**
+ * Shared holder used to hand the tech-insights-scoped service from the
+ * `tech-insights` module to the `catalog` module. They cannot live in the
+ * same backend module because their dependencies belong to two different
+ * plugin scopes.
+ */
+const factInsertHolder: { current?: TechInsightsFactInsertService } = {};
+
+/**
+ * Stand-in for a real external API call. Returns the length of the entity
+ * name as the fact value.
+ */
+async function fetchExampleCount(entity: Entity): Promise<number> {
+  return entity.metadata.name.length;
+}
+
+/**
+ * Module on `tech-insights`: captures the fact-insert service (which binds
+ * to the tech insights plugin database) and registers the fact schema once
+ * at startup.
+ */
+const techInsightsModuleIncrementalExample = createBackendModule({
+  pluginId: 'tech-insights',
+  moduleId: 'incremental-example-capture',
+  register(env) {
+    env.registerInit({
+      deps: {
+        factInsert: techInsightsFactInsertServiceRef,
+      },
+      async init({ factInsert }) {
+        factInsertHolder.current = factInsert;
+        await factInsert.insertFactSchema({
+          id: EXAMPLE_FACT_ID,
+          version: EXAMPLE_FACT_VERSION,
+          entityFilter: [{ kind: 'Component' }],
+          schema: {
+            exampleCount: {
+              type: 'integer',
+              description: 'An example numeric fact for the entity',
+            },
+          },
+        });
+      },
+    });
+  },
+});
+
+/**
+ * Module on `catalog`: registers an incremental entity provider whose
+ * `next()` walks `Component` entities one at a time, calls a stand-in
+ * external API, and writes a single fact per iteration via the captured
+ * fact-insert service. Returns `entities: []` so the catalog is never
+ * mutated — the incremental engine is used purely as a resumable
+ * scheduler.
+ */
+const catalogModuleIncrementalExample = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'incremental-example-fact-ingestion',
+  register(env) {
+    env.registerInit({
+      deps: {
+        logger: coreServices.logger,
+        auth: coreServices.auth,
+        discovery: coreServices.discovery,
+        incremental: incrementalIngestionProvidersExtensionPoint,
+      },
+      async init({ logger, auth, discovery, incremental }) {
+        incremental.addProvider({
+          options: {
+            burstLength: { seconds: 3 },
+            burstInterval: { seconds: 1 },
+            restLength: { seconds: 15 },
+          },
+          provider: {
+            getProviderName: () => EXAMPLE_FACT_ID,
+
+            async around(burst) {
+              const catalog = new CatalogClient({ discoveryApi: discovery });
+              await burst({ catalog });
+            },
+
+            async next(
+              { catalog }: { catalog: CatalogClient },
+              cursor: { offset: number } = { offset: 0 },
+            ): Promise<EntityIteratorResult<{ offset: number }>> {
+              const factInsert = factInsertHolder.current;
+              if (!factInsert) {
+                throw new Error(
+                  'TechInsightsFactInsertService not yet initialized; ' +
+                    'is techInsightsModuleIncrementalExample added to the backend?',
+                );
+              }
+
+              const { token } = await auth.getPluginRequestToken({
+                onBehalfOf: await auth.getOwnServiceCredentials(),
+                targetPluginId: 'catalog',
+              });
+
+              const { items } = await catalog.getEntities(
+                {
+                  filter: { kind: 'Component' },
+                  limit: 1,
+                  offset: cursor.offset,
+                  order: { field: 'metadata.name', order: 'asc' },
+                },
+                { token },
+              );
+              const entity = items[0];
+
+              if (!entity) {
+                return {
+                  done: true,
+                  entities: [],
+                  cursor: { offset: cursor.offset },
+                };
+              }
+
+              await factInsert.insertFacts({
+                id: EXAMPLE_FACT_ID,
+                facts: [
+                  {
+                    entity: {
+                      namespace: entity.metadata.namespace ?? 'default',
+                      kind: entity.kind,
+                      name: entity.metadata.name,
+                    },
+                    facts: {
+                      exampleCount: await fetchExampleCount(entity),
+                    },
+                  },
+                ],
+                lifecycle: { timeToLive: { weeks: 2 } },
+              });
+
+              return {
+                done: false,
+                entities: [],
+                cursor: { offset: cursor.offset + 1 },
+              };
+            },
+          },
+        });
+
+        logger.info(
+          `Registered example incremental fact ingestion: ${EXAMPLE_FACT_ID}`,
+        );
+      },
+    });
+  },
+});
+
+/**
+ * Default export bundles both modules so they can be added with a single
+ * `backend.add(...)` call from `index.ts`.
+ */
+export default createBackendFeatureLoader({
+  loader: () => [
+    techInsightsModuleIncrementalExample,
+    catalogModuleIncrementalExample,
+  ],
+});

--- a/workspaces/tech-insights/packages/backend/src/plugins/tech-insights.ts
+++ b/workspaces/tech-insights/packages/backend/src/plugins/tech-insights.ts
@@ -59,6 +59,30 @@ export const checks = [
       },
     },
   },
+  {
+    // Demonstrates that facts inserted via the
+    // `techInsightsFactInsertServiceRef` (see ./incrementalFactExample.ts)
+    // are queryable by checks just like facts produced by a registered
+    // FactRetriever. The fact id below must match `EXAMPLE_FACT_ID` in
+    // that example file.
+    id: 'exampleCountCheck',
+    type: JSON_RULE_ENGINE_CHECK_TYPE,
+    name: 'Example Count Check',
+    description:
+      'Verifies that the example incremental fact source produced a non-zero exampleCount for the entity',
+    factIds: ['example-incremental-facts'],
+    rule: {
+      conditions: {
+        all: [
+          {
+            fact: 'exampleCount',
+            operator: 'greaterThan',
+            value: 0,
+          },
+        ],
+      },
+    },
+  },
 ];
 
 export const apiDefinitionFactRetriever: FactRetriever = {

--- a/workspaces/tech-insights/plugins/tech-insights-backend/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/README.md
@@ -108,6 +108,111 @@ techInsights:
                 value: true
 ```
 
+## Inserting facts from an external module (e.g. incremental ingestion)
+
+The `FactRetriever` pipeline collects all facts for a given retriever in a
+single in-memory batch. For very large data sources — for example, an
+incremental ingestion engine that walks catalog entities in bursts — it is
+useful to write facts directly to the store, one batch at a time, without
+registering a `FactRetriever`.
+
+The tech insights backend exposes a plugin-scoped service for this:
+`techInsightsFactInsertServiceRef` (defined in
+`@backstage-community/plugin-tech-insights-node`). The factory is registered
+automatically when you add this package to your backend — no extra wiring is
+required:
+
+```ts title="packages/backend/src/index.ts"
+backend.add(import('@backstage-community/plugin-tech-insights-backend'));
+```
+
+> If you prefer to opt in explicitly (for example, when consuming the named
+> `techInsightsPlugin` export directly instead of the default), the factory
+> is also exported as `techInsightsFactInsertServiceFactory` and can be added
+> separately with `backend.add(techInsightsFactInsertServiceFactory)`.
+
+The service exposes a narrow write-only surface:
+
+```ts
+interface TechInsightsFactInsertService {
+  insertFactSchema(schemaDefinition: FactSchemaDefinition): Promise<void>;
+  insertFacts(options: {
+    id: string;
+    facts: TechInsightFact[];
+    lifecycle?: FactLifecycle;
+  }): Promise<void>;
+}
+```
+
+### Pattern
+
+`techInsightsFactInsertServiceRef` is plugin-scoped to `tech-insights`, so
+its factory only binds inside a `pluginId: 'tech-insights'` module. Many
+external triggers — incremental ingestion in particular — live on the
+`catalog` plugin, so the two cannot be wired in a single module. The
+recommended shape is **one module per plugin scope, communicating via a
+shared module-level holder**:
+
+```ts
+// Captured by the tech-insights module, read by the catalog module.
+const factInsertHolder: { current?: TechInsightsFactInsertService } = {};
+
+// Module on `tech-insights`: register the schema once and stash the service.
+createBackendModule({
+  pluginId: 'tech-insights',
+  moduleId: 'my-fact-capture',
+  register(env) {
+    env.registerInit({
+      deps: { factInsert: techInsightsFactInsertServiceRef },
+      async init({ factInsert }) {
+        factInsertHolder.current = factInsert;
+        await factInsert.insertFactSchema({
+          id: 'my-incremental-facts',
+          version: '0.1.0',
+          entityFilter: [{ kind: 'Component' }],
+          schema: {
+            myCount: { type: 'integer', description: 'A counted value' },
+          },
+        });
+      },
+    });
+  },
+});
+
+// Module on `catalog`: register an incremental provider whose `next()`
+// reads from `factInsertHolder.current` and writes via `insertFacts`.
+```
+
+Two caveats worth knowing before copying this:
+
+1. The catalog module's `init` may resolve before the tech-insights
+   module's `init`. The provider's `next()` must defend against an empty
+   holder — throwing explicitly is preferable so the incremental engine
+   surfaces the misconfiguration instead of silently skipping facts.
+2. The holder retains a reference across hot-reloads in dev, which can
+   keep a stale service alive longer than expected. Don't store anything
+   in it other than the service itself.
+
+`insertFactSchema` is idempotent for a given `(id, version)` pair and only
+needs to be called once at startup; `insertFacts` may be called repeatedly
+(once per entity in a single-entity iteration pattern).
+
+### Runnable example
+
+A complete, runnable version of this pattern — including the catalog
+module that drives the incremental provider — lives in this repository at
+[`workspaces/tech-insights/packages/backend/src/plugins/incrementalFactExample.ts`](../../packages/backend/src/plugins/incrementalFactExample.ts).
+It is wired into the example backend's
+[`index.ts`](../../packages/backend/src/index.ts) alongside
+`@backstage/plugin-catalog-backend-module-incremental-ingestion`. Use it as
+the canonical reference; the snippet above only shows the cross-plugin
+glue.
+
+> The example uses incremental ingestion as a **scheduler over catalog
+> entities** rather than as a source of catalog entities — its `next()`
+> returns `entities: []` so it never mutates the catalog. The actual write
+> goes to the tech insights store via `factInsert.insertFacts`.
+
 ## Creating custom implementations of FactRetrievers
 
 ### Creating Fact Retrievers

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/index.ts
@@ -14,6 +14,33 @@
  * limitations under the License.
  */
 
-export { techInsightsPlugin as default } from './plugin';
+import { createBackendFeatureLoader } from '@backstage/backend-plugin-api';
+import {
+  techInsightsPlugin,
+  techInsightsFactInsertServiceFactory,
+} from './plugin';
+
+/**
+ * The default export bundles the tech-insights plugin together with built-in
+ * service factories (such as {@link techInsightsFactInsertServiceFactory}) so
+ * a single `backend.add(import('@backstage-community/plugin-tech-insights-backend'))`
+ * registers everything needed to read and write facts.
+ *
+ * Note: prior to this change the default export was `techInsightsPlugin`
+ * directly. The two are interchangeable when passed to `backend.add(...)`,
+ * but consumers who imported the default and used it outside of
+ * `backend.add` (for example, in custom composition or tests) may need to
+ * switch to the named `techInsightsPlugin` export.
+ *
+ * @public
+ */
+export default createBackendFeatureLoader({
+  loader: () => [techInsightsPlugin, techInsightsFactInsertServiceFactory],
+});
+
+export {
+  techInsightsPlugin,
+  techInsightsFactInsertServiceFactory,
+} from './plugin';
 export * from './deprecated';
 export * from './service';

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './plugin';
+export { techInsightsFactInsertServiceFactory } from './techInsightsFactInsertServiceFactory';

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/techInsightsFactInsertServiceFactory.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/techInsightsFactInsertServiceFactory.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackendFeature,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import {
+  TechInsightsFactInsertService,
+  techInsightsFactInsertServiceRef,
+} from '@backstage-community/plugin-tech-insights-node';
+import { techInsightsFactInsertServiceFactory } from './techInsightsFactInsertServiceFactory';
+
+/**
+ * Starts a test backend wired up just enough to resolve
+ * `techInsightsFactInsertServiceRef` and hands the resolved service back via a
+ * capture module. The factory is plugin-scoped, and `startTestBackend`
+ * requires a module attached to the same plugin id (`tech-insights`) to
+ * trigger instantiation.
+ */
+async function captureFactInsertService(
+  features: Array<BackendFeature | Promise<{ default: BackendFeature }>>,
+): Promise<TechInsightsFactInsertService> {
+  let captured: TechInsightsFactInsertService | undefined;
+  const captureModule = createBackendModule({
+    pluginId: 'tech-insights',
+    moduleId: 'capture-fact-insert-service',
+    register(env) {
+      env.registerInit({
+        deps: { service: techInsightsFactInsertServiceRef },
+        async init({ service }) {
+          captured = service;
+        },
+      });
+    },
+  });
+  await startTestBackend({
+    features: [...features, captureModule, mockServices.database.factory()],
+  });
+  if (!captured) {
+    throw new Error('techInsightsFactInsertServiceRef was never resolved');
+  }
+  return captured;
+}
+
+describe('techInsightsFactInsertServiceFactory', () => {
+  it('provides a service that inserts schemas and facts via the tech insights store', async () => {
+    const service = await captureFactInsertService([
+      techInsightsFactInsertServiceFactory,
+    ]);
+
+    await service.insertFactSchema({
+      id: 'test-fact-insert',
+      version: '0.0.1-test',
+      schema: {
+        testNumberFact: {
+          type: 'integer',
+          description: 'Test fact with a number type',
+        },
+      },
+    });
+
+    await expect(
+      service.insertFacts({
+        id: 'test-fact-insert',
+        facts: [
+          {
+            entity: { namespace: 'default', kind: 'Component', name: 'a' },
+            facts: { testNumberFact: 42 },
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('treats insertFactSchema as idempotent for the same (id, version)', async () => {
+    const service = await captureFactInsertService([
+      techInsightsFactInsertServiceFactory,
+    ]);
+
+    const schema = {
+      id: 'idempotent-schema',
+      version: '1.0.0',
+      schema: {
+        count: { type: 'integer' as const, description: 'count' },
+      },
+    };
+
+    await service.insertFactSchema(schema);
+    await expect(service.insertFactSchema(schema)).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when insertFacts is called with an empty facts array', async () => {
+    const service = await captureFactInsertService([
+      techInsightsFactInsertServiceFactory,
+    ]);
+
+    // No schema is registered for this id — if the store actually tried to
+    // look up the latest schema this call would throw. The contract says
+    // empty `facts` short-circuits.
+    await expect(
+      service.insertFacts({ id: 'never-registered', facts: [] }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('exposes only the write-only surface and not the underlying store reads', async () => {
+    // The factory wraps the persistence store in a narrow adapter. If
+    // someone ever returns the store directly again, this test will
+    // catch the leak of read methods like `getLatestSchemas` etc.
+    const service = await captureFactInsertService([
+      techInsightsFactInsertServiceFactory,
+    ]);
+
+    expect(Object.keys(service).sort()).toEqual(
+      ['insertFactSchema', 'insertFacts'].sort(),
+    );
+    expect(typeof service.insertFactSchema).toBe('function');
+    expect(typeof service.insertFacts).toBe('function');
+  });
+});

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/techInsightsFactInsertServiceFactory.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/plugin/techInsightsFactInsertServiceFactory.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
+import { techInsightsFactInsertServiceRef } from '@backstage-community/plugin-tech-insights-node';
+import { initializePersistenceContext } from '../service/persistence';
+
+/**
+ * A plugin-scoped service factory that provides the {@link TechInsightsFactInsertService}.
+ *
+ * Enables backend modules (such as incremental fact retrievers) to insert facts
+ * and schemas into the tech insights store without requiring direct database access.
+ *
+ * This factory is bundled into the default export of
+ * `@backstage-community/plugin-tech-insights-backend` and is registered
+ * automatically when the package is added to a backend:
+ *
+ * ```ts
+ * backend.add(import('@backstage-community/plugin-tech-insights-backend'));
+ * ```
+ *
+ * It is also exported as a named symbol so it can be added explicitly when
+ * consuming `techInsightsPlugin` directly:
+ *
+ * ```ts
+ * backend.add(techInsightsPlugin);
+ * backend.add(techInsightsFactInsertServiceFactory);
+ * ```
+ *
+ * @public
+ */
+export const techInsightsFactInsertServiceFactory = createServiceFactory({
+  service: techInsightsFactInsertServiceRef,
+  deps: {
+    database: coreServices.database,
+    logger: coreServices.logger,
+  },
+  async factory({ database, logger }) {
+    // `initializePersistenceContext` is memoized per `DatabaseService`
+    // instance, so this shares the same Knex pool and migrations run as
+    // `techInsightsPlugin` when both are added to the same backend.
+    const { techInsightsStore } = await initializePersistenceContext(database, {
+      logger,
+    });
+
+    // Return an adapter rather than the store itself. The store implements
+    // many read methods that are intentionally *not* part of the public
+    // `TechInsightsFactInsertService` contract (reads should go through
+    // `techInsightsServiceRef`). Without this wrapper, a caller could cast
+    // the service to the store interface at runtime and reach the reads.
+    return {
+      insertFactSchema: schemaDefinition =>
+        techInsightsStore.insertFactSchema(schemaDefinition),
+      insertFacts: options => techInsightsStore.insertFacts(options),
+    };
+  },
+});

--- a/workspaces/tech-insights/plugins/tech-insights-backend/src/service/persistence/persistenceContext.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/src/service/persistence/persistenceContext.ts
@@ -36,7 +36,28 @@ export type PersistenceContextOptions = {
 };
 
 /**
+ * Cache of `PersistenceContext` promises keyed by `DatabaseService`.
+ *
+ * Two service factories in this package — `techInsightsPlugin` and
+ * `techInsightsFactInsertServiceFactory` — both initialize a persistence
+ * context for the same plugin-scoped `DatabaseService`. Without this
+ * cache they would each open their own Knex pool and race to run the
+ * same migrations. Keying on the `DatabaseService` instance (which is
+ * itself plugin-scoped) means the cache is implicitly scoped per-plugin
+ * and is garbage collected when the backend shuts down.
+ */
+const persistenceContextCache = new WeakMap<
+  DatabaseService,
+  Promise<PersistenceContext>
+>();
+
+/**
  * A factory function to construct persistence context for running implementation.
+ *
+ * Memoized per `DatabaseService` instance: repeated calls with the same
+ * database return the same `PersistenceContext` and run migrations
+ * exactly once. A rejected initialization is purged from the cache so
+ * the next caller can retry.
  *
  * @public
  */
@@ -44,15 +65,32 @@ export const initializePersistenceContext = async (
   database: DatabaseService,
   options: PersistenceContextOptions,
 ): Promise<PersistenceContext> => {
-  const client = await database.getClient();
-
-  if (!database.migrations?.skip) {
-    await client.migrate.latest({
-      directory: migrationsDir,
-    });
+  const cached = persistenceContextCache.get(database);
+  if (cached) {
+    return cached;
   }
 
-  return {
-    techInsightsStore: new TechInsightsDatabase(client, options.logger),
-  };
+  const created = (async () => {
+    const client = await database.getClient();
+
+    if (!database.migrations?.skip) {
+      await client.migrate.latest({
+        directory: migrationsDir,
+      });
+    }
+
+    return {
+      techInsightsStore: new TechInsightsDatabase(client, options.logger),
+    };
+  })();
+
+  persistenceContextCache.set(database, created);
+
+  try {
+    return await created;
+  } catch (error) {
+    // Don't keep a rejected promise in the cache — let the next caller retry.
+    persistenceContextCache.delete(database);
+    throw error;
+  }
 };

--- a/workspaces/tech-insights/plugins/tech-insights-node/src/index.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-node/src/index.ts
@@ -23,3 +23,8 @@ export {
   techInsightsServiceRef,
   type TechInsightsService,
 } from './techInsightsService';
+
+export {
+  techInsightsFactInsertServiceRef,
+  type TechInsightsFactInsertService,
+} from './techInsightsFactInsertService';

--- a/workspaces/tech-insights/plugins/tech-insights-node/src/techInsightsFactInsertService.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-node/src/techInsightsFactInsertService.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createServiceRef } from '@backstage/backend-plugin-api';
+import { FactLifecycle, FactSchemaDefinition, TechInsightFact } from './facts';
+
+/**
+ * A narrow write-only service for inserting facts and fact schemas into the
+ * Tech Insights store from outside the built-in fact retriever pipeline.
+ *
+ * This is intended for backend modules that iterate over their own data
+ * sources (for example, an incremental ingestion engine that walks catalog
+ * entities in bursts) and need to commit facts directly without registering
+ * a `FactRetriever`.
+ *
+ * Reads should continue to go through the `techInsightsServiceRef` HTTP
+ * client — this service exposes no query surface by design.
+ *
+ * @public
+ */
+export interface TechInsightsFactInsertService {
+  /**
+   * Stores a versioned fact schema into the data store. Should be called at
+   * least once before inserting facts for a given retriever id/version.
+   *
+   * Idempotent for a given `(id, version)` pair: if a row already exists,
+   * this is a no-op and the existing schema is preserved untouched. To
+   * publish a changed schema, bump `version`.
+   *
+   * Reads of facts continue to flow through `techInsightsServiceRef`.
+   */
+  insertFactSchema(schemaDefinition: FactSchemaDefinition): Promise<void>;
+
+  /**
+   * Stores a collection of facts against the given retriever id. Each entry
+   * is associated with an entity and one or more fact values matching the
+   * registered schema. Facts are written under the latest schema version
+   * registered for `id`, so `insertFactSchema` must have been called first.
+   *
+   * No-op when `facts` is empty.
+   *
+   * When `lifecycle` is provided, TTL/`maxItems` pruning runs in the same
+   * transaction as the insert, so retention is enforced atomically per call.
+   *
+   * Reads of facts continue to flow through `techInsightsServiceRef`.
+   */
+  insertFacts(options: {
+    id: string;
+    facts: TechInsightFact[];
+    lifecycle?: FactLifecycle;
+  }): Promise<void>;
+}
+
+/**
+ * A plugin-scoped service reference for the {@link TechInsightsFactInsertService}.
+ *
+ * The factory is registered automatically by the default export of
+ * `@backstage-community/plugin-tech-insights-backend`:
+ *
+ * ```ts
+ * backend.add(import('@backstage-community/plugin-tech-insights-backend'));
+ * ```
+ *
+ * @public
+ */
+export const techInsightsFactInsertServiceRef =
+  createServiceRef<TechInsightsFactInsertService>({
+    id: 'tech-insights.fact-insert',
+    scope: 'plugin',
+  });

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -2131,6 +2131,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-app-api@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@backstage/backend-app-api@npm:1.7.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+  checksum: 10/3355550d575fd8258561aeba4aad99bbbf7ddddcc20479e6bad6500bc29b9d72ce3877c0783c63ab1f37fb0fe6bc8e57de49757cd0e6b891a34519236f31f3de
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-defaults@backstage:^::backstage=1.50.2&npm=0.17.0, @backstage/backend-defaults@npm:^0.17.0":
   version: 0.17.0
   resolution: "@backstage/backend-defaults@npm:0.17.0"
@@ -2220,6 +2231,95 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-defaults@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@backstage/backend-defaults@npm:0.17.1"
+  dependencies:
+    "@aws-sdk/abort-controller": "npm:^3.347.0"
+    "@aws-sdk/client-codecommit": "npm:^3.350.0"
+    "@aws-sdk/client-s3": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/rds-signer": "npm:^3.0.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/backend-app-api": "npm:^1.7.0"
+    "@backstage/backend-dev-utils": "npm:^0.1.7"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/cli-node": "npm:^0.3.2"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/config-loader": "npm:^1.10.11"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/integration": "npm:^2.0.2"
+    "@backstage/integration-aws-node": "npm:^0.2.0"
+    "@backstage/plugin-auth-node": "npm:^0.7.1"
+    "@backstage/plugin-events-node": "npm:^0.4.22"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@google-cloud/storage": "npm:^7.0.0"
+    "@keyv/memcache": "npm:^2.0.1"
+    "@keyv/redis": "npm:^4.0.1"
+    "@keyv/valkey": "npm:^1.0.1"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@octokit/rest": "npm:^19.0.3"
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@types/cors": "npm:^2.8.6"
+    "@types/express": "npm:^4.17.6"
+    archiver: "npm:^7.0.0"
+    base64-stream: "npm:^1.0.0"
+    compression: "npm:^1.7.4"
+    concat-stream: "npm:^2.0.0"
+    cookie: "npm:^0.7.0"
+    cors: "npm:^2.8.5"
+    cron: "npm:^3.0.0"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    express-rate-limit: "npm:^8.2.2"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    helmet: "npm:^6.0.0"
+    infinispan: "npm:^0.12.0"
+    iovalkey: "npm:^0.3.3"
+    is-glob: "npm:^4.0.3"
+    jose: "npm:^5.0.0"
+    keyv: "npm:^5.2.1"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    logform: "npm:^2.3.2"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^10.2.1"
+    mysql2: "npm:^3.0.0"
+    node-fetch: "npm:^2.7.0"
+    node-forge: "npm:^1.3.2"
+    p-limit: "npm:^3.1.0"
+    path-to-regexp: "npm:^8.0.0"
+    pg: "npm:^8.11.3"
+    pg-connection-string: "npm:^2.3.0"
+    pg-format: "npm:^1.0.4"
+    rate-limit-redis: "npm:^4.2.0"
+    raw-body: "npm:^2.4.1"
+    selfsigned: "npm:^2.0.0"
+    tar: "npm:^7.5.6"
+    triple-beam: "npm:^1.4.1"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.5.0"
+    yauzl: "npm:^3.2.1"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+    better-sqlite3: ^12.0.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+    better-sqlite3:
+      optional: true
+  checksum: 10/4993272dc1ad13b8a21d705b0e0656bfdf1015faa473d91eb649eb670d7afb14ea6621c16d62396747b49650a2bef225e93c5ce54b45bd69a62ced55e47f7a56
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-dev-utils@npm:^0.1.7":
   version: 0.1.7
   resolution: "@backstage/backend-dev-utils@npm:0.1.7"
@@ -2251,6 +2351,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-openapi-utils@npm:^0.6.9":
+  version: 0.6.9
+  resolution: "@backstage/backend-openapi-utils@npm:0.6.9"
+  dependencies:
+    "@apidevtools/swagger-parser": "npm:^10.1.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/express-serve-static-core": "npm:^4.17.5"
+    ajv: "npm:^8.16.0"
+    express: "npm:^4.22.0"
+    express-openapi-validator: "npm:^5.5.8"
+    express-promise-router: "npm:^4.1.0"
+    get-port: "npm:^5.1.1"
+    json-schema-to-ts: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    mockttp: "npm:^3.13.0"
+    openapi-merge: "npm:^1.3.2"
+    openapi3-ts: "npm:^3.1.2"
+  checksum: 10/063828a26f1b3ee288d35af1a9b6d8d3cbd0b57d5824863355b5b770210c53fcd4c07b0bfc1e5f5447268a32fb15ecefba7e2c745beecfe088a3bbd722fd839f
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@backstage:^::backstage=1.50.2&npm=1.9.0, @backstage/backend-plugin-api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@backstage/backend-plugin-api@npm:1.9.0"
@@ -2270,6 +2394,28 @@ __metadata:
     luxon: "npm:^3.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   checksum: 10/7286c8a490033a5f3c7e09ab1b37086f037bf604d4b6db18dd5ffd22a50601ecfa33807be7754f3fb444e89c5d6a41cc825f0cf150fd6e3b3ef3432c0ad6c393
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@backstage/backend-plugin-api@npm:1.9.1"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.2"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    json-schema: "npm:^0.4.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10/deb919cbb1a8dbcd57c1ae8f37531db433422bdefd4f46d4bce21f0198cca33267223d296b8b6052d8cf9cb1e77f4b5ba75c1eecde159f4ca261e41d044b48dc
   languageName: node
   linkType: hard
 
@@ -2332,6 +2478,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@backstage/catalog-client@npm:1.15.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.3"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10/6d319a45ed21463cc2ebd9ac26ab3e2635389d30d32c6b13a5ebbdf0ad06dc8aa9100071013f866e008426ee430152dc6918eb0a3ebb10b5380e324ab5a62c82
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-model@backstage:^::backstage=1.50.2&npm=1.8.0, @backstage/catalog-model@npm:^1.8.0":
   version: 1.8.0
   resolution: "@backstage/catalog-model@npm:1.8.0"
@@ -2346,6 +2506,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-model@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage/catalog-model@npm:1.9.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.25.76"
+  checksum: 10/3569dde23f66960f05ab463444e33a1c61023c69bd55a2d3390b7b4fd3c4999c85f7d38223a7e84047819027ee747ed758a3508177de128511edbbb98f6cf161
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.2.1":
   version: 0.2.1
   resolution: "@backstage/cli-common@npm:0.2.1"
@@ -2355,6 +2529,18 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.24.5"
   checksum: 10/29dd65792dfd1f762b66de3754a9ca2dbe3be555b5390b809fb66d7bc3347489c9d74bcc29de608bcb0a31c243ca0ef41834ee9f127b42b5ad74f83fdfb0aba8
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@backstage/cli-common@npm:0.2.2"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+    global-agent: "npm:^3.0.0"
+    undici: "npm:^7.24.5"
+  checksum: 10/1fc0067fbdb113e317e68e631d4e5bad92efc41d2a6671a15c143c05d87567281e43991f2bb25902e4752c59762577258e97097299f57b3f2d471c863cc1d244
   languageName: node
   linkType: hard
 
@@ -2711,6 +2897,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/cli-node@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@backstage/cli-node@npm:0.3.2"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.2"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:^3.0.0"
+    chalk: "npm:^4.0.0"
+    commander: "npm:^12.0.0"
+    fs-extra: "npm:^11.2.0"
+    keytar: "npm:^7.9.0"
+    pirates: "npm:^4.0.6"
+    proper-lockfile: "npm:^4.1.2"
+    semver: "npm:^7.5.3"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@swc/core": ^1.15.6
+  dependenciesMeta:
+    keytar:
+      optional: true
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+  checksum: 10/0629327c8b75ac942504573451872ed1b51d02c985a67c7f05447f1684fb14826f399bd1588b9c9c4990eb19c6757fea7329297b96e42b12af5be3b69c6683cd
+  languageName: node
+  linkType: hard
+
 "@backstage/cli@backstage:^::backstage=1.50.2&npm=0.36.1, @backstage/cli@npm:^0.36.1":
   version: 0.36.1
   resolution: "@backstage/cli@npm:0.36.1"
@@ -2791,6 +3008,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:^1.10.11":
+  version: 1.10.11
+  resolution: "@backstage/config-loader@npm:1.10.11"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.2.2"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema: "npm:^0.4.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    typescript-json-schema: "npm:^0.67.0"
+    yaml: "npm:^2.0.0"
+  checksum: 10/f0bdaac1a2c1eda1d53f8d40643436788d8c6b9a7c33b0d22874d40274ab0ea598172d93ea13e251eed10a30734696ec00b1ed0ecc872dfb5c1c8241a3f83bba
+  languageName: node
+  linkType: hard
+
 "@backstage/config@backstage:^::backstage=1.50.2&npm=1.3.7, @backstage/config@npm:^1.3.7":
   version: 1.3.7
   resolution: "@backstage/config@npm:1.3.7"
@@ -2799,6 +3039,17 @@ __metadata:
     "@backstage/types": "npm:^1.2.2"
     ms: "npm:^2.1.3"
   checksum: 10/641986bc4fd1a8dff16295c7291b2b22699e4d68f3fb42ff773065833821c3440251d0dd576565cdb5ffe0875c0c56d4b3b36bb442e7bf64f8fd09db89e17988
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "@backstage/config@npm:1.3.8"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10/2cb67da7b57c1cefb91ed2ec9855cd0aa52934ec1b8b5e24384a7a5b88348e4fd9992217c484c42243abd31f3b558d16d8041d58bf1a6dc57a395360d8e9bfb4
   languageName: node
   linkType: hard
 
@@ -2991,6 +3242,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/errors@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/errors@npm:1.3.1"
+  dependencies:
+    "@backstage/types": "npm:^1.2.2"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10/c4611ab47f7b39dc9e8223590bbf3bdba7eddcd8444fe0c9fc43b4dbe95aeb8d9bab2923208a2e2e7b85fd4339d979fc70679d03ee6e07bc40ee1c85e66ae179
+  languageName: node
+  linkType: hard
+
 "@backstage/eslint-plugin@npm:^0.2.3":
   version: 0.2.3
   resolution: "@backstage/eslint-plugin@npm:0.2.3"
@@ -3011,6 +3272,19 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^4.0.2"
   checksum: 10/03b49f1c6f468807408edf87d636b11a7382aece1c5b7287e0960a098478f744534c82284e7758e108644adc82ec22b9f57280eeaebdd3b619967e593850d3bb
+  languageName: node
+  linkType: hard
+
+"@backstage/filter-predicates@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@backstage/filter-predicates@npm:0.1.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/b84c43e86efef80baececb0391efdb000284de66c0454109e30f5f70af01d5c3421783e9fb75ab237eae47644860fa23d663420462cb806c732ec8ca319144a8
   languageName: node
   linkType: hard
 
@@ -3052,6 +3326,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration-aws-node@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@backstage/integration-aws-node@npm:0.2.0"
+  dependencies:
+    "@aws-sdk/client-sts": "npm:^3.350.0"
+    "@aws-sdk/credential-provider-node": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@aws-sdk/util-arn-parser": "npm:^3.310.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+  checksum: 10/ba7aa0ddec647b29a7368a46447474606ff962212a24aae0875362bbaec987527d6c2d9f2189ce30d7335bc0dadc8b6df2fb17c187ca5d75eef12d04cd03581c
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-react@backstage:^::backstage=1.50.2&npm=1.2.17, @backstage/integration-react@npm:^1.2.17":
   version: 1.2.17
   resolution: "@backstage/integration-react@npm:1.2.17"
@@ -3089,6 +3378,25 @@ __metadata:
     luxon: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
   checksum: 10/a7adedb22e506f12e00dd95385bb570e27f06ad898775bbdd0ef807c0bd9eb317a1a399405ea61d1fd389599d30f433f4fc5ee63f4b793970ca2aa9e1176d586
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@backstage/integration@npm:2.0.2"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10/21dae31d18eace19d7d357eebe82320d33cccf6bb686d9e9809cc369be10c7d7a7a1f15526265e003eaf6121001ad29874734ccf80ab687f0f47291ae06b4f8a
   languageName: node
   linkType: hard
 
@@ -3288,6 +3596,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@backstage/plugin-auth-node@npm:0.7.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/e799d61a7b213d76a69d1214f26cfa36e7cbb528a65fbdc25b638a09cf411a9a2bee97ea7bd9665a2ca2ff124d7edec71780a5b1be8f0b8e6a4de492a5f88584
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:^0.1.26":
   version: 0.1.26
   resolution: "@backstage/plugin-auth-react@npm:0.1.26"
@@ -3306,6 +3637,27 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/8a01b16c7366c3332268228ccfcb41b5591da43f20dfb16ff16cdc5b13dadf693a4ed24b10d025f6d3dea6440a6b6ceb468ca6a0378d122a3c9aa0d609a7ff29
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-incremental-ingestion@backstage:^::backstage=1.50.2&npm=0.7.11, @backstage/plugin-catalog-backend-module-incremental-ingestion@npm:^0.7.11":
+  version: 0.7.12
+  resolution: "@backstage/plugin-catalog-backend-module-incremental-ingestion@npm:0.7.12"
+  dependencies:
+    "@backstage/backend-defaults": "npm:^0.17.1"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-catalog-backend": "npm:^3.7.0"
+    "@backstage/plugin-catalog-node": "npm:^2.2.1"
+    "@backstage/plugin-events-node": "npm:^0.4.22"
+    "@backstage/types": "npm:^1.2.2"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+  checksum: 10/78a7e2d4961ac0b9820ee9673a27a5f6b627ac370069883dce18890bc27a28cca1463e2d157ad220843a4e479a5b8ab665a0e262ad751d194c831bf02e1b6a71
   languageName: node
   linkType: hard
 
@@ -3352,6 +3704,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-backend@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@backstage/plugin-catalog-backend@npm:3.7.0"
+  dependencies:
+    "@backstage/backend-openapi-utils": "npm:^0.6.9"
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.3"
+    "@backstage/integration": "npm:^2.0.2"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    "@backstage/plugin-catalog-node": "npm:^2.2.1"
+    "@backstage/plugin-events-node": "npm:^0.4.22"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    codeowners-utils: "npm:^1.0.2"
+    core-js: "npm:^3.6.5"
+    express: "npm:^4.22.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    glob: "npm:^13.0.0"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^10.2.1"
+    p-limit: "npm:^3.0.2"
+    prom-client: "npm:^15.0.0"
+    yaml: "npm:^2.0.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/5dd9efcd56516047aba5963e20ae1a80ceaafd12203213f05aea2798d81514104eaad233398844963511cbd920f3fedc4d3fb9974b95e096243f1e3caca71c8d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-common@backstage:^::backstage=1.50.2&npm=1.1.9, @backstage/plugin-catalog-common@npm:^1.1.9":
   version: 1.1.9
   resolution: "@backstage/plugin-catalog-common@npm:1.1.9"
@@ -3360,6 +3754,17 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.8"
     "@backstage/plugin-search-common": "npm:^1.2.23"
   checksum: 10/b4249476bd10c67a8ad5128698782b607fcaceb355fa02dedd0b44d24dcc4946fe5046c5c0a6e3fe333e2049795cf0a3171900f62dbb8a984530dc1e81ba126d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-search-common": "npm:^1.2.24"
+  checksum: 10/c9321921bba0f76b7431fe615799016bc8acdcf59560b1dd3d82565235316c150091b6aad1f932cded47a2317b4d6a527691cc6035e620f1bdebade3e12a3f5d
   languageName: node
   linkType: hard
 
@@ -3457,6 +3862,30 @@ __metadata:
     "@backstage/backend-test-utils":
       optional: true
   checksum: 10/dc76cbf4889fdf75d2a3449d0ee4d6c73549d4d928e119adbbf4d768fa93abfff421f53b791fed5537fe10fabeb4cc692117953ad57b3975a20fdc100a87fdba
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "@backstage/plugin-catalog-node@npm:2.2.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/types": "npm:^1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    "@backstage/backend-test-utils": ^1.11.3
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10/71faa299520540260a58a5b582fd7eeb56109a8522e411b1341112f20cf6cb9d220826d597e223d77121697949cfad6cbaef7be4e126dd35b5e7cd400bdb35fb
   languageName: node
   linkType: hard
 
@@ -3572,6 +4001,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-events-node@npm:^0.4.22":
+  version: 0.4.22
+  resolution: "@backstage/plugin-events-node@npm:0.4.22"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/content-type": "npm:^1.1.8"
+    "@types/express": "npm:^4.17.6"
+    content-type: "npm:^1.0.5"
+    cross-fetch: "npm:^4.0.0"
+    express: "npm:^4.22.0"
+    uri-template: "npm:^2.0.0"
+  checksum: 10/c48fac834b72a4e6cc3e0a16194bfff1618a7d82c0ca3e4988bca1bc49c117eead02dca2d140066e2398a4d2fb4a8206688e1556fd282094df79b7c716f97a1b
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-org@backstage:^::backstage=1.50.2&npm=0.7.3, @backstage/plugin-org@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/plugin-org@npm:0.7.3"
@@ -3652,6 +4098,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.9":
+  version: 0.9.9
+  resolution: "@backstage/plugin-permission-common@npm:0.9.9"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/dbc4e26666657b7801fb6d8c732567e8fb1d0706e228713f3f9194cf84b783f04b4c8b7920a508b5296904aee6b0fc82959c08a0a6e17c3817d79bcce20b4905
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@backstage:^::backstage=1.50.2&npm=0.10.12, @backstage/plugin-permission-node@npm:^0.10.12":
   version: 0.10.12
   resolution: "@backstage/plugin-permission-node@npm:0.10.12"
@@ -3667,6 +4127,23 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10/43122a8248a0599a09d1c59fa3004725c45c74ca94765c7d89b6572a08d6cf6c8903e2fde0872d5a870a198bd5bef30df16d006be2f45060a2e5263b0185651d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@backstage/plugin-permission-node@npm:0.11.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.1"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/4376f5f41c31739e85ff4285fee6c361f04649a68eadadaa8e556a698909e48ad7f8c8eb6606a6ba4d721114bb217762c8dcc6ee95071021998f668a5bb30224
   languageName: node
   linkType: hard
 
@@ -3818,6 +4295,16 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.8"
     "@backstage/types": "npm:^1.2.2"
   checksum: 10/871618eb5c95044ae63b5e2ffb9981f052a6c1fc04f8b2ec5efb9ad34086814ccfb7e846dfe51506d73a43750b7157ca8767f2c4bdc1930f3a4036b2e82ca134
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.24":
+  version: 1.2.24
+  resolution: "@backstage/plugin-search-common@npm:1.2.24"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/types": "npm:^1.2.2"
+  checksum: 10/fabeca15dcc560b37bee9566a99659f3e2a3c502d0ec84ff2c66eb093c0489a2def92ebc9e3b20a666fc4aa5543272bc7821f7a132e313a42a2ec718c283eccd
   languageName: node
   linkType: hard
 
@@ -13572,6 +14059,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^"
     "@backstage/plugin-auth-node": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"
+    "@backstage/plugin-catalog-backend-module-incremental-ingestion": "backstage:^"
     "@backstage/plugin-catalog-node": "backstage:^"
     "@backstage/plugin-permission-backend": "backstage:^"
     "@backstage/plugin-permission-backend-module-allow-all-policy": "backstage:^"
@@ -20086,6 +20574,23 @@ __metadata:
     redis-parser: "npm:^3.0.0"
     standard-as-callback: "npm:^2.1.0"
   checksum: 10/afe5e0218810d902263dca2b22dd4501fb74698111f1850804d0948bd6a97793a7f5006757f9b6e8c8131bac6bd532d07ad971e7776bed7f6dc1f6e471706c53
+  languageName: node
+  linkType: hard
+
+"iovalkey@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "iovalkey@npm:0.3.3"
+  dependencies:
+    "@iovalkey/commands": "npm:^0.1.0"
+    cluster-key-slot: "npm:^1.1.0"
+    debug: "npm:^4.3.4"
+    denque: "npm:^2.1.0"
+    lodash.defaults: "npm:^4.2.0"
+    lodash.isarguments: "npm:^3.1.0"
+    redis-errors: "npm:^1.2.0"
+    redis-parser: "npm:^3.0.0"
+    standard-as-callback: "npm:^2.1.0"
+  checksum: 10/39368842e6a9dbc85e92dfcd4c1c917a76240bac5c4210e19a0bd3bc7984af9b567dce5de7c560c4517d5d4cb03af229f38582c1dd055c6fd452060774318e8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Partially addresses #7574 — the "expose a backend service to insert facts" half.

Adds a plugin-scoped service that lets external backend modules write tech-insights facts and schemas without registering a FactRetriever. Useful for incremental ingestion, webhooks, or any push-style source.

- `techInsightsFactInsertServiceRef` in `plugin-tech-insights-node` — write-only surface (`insertFactSchema`, `insertFacts`).
- `techInsightsFactInsertServiceFactory` in `plugin-tech-insights-backend` — bundled into the default export, so it's registered automatically.
- `initializePersistenceContext` is memoized per `DatabaseService` so the factory and `techInsightsPlugin` share one Knex pool and run migrations once.
- README section + runnable example at `packages/backend/src/plugins/incrementalFactExample.ts` driving the service from `plugin-catalog-backend-module-incremental-ingestion`.

Note: the default export of `plugin-tech-insights-backend` is now a `createBackendFeatureLoader([...])`. Equivalent for `backend.add(...);` consumers using the default outside of `backend.add` should switch to the named `techInsightsPlugin` export.

Another note: there may be a better direction for this, and I am open to feedback and other ways of achieving this functionality.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
