### PR TITLE
(tech-insights) Update package.json to remove unused repotools and msw dependencies

### DIFF
--- a/workspaces/tech-insights/.changeset/rich-garlics-divide.md
+++ b/workspaces/tech-insights/.changeset/rich-garlics-divide.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-maturity-common': patch
+---
+
+Removed unused dependencies msw and repo-tools

--- a/workspaces/tech-insights/plugins/tech-insights-maturity-common/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity-common/knip-report.md
@@ -1,9 +1,2 @@
 # Knip report
 
-## Unused dependencies (2)
-
-| Name                  | Location          | Severity |
-| :-------------------- | :---------------- | :------- |
-| @backstage/repo-tools | package.json:56:6 | error    |
-| msw                   | package.json:57:6 | error    |
-

--- a/workspaces/tech-insights/plugins/tech-insights-maturity-common/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity-common/package.json
@@ -52,9 +52,7 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage-community/plugin-tech-insights-common": "workspace:^",
-    "@backstage/repo-tools": "backstage:^",
-    "msw": "2.7.0"
+    "@backstage-community/plugin-tech-insights-common": "workspace:^"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^"

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/knip-report.md
@@ -4,12 +4,12 @@
 
 | Name            | Location          | Severity |
 | :-------------- | :---------------- | :------- |
-| @types/d3-scale | package.json:69:6 | error    |
-| @types/d3-shape | package.json:70:6 | error    |
+| @types/d3-scale | package.json:75:6 | error    |
+| @types/d3-shape | package.json:76:6 | error    |
 
 ## Unused devDependencies (1)
 
 | Name | Location          | Severity |
 | :-- | :---------------- | :------- |
-| msw | package.json:85:6 | error    |
+| msw | package.json:91:6 | error    |
 

--- a/workspaces/tech-insights/yarn.lock
+++ b/workspaces/tech-insights/yarn.lock
@@ -1973,8 +1973,6 @@ __metadata:
   dependencies:
     "@backstage-community/plugin-tech-insights-common": "workspace:^"
     "@backstage/cli": "backstage:^"
-    "@backstage/repo-tools": "backstage:^"
-    msw: "npm:2.7.0"
   languageName: unknown
   linkType: soft
 
@@ -23383,39 +23381,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:2.7.0, msw@npm:^2.0.0":
-  version: 2.7.0
-  resolution: "msw@npm:2.7.0"
-  dependencies:
-    "@bundled-es-modules/cookie": "npm:^2.0.1"
-    "@bundled-es-modules/statuses": "npm:^1.0.1"
-    "@bundled-es-modules/tough-cookie": "npm:^0.1.6"
-    "@inquirer/confirm": "npm:^5.0.0"
-    "@mswjs/interceptors": "npm:^0.37.0"
-    "@open-draft/deferred-promise": "npm:^2.2.0"
-    "@open-draft/until": "npm:^2.1.0"
-    "@types/cookie": "npm:^0.6.0"
-    "@types/statuses": "npm:^2.0.4"
-    graphql: "npm:^16.8.1"
-    headers-polyfill: "npm:^4.0.2"
-    is-node-process: "npm:^1.2.0"
-    outvariant: "npm:^1.4.3"
-    path-to-regexp: "npm:^6.3.0"
-    picocolors: "npm:^1.1.1"
-    strict-event-emitter: "npm:^0.5.1"
-    type-fest: "npm:^4.26.1"
-    yargs: "npm:^17.7.2"
-  peerDependencies:
-    typescript: ">= 4.8.x"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    msw: cli/index.js
-  checksum: 10/165ccf37d90da0d5271fdb8e01f89f48f7a60fb810038ff73d18c0e5e5ddfdb1266002d19cde61b9ae689ef37c39499b10d9d07e0d16662a31630ce9adce1d77
-  languageName: node
-  linkType: hard
-
 "msw@npm:^1.0.0":
   version: 1.3.5
   resolution: "msw@npm:1.3.5"
@@ -23447,6 +23412,39 @@ __metadata:
   bin:
     msw: cli/index.js
   checksum: 10/bc45d14bfc7b28d6deaeefe0d24d3fa2b0b1032a83f337d74bf9c4a94875085893317fa01f754cfdf743b17ded76b9886fd69de5f6defe51ed2b77876bf2041c
+  languageName: node
+  linkType: hard
+
+"msw@npm:^2.0.0":
+  version: 2.7.0
+  resolution: "msw@npm:2.7.0"
+  dependencies:
+    "@bundled-es-modules/cookie": "npm:^2.0.1"
+    "@bundled-es-modules/statuses": "npm:^1.0.1"
+    "@bundled-es-modules/tough-cookie": "npm:^0.1.6"
+    "@inquirer/confirm": "npm:^5.0.0"
+    "@mswjs/interceptors": "npm:^0.37.0"
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/until": "npm:^2.1.0"
+    "@types/cookie": "npm:^0.6.0"
+    "@types/statuses": "npm:^2.0.4"
+    graphql: "npm:^16.8.1"
+    headers-polyfill: "npm:^4.0.2"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    strict-event-emitter: "npm:^0.5.1"
+    type-fest: "npm:^4.26.1"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10/165ccf37d90da0d5271fdb8e01f89f48f7a60fb810038ff73d18c0e5e5ddfdb1266002d19cde61b9ae689ef37c39499b10d9d07e0d16662a31630ce9adce1d77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed unused dependencies msw and repotools.
- Unused according to knip-report
- repotools adds vulnerable package basic-ftp@5.0.5

## Hey, I just made a Pull Request!

Removed unused dependencies from package.json

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
