### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-5dc52e6.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-5dc52e6.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.98.2`.

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.15.2
+
+### Patch Changes
+
+- a4d0ef7: Updated dependency `@hey-api/openapi-ts` to `0.98.2`.
+
 ## 2.15.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.15.2

### Patch Changes

-   a4d0ef7: Updated dependency `@hey-api/openapi-ts` to `0.98.2`.
