### PR TITLE
feat(code-coverage): add EntityCodeCoverageCard for entity overview page

### DIFF
--- a/workspaces/code-coverage/.changeset/healthy-goats-glow.md
+++ b/workspaces/code-coverage/.changeset/healthy-goats-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-code-coverage': minor
+---
+
+Add `EntityCodeCoverageCard` — a compact overview card displaying line and branch coverage with build-over-build trend, intended for entity overview pages.

--- a/workspaces/code-coverage/app-config.yaml
+++ b/workspaces/code-coverage/app-config.yaml
@@ -1,0 +1,9 @@
+app:
+  title: Code Coverage Plugin Dev
+  baseUrl: http://localhost:3000
+
+backend:
+  baseUrl: http://localhost:7007
+
+organization:
+  name: Dev

--- a/workspaces/code-coverage/plugins/code-coverage/README.md
+++ b/workspaces/code-coverage/plugins/code-coverage/README.md
@@ -30,6 +30,30 @@ Finally you need to import and render the code coverage entity, in `packages/app
  );
 ```
 
+### Overview card (optional)
+
+You can also display a compact summary of line and branch coverage on the entity overview page using `EntityCodeCoverageCard`. The card shows the current percentages along with the trend versus the previous build, and links to the full report.
+
+```diff
+@@ EntityPage.tsx
++import { EntityCodeCoverageCard } from '@backstage-community/plugin-code-coverage';
+
+ const overviewContent = (
+   <Grid container spacing={3} alignItems="stretch">
+     {/* ...other cards... */}
++    <EntitySwitch>
++      <EntitySwitch.Case if={isCodeCoverageAvailable}>
++        <Grid item md={6} xs={12}>
++          <EntityCodeCoverageCard variant="gridItem" />
++        </Grid>
++      </EntitySwitch.Case>
++    </EntitySwitch>
+   </Grid>
+ );
+```
+
+`isCodeCoverageAvailable` is exported from the same package and checks for the `backstage.io/code-coverage` annotation.
+
 ## Configuring your entity
 
 In order to use this plugin, you must set the `backstage.io/code-coverage` annotation on entities for which coverage ingestion has been enabled.

--- a/workspaces/code-coverage/plugins/code-coverage/dev/index.tsx
+++ b/workspaces/code-coverage/plugins/code-coverage/dev/index.tsx
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 import { createDevApp } from '@backstage/dev-utils';
-import { codeCoveragePlugin, EntityCodeCoverageContent } from '../src/plugin';
+import {
+  codeCoveragePlugin,
+  EntityCodeCoverageContent,
+  EntityCodeCoverageCard,
+} from '../src/plugin';
+import Grid from '@material-ui/core/Grid';
 import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { codeCoverageApiRef, CodeCoverageApi } from '../src/api';
@@ -74,6 +79,18 @@ createDevApp()
         <EntityCodeCoverageContent />
       </EntityProvider>
     ),
-    title: 'Root Page',
+    title: 'Full Page',
+  })
+  .addPage({
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <Grid container spacing={3} style={{ padding: 24 }}>
+          <Grid item md={6} xs={12}>
+            <EntityCodeCoverageCard variant="gridItem" />
+          </Grid>
+        </Grid>
+      </EntityProvider>
+    ),
+    title: 'Overview Card',
   })
   .render();

