### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
+++ b/workspaces/jfrog-artifactory/.changeset/slick-maps-make.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Migrated the JFrog Artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). The repository table now uses BUI `Table`, `SearchField`, and pagination controls. Removed direct MUI dependencies; no breaking API changes.
-
-Also fixed the filter input growing when typing, and added i18n support for pagination labels (page size selector and result range) in all supported locales.
-
-**Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.

--- a/workspaces/jfrog-artifactory/.changeset/version-bump-1-51-0.md
+++ b/workspaces/jfrog-artifactory/.changeset/version-bump-1-51-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/jfrog-artifactory/.changeset/version-bump-1-52-0.md
+++ b/workspaces/jfrog-artifactory/.changeset/version-bump-1-52-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-jfrog-artifactory
 
+## 1.30.0
+
+### Minor Changes
+
+- 7485585: Backstage version bump to v1.51.0
+- ec5bab3: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- a938525: Migrated the JFrog Artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). The repository table now uses BUI `Table`, `SearchField`, and pagination controls. Removed direct MUI dependencies; no breaking API changes.
+
+  Also fixed the filter input growing when typing, and added i18n support for pagination labels (page size selector and result range) in all supported locales.
+
+  **Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.
+
 ## 1.29.1
 
 ### Patch Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.30.0

### Minor Changes

-   7485585: Backstage version bump to v1.51.0
-   ec5bab3: Backstage version bump to v1.52.0

### Patch Changes

-   a938525: Migrated the JFrog Artifactory plugin UI from Material UI to Backstage UI (`@backstage/ui`). The repository table now uses BUI `Table`, `SearchField`, and pagination controls. Removed direct MUI dependencies; no breaking API changes.

    Also fixed the filter input growing when typing, and added i18n support for pagination labels (page size selector and result range) in all supported locales.

    **Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.
