### PR TITLE
Version Packages (scaffolder-backend-module-kubernetes)

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-51-0.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/version-bump-1-51-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-kubernetes
 
+## 2.18.0
+
+### Minor Changes
+
+- 1f964ea: Backstage version bump to v1.51.0
+
 ## 2.17.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.18.0

### Minor Changes

-   1f964ea: Backstage version bump to v1.51.0
