### PR TITLE
fix(keycloak): provide frontend visibility to auth provider configs

### DIFF
--- a/workspaces/keycloak/.changeset/tender-beers-tan.md
+++ b/workspaces/keycloak/.changeset/tender-beers-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-auth-backend-module-keycloak-provider': patch
+---
+
+Mark the Keycloak auth provider config with @visibility frontend and add resolver details to config.d.ts

--- a/workspaces/keycloak/plugins/auth-backend-module-keycloak/config.d.ts
+++ b/workspaces/keycloak/plugins/auth-backend-module-keycloak/config.d.ts
@@ -17,6 +17,7 @@
 export interface Config {
   auth?: {
     providers?: {
+      /** @visibility frontend */
       keycloak?: {
         [authEnv: string]: {
           /**
@@ -55,6 +56,32 @@ export interface Config {
            * @example "login"
            */
           prompt?: string;
+          signIn?: {
+            resolvers: Array<
+              | {
+                  resolver: 'emailLocalPartMatchingUserEntityName';
+                  allowedDomains?: string[];
+                  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+                }
+              | {
+                  resolver: 'emailMatchingUserEntityProfileEmail';
+                  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+                }
+              | {
+                  resolver: 'preferredUsernameMatchingUserEntityName';
+                  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+                }
+              | {
+                  resolver: 'oidcSubClaimMatchingKeycloakUserId';
+                  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+                }
+              | {
+                  resolver: 'ldapUuidMatchingAnnotation';
+                  dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+                  ldapUuidKey?: string;
+                }
+            >;
+          };
         };
       };
     };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Mark the Keycloak auth provider config with `@visibility` frontend so configs can be exposed to the app to implement sign-in UI
- Added `signIn.resolvers` entries for all resolvers to mirror other existing auth providers

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
