### PR TITLE
fix(jfrog-artifactory): migrated MUI to BUI

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
+++ b/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jfrog-artifactory': patch
+---
+
+Migrated the JFrog-artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.

--- a/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
+++ b/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
@@ -2,4 +2,8 @@
 '@backstage-community/plugin-jfrog-artifactory': patch
 ---
 
-Migrated the JFrog-artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
+Migrated the JFrog Artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). The repository table now uses BUI `Table`, `SearchField`, and pagination controls. Removed direct MUI dependencies; no breaking API changes.
+
+Also fixed the filter input growing when typing, and added i18n support for pagination labels (page size selector and result range) in all supported locales.
+
+**Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/dev/index.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/dev/index.tsx
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// eslint-disable-next-line @backstage/no-ui-css-imports-in-non-frontend
+import '@backstage/ui/css/styles.css';
+
 import { Entity } from '@backstage/catalog-model';
 import { createDevApp } from '@backstage/dev-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -46,8 +46,7 @@
     "@backstage/core-components": "^0.18.9",
     "@backstage/core-plugin-api": "^1.12.5",
     "@backstage/plugin-catalog-react": "^2.1.4",
-    "@backstage/theme": "^0.7.3",
-    "@material-ui/core": "^4.9.13",
+    "@backstage/ui": "^0.14.3",
     "filesize": "^11.0.0",
     "luxon": "^3.6.1",
     "react-use": "^17.4.0"

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/report-alpha.api.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/report-alpha.api.md
@@ -12,7 +12,6 @@ export const jfrogArtifactoryTranslationRef: TranslationRef<
   {
     readonly 'page.title': string;
     readonly 'table.searchPlaceholder': string;
-    readonly 'table.labelRowsSelect': string;
     readonly 'table.pagination.showResults': string;
     readonly 'table.pagination.rangeLabel': string;
     readonly 'table.columns.version': string;

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/report-alpha.api.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/report-alpha.api.md
@@ -13,6 +13,8 @@ export const jfrogArtifactoryTranslationRef: TranslationRef<
     readonly 'page.title': string;
     readonly 'table.searchPlaceholder': string;
     readonly 'table.labelRowsSelect': string;
+    readonly 'table.pagination.showResults': string;
+    readonly 'table.pagination.rangeLabel': string;
     readonly 'table.columns.version': string;
     readonly 'table.columns.repositories': string;
     readonly 'table.columns.manifest': string;

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/__fixtures__/mockTags.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/__fixtures__/mockTags.ts
@@ -96,7 +96,7 @@ export const mockTags = {
               },
             ],
             licenses: [],
-            size: '4757',
+            size: '5500',
             stats: {
               downloadCount: 0,
             },
@@ -114,10 +114,10 @@ export const mockTags = {
                 name: 'manifest.json',
                 lead: true,
                 size: '1039',
-                md5: '579abdf9c2d5583ca73fd7dd063aae02',
-                sha1: '4baef62a3759202d46c3872e1b9e4e7bc3b7fe90',
+                md5: '689abdf9c2d5583ca73fd7dd063aae03',
+                sha1: '5baef62a3759202d46c3872e1b9e4e7bc3b7fe91',
                 sha256:
-                  'a3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc7f',
+                  'b3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc8e',
                 mimeType: 'application/json',
               },
               {
@@ -159,7 +159,7 @@ export const mockTags = {
               },
             ],
             licenses: [],
-            size: '4757',
+            size: '5300',
             stats: {
               downloadCount: 0,
             },
@@ -187,10 +187,10 @@ export const mockTags = {
                 name: 'manifest.json',
                 lead: true,
                 size: '1039',
-                md5: '579abdf9c2d5583ca73fd7dd063aae02',
-                sha1: '4baef62a3759202d46c3872e1b9e4e7bc3b7fe90',
+                md5: '789abdf9c2d5583ca73fd7dd063aae04',
+                sha1: '6baef62a3759202d46c3872e1b9e4e7bc3b7fe92',
                 sha256:
-                  'a3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc7f',
+                  'c3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc9f',
                 mimeType: 'application/json',
               },
               {
@@ -222,7 +222,7 @@ export const mockTags = {
               },
             ],
             licenses: [],
