### PR TITLE
feat(rbac): add support for Azure PostgreSQL passwordless authentication

### DIFF
--- a/workspaces/rbac/.changeset/proud-monkeys-prove.md
+++ b/workspaces/rbac/.changeset/proud-monkeys-prove.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': minor
+---
+
+add support for Azure PostgreSQL passwordless authentication with managed identity

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -333,6 +333,28 @@ The RBAC plugin offers the option to store policies in a database. It supports t
 
 Ensure that you have already configured the database backend for your Backstage instance, as the RBAC plugin utilizes the same database configuration.
 
+#### Database connections and pool limits
+
+The RBAC backend currently uses **two separate PostgreSQL connection paths** for the database:
+
+1. **Knex** — conditional policies, role metadata, etc for the permission plugin
+2. **TypeORM (Casbin adapter)** — Casbin policy storage for RBAC
+
+Each path maintains its own connection pool. In horizontally scaled (HA) deployments, this extra pool can contribute to maxing out connection resources.
+
+**Mitigations today:**
+
+- Lower `backend.database.knexConfig.pool.max` to reduce per-plugin pool size.
+- Size your PostgreSQL instance to account for total connections across all Backstage core plugins and RBAC's Casbin pool.
+
+Consolidating RBAC onto a single shared database connection for both Knex and Casbin is a known improvement area to be addressed in the future.
+
+#### Passwordless PostgreSQL in the Cloud
+
+The RBAC plugin stores policies in the same database configured under `backend.database`. Passwordless authentication is supported when Backstage configures a dynamic Knex connection resolver, including **Azure Database for PostgreSQL with Entra authentication** (`connection.type: azure`) and **AWS RDS with IAM authentication** (`connection.type: rds`). Configure `backend.database` the same way as the rest of your Backstage instance — see [Passwordless PostgreSQL in the Cloud](https://backstage.io/docs/getting-started/config/database/#passwordless-postgresql-in-the-cloud) in the Backstage documentation. No additional RBAC-specific database configuration is required.
+
+Google Cloud SQL with Cloud IAM (`connection.type: cloudsql`) is not supported for RBAC policy storage yet.
+
 ### Optional maximum depth
 
 The RBAC plugin also includes an option max depth feature for organizations with potentially complex group hierarchy, this configuration value will ensure that the RBAC plugin will stop at a certain depth when building user graphs.

--- a/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.test.ts
@@ -38,6 +38,7 @@ describe('CasbinAdapterFactory', () => {
     >;
     jest.clearAllMocks();
   });
+
   it('test building an adapter using a better-sqlite3 configuration.', async () => {
     db = knex.knex({
       client: 'better-sqlite3',
@@ -307,6 +308,233 @@ describe('CasbinAdapterFactory', () => {
           rejectUnauthorized: false,
         },
       });
+    });
+  });
+
+  describe('build adapter with dynamic Knex connection resolvers', () => {
+    it('should resolve database name when knex connection is a dynamic resolver function', async () => {
+      const dynamicConnectionDb = knex.knex({
+        client: 'pg',
+        connection: async () => ({
+          host: 'myserver.postgres.database.azure.com',
+          port: 5432,
+          user: 'myuser@myserver',
+          password: 'mock-azure-token-1234567890',
+          database: 'backstage_plugin_permission',
+          ssl: { rejectUnauthorized: false },
+        }),
+      });
+
+      const config = mockServices.rootConfig({
+        data: {
+          backend: {
+            database: {
+              client: 'pg',
+              connection: {
+                type: 'azure',
+                host: 'myserver.postgres.database.azure.com',
+                port: '5432',
+                user: 'myuser@myserver',
+                ssl: {
+                  rejectUnauthorized: false,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const factory = new CasbinDBAdapterFactory(config, dynamicConnectionDb);
+      await factory.createAdapter();
+
+      expect(newAdapterMock).toHaveBeenCalled();
+      const adapterConfig = newAdapterMock.mock.calls[0][0];
+      expect(adapterConfig.database).toBe('backstage_plugin_permission');
+      expect(adapterConfig.host).toBe('myserver.postgres.database.azure.com');
+      expect(adapterConfig.username).toBe('myuser@myserver');
+      expect(adapterConfig.ssl).toEqual({ rejectUnauthorized: false });
+      expect(typeof adapterConfig.password).toBe('function');
+
+      await dynamicConnectionDb.destroy();
+    });
+
+    it('should call the dynamic resolver on each password function invocation', async () => {
+      const connectionResolver = jest.fn(async () => ({
+        host: 'myserver.postgres.database.azure.com',
+        port: 5432,
+        user: 'myuser@myserver',
+        password: 'mock-azure-token-1234567890',
+        database: 'test-database',
+        ssl: { rejectUnauthorized: false },
+      }));
+
+      const dynamicConnectionDb = knex.knex({
+        client: 'pg',
+        connection: connectionResolver,
+      });
+
+      const config = mockServices.rootConfig({
+        data: {
+          backend: {
+            database: {
+              client: 'pg',
+              connection: {
+                type: 'azure',
+                host: 'myserver.postgres.database.azure.com',
+                port: '5432',
+                user: 'myuser@myserver',
+              },
+            },
+          },
+        },
+      });
+
+      const factory = new CasbinDBAdapterFactory(config, dynamicConnectionDb);
+      await factory.createAdapter();
+
+      connectionResolver.mockClear();
+
+      const adapterConfig = newAdapterMock.mock.calls[0][0];
+      const passwordFn = adapterConfig.password;
+      const tokenResult = await passwordFn();
+
+      expect(connectionResolver).toHaveBeenCalledTimes(1);
+      expect(tokenResult).toBe('mock-azure-token-1234567890');
+
+      connectionResolver.mockResolvedValueOnce({
+        host: 'myserver.postgres.database.azure.com',
+        port: 5432,
+        user: 'myuser@myserver',
+        password: 'new-token-different',
+        database: 'test-database',
+        ssl: { rejectUnauthorized: false },
+      });
+
+      const tokenResult2 = await passwordFn();
+      expect(tokenResult2).toBe('new-token-different');
+      expect(connectionResolver).toHaveBeenCalledTimes(2);
+
+      await dynamicConnectionDb.destroy();
+    });
+
+    it('should support RDS-style dynamic connection resolvers', async () => {
+      const dynamicConnectionDb = knex.knex({
+        client: 'pg',
+        connection: async () => ({
+          host: 'mydb.abc123.us-east-1.rds.amazonaws.com',
+          port: 5432,
+          user: 'backstage',
+          password: 'mock-rds-iam-token',
+          database: 'backstage_plugin_permission',
+          ssl: { rejectUnauthorized: true },
+        }),
+      });
+
+      const config = mockServices.rootConfig({
+        data: {
+          backend: {
+            database: {
+              client: 'pg',
+              connection: {
+                type: 'rds',
+                host: 'mydb.abc123.us-east-1.rds.amazonaws.com',
+                port: '5432',
+                user: 'backstage',
+                region: 'us-east-1',
+              },
+            },
+          },
+        },
+      });
+
+      const factory = new CasbinDBAdapterFactory(config, dynamicConnectionDb);
+      await factory.createAdapter();
+
+      expect(newAdapterMock).toHaveBeenCalled();
+      const adapterConfig = newAdapterMock.mock.calls[0][0];
+      expect(adapterConfig.database).toBe('backstage_plugin_permission');
+      expect(adapterConfig.host).toBe(
+        'mydb.abc123.us-east-1.rds.amazonaws.com',
+      );
+      expect(typeof adapterConfig.password).toBe('function');
+
+      const tokenResult = await adapterConfig.password();
+      expect(tokenResult).toBe('mock-rds-iam-token');
+
+      await dynamicConnectionDb.destroy();
+    });
+
+    it('should throw error when dynamic resolver returns no password', async () => {
+      const dynamicConnectionDb = knex.knex({
+        client: 'pg',
+        connection: async () => ({
+          host: 'myserver.postgres.database.azure.com',
+          port: 5432,
+          user: 'myuser@myserver',
+          database: 'test-database',
+        }),
+      });
+
+      const config = mockServices.rootConfig({
+        data: {
+          backend: {
+            database: {
+              client: 'pg',
+              connection: {
+                type: 'azure',
+                host: 'myserver.postgres.database.azure.com',
+                port: '5432',
+                user: 'myuser@myserver',
+              },
+            },
+          },
+        },
+      });
+
+      const factory = new CasbinDBAdapterFactory(config, dynamicConnectionDb);
+      await factory.createAdapter();
+
+      const adapterConfig = newAdapterMock.mock.calls[0][0];
+      await expect(adapterConfig.password()).rejects.toThrow(
+        'missing password on resolved Knex connection',
+      );
+
+      await dynamicConnectionDb.destroy();
+    });
+
+    it('should throw error when dynamic resolver returns no database name', async () => {
+      const dynamicConnectionDb = knex.knex({
+        client: 'pg',
+        connection: async () => ({
+          host: 'myserver.postgres.database.azure.com',
+          port: 5432,
+          user: 'myuser@myserver',
+          password: 'mock-azure-token',
+        }),
+      });
+
+      const config = mockServices.rootConfig({
+        data: {
+          backend: {
+            database: {
+              client: 'pg',
+              connection: {
+                type: 'azure',
+                host: 'myserver.postgres.database.azure.com',
+                port: '5432',
+                user: 'myuser@myserver',
+              },
+            },
+          },
+        },
+      });
+
+      const factory = new CasbinDBAdapterFactory(config, dynamicConnectionDb);
+      await expect(factory.createAdapter()).rejects.toThrow(
+        'missing database name on Knex connection',
+      );
+
+      await dynamicConnectionDb.destroy();
     });
   });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/casbin-adapter-factory.ts
@@ -26,6 +26,9 @@ import '@backstage/backend-defaults/database';
 
 const DEFAULT_SQLITE3_STORAGE_FILE_NAME = 'rbac.sqlite';
 
+const UNSUPPORTED_PG_CONNECTION_STRING_ERROR =
+  'Postgres connection config in string format is not supported yet, an object is expected';
+
 export class CasbinDBAdapterFactory {
   public constructor(
     private readonly config: ConfigApi,
@@ -38,21 +41,37 @@ export class CasbinDBAdapterFactory {
 
     let adapter;
     if (client === 'pg') {
-      const dbName =
-        await this.databaseClient.client.config.connection.database;
+      const knexConnection = this.databaseClient.client.config.connection;
+      const resolved = await this.resolveKnexPgConnection();
+
+      if (!resolved.database) {
+        throw new Error('missing database name on Knex connection');
+      }
+
       const schema =
         (await this.databaseClient.client.searchPath?.[0]) ?? 'public';
 
       const ssl = this.handlePostgresSSL(databaseConfig!);
+
+      const password =
+        typeof knexConnection === 'function'
+          ? async () => {
+              const connection = await knexConnection();
+              if (connection.password === undefined) {
+                throw new Error('missing password on resolved Knex connection');
+              }
+              return String(connection.password);
+            }
+          : databaseConfig?.getOptionalString('connection.password');
 
       adapter = await TypeORMAdapter.newAdapter({
         type: 'postgres',
         host: databaseConfig?.getString('connection.host'),
         port: databaseConfig?.getNumber('connection.port'),
         username: databaseConfig?.getOptionalString('connection.user'),
-        password: databaseConfig?.getOptionalString('connection.password'),
+        password: password as any, // TypeORM types don't include function, but pg driver supports it
         ssl,
-        database: dbName,
+        database: resolved.database,
         schema: schema,
         poolSize: databaseConfig?.getOptionalNumber('knexConfig.pool.max'),
       });
@@ -81,6 +100,20 @@ export class CasbinDBAdapterFactory {
     return adapter;
   }
 
+  private async resolveKnexPgConnection(): Promise<Knex.PgConnectionConfig> {
+    const connection = this.databaseClient.client.config.connection;
+
+    if (typeof connection === 'function') {
+      return await connection();
+    }
+
+    if (typeof connection === 'string' || connection instanceof String) {
+      throw new Error(UNSUPPORTED_PG_CONNECTION_STRING_ERROR);
+    }
+
+    return connection;
+  }
+
   private handlePostgresSSL(
     dbConfig: Config,
   ): boolean | TlsOptions | undefined {
@@ -92,9 +125,7 @@ export class CasbinDBAdapterFactory {
     }
 
     if (typeof connection === 'string' || connection instanceof String) {
-      throw new Error(
-        `rbac backend plugin doesn't support postgres connection in a string format yet`,
-      );
+      throw new Error(UNSUPPORTED_PG_CONNECTION_STRING_ERROR);
     }
 
     const ssl: boolean | ConnectionOptions | undefined = connection.ssl;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds Azure PostgreSQL passwordless authentication for RBAC policy storage when `backend.database.connection.type` is `azure`.

See [upstream docs](https://backstage.io/docs/getting-started/config/database/#azure-with-entra-authentication) for configuration instructions and note that Google Cloud SQL is not supported yet.

Relates to https://github.com/backstage/backstage/pull/31855

Fixes https://github.com/backstage/community-plugins/issues/8951

### Manual Testing Efforts
Tested with ARO cluster with managed identity
- creating/updating policies with the API, UI, and policy file
- conditional access with file

**Note on testing with HA**: during testing w/ multiple pods, we hit Azure database connection limits, resulting in the following error, but it was not able to be reproduced consistently. 

```
info permission.permission-evaluation Unable to find all roles. Cause: error: remaining connection slots are reserved for roles with the SUPERUSER attribute
```

It may just be a matter of needing to configure more resources in the Azure database. It would be helpful to test this scenario with other setups to see if it's a persistent issue.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
