### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/fix-pagination-i18n.md
+++ b/workspaces/rbac/.changeset/fix-pagination-i18n.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac': patch
----
-
-Fixed RBAC table pagination text not being translated in non-English locales by adding `labelDisplayedRows` and `labelRowsPerPage` translation keys and wiring them into all table components.

--- a/workspaces/rbac/plugins/rbac/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rbac
 
+## 1.53.1
+
+### Patch Changes
+
+- 91cce2e: Fixed RBAC table pagination text not being translated in non-English locales by adding `labelDisplayedRows` and `labelRowsPerPage` translation keys and wiring them into all table components.
+
 ## 1.53.0
 
 ### Minor Changes

--- a/workspaces/rbac/plugins/rbac/package.json
+++ b/workspaces/rbac/plugins/rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac@1.53.1

### Patch Changes

-   91cce2e: Fixed RBAC table pagination text not being translated in non-English locales by adding `labelDisplayedRows` and `labelRowsPerPage` translation keys and wiring them into all table components.
