### PR TITLE
fix(shortcuts): avoid nested sidebar scrolling

### DIFF
--- a/workspaces/shortcuts/.changeset/shortcuts-sidebar-scroll.md
+++ b/workspaces/shortcuts/.changeset/shortcuts-sidebar-scroll.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-shortcuts': patch
+---
+
+Remove the nested sidebar scroll wrapper around shortcut items.

--- a/workspaces/shortcuts/plugins/shortcuts/src/Shortcuts.tsx
+++ b/workspaces/shortcuts/plugins/shortcuts/src/Shortcuts.tsx
@@ -23,11 +23,7 @@ import { ShortcutItem } from './ShortcutItem';
 import { AddShortcut } from './AddShortcut';
 import { shortcutsApiRef } from './api';
 
-import {
-  Progress,
-  SidebarItem,
-  SidebarScrollWrapper,
-} from '@backstage/core-components';
+import { Progress, SidebarItem } from '@backstage/core-components';
 import { IconComponent, useApi } from '@backstage/core-plugin-api';
 
 /**
@@ -55,7 +51,7 @@ export const Shortcuts = (props: ShortcutsProps) => {
   };
 
   return (
-    <SidebarScrollWrapper>
+    <>
       <SidebarItem
         icon={props.icon ?? PlayListAddIcon}
         text="Add Shortcuts"
@@ -79,6 +75,6 @@ export const Shortcuts = (props: ShortcutsProps) => {
           />
         ))
       )}
-    </SidebarScrollWrapper>
+    </>
   );
 };


### PR DESCRIPTION
Fixes #4841

Removes the shortcuts plugin's nested SidebarScrollWrapper, so shortcut items use the app sidebar's main scroll area instead of a hidden inner scroll region.

Checklist:
- [x] Changeset included.
- [ ] Documentation not changed.
- [x] Focused test/lint/build checks passed.
- [ ] Screenshot not attached.
- [x] Commit has Signed-off-by.

Checked:
- yarn workspace @backstage-community/plugin-shortcuts test --runInBand --watchAll=false src/Shortcuts.test.tsx
- yarn workspace @backstage-community/plugin-shortcuts lint
- yarn tsc
- yarn workspace @backstage-community/plugin-shortcuts build
- yarn prettier --check plugins/shortcuts/src/Shortcuts.tsx .changeset/shortcuts-sidebar-scroll.md
- git diff --check