-            size: '4757',
+            size: '5120',
             stats: {
               downloadCount: 0,
             },
@@ -240,10 +240,10 @@ export const mockTags = {
                 name: 'manifest.json',
                 lead: true,
                 size: '1039',
-                md5: '579abdf9c2d5583ca73fd7dd063aae02',
-                sha1: '4baef62a3759202d46c3872e1b9e4e7bc3b7fe90',
+                md5: '889abdf9c2d5583ca73fd7dd063aae05',
+                sha1: '7baef62a3759202d46c3872e1b9e4e7bc3b7fe93',
                 sha256:
-                  'a3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc7f',
+                  'd3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dcaa',
                 mimeType: 'application/json',
               },
               {
@@ -285,7 +285,7 @@ export const mockTags = {
               },
             ],
             licenses: [],
-            size: '4757',
+            size: '4820',
             stats: {
               downloadCount: 0,
             },
@@ -303,10 +303,10 @@ export const mockTags = {
                 name: 'manifest.json',
                 lead: true,
                 size: '1039',
-                md5: '579abdf9c2d5583ca73fd7dd063aae02',
-                sha1: '4baef62a3759202d46c3872e1b9e4e7bc3b7fe90',
+                md5: '989abdf9c2d5583ca73fd7dd063aae06',
+                sha1: '8baef62a3759202d46c3872e1b9e4e7bc3b7fe94',
                 sha256:
-                  'a3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc7f',
+                  'e3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dcbb',
                 mimeType: 'application/json',
               },
               {
@@ -348,7 +348,7 @@ export const mockTags = {
               },
             ],
             licenses: [],
-            size: '4757',
+            size: '4689',
             stats: {
               downloadCount: 0,
             },
