### PR TITLE
fix(nexus-repo-manager): migrated MUI to BUI

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
+++ b/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
@@ -3,3 +3,5 @@
 ---
 
 Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
+
+Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`.

--- a/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
+++ b/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
@@ -4,4 +4,4 @@
 
 Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
 
-Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`.
+Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`. Bumped `react-router-dom` dev dependency to `^6.30.2` to satisfy the peer requirement from `@backstage/frontend-test-utils`.

--- a/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
+++ b/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-nexus-repository-manager': patch
+---
+
+Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.

--- a/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
+++ b/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
@@ -5,3 +5,5 @@
 Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
 
 Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`. Bumped `react-router-dom` dev dependency to `^6.30.2` to satisfy the peer requirement from `@backstage/frontend-test-utils`.
+
+Fixed the alpha dev app so `maven-example` loads correctly: the entity-content filter now uses `isNexusRepositoryManagerExperimentalAvailable` (so Maven annotations show the Build Artifacts tab), and the dev mocks include experimental annotations plus Maven fixture data.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/catalogApiMock.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/catalogApiMock.ts
@@ -27,7 +27,7 @@ export const catalogApi = catalogApiMock({
         description:
           'An example component with a Maven Nexus artifact annotation',
         annotations: {
-          'nexus-repository-manager/maven.group-id': 'org.apache.logging.log4j',
+          'nexus-repository-manager/maven.group-id': 'com.example',
         },
       },
       spec: {

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/nexusRepositoryManagerMock.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/dev/alpha/nexusRepositoryManagerMock.ts
@@ -1,5 +1,9 @@
 import { NexusRepositoryManagerApiClientMock } from '../../src/__fixtures__/mocks';
-import components from '../../src/__fixtures__/components/all.json';
+import dockerComponents from '../../src/__fixtures__/components/all.json';
+import mavenComponents from '../../src/__fixtures__/components/maven.json';
 
 export const nexusRepositoryManagerApiMock =
-  new NexusRepositoryManagerApiClientMock(components);
+  new NexusRepositoryManagerApiClientMock([
+    ...dockerComponents,
+    ...mavenComponents,
+  ]);

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/knip-report.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/knip-report.md
@@ -1,2 +1,8 @@
 # Knip report
 
+## Unused dependencies (1)
+
+| Name                         | Location          | Severity |
+| :--------------------------- | :---------------- | :------- |
+| @backstage/filter-predicates | package.json:51:6 | error    |
+

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -52,7 +52,7 @@
     "@backstage/frontend-plugin-api": "^0.16.2",
     "@backstage/plugin-catalog-react": "^2.1.4",
     "@backstage/theme": "^0.7.3",
-    "@material-ui/core": "^4.9.13",
+    "@backstage/ui": "^0.14.3",
     "filesize": "^11.0.0",
     "luxon": "^3.6.1",
     "react-use": "^17.4.0"
@@ -70,7 +70,6 @@
     "@backstage/frontend-defaults": "^0.5.1",
     "@backstage/plugin-catalog": "^2.0.4",
     "@backstage/test-utils": "^1.7.17",
-    "@backstage/ui": "^0.14.3",
     "@hey-api/openapi-ts": "0.97.1",
     "@playwright/test": "1.60.0",
     "@testing-library/dom": "^10.4.1",

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -84,7 +84,7 @@
     "msw": "1.3.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-router-dom": "^6.0.0"
+    "react-router-dom": "^6.30.2"
   },
   "files": [
     "app-config.example.yaml",

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -68,6 +68,7 @@
     "@backstage/core-app-api": "^1.20.0",
     "@backstage/dev-utils": "^1.1.22",
     "@backstage/frontend-defaults": "^0.5.1",
+    "@backstage/frontend-test-utils": "^0.5.2",
     "@backstage/plugin-catalog": "^2.0.4",
     "@backstage/test-utils": "^1.7.17",
     "@hey-api/openapi-ts": "0.97.1",

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/__fixtures__/mocks/nexus-repository-manager-api-client.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/__fixtures__/mocks/nexus-repository-manager-api-client.ts
@@ -1,4 +1,7 @@
-import { NEXUS_REPOSITORY_MANAGER_ANNOTATIONS } from '../../annotations';
+import {
+  NEXUS_REPOSITORY_MANAGER_ANNOTATIONS,
+  NEXUS_REPOSITORY_MANAGER_EXPERIMENTAL_ANNOTATIONS,
+} from '../../annotations';
 import { NexusRepositoryManagerApiV1 } from '../../api';
 import { SearchServiceQuery } from '../../types';
 
@@ -16,6 +19,11 @@ export class NexusRepositoryManagerApiClientMock
   }
 
   getAnnotations() {
-    return { ANNOTATIONS: NEXUS_REPOSITORY_MANAGER_ANNOTATIONS };
+    return {
+      ANNOTATIONS: [
+        ...NEXUS_REPOSITORY_MANAGER_ANNOTATIONS,
+        ...NEXUS_REPOSITORY_MANAGER_EXPERIMENTAL_ANNOTATIONS,
+      ],
+    };
   }
 }

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/alpha/entityContents.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/alpha/entityContents.tsx
@@ -3,9 +3,8 @@ import {
   convertLegacyRouteRef,
 } from '@backstage/core-compat-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import type { FilterPredicate } from '@backstage/filter-predicates';
