### PR TITLE
Version Packages (topology)

### DIFF
--- a/workspaces/topology/.changeset/green-peas-marry.md
+++ b/workspaces/topology/.changeset/green-peas-marry.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': patch
----
-
-Migrated the topology plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.

--- a/workspaces/topology/.changeset/light-turkeys-accept.md
+++ b/workspaces/topology/.changeset/light-turkeys-accept.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-Added support for the New Frontend System (NFS), including alpha exports with `EntityContentBlueprint` and `TranslationBlueprint`, plus dedicated dev entrypoints for backend and mock modes. Added explicit mock-only dev entry files for both legacy and NFS flows (`dev/index.mock.tsx` and `dev/alpha/index.mock.tsx`) so local development and e2e can run without backend dependencies. Removed packages/app and packages/backend to eliminate the need for a full Backstage app setup, and introduced a lightweight Topology backend that imports and relies on the Kubernetes backend plugin for real data integration when using backend mode.

--- a/workspaces/topology/.changeset/version-bump-1-52-0.md
+++ b/workspaces/topology/.changeset/version-bump-1-52-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-topology': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/topology/plugins/topology/CHANGELOG.md
+++ b/workspaces/topology/plugins/topology/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-topology
 
+## 2.15.0
+
+### Minor Changes
+
+- 13db2ee: Added support for the New Frontend System (NFS), including alpha exports with `EntityContentBlueprint` and `TranslationBlueprint`, plus dedicated dev entrypoints for backend and mock modes. Added explicit mock-only dev entry files for both legacy and NFS flows (`dev/index.mock.tsx` and `dev/alpha/index.mock.tsx`) so local development and e2e can run without backend dependencies. Removed packages/app and packages/backend to eliminate the need for a full Backstage app setup, and introduced a lightweight Topology backend that imports and relies on the Kubernetes backend plugin for real data integration when using backend mode.
+- 73d37f1: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 70da59a: Migrated the topology plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
+
 ## 2.14.0
 
 ### Minor Changes

--- a/workspaces/topology/plugins/topology/package.json
+++ b/workspaces/topology/plugins/topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-topology",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-topology@2.15.0

### Minor Changes

-   13db2ee: Added support for the New Frontend System (NFS), including alpha exports with `EntityContentBlueprint` and `TranslationBlueprint`, plus dedicated dev entrypoints for backend and mock modes. Added explicit mock-only dev entry files for both legacy and NFS flows (`dev/index.mock.tsx` and `dev/alpha/index.mock.tsx`) so local development and e2e can run without backend dependencies. Removed packages/app and packages/backend to eliminate the need for a full Backstage app setup, and introduced a lightweight Topology backend that imports and relies on the Kubernetes backend plugin for real data integration when using backend mode.
-   73d37f1: Backstage version bump to v1.52.0

### Patch Changes

-   70da59a: Migrated the topology plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
