### PR TITLE
fix: reverse order of records for tech-insights-maturity codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,8 +120,8 @@ yarn.lock                                                               @backsta
 /workspaces/splunk                                                      @backstage/community-plugins-maintainers
 /workspaces/stack-overflow                                              @backstage/community-plugins-maintainers
 /workspaces/stackstorm                                                  @backstage/community-plugins-maintainers
-/workspaces/tech-insights/plugins/tech-insights-maturity                @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking @maicaballangan
 /workspaces/tech-insights                                               @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking
+/workspaces/tech-insights/plugins/tech-insights-maturity                @backstage/community-plugins-maintainers  @xantier @punkle @kurtaking @maicaballangan
 /workspaces/tech-radar                                                  @backstage/community-plugins-maintainers
 /workspaces/tekton                                                      @backstage/community-plugins-maintainers  @caugello @cryptorodeo @djanickova @Eswaraiahsapram @christoph-jerolimov @ciiay @debsmita1 @divyanshiGupta @its-mitesh-kumar @lokanandaprabhu @rohitkrai03 @jrichter1 @HusneShabbir @karthikjeeyar 
 /workspaces/todo                                                        @backstage/community-plugins-maintainers


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reverting https://github.com/backstage/community-plugins/pull/8773 did not do what we intended. It removed @maicaballangan as codeowner due to the ordering. The correct fix was ensuring the members listed for `tech-insights` were also included for `tech-insights-maturity` **without reversing** the order of records in the file.

You can see how @maicaballangan is no longer listed as codeowner in https://github.com/backstage/community-plugins/pull/8973.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