+import { isNexusRepositoryManagerExperimentalAvailable } from '../plugin';
 import { rootRouteRef } from '../routes';
-import { NEXUS_REPOSITORY_MANAGER_ANNOTATIONS } from '../annotations';
 
 /**
  * @alpha
@@ -15,11 +14,7 @@ export const nexusRepositoryManagerEntityContent = EntityContentBlueprint.make({
     path: '/build-artifacts',
     title: 'Build Artifacts',
     routeRef: convertLegacyRouteRef(rootRouteRef),
-    filter: {
-      $any: NEXUS_REPOSITORY_MANAGER_ANNOTATIONS.map(value => ({
-        [`metadata.annotations.${value.annotation}`]: { $exists: true },
-      })),
-    } as FilterPredicate,
+    filter: isNexusRepositoryManagerExperimentalAvailable,
     loader: async () =>
       import('../components').then(m =>
         compatWrapper(<m.NexusRepositoryManager />),

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @layer components {
   .chip {
     margin: 0;

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
@@ -1,0 +1,18 @@
+@layer components {
+  .chip {
+    margin: 0;
+    margin-right: 0.2em;
+    height: 1.5em;
+  }
+
+  .variants {
+    margin-top: 0.2em;
+    flex-wrap: wrap;
+  }
+
+  .empty {
+    padding: var(--bui-space-4);
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
@@ -21,18 +21,6 @@
     height: 1.5em;
   }
 
-  .algorithmChip {
-    display: inline-flex;
-    align-items: center;
-    padding: 0 var(--bui-space-2);
-    margin-right: 0.2em;
-    height: 1.5em;
-    font-size: var(--bui-font-size-1);
-    color: var(--bui-fg-primary);
-    background-color: var(--bui-bg-neutral-2);
-    border-radius: var(--bui-radius-2);
-  }
-
   .variants {
     margin-top: 0.2em;
     flex-wrap: wrap;

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.module.css
@@ -5,6 +5,18 @@
     height: 1.5em;
   }
 
+  .algorithmChip {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 var(--bui-space-2);
+    margin-right: 0.2em;
+    height: 1.5em;
+    font-size: var(--bui-font-size-1);
+    color: var(--bui-fg-primary);
+    background-color: var(--bui-bg-neutral-2);
+    border-radius: var(--bui-radius-2);
+  }
+
   .variants {
     margin-top: 0.2em;
     flex-wrap: wrap;

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from 'react';
 
 import { Link, Table, type TableColumn } from '@backstage/core-components';
-
-import { Box, Chip, makeStyles } from '@material-ui/core';
+import { Flex, Tag, TagGroup } from '@backstage/ui';
 
 import { formatByteSize } from '../../utils/format-byte-size/format-byte-size';
 import { useTranslation } from '../../hooks/useTranslation';
 
 import type { AssetHash } from '../../types';
+
+import styles from './ArtifactTable.module.css';
 
 export type ArtifactRowData = {
   id?: string;
@@ -20,22 +21,6 @@ export type ArtifactRowData = {
   sizeBytes?: number;
 };
 
-const useStyles = makeStyles(theme => ({
-  chip: {
-    margin: 0,
-    marginRight: '.2em',
-    height: '1.5em',
-    '& > span': {
-      padding: '.3em',
-    },
-  },
-  empty: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-}));
-
 export const ArtifactTable = ({
   artifacts,
   title,
@@ -43,7 +28,6 @@ export const ArtifactTable = ({
   artifacts: ArtifactRowData[];
   title: string;
 }) => {
-  const classes = useStyles();
   const { t } = useTranslation();
 
   const columns: TableColumn<ArtifactRowData>[] = useMemo(
@@ -61,28 +45,19 @@ export const ArtifactTable = ({
         render: rowData => (
           <>
             {rowData.artifact}
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                flexWrap: 'wrap',
-                marginTop: '0.2em',
-              }}
-            >
-              {/* sort/reverse for stable order, and so we get `jar +sources` */}
-              {[...rowData.assetVariants]
-                .sort((a, b) => a.localeCompare(b))
-                .reverse()
-                .map(variant => {
-                  return (
-                    <Chip
-                      label={variant}
-                      key={variant}
-                      className={classes.chip}
-                    />
-                  );
-                })}
-            </Box>
+            <Flex className={styles.variants} direction="row" align="center">
+              <TagGroup>
+                {/* sort/reverse for stable order, and so we get `jar +sources` */}
+                {[...rowData.assetVariants]
+                  .sort((a, b) => a.localeCompare(b))
+                  .reverse()
+                  .map(variant => (
+                    <Tag key={variant} className={styles.chip}>
+                      {variant}
+                    </Tag>
+                  ))}
+              </TagGroup>
+            </Flex>
           </>
         ),
       },