@@ -366,10 +366,10 @@ export const mockTags = {
                 name: 'manifest.json',
                 lead: true,
                 size: '1039',
-                md5: '579abdf9c2d5583ca73fd7dd063aae02',
-                sha1: '4baef62a3759202d46c3872e1b9e4e7bc3b7fe90',
+                md5: 'a89abdf9c2d5583ca73fd7dd063aae07',
+                sha1: '9baef62a3759202d46c3872e1b9e4e7bc3b7fe95',
                 sha256:
-                  'a3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dc7f',
+                  'f3f53a068794afb31f76ae82f79c71db0fb05a3ec960c62cd15027e214d7dcce',
                 mimeType: 'application/json',
               },
               {

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
@@ -37,6 +37,8 @@
   }
 
   .searchBar {
-    min-width: 240px;
+    width: 240px;
+    max-width: 240px;
+    flex-shrink: 0;
   }
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
@@ -16,7 +16,7 @@
 
 @layer components {
   .tableContainer {
-    border: 1px solid var(--bui-border);
+    border: 1px solid var(--bui-border-1);
   }
 
   .manifestDigest {
@@ -40,5 +40,10 @@
     width: 240px;
     max-width: 240px;
     flex-shrink: 0;
+  }
+
+  .tableContainer [class*='bui-TablePagination__'] {
+    padding-top: 10px;
+    padding-bottom: 10px;
   }
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,17 @@
 @layer components {
   .tableContainer {
     border: 1px solid var(--bui-border-1);
+  }
+
+  /* TablePagination is always the last child of the BUI Table wrapper */
+  .table > :last-child {
+    align-items: center;
+    padding-top: var(--bui-space-3);
+    padding-bottom: var(--bui-space-3);
+  }
+
+  .table > :last-child > * {
+    align-items: center;
   }
 
   .manifestDigest {
@@ -40,10 +51,5 @@
     width: 240px;
     max-width: 240px;
     flex-shrink: 0;
-  }
-
-  .tableContainer [class*='bui-TablePagination__'] {
-    padding-top: 10px;
-    padding-bottom: 10px;
   }
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.module.css
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@layer components {
+  .tableContainer {
+    border: 1px solid var(--bui-border);
+  }
+
+  .manifestDigest {
+    display: flex;
+    align-items: center;
+  }
+
+  .chip {
+    margin: 0;
+    margin-right: 0.2em;
+    height: 1.5em;
+  }
+
+  .empty {
+    padding: var(--bui-space-4);
+    display: flex;
+    justify-content: center;
+  }
+
+  .searchBar {
+    min-width: 240px;
+  }
+}

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -132,7 +132,10 @@ export function JfrogArtifactoryRepository({
   }
 
   return (
-    <div className={styles.tableContainer}>
+    <div
+      className={styles.tableContainer}
+      data-testid="jfrog-artifactory-table"
+    >
       <Header
         title={title}
         customActions={

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -166,6 +166,7 @@ export function JfrogArtifactoryRepository({
           </div>
         }
         {...tableProps}
+        className={styles.table}
       />
     </div>
   );

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -13,30 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
-import { Link, Progress, Table } from '@backstage/core-components';
+import { Link, Progress } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-
-import { Box, Chip, makeStyles } from '@material-ui/core';
+import {
+  Flex,
+  Header,
+  SearchField,
+  Table,
+  Text,
+  useTable,
+} from '@backstage/ui';
 
 import { jfrogArtifactoryApiRef } from '../../api';
 import { Edge } from '../../types';
-import { getColumns, useStyles } from './tableHeading';
-import { formatByteSize, formatDate } from '../../utils';
+import {
+  filterRepositoryRows,
+  getColumns,
+  RepositoryRowData,
+  sortRepositoryRows,
+} from './tableHeading';
+import { formatByteSize, formatDate, parseSizeBytes } from '../../utils';
 import { useTranslation } from '../../hooks/useTranslation';
-
-const useLocalStyles = makeStyles({
-  chip: {
-    margin: 0,
-    marginRight: '.2em',
-    height: '1.5em',
-    '& > span': {
-      padding: '.3em',
-    },
-  },
-});
+import styles from './JfrogArtifactoryRepository.module.css';
 
 export function JfrogArtifactoryRepository({
   image,
@@ -44,70 +45,82 @@ export function JfrogArtifactoryRepository({
   repoFilter,
 }: RepositoryProps) {
   const jfrogArtifactoryClient = useApi(jfrogArtifactoryApiRef);
-  const classes = useStyles();
-  const localClasses = useLocalStyles();
   const { t } = useTranslation();
-  const [edges, setEdges] = useState<Edge[]>([]);
-  const titleprop = t('page.title', { image } as Record<string, string>);
+  const title = t('page.title', { image } as Record<string, string>);
 
-  const { loading } = useAsync(async () => {
-    const tagsResponse = await jfrogArtifactoryClient.getTags(
-      image,
-      target,
-      repoFilter,
-    );
+  const { loading, value: tagsResponse } = useAsync(async () => {
+    return jfrogArtifactoryClient.getTags(image, target, repoFilter);
+  }, [jfrogArtifactoryClient, image, target, repoFilter]);
 
-    setEdges(tagsResponse.data.versions.edges);
+  const data = useMemo<RepositoryRowData[]>(() => {
+    const edges = tagsResponse?.data.versions.edges ?? [];
+    return edges.map((edge: Edge) => {
+      const sizeBytes = parseSizeBytes(edge.node.size);
 
-    return tagsResponse;
-  });
+      return {
+        id: edge.node.name,
+        name: edge.node.name,
+        repositories:
+          `${edge.node.repos.length}` +
+          ' | ' +
+          `${edge.node.repos.map(repo => repo.name).join('| ')}`,
+        manifestHash: edge.node.files.find(
+          manifest => manifest.name === 'manifest.json',
+        )?.sha256,
+        modified: edge.node.modified,
+        modifiedDisplay: formatDate(edge.node.modified),
+        size: formatByteSize(sizeBytes),
+        sizeBytes,
+      };
+    });
+  }, [tagsResponse]);
 
   const columns = useMemo(() => getColumns(t), [t]);
+
+  const { tableProps, search } = useTable({
+    mode: 'complete',
+    data,
+    searchFn: filterRepositoryRows,
+    sortFn: sortRepositoryRows,
+    paginationOptions: {
+      pageSize: 10,
+      showPageSizeOptions: true,
+    },
+  });
 
   if (loading) {
     return <Progress />;
   }
 
-  const data = edges?.map((edge: Edge) => {
-    const shortHash = edge.node.files
-      .find(manifest => manifest.name === 'manifest.json')
-      ?.sha256.substring(0, 12);
-    return {
-      name: edge.node.name,
-      last_modified: formatDate(edge.node.modified),
-      size: formatByteSize(Number(edge.node.size)),
-      manifest_digest: (
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <Chip label={t('manifest.sha256')} className={localClasses.chip} />
-          {shortHash}
-        </Box>
-      ),
-      repositories:
-        `${edge.node.repos.length}` +
-        ' | ' +
-        `${edge.node.repos.map(repo => repo.name).join('| ')}`,
-    };
-  });
-
   return (
-    <div style={{ border: '1px solid #ddd' }}>
+    <div className={styles.tableContainer}>
+      <Header
+        title={title}
+        customActions={
+          <Flex className={styles.searchBar}>
+            <SearchField
+              aria-label={t('table.searchPlaceholder')}
+              placeholder={t('table.searchPlaceholder')}
+              value={search.value}
+              onChange={search.onChange}
+            />
+          </Flex>
+        }
+      />
       <Table
-        title={titleprop}
-        options={{ paging: true, padding: 'dense' }}
-        data={data}
-        columns={columns}
-        emptyContent={
-          <div className={classes.empty}>
-            {t('table.emptyContent.message')}&nbsp;
-            <Link to="https://backstage.io/">
-              {t('table.emptyContent.learnMore')}
-            </Link>
+        aria-label={title}
+        columnConfig={columns}
+        emptyState={
+          <div className={styles.empty}>
+            <Text>
+              {t('table.emptyContent.message')}&nbsp;
+              <Link to="https://backstage.io/">
+                {t('table.emptyContent.learnMore')}
+              </Link>
+            </Text>
           </div>
         }
-        localization={{
-          toolbar: { searchPlaceholder: t('table.searchPlaceholder') },
-          pagination: { labelRowsSelect: t('table.labelRowsSelect') },
-        }}
+        {...tableProps}
       />
     </div>
   );

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -106,13 +106,15 @@ export function JfrogArtifactoryRepository({
         offset?: number;
         totalCount?: number;
       }) => {
-        const fromCount = (offset ?? 0) + 1;
-        const toCount = Math.min((offset ?? 0) + pageSize, totalCount ?? 0);
+        const total = totalCount ?? 0;
+        const fromCount = total === 0 ? 0 : (offset ?? 0) + 1;
+        const toCount =
+          total === 0 ? 0 : Math.min((offset ?? 0) + pageSize, total);
 
         return t('table.pagination.rangeLabel', {
           start: String(fromCount),
           end: String(toCount),
-          total: String(totalCount ?? 0),
+          total: String(total),
         } as Record<string, string>);
       },
     }),

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/JfrogArtifactoryRepository.tsx
@@ -21,6 +21,7 @@ import { useApi } from '@backstage/core-plugin-api';
 import {
   Flex,
   Header,
+  PageSizeOption,
   SearchField,
   Table,
   Text,
@@ -38,6 +39,9 @@ import {
 import { formatByteSize, formatDate, parseSizeBytes } from '../../utils';
 import { useTranslation } from '../../hooks/useTranslation';
 import styles from './JfrogArtifactoryRepository.module.css';
+
+const PAGE_SIZE_OPTIONS = [5, 10, 20, 30, 40, 50];
+const DEFAULT_PAGE_SIZE = 10;
 
 export function JfrogArtifactoryRepository({
   image,
@@ -77,15 +81,50 @@ export function JfrogArtifactoryRepository({
 
   const columns = useMemo(() => getColumns(t), [t]);
 
+  const pageSizeOptions = useMemo<PageSizeOption[]>(
+    () =>
+      PAGE_SIZE_OPTIONS.map(value => ({
+        value,
+        label: t('table.pagination.showResults', {
+          count: String(value),
+        } as Record<string, string>),
+      })),
+    [t],
+  );
+
+  const paginationOptions = useMemo(
+    () => ({
+      pageSize: DEFAULT_PAGE_SIZE,
+      showPageSizeOptions: true,
+      pageSizeOptions,
+      getLabel: ({
+        pageSize,
+        offset,
+        totalCount,
+      }: {
+        pageSize: number;
+        offset?: number;
+        totalCount?: number;
+      }) => {
+        const fromCount = (offset ?? 0) + 1;
+        const toCount = Math.min((offset ?? 0) + pageSize, totalCount ?? 0);
+
+        return t('table.pagination.rangeLabel', {
+          start: String(fromCount),
+          end: String(toCount),
+          total: String(totalCount ?? 0),
+        } as Record<string, string>);
+      },
+    }),
+    [pageSizeOptions, t],
+  );
+
   const { tableProps, search } = useTable({
     mode: 'complete',
     data,
     searchFn: filterRepositoryRows,
     sortFn: sortRepositoryRows,
-    paginationOptions: {
-      pageSize: 10,
-      showPageSizeOptions: true,
-    },
+    paginationOptions,
   });
 
   if (loading) {
@@ -103,6 +142,7 @@ export function JfrogArtifactoryRepository({
               placeholder={t('table.searchPlaceholder')}
               value={search.value}
               onChange={search.onChange}
+              style={{ width: '100%' }}
             />
           </Flex>
         }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/tableHeading.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/tableHeading.tsx
@@ -13,47 +13,127 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TableColumn } from '@backstage/core-components';
+import {
+  Cell,
+  CellText,
+  Flex,
+  Tag,
+  TagGroup,
+  type ColumnConfig,
+  type SortDescriptor,
+} from '@backstage/ui';
 import { TranslationFunction } from '@backstage/core-plugin-api/alpha';
-import { jfrogArtifactoryTranslationRef } from '../../translations';
 
-import makeStyles from '@material-ui/core/styles/makeStyles';
+import { jfrogArtifactoryTranslationRef } from '../../translations';
+import styles from './JfrogArtifactoryRepository.module.css';
+
+export type RepositoryRowData = {
+  id: string;
+  name: string;
+  repositories: string;
+  manifestHash?: string;
+  modified: string | Date;
+  modifiedDisplay: string;
+  size: string;
+  sizeBytes: number;
+};
+
+const compareStrings = (a?: string, b?: string) =>
+  (a ?? '').localeCompare(b ?? '');
+
+const compareDates = (a: string | Date, b: string | Date) =>
+  new Date(a).getTime() - new Date(b).getTime();
+
+export const sortRepositoryRows = (
+  items: RepositoryRowData[],
+  sort: SortDescriptor,
+) => {
+  const sorted = [...items].sort((a, b) => {
+    switch (String(sort.column)) {
+      case 'name':
+        return compareStrings(a.name, b.name);
+      case 'repositories':
+        return compareStrings(a.repositories, b.repositories);
+      case 'manifestHash':
+        return compareStrings(a.manifestHash, b.manifestHash);
+      case 'modified':
+        return compareDates(a.modified, b.modified);
+      case 'size':
+        return a.sizeBytes - b.sizeBytes;
+      default:
+        return 0;
+    }
+  });
+
+  return sort.direction === 'ascending' ? sorted : sorted.reverse();
+};
+
+export const filterRepositoryRows = (
+  items: RepositoryRowData[],
+  query: string,
+) => {
+  if (!query) {
+    return items;
+  }
+
+  const lowerQuery = query.toLowerCase();
+  return items.filter(
+    item =>
+      item.name.toLowerCase().includes(lowerQuery) ||
+      item.repositories.toLowerCase().includes(lowerQuery) ||
+      item.manifestHash?.toLowerCase().includes(lowerQuery) ||
+      item.modifiedDisplay.toLowerCase().includes(lowerQuery) ||
+      item.size.toLowerCase().includes(lowerQuery),
+  );
+};
 
 export const getColumns = (
   t: TranslationFunction<typeof jfrogArtifactoryTranslationRef.T>,
-): TableColumn[] => [
+): ColumnConfig<RepositoryRowData>[] => [
   {
-    title: t('table.columns.version'),
-    field: 'name',
-    type: 'string',
-    highlight: true,
+    id: 'name',
+    label: t('table.columns.version'),
+    isRowHeader: true,
+    isSortable: true,
+    cell: row => <CellText title={row.name}>{row.name}</CellText>,
   },
   {
-    title: t('table.columns.repositories'),
-    field: 'repositories',
-    type: 'string',
+    id: 'repositories',
+    label: t('table.columns.repositories'),
+    isSortable: true,
+    cell: row => (
+      <CellText title={row.repositories}>{row.repositories}</CellText>
+    ),
   },
   {
-    title: t('table.columns.manifest'),
-    field: 'manifest_digest',
-    type: 'string',
+    id: 'manifestHash',
+    label: t('table.columns.manifest'),
+    isSortable: true,
+    cell: row => (
+      <Cell>
+        <Flex align="center" className={styles.manifestDigest}>
+          <TagGroup>
+            <Tag size="small" className={styles.chip}>
+              {t('manifest.sha256')}
+            </Tag>
+          </TagGroup>
+          {row.manifestHash?.substring(0, 12)}
+        </Flex>
+      </Cell>
+    ),
   },
   {
-    title: t('table.columns.modified'),
-    field: 'last_modified',
-    type: 'date',
+    id: 'modified',
+    label: t('table.columns.modified'),
+    isSortable: true,
+    cell: row => (
+      <CellText title={row.modifiedDisplay}>{row.modifiedDisplay}</CellText>
+    ),
   },
   {
-    title: t('table.columns.size'),
-    field: 'size',
-    type: 'string',
+    id: 'size',
+    label: t('table.columns.size'),
+    isSortable: true,
+    cell: row => <CellText title={row.size}>{row.size}</CellText>,
   },
 ];
-
-export const useStyles = makeStyles(theme => ({
-  empty: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-}));

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/tableHeading.tsx
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/components/JfrogArtifactoryRepository/tableHeading.tsx
@@ -48,6 +48,10 @@ export const sortRepositoryRows = (
   items: RepositoryRowData[],
   sort: SortDescriptor,
 ) => {
+  if (!sort?.column) {
+    return items;
+  }
+
   const sorted = [...items].sort((a, b) => {
     switch (String(sort.column)) {
       case 'name':

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/de.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/de.ts
@@ -27,6 +27,8 @@ const jfrogArtifactoryTranslationDe = createTranslationMessages({
     'page.title': 'JFrog Artifactory-Repository: {{image}}',
     'table.searchPlaceholder': 'Filter',
     'table.labelRowsSelect': 'Zeilen',
+    'table.pagination.showResults': '{{count}} Ergebnisse anzeigen',
+    'table.pagination.rangeLabel': '{{start}} - {{end}} von {{total}}',
     'table.columns.version': 'Version',
     'table.columns.repositories': 'Repositorys',
     'table.columns.manifest': 'Manifest',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/de.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/de.ts
@@ -26,7 +26,6 @@ const jfrogArtifactoryTranslationDe = createTranslationMessages({
   messages: {
     'page.title': 'JFrog Artifactory-Repository: {{image}}',
     'table.searchPlaceholder': 'Filter',
-    'table.labelRowsSelect': 'Zeilen',
     'table.pagination.showResults': '{{count}} Ergebnisse anzeigen',
     'table.pagination.rangeLabel': '{{start}} - {{end}} von {{total}}',
     'table.columns.version': 'Version',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/es.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/es.ts
@@ -27,6 +27,8 @@ const jfrogArtifactoryTranslationEs = createTranslationMessages({
     'page.title': 'Repositorio de JFrog Artifactory: {{image}}',
     'table.searchPlaceholder': 'Filtrar',
     'table.labelRowsSelect': 'Filas',
+    'table.pagination.showResults': 'Mostrar {{count}} resultados',
+    'table.pagination.rangeLabel': '{{start}} - {{end}} de {{total}}',
     'table.columns.version': 'Versión',
     'table.columns.repositories': 'Repositorios',
     'table.columns.manifest': 'Manifiesto',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/es.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/es.ts
@@ -26,7 +26,6 @@ const jfrogArtifactoryTranslationEs = createTranslationMessages({
   messages: {
     'page.title': 'Repositorio de JFrog Artifactory: {{image}}',
     'table.searchPlaceholder': 'Filtrar',
-    'table.labelRowsSelect': 'Filas',
     'table.pagination.showResults': 'Mostrar {{count}} resultados',
     'table.pagination.rangeLabel': '{{start}} - {{end}} de {{total}}',
     'table.columns.version': 'Versión',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/fr.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/fr.ts
@@ -27,6 +27,8 @@ const jfrogArtifactoryTranslationFr = createTranslationMessages({
     'page.title': 'Référentiel JFrog Artifactory : {{image}}',
     'table.searchPlaceholder': 'Filtre',
     'table.labelRowsSelect': 'Rangées',
+    'table.pagination.showResults': 'Afficher {{count}} résultats',
+    'table.pagination.rangeLabel': '{{start}} - {{end}} sur {{total}}',
     'table.columns.version': 'Version',
     'table.columns.repositories': 'Référentiels',
     'table.columns.manifest': 'Manifeste',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/fr.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/fr.ts
@@ -26,7 +26,6 @@ const jfrogArtifactoryTranslationFr = createTranslationMessages({
   messages: {
     'page.title': 'Référentiel JFrog Artifactory : {{image}}',
     'table.searchPlaceholder': 'Filtre',
-    'table.labelRowsSelect': 'Rangées',
     'table.pagination.showResults': 'Afficher {{count}} résultats',
     'table.pagination.rangeLabel': '{{start}} - {{end}} sur {{total}}',
     'table.columns.version': 'Version',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/it.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/it.ts
@@ -26,7 +26,6 @@ const jfrogArtifactoryTranslationIt = createTranslationMessages({
   messages: {
     'page.title': 'Repository Artifactory di JFrog: {{image}}',
     'table.searchPlaceholder': 'Filtro',
-    'table.labelRowsSelect': 'Righe',
     'table.pagination.showResults': 'Mostra {{count}} risultati',
     'table.pagination.rangeLabel': '{{start}} - {{end}} di {{total}}',
     'table.columns.version': 'Versione',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/it.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/it.ts
@@ -27,6 +27,8 @@ const jfrogArtifactoryTranslationIt = createTranslationMessages({
     'page.title': 'Repository Artifactory di JFrog: {{image}}',
     'table.searchPlaceholder': 'Filtro',
     'table.labelRowsSelect': 'Righe',
+    'table.pagination.showResults': 'Mostra {{count}} risultati',
+    'table.pagination.rangeLabel': '{{start}} - {{end}} di {{total}}',
     'table.columns.version': 'Versione',
     'table.columns.repositories': 'Repository',
     'table.columns.manifest': 'Manifesto',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ja.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ja.ts
@@ -26,7 +26,6 @@ const jfrogArtifactoryTranslationJa = createTranslationMessages({
   messages: {
     'page.title': 'JFrog Artifactory リポジトリー: {{image}}',
     'table.searchPlaceholder': 'フィルター',
-    'table.labelRowsSelect': '行',
     'table.pagination.showResults': '{{count}} 件表示',
     'table.pagination.rangeLabel': '{{total}} 件中 {{start}} - {{end}}',
     'table.columns.version': 'バージョン',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ja.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ja.ts
@@ -27,6 +27,8 @@ const jfrogArtifactoryTranslationJa = createTranslationMessages({
     'page.title': 'JFrog Artifactory リポジトリー: {{image}}',
     'table.searchPlaceholder': 'フィルター',
     'table.labelRowsSelect': '行',
+    'table.pagination.showResults': '{{count}} 件表示',
+    'table.pagination.rangeLabel': '{{total}} 件中 {{start}} - {{end}}',
     'table.columns.version': 'バージョン',
     'table.columns.repositories': 'リポジトリー',
     'table.columns.manifest': 'マニフェスト',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ref.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ref.ts
@@ -23,6 +23,10 @@ export const jfrogArtifactoryMessages = {
   table: {
     searchPlaceholder: 'Filter',
     labelRowsSelect: 'Rows',
+    pagination: {
+      showResults: 'Show {{count}} results',
+      rangeLabel: '{{start}} - {{end}} of {{total}}',
+    },
     columns: {
       version: 'Version',
       repositories: 'Repositories',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ref.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/translations/ref.ts
@@ -22,7 +22,6 @@ export const jfrogArtifactoryMessages = {
   },
   table: {
     searchPlaceholder: 'Filter',
-    labelRowsSelect: 'Rows',
     pagination: {
       showResults: 'Show {{count}} results',
       rangeLabel: '{{start}} - {{end}} of {{total}}',

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.test.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.test.ts
@@ -14,8 +14,20 @@
  * limitations under the License.
  */
 
-import { formatByteSize, formatDate } from './utils';
+import { formatByteSize, formatDate, parseSizeBytes } from './utils';
 import { DateTime } from 'luxon';
+
+describe('parseSizeBytes', () => {
+  it('parses string sizes from the API', () => {
+    expect(parseSizeBytes('4757')).toEqual(4757);
+  });
+
+  it('returns 0 for invalid values', () => {
+    expect(parseSizeBytes(undefined)).toEqual(0);
+    expect(parseSizeBytes('')).toEqual(0);
+    expect(parseSizeBytes('not-a-number')).toEqual(0);
+  });
+});
 
 describe('formatByteSize', () => {
   it('should return N/A if sizeInBytes is not defined', () => {
@@ -42,6 +54,7 @@ describe('formatByteSize', () => {
     expect(formatByteSize(500)).toEqual('500 B');
     expect(formatByteSize(1500)).toMatch('1.5 kB');
     expect(formatByteSize(1048576)).toMatch('1.05 MB');
+    expect(formatByteSize(4757)).toEqual('4.76 kB');
   });
 });
 

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.ts
@@ -17,6 +17,15 @@
 import { filesize } from 'filesize';
 import { DateTime } from 'luxon';
 
+export function parseSizeBytes(size: string | number | undefined): number {
+  if (size === undefined || size === null || size === '') {
+    return 0;
+  }
+
+  const parsed = Number(size);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export function formatByteSize(sizeInBytes: number | undefined): string {
   if (!sizeInBytes) return 'N/A';
 

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/utils.ts
@@ -18,7 +18,7 @@ import { filesize } from 'filesize';
 import { DateTime } from 'luxon';
 
 export function parseSizeBytes(size: string | number | undefined): number {
-  if (size === undefined || size === null || size === '') {
+  if (size === undefined || size === '') {
     return 0;
   }
 

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/tests/jfrog.spec.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/tests/jfrog.spec.ts
@@ -57,13 +57,14 @@ test.describe('JFrog Artifactory plugin', () => {
   });
 
   test('Filters work', async () => {
-    const filter = page.getByPlaceholder(translations.table.searchPlaceholder);
-    const tableRow = page.getByRole('row').filter({ hasText: 'sha256' });
+    const table = page.getByTestId('jfrog-artifactory-table');
+    const filter = table.getByPlaceholder(translations.table.searchPlaceholder);
+    const tableRow = table.locator('tbody tr').filter({ hasText: 'sha256' });
 
-    await expect(tableRow).toHaveCount(5);
+    await expect(tableRow).toHaveCount(6);
     await filter.fill('1.0');
     await expect(tableRow).toHaveCount(1);
-    await page.getByRole('button', { name: 'Clear Search' }).click();
-    await expect(tableRow).toHaveCount(5);
+    await filter.fill('');
+    await expect(tableRow).toHaveCount(6);
   });
 });

--- a/workspaces/jfrog-artifactory/yarn.lock
+++ b/workspaces/jfrog-artifactory/yarn.lock
@@ -722,8 +722,7 @@ __metadata:
     "@backstage/dev-utils": "npm:^1.1.22"
     "@backstage/plugin-catalog-react": "npm:^2.1.4"
     "@backstage/test-utils": "npm:^1.7.17"
-    "@backstage/theme": "npm:^0.7.3"
-    "@material-ui/core": "npm:^4.9.13"
+    "@backstage/ui": "npm:^0.14.3"
     "@playwright/test": "npm:1.60.0"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
@@ -1865,7 +1864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.14.0, @backstage/ui@npm:^0.14.2":
+"@backstage/ui@npm:^0.14.0, @backstage/ui@npm:^0.14.2, @backstage/ui@npm:^0.14.3":
   version: 0.14.3
   resolution: "@backstage/ui@npm:0.14.3"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Migrated the JFrog Artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). The repository table now uses BUI `Table`, `SearchField`, and pagination controls. Removed direct MUI dependencies; no breaking API changes.

Also fixed the filter input growing when typing, and added i18n support for pagination labels (page size selector and result range) in all supported locales.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

screen recording (updated 6/5)

https://github.com/user-attachments/assets/ae14e433-36c6-42c8-bd56-8cd68b8b256f

