### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/renovate-5dc52e6.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-5dc52e6.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.98.2`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-f663da4.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-f663da4.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@types/node` to `22.19.19`.

--- a/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
+++ b/workspaces/nexus-repository-manager/.changeset/silent-pets-pretend.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
-
-Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`. Bumped `react-router-dom` dev dependency to `^6.30.2` to satisfy the peer requirement from `@backstage/frontend-test-utils`.
-
-Fixed the alpha dev app so `maven-example` loads correctly: the entity-content filter now uses `isNexusRepositoryManagerExperimentalAvailable` (so Maven annotations show the Build Artifacts tab), and the dev mocks include experimental annotations plus Maven fixture data.

--- a/workspaces/nexus-repository-manager/.changeset/version-bump-1-51-0.md
+++ b/workspaces/nexus-repository-manager/.changeset/version-bump-1-51-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/nexus-repository-manager/.changeset/version-bump-1-52-0.md
+++ b/workspaces/nexus-repository-manager/.changeset/version-bump-1-52-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @backstage-community/plugin-nexus-repository-manager
 
+## 1.25.0
+
+### Minor Changes
+
+- ea029e4: Backstage version bump to v1.51.0
+- 8e77b78: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- a4d0ef7: Updated dependency `@hey-api/openapi-ts` to `0.98.2`.
+- 387d2e9: Updated dependency `@types/node` to `22.19.19`.
+- 655f29c: Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.
+
+  Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`. Bumped `react-router-dom` dev dependency to `^6.30.2` to satisfy the peer requirement from `@backstage/frontend-test-utils`.
+
+  Fixed the alpha dev app so `maven-example` loads correctly: the entity-content filter now uses `isNexusRepositoryManagerExperimentalAvailable` (so Maven annotations show the Build Artifacts tab), and the dev mocks include experimental annotations plus Maven fixture data.
+
 ## 1.24.1
 
 ### Patch Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.25.0

### Minor Changes

-   ea029e4: Backstage version bump to v1.51.0
-   8e77b78: Backstage version bump to v1.52.0

### Patch Changes

-   a4d0ef7: Updated dependency `@hey-api/openapi-ts` to `0.98.2`.
-   387d2e9: Updated dependency `@types/node` to `22.19.19`.
-   655f29c: Migrated the Nexus Repository Manager plugin UI from Material UI to Backstage UI (`@backstage/ui`). Removed direct MUI dependencies; no breaking API changes.

    Added `@backstage/frontend-test-utils` as a dev dependency so the alpha dev app (`yarn start:alpha`) can resolve `@backstage/plugin-catalog-react/testUtils`. Bumped `react-router-dom` dev dependency to `^6.30.2` to satisfy the peer requirement from `@backstage/frontend-test-utils`.

    Fixed the alpha dev app so `maven-example` loads correctly: the entity-content filter now uses `isNexusRepositoryManagerExperimentalAvailable` (so Maven annotations show the Build Artifacts tab), and the dev mocks include experimental annotations plus Maven fixture data.
