### PR TITLE
fix: don't prefill announcement form end date

### DIFF
--- a/workspaces/announcements/.changeset/nine-cherries-decide.md
+++ b/workspaces/announcements/.changeset/nine-cherries-decide.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Fixed a bug in the announcement form where editing an existing announcement with an empty end date would prefill the field with today + 7 days, silently setting an `until_date` on announcements that were meant to be open-ended. The field now starts empty for both new and edited announcements.

--- a/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/components/admin/announcements/AnnouncementForm/AnnouncementForm.tsx
@@ -83,7 +83,7 @@ export const AnnouncementForm = ({
 
   const formattedUntilDate = initialData.until_date
     ? DateTime.fromISO(initialData.until_date).toISODate()
-    : DateTime.now().endOf('day').plus({ days: 7 }).toISODate();
+    : '';
 
   const [form, setForm] = useState({
     ...initialData,


### PR DESCRIPTION
The until_date field defaulted to today + 7 days, which silently populated an end date when editing announcements that were meant to be open-ended. The field now starts empty for both new and edited announcements, and empty values are submitted as undefined.

## Hey, I just made a Pull Request!

The `until_date` field is being populated using the today's date + 7 days.
This has several UX issues like:

- Assuming that all announcements will end after 7 days. 
- Not adjusting the until_date value when you choose a `start_at` date that is after it.
- If you open to edit an existing announcement with an empty end_date, it will populate the field with the today's date + 7 days.

The current fallback creates UX issues and a bug while you try to edit an existing announcement.

This PR tries to resolve this by assigning as a fallback value an empty string.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
