### PR TITLE
Version Packages (tech-insights)

### DIFF
--- a/workspaces/tech-insights/.changeset/great-pumas-decide.md
+++ b/workspaces/tech-insights/.changeset/great-pumas-decide.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-maturity': patch
----
-
-Remove unused `msw` dependency

--- a/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
+++ b/workspaces/tech-insights/.changeset/perfect-sheep-exercise.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-tech-insights-maturity': patch
----
-
-Add a `techInsights.maturity.enableCompoundEntityCheck` config option that lets
-non-Component entities (System, Domain, Group, API, Resource, etc.) have their
-own maturity scorecard. When enabled, the Maturity Summary page additionally
-renders the entity's own scorecard alongside the rollup of its related
-components. Defaults to `false`, preserving existing behavior.

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/CHANGELOG.md
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-tech-insights-maturity
 
+## 0.9.1
+
+### Patch Changes
+
+- 43f04bb: Remove unused `msw` dependency
+- 832bfe3: Add a `techInsights.maturity.enableCompoundEntityCheck` config option that lets
+  non-Component entities (System, Domain, Group, API, Resource, etc.) have their
+  own maturity scorecard. When enabled, the Maturity Summary page additionally
+  renders the entity's own scorecard alongside the rollup of its related
+  components. Defaults to `false`, preserving existing behavior.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-maturity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tech-insights-maturity",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tech-insights-maturity@0.9.1

### Patch Changes

-   43f04bb: Remove unused `msw` dependency
-   832bfe3: Add a `techInsights.maturity.enableCompoundEntityCheck` config option that lets
    non-Component entities (System, Domain, Group, API, Resource, etc.) have their
    own maturity scorecard. When enabled, the Maturity Summary page additionally
    renders the entity's own scorecard alongside the rollup of its related
    components. Defaults to `false`, preserving existing behavior.
