### PR TITLE
catalog-backend-module-annotate-scm-slug: add option for configuring applicable entity kinds

### DIFF
--- a/workspaces/catalog/.changeset/wet-geese-tease.md
+++ b/workspaces/catalog/.changeset/wet-geese-tease.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-annotate-scm-slug': patch
+---
+
+add an option for configuring applicable entity kinds through app-config.yaml

--- a/workspaces/catalog/.changeset/wet-geese-tease.md
+++ b/workspaces/catalog/.changeset/wet-geese-tease.md
@@ -2,4 +2,15 @@
 '@backstage-community/plugin-catalog-backend-module-annotate-scm-slug': patch
 ---
 
-add an option for configuring applicable entity kinds through app-config.yaml
+add an option for configuring applicable entity kinds through app-config.yaml:
+
+```yaml
+catalog:
+  processors:
+    annotateScmSlug:
+      kinds:
+        - API
+        - Component
+        - Resource
+        - System
+```

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/README.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/README.md
@@ -31,6 +31,21 @@ Here's how to get the module up and running:
 
 Once catalog process has ran you should see the SCM slug added as an annotation on your entities.
 
+## Configuration
+
+By default, the processor only annotates `Component` entities. You can configure which entity kinds are processed in `app-config.yaml`:
+
+```yaml
+catalog:
+  processors:
+    annotateScmSlug:
+      kinds:
+        - API
+        - Component
+        - Resource
+        - System
+```
+
 ## Slugs Added
 
 These are the current SCM tools and their related annotation and value that are being added by this processor.

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/config.d.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/config.d.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  catalog?: {
+    processors?: {
+      /**
+       * Configuration for the annotate-scm-slug catalog processor.
+       */
+      annotateScmSlug?: {
+        /**
+         * Entity kinds that the processor should annotate with SCM slug metadata.
+         * Defaults to ['Component'] when not specified.
+         */
+        kinds?: string[];
+      };
+    };
+  };
+}

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
@@ -41,10 +41,13 @@
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",
+    "@backstage/config": "backstage:^",
     "@types/git-url-parse": "^9.0.3",
     "@types/lodash": "^4.17.13"
   },
   "files": [
-    "dist"
-  ]
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
 }

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",
-    "@backstage/config": "backstage:^",
     "@types/git-url-parse": "^9.0.3",
     "@types/lodash": "^4.17.13"
   },

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/config.test.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/config.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { readAnnotateScmSlugProcessorConfig } from './config';
+
+describe('readAnnotateScmSlugProcessorConfig', () => {
+  it('returns undefined kinds when config is not set', () => {
+    expect(readAnnotateScmSlugProcessorConfig(new ConfigReader({}))).toEqual({
+      kinds: undefined,
+    });
+  });
+
+  it('reads kinds from config', () => {
+    const config = new ConfigReader({
+      catalog: {
+        processors: {
+          annotateScmSlug: {
+            kinds: ['API', 'Component', 'Resource', 'System'],
+          },
+        },
+      },
+    });
+
+    expect(readAnnotateScmSlugProcessorConfig(config)).toEqual({
+      kinds: ['API', 'Component', 'Resource', 'System'],
+    });
+  });
+});

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/config.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/config.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Config } from '@backstage/config';
+
+/** @internal */
+export function readAnnotateScmSlugProcessorConfig(config: Config): {
+  kinds?: string[];
+} {
+  return {
+    kinds: config.getOptionalStringArray(
+      'catalog.processors.annotateScmSlug.kinds',
+    ),
+  };
+}

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/module.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/src/module.ts
@@ -18,6 +18,7 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { readAnnotateScmSlugProcessorConfig } from './config';
 import { AnnotateScmSlugEntityProcessor } from './processor/AnnotateScmSlugEntityProcessor';
 
 /** @public */
@@ -31,7 +32,10 @@ export const catalogModuleAnnotateScmSlug = createBackendModule({
         catalog: catalogProcessingExtensionPoint,
       },
       async init({ catalog, config }) {
-        catalog.addProcessor(AnnotateScmSlugEntityProcessor.fromConfig(config));
+        const processorConfig = readAnnotateScmSlugProcessorConfig(config);
+        catalog.addProcessor(
+          AnnotateScmSlugEntityProcessor.fromConfig(config, processorConfig),
+        );
       },
     });
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`catalog-backend-module-annotate-scm-slug` already supports multiple kinds, this PR allows applicable kinds to be set through `app-config.yaml`.

Fixes: https://github.com/backstage/community-plugins/issues/9397

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
