### PR TITLE
Add CODEOWNERS entry for healert workspace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@ yarn.lock                                                               @backsta
 /workspaces/grafana                                                     @backstage/community-plugins-maintainers
 /workspaces/graphiql                                                    @backstage/community-plugins-maintainers
 /workspaces/graphql-voyager                                             @backstage/community-plugins-maintainers
+/workspaces/healert                                                     @backstage/community-plugins-maintainers  @amgadmag  @israa-mosad
 /workspaces/ilert                                                       @backstage/community-plugins-maintainers
 /workspaces/jaeger                                                      @backstage/community-plugins-maintainers
 /workspaces/jenkins                                                     @backstage/community-plugins-maintainers
@@ -129,4 +130,4 @@ yarn.lock                                                               @backsta
 /workspaces/vault                                                       @backstage/community-plugins-maintainers
 /workspaces/wheel-of-names                                              @backstage/community-plugins-maintainers  @philippeckelintive @johannes-kirchner
 /workspaces/xcmetrics                                                   @backstage/community-plugins-maintainers
-/workspaces/healert                                                     @backstage/community-plugins-maintainers  @amgadmag  @israa-mosad
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -129,3 +129,4 @@ yarn.lock                                                               @backsta
 /workspaces/vault                                                       @backstage/community-plugins-maintainers
 /workspaces/wheel-of-names                                              @backstage/community-plugins-maintainers  @philippeckelintive @johannes-kirchner
 /workspaces/xcmetrics                                                   @backstage/community-plugins-maintainers
+/workspaces/healert                                                     @backstage/community-plugins-maintainers  @amgadmag  @israa-mosad


### PR DESCRIPTION
We are the authors and maintainers of the Healert plugin
submitted in PR #9207.

Requesting to be added as an org member so I can
carry out plugin maintainer responsibilities as
described in the maintainer guide.

GitHub username: @amgadmag
Github username: @israa-mosad
Plugin workspace: workspaces/healert/

Thank you