### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/fuzzy-berries-collect.md
+++ b/workspaces/announcements/.changeset/fuzzy-berries-collect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-announcements': patch
----
-
-Remove the deprecated navItem. This component is no longer needed as a separate extension in the new frontend system

--- a/workspaces/announcements/plugins/announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/announcements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-announcements
 
+## 2.9.1
+
+### Patch Changes
+
+- 1df945e: Remove the deprecated navItem. This component is no longer needed as a separate extension in the new frontend system
+
 ## 2.9.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-announcements",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-announcements@2.9.1

### Patch Changes

-   1df945e: Remove the deprecated navItem. This component is no longer needed as a separate extension in the new frontend system