--- a/workspaces/code-coverage/plugins/code-coverage/report.api.md
+++ b/workspaces/code-coverage/plugins/code-coverage/report.api.md
@@ -5,6 +5,8 @@
 ```ts
 import { BackstagePlugin } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { InfoCardVariants } from '@backstage/core-components';
+import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { RouteRef } from '@backstage/core-plugin-api';
 
 // @public (undocumented)
@@ -15,6 +17,16 @@ export const codeCoveragePlugin: BackstagePlugin<
   {},
   {}
 >;
+
+// @public
+export type CoverageCardProps = {
+  variant?: InfoCardVariants;
+};
+
+// @public
+export const EntityCodeCoverageCard: (
+  input: CoverageCardProps,
+) => JSX_2.Element;
 
 // @public
 export const EntityCodeCoverageContent: () => JSX.Element;

--- a/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageCard/CoverageCard.tsx
+++ b/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageCard/CoverageCard.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { useApi, useRouteRef } from '@backstage/core-plugin-api';
+import {
+  Progress,
+  ResponseErrorPanel,
+  InfoCard,
+  InfoCardVariants,
+  MissingAnnotationEmptyState,
+} from '@backstage/core-components';
+import Box from '@material-ui/core/Box';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
+import useAsync from 'react-use/esm/useAsync';
+import { codeCoverageApiRef } from '../../api';
+import { getTrendForCoverage, CoverageType } from '../../utils/coverageTrend';
+import { TrendIcon } from '../../utils/TrendIcon';
+import { rootRouteRef } from '../../routes';
+import { isCodeCoverageAvailable } from '../Router';
+
+const ANNOTATION_CODE_COVERAGE = 'backstage.io/code-coverage';
+
+const useStyles = makeStyles(theme => ({
+  percentage: {
+    fontSize: '2rem',
+    fontWeight: 'bold',
+    lineHeight: 1,
+  },
+  label: {
+    color: theme.palette.text.secondary,
+    marginBottom: theme.spacing(1),
+  },
+  metricBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    padding: theme.spacing(2),
+  },
+  trendRow: {
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: theme.spacing(0.5),
+  },
+}));
+
+function CoverageMetric({
+  label,
+  percentage,
+  trend,
+  hasPreviousBuild,
+  classes,
+}: {
+  label: string;
+  percentage: number;
+  trend: number;
+  hasPreviousBuild: boolean;
+  classes: ReturnType<typeof useStyles>;
+}) {
+  let trendLabel: string;
+  if (!hasPreviousBuild) {
+    trendLabel = 'No previous build';
+  } else if (trend === 0) {
+    trendLabel = 'No change vs last build';
+  } else {
+    trendLabel = `${Math.abs(Math.floor(trend))}% vs last build`;
+  }
+
+  return (
+    <Box className={classes.metricBox}>
+      <Typography className={classes.label} variant="overline">
+        {label}
+      </Typography>
+      <Typography className={classes.percentage}>
+        {percentage.toFixed(1)}%
+      </Typography>
+      <Box className={classes.trendRow}>
+        <TrendIcon trend={trend} />
+        <Typography variant="caption">{trendLabel}</Typography>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Props for {@link EntityCodeCoverageCard}.
+ *
+ * @public
+ */
+export type CoverageCardProps = {
+  variant?: InfoCardVariants;
+};
+
+export const CoverageCard = ({ variant }: CoverageCardProps) => {
+  const { entity } = useEntity();
+  const codeCoverageApi = useApi(codeCoverageApiRef);
+  const rootLink = useRouteRef(rootRouteRef);
+  const classes = useStyles();
+
+  const entityRef = {
+    kind: entity.kind,
+    namespace: entity.metadata.namespace || 'default',
+    name: entity.metadata.name,
+  };
+
+  const {
+    loading: loadingCoverage,
+    error: errorCoverage,
+    value: valueCoverage,
+  } = useAsync(
+    async () => await codeCoverageApi.getCoverageForEntity(entityRef),
+  );
+
+  const {
+    loading: loadingHistory,
+    error: errorHistory,
+    value: valueHistory,
+  } = useAsync(
+    async () => await codeCoverageApi.getCoverageHistoryForEntity(entityRef, 2),
+  );
+
+  if (!isCodeCoverageAvailable(entity)) {
+    return (
+      <MissingAnnotationEmptyState annotation={ANNOTATION_CODE_COVERAGE} />
+    );
+  }
+
+  if (loadingCoverage || loadingHistory) {
+    return <Progress />;
+  }
+
+  if (errorCoverage) {
+    return <ResponseErrorPanel error={errorCoverage} />;
+  }
+
+  if (errorHistory) {
+    return <ResponseErrorPanel error={errorHistory} />;
+  }
+
+  if (!valueCoverage || !valueHistory) {
+    return <Alert severity="warning">No coverage data found.</Alert>;
+  }
+
+  const history = valueHistory.history;
+  const latest = history[0];
+  const previous = history[1];
+
+  if (!latest) {
+    return <Alert severity="warning">No coverage history found.</Alert>;
+  }
+
+  const getTrend = (type: CoverageType) =>
+    previous ? getTrendForCoverage(latest, previous, type) : 0;
+
+  const lineTrend = getTrend('line');
+  const branchTrend = getTrend('branch');
+  const hasPreviousBuild = Boolean(previous);
+  const hasBranchCoverage = latest.branch.available > 0;
+
+  return (
+    <InfoCard
+      title="Code Coverage"
+      variant={variant}
+      deepLink={{ title: 'View full report', link: rootLink() }}
+    >
+      <Grid container justifyContent="space-around">
+        <Grid item>
+          <CoverageMetric
+            label="Line Coverage"
+            percentage={latest.line.percentage}
+            trend={lineTrend}
+            hasPreviousBuild={hasPreviousBuild}
+            classes={classes}
+          />
+        </Grid>
+        {hasBranchCoverage && (
+          <Grid item>
+            <CoverageMetric
+              label="Branch Coverage"
+              percentage={latest.branch.percentage}
+              trend={branchTrend}
+              hasPreviousBuild={hasPreviousBuild}
+              classes={classes}
+            />
+          </Grid>
+        )}
+      </Grid>
+    </InfoCard>
+  );
+};

--- a/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageCard/index.ts
+++ b/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageCard/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2020 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,5 @@
  * limitations under the License.
  */
 
-/**
- * A Backstage plugin that helps you keep track of your code coverage
- *
- * @packageDocumentation
- */
-
-import { isCodeCoverageAvailable } from './components/Router';
-
-export {
-  codeCoveragePlugin,
-  EntityCodeCoverageContent,
-  EntityCodeCoverageCard,
-} from './plugin';
-export type { CoverageCardProps } from './components/CoverageCard';
-export { isCodeCoverageAvailable };
-
-/**
- * @public
- * @deprecated Use `isPluginApplicableToEntity` instead.
- */
-export const isPluginApplicableToEntity = isCodeCoverageAvailable;
+export { CoverageCard } from './CoverageCard';
+export type { CoverageCardProps } from './CoverageCard';

--- a/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
+++ b/workspaces/code-coverage/plugins/code-coverage/src/components/CoverageHistoryChart/CoverageHistoryChart.tsx
@@ -20,12 +20,7 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-import TrendingDownIcon from '@material-ui/icons/TrendingDown';
-import TrendingFlatIcon from '@material-ui/icons/TrendingFlat';
-import TrendingUpIcon from '@material-ui/icons/TrendingUp';
 import Alert from '@material-ui/lab/Alert';
-import { ClassNameMap } from '@material-ui/styles/withStyles';
 import useAsync from 'react-use/esm/useAsync';
 import {
   CartesianGrid,
@@ -38,34 +33,13 @@ import {
   YAxis,
 } from 'recharts';
 import { codeCoverageApiRef } from '../../api';
+import { getTrendForCoverage } from '../../utils/coverageTrend';
+import { TrendIcon } from '../../utils/TrendIcon';
 
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 
 import { DateTime } from 'luxon';
-
-type Coverage = 'line' | 'branch';
-
-const useStyles = makeStyles(theme => ({
-  trendDown: {
-    color: theme.palette.status.warning,
-  },
-  trendUp: {
-    color: theme.palette.status.ok,
-  },
-}));
-
-const getTrendIcon = (trend: number, classes: ClassNameMap) => {
-  switch (true) {
-    case trend > 0:
-      return <TrendingUpIcon className={classes.trendUp} />;
-    case trend < 0:
-      return <TrendingDownIcon className={classes.trendDown} />;
-    case trend === 0:
-    default:
-      return <TrendingFlatIcon />;
-  }
-};
 
 // convert timestamp to human friendly form
 function formatDateToHuman(timeStamp: string | number) {
@@ -89,7 +63,6 @@ export const CoverageHistoryChart = () => {
         name: entity.metadata.name,
       }),
   );
-  const classes = useStyles();
 
   if (loadingHistory) {
     return <Progress />;
@@ -112,19 +85,12 @@ export const CoverageHistoryChart = () => {
   const [oldestCoverage] = valueHistory.history.slice(-1);
   const latestCoverage = valueHistory.history[0];
 
-  const getTrendForCoverage = (type: Coverage) => {
-    if (!oldestCoverage[type].percentage) {
-      return 0;
-    }
-    return (
-      ((latestCoverage[type].percentage - oldestCoverage[type].percentage) /
-        oldestCoverage[type].percentage) *
-      100
-    );
-  };
-
-  const lineTrend = getTrendForCoverage('line');
-  const branchTrend = getTrendForCoverage('branch');
+  const lineTrend = getTrendForCoverage(latestCoverage, oldestCoverage, 'line');
+  const branchTrend = getTrendForCoverage(
+    latestCoverage,
+    oldestCoverage,
+    'branch',
+  );
 
   return (
     <Card>
@@ -132,7 +98,7 @@ export const CoverageHistoryChart = () => {
       <CardContent>
         <Box px={6} display="flex">
           <Box display="flex" mr={4}>
-            {getTrendIcon(lineTrend, classes)}
+            <TrendIcon trend={lineTrend} />
             <Typography>
               Current line: {latestCoverage.line.percentage}%<br />(
               {Math.floor(lineTrend)}% change over {valueHistory.history.length}{' '}
@@ -140,7 +106,7 @@ export const CoverageHistoryChart = () => {
             </Typography>
           </Box>
           <Box display="flex">
-            {getTrendIcon(branchTrend, classes)}
+            <TrendIcon trend={branchTrend} />
             <Typography>
               Current branch: {latestCoverage.branch.percentage}%<br />(
               {Math.floor(branchTrend)}% change over{' '}

--- a/workspaces/code-coverage/plugins/code-coverage/src/plugin.ts
+++ b/workspaces/code-coverage/plugins/code-coverage/src/plugin.ts
@@ -18,6 +18,7 @@ import { rootRouteRef } from './routes';
 
 import {
   createApiFactory,
+  createComponentExtension,
   createPlugin,
   createRoutableExtension,
   discoveryApiRef,
@@ -52,5 +53,20 @@ export const EntityCodeCoverageContent = codeCoveragePlugin.provide(
     name: 'EntityCodeCoverageContent',
     component: () => import('./components/Router').then(m => m.Router),
     mountPoint: rootRouteRef,
+  }),
+);
+
+/**
+ * A compact overview card showing current line and branch coverage with trend.
+ * Intended for use on an entity's overview page.
+ *
+ * @public
+ */
+export const EntityCodeCoverageCard = codeCoveragePlugin.provide(
+  createComponentExtension({
+    name: 'EntityCodeCoverageCard',
+    component: {
+      lazy: () => import('./components/CoverageCard').then(m => m.CoverageCard),
+    },
   }),
 );

--- a/workspaces/code-coverage/plugins/code-coverage/src/utils/TrendIcon.tsx
+++ b/workspaces/code-coverage/plugins/code-coverage/src/utils/TrendIcon.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeStyles } from '@material-ui/core/styles';
+import TrendingDownIcon from '@material-ui/icons/TrendingDown';
+import TrendingFlatIcon from '@material-ui/icons/TrendingFlat';
+import TrendingUpIcon from '@material-ui/icons/TrendingUp';
+
+const useStyles = makeStyles(theme => ({
+  trendDown: {
+    color: theme.palette.status.warning,
+  },
+  trendUp: {
+    color: theme.palette.status.ok,
+  },
+}));
+
+export const TrendIcon = ({ trend }: { trend: number }) => {
+  const classes = useStyles();
+  if (trend > 0) return <TrendingUpIcon className={classes.trendUp} />;
+  if (trend < 0) return <TrendingDownIcon className={classes.trendDown} />;
+  return <TrendingFlatIcon />;
+};

--- a/workspaces/code-coverage/plugins/code-coverage/src/utils/coverageTrend.test.ts
+++ b/workspaces/code-coverage/plugins/code-coverage/src/utils/coverageTrend.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AggregateCoverage } from '../types';
+import { getTrendForCoverage } from './coverageTrend';
+
+const snapshot = (
+  linePct: number,
+  branchPct: number,
+  timestamp = 0,
+): AggregateCoverage => ({
+  timestamp,
+  line: {
+    available: 100,
+    covered: linePct,
+    missed: 100 - linePct,
+    percentage: linePct,
+  },
+  branch: {
+    available: 100,
+    covered: branchPct,
+    missed: 100 - branchPct,
+    percentage: branchPct,
+  },
+});
+
+describe('getTrendForCoverage', () => {
+  it('returns a positive trend when coverage improves', () => {
+    const trend = getTrendForCoverage(snapshot(80, 0), snapshot(40, 0), 'line');
+    expect(trend).toBe(100); // 40 -> 80 is +100%
+  });
+
+  it('returns a negative trend when coverage drops', () => {
+    const trend = getTrendForCoverage(
+      snapshot(50, 0),
+      snapshot(100, 0),
+      'line',
+    );
+    expect(trend).toBe(-50); // 100 -> 50 is -50%
+  });
+
+  it('returns 0 when coverage is unchanged', () => {
+    const trend = getTrendForCoverage(snapshot(75, 0), snapshot(75, 0), 'line');
+    expect(trend).toBe(0);
+  });
+
+  it('returns 0 when the baseline percentage is 0 (avoids divide-by-zero)', () => {
+    const trend = getTrendForCoverage(snapshot(60, 0), snapshot(0, 0), 'line');
+    expect(trend).toBe(0);
+  });
+
+  it('computes branch trend independently from line trend', () => {
+    const latest = snapshot(80, 90);
+    const previous = snapshot(40, 60);
+    expect(getTrendForCoverage(latest, previous, 'line')).toBe(100);
+    expect(getTrendForCoverage(latest, previous, 'branch')).toBe(50);
+  });
+});

--- a/workspaces/code-coverage/plugins/code-coverage/src/utils/coverageTrend.ts
+++ b/workspaces/code-coverage/plugins/code-coverage/src/utils/coverageTrend.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Backstage Authors
+ * Copyright 2020 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 
-/**
- * A Backstage plugin that helps you keep track of your code coverage
- *
- * @packageDocumentation
- */
+import { AggregateCoverage } from '../types';
 
-import { isCodeCoverageAvailable } from './components/Router';
-
-export {
-  codeCoveragePlugin,
-  EntityCodeCoverageContent,
-  EntityCodeCoverageCard,
-} from './plugin';
-export type { CoverageCardProps } from './components/CoverageCard';
-export { isCodeCoverageAvailable };
+export type CoverageType = 'line' | 'branch';
 
 /**
- * @public
- * @deprecated Use `isPluginApplicableToEntity` instead.
+ * Computes percentage change between the oldest and latest coverage snapshots.
+ * Returns 0 if there is no baseline to compare against.
  */
-export const isPluginApplicableToEntity = isCodeCoverageAvailable;
+export function getTrendForCoverage(
+  latest: AggregateCoverage,
+  oldest: AggregateCoverage,
+  type: CoverageType,
+): number {
+  const base = oldest[type].percentage;
+  if (!base) return 0;
+  return ((latest[type].percentage - base) / base) * 100;
+}


### PR DESCRIPTION
  Adds a new EntityCodeCoverageCard extension that surfaces line and branch
  coverage with a build-over-build trend, intended for use on an entity's
  overview page. Extracts shared getTrendForCoverage and TrendIcon utilities
  to avoid duplication with CoverageHistoryChart.

## Hey, I just made a Pull Request!

<img width="1388" height="684" alt="image" src="https://github.com/user-attachments/assets/a61175bf-3348-43ef-bd7d-a17cb4724a90" />


#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