@@ -96,10 +71,12 @@ export const ArtifactTable = ({
         field: 'hash',
         emptyValue: t('table.emptyValue'),
         render: rowData => (
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Chip label={rowData.hash?.algorithm} className={classes.chip} />
+          <Flex direction="row" align="center">
+            <TagGroup>
+              <Tag className={styles.chip}>{rowData.hash?.algorithm}</Tag>
+            </TagGroup>
             {rowData.hash?.value.slice(0, 12)}
-          </Box>
+          </Flex>
         ),
         customFilterAndSearch: (term, rowData) => {
           if (!rowData.hash) {
@@ -131,7 +108,7 @@ export const ArtifactTable = ({
         render: rowData => formatByteSize(rowData.sizeBytes),
       },
     ],
-    [t, classes.chip],
+    [t],
   );
 
   return (
@@ -146,7 +123,7 @@ export const ArtifactTable = ({
       }}
       emptyContent={
         <div
-          className={classes.empty}
+          className={styles.empty}
           data-testid="nexus-repository-manager-empty-table"
         >
           {t('table.emptyContent.message')}&nbsp;

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
@@ -70,14 +70,20 @@ export const ArtifactTable = ({
         title: t('table.columns.checksum'),
         field: 'hash',
         emptyValue: t('table.emptyValue'),
-        render: rowData => (
-          <Flex direction="row" align="center" gap="1">
-            <span className={styles.algorithmChip}>
-              {rowData.hash?.algorithm}
-            </span>
-            {rowData.hash?.value.slice(0, 12)}
-          </Flex>
-        ),
+        render: rowData => {
+          if (!rowData.hash) {
+            return t('table.emptyValue');
+          }
+
+          return (
+            <Flex direction="row" align="center" gap="1">
+              <span className={styles.algorithmChip}>
+                {rowData.hash.algorithm}
+              </span>
+              {rowData.hash.value.slice(0, 12)}
+            </Flex>
+          );
+        },
         customFilterAndSearch: (term, rowData) => {
           if (!rowData.hash) {
             return false;

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
@@ -71,10 +71,10 @@ export const ArtifactTable = ({
         field: 'hash',
         emptyValue: t('table.emptyValue'),
         render: rowData => (
-          <Flex direction="row" align="center">
-            <TagGroup>
-              <Tag className={styles.chip}>{rowData.hash?.algorithm}</Tag>
-            </TagGroup>
+          <Flex direction="row" align="center" gap="1">
+            <span className={styles.algorithmChip}>
+              {rowData.hash?.algorithm}
+            </span>
             {rowData.hash?.value.slice(0, 12)}
           </Flex>
         ),

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/src/components/ArtifactTable/ArtifactTable.tsx
@@ -77,9 +77,9 @@ export const ArtifactTable = ({
 
           return (
             <Flex direction="row" align="center" gap="1">
-              <span className={styles.algorithmChip}>
-                {rowData.hash.algorithm}
-              </span>
+              <TagGroup>
+                <Tag className={styles.chip}>{rowData.hash.algorithm}</Tag>
+              </TagGroup>
               {rowData.hash.value.slice(0, 12)}
             </Flex>
           );

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/tests/nexus.spec.ts
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/tests/nexus.spec.ts
@@ -60,7 +60,10 @@ test.describe('Nexus Repository Manager plugin', () => {
 
   test('Filters work', async () => {
     const filter = page.getByPlaceholder(translations.table.searchPlaceholder);
-    const tableRow = page.getByRole('row').filter({ hasText: 'sha256' });
+    const tableRow = page
+      .getByTestId('nexus-repository-manager-table')
+      .locator('tbody tr')
+      .filter({ hasText: 'sha256' });
 
     await expect(tableRow).toHaveCount(3);
     await filter.fill('latest');

--- a/workspaces/nexus-repository-manager/yarn.lock
+++ b/workspaces/nexus-repository-manager/yarn.lock
@@ -757,7 +757,7 @@ __metadata:
     msw: "npm:1.3.5"
     react: "npm:^18.0.0"
     react-dom: "npm:^18.0.0"
-    react-router-dom: "npm:^6.0.0"
+    react-router-dom: "npm:^6.30.2"
     react-use: "npm:^17.4.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -5191,10 +5191,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@remix-run/router@npm:1.23.0"
-  checksum: 10/0a9f02c26c150d8210b05927c43d2f57ee8b7f812c81abb76df1721c7367ef692e54f4044981e756ce13d0619fb3c6a9b1514524d69aea9b32bfaf565299a8c7
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 10/a12ae9994bf017d47392ce2be24252b4e2281f4b27eac78f0e9b48afa5f522be9c0ec64b85db013ded1fff140d9512b97ac8ea5dd182138dcd6d3ded3136cbf6
   languageName: node
   linkType: hard
 
@@ -19242,27 +19242,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.0.0":
-  version: 6.30.1
-  resolution: "react-router-dom@npm:6.30.1"
+"react-router-dom@npm:^6.30.2":
+  version: 6.30.4
+  resolution: "react-router-dom@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.1"
+    "@remix-run/router": "npm:1.23.3"
+    react-router: "npm:6.30.4"
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-  checksum: 10/d61f04a36ca8a0a61e71bac2616f3f0d4142ced4a473d872738ca363b43d042f4d6dc249e7f7ae1c06f89599277e2fde11583d61cf6b34e999e79caf845acb37
+  checksum: 10/e220abac766bb9bcc56a99b78d30d99745cae3618f84baa92bd6ec481eccb6afb12c724d49dc68e6f870b70ff449f751f20f4aa33f1896d3f7d3bda8e47a6ce1
   languageName: node
   linkType: hard
 
-"react-router@npm:6.30.1":
-  version: 6.30.1
-  resolution: "react-router@npm:6.30.1"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": "npm:1.23.0"
+    "@remix-run/router": "npm:1.23.3"
   peerDependencies:
     react: ">=16.8"
-  checksum: 10/880d6cafd6376dd1e624f6f600b7a208c4142d60eaea66241980ef57260c237b3465c3ff96b28f21ae354410345bbbb1817c3bba083012aade6626027d53506f
+  checksum: 10/59c1b64a210cde2f1d069ffc47dce2d58991bd4d81bb0743e22ba7c6b742e63ebbdc976c42c3a3ebd90bf38a2f05258bd0efa82c162b259be000d39787716043
   languageName: node
   linkType: hard
 

--- a/workspaces/nexus-repository-manager/yarn.lock
+++ b/workspaces/nexus-repository-manager/yarn.lock
@@ -742,7 +742,6 @@ __metadata:
     "@backstage/theme": "npm:^0.7.3"
     "@backstage/ui": "npm:^0.14.3"
     "@hey-api/openapi-ts": "npm:0.97.1"
-    "@material-ui/core": "npm:^4.9.13"
     "@playwright/test": "npm:1.60.0"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"

--- a/workspaces/nexus-repository-manager/yarn.lock
+++ b/workspaces/nexus-repository-manager/yarn.lock
@@ -736,6 +736,7 @@ __metadata:
     "@backstage/filter-predicates": "npm:^0.1.2"
     "@backstage/frontend-defaults": "npm:^0.5.1"
     "@backstage/frontend-plugin-api": "npm:^0.16.2"
+    "@backstage/frontend-test-utils": "npm:^0.5.2"
     "@backstage/plugin-catalog": "npm:^2.0.4"
     "@backstage/plugin-catalog-react": "npm:^2.1.4"
     "@backstage/test-utils": "npm:^1.7.17"
@@ -1576,6 +1577,42 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/cba133859bc5feb099744a22694bf688b96c35fb924565f1b39123d441cdfea1348ea8301e6fe8275b1b2a2aa064943043ac49b3059f315f7b4c5efa5be1e425
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-test-utils@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@backstage/frontend-test-utils@npm:0.5.2"
+  dependencies:
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/core-app-api": "npm:^1.20.0"
+    "@backstage/core-plugin-api": "npm:^1.12.5"
+    "@backstage/filter-predicates": "npm:^0.1.2"
+    "@backstage/frontend-app-api": "npm:^0.16.2"
+    "@backstage/frontend-plugin-api": "npm:^0.16.0"
+    "@backstage/plugin-app": "npm:^0.4.3"
+    "@backstage/plugin-app-react": "npm:^0.2.2"
+    "@backstage/plugin-permission-common": "npm:^0.9.8"
+    "@backstage/plugin-permission-react": "npm:^0.5.0"
+    "@backstage/test-utils": "npm:^1.7.17"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/06d3f6344c771ed8049d367153773da69e0a0b324902c4ac4d1942811525a877e3753eed573ce97139451946bf630615ddd403ee3a627cf66a12261dbb0cac8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

screen recording:

https://github.com/user-attachments/assets/cbd6b596-45db-432b-8812-07c1612f4ae6
