### PR TITLE
feat(tech-insights-backend-module-jsonfc): support params.factRetrieverId for cross-retriever conditions

### DIFF
--- a/workspaces/tech-insights/.changeset/jsonfc-params-factRetrieverId.md
+++ b/workspaces/tech-insights/.changeset/jsonfc-params-factRetrieverId.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend-module-jsonfc': patch
+---
+
+Conditions can now set `params.factRetrieverId` to disambiguate between fact retrievers that publish facts under the same name. When set, the condition resolves against that retriever's value; when omitted, the existing flat-merge behaviour is preserved unchanged.

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/README.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/README.md
@@ -47,8 +47,42 @@ techInsights:
 
 ### More than one `factIds` for a check
 
-When more than one is supplied, the requested fact **MUST** be present in at least one of the fact retrievers.
-The order of the fact retrievers defined in the `factIds` array has no bearing on the checks, the check will merge all facts from the various retrievers, and then check against latest fact .
+When more than one is supplied, the requested fact **MUST** be present in at least one of the fact retrievers. The check merges all facts from the listed retrievers into a single object before evaluating conditions. As long as fact names do not collide, the order of `factIds` does not affect the result. When several retrievers expose facts under the same name, the merge is last-write-wins in `factIds` order; see the next section for an explicit alternative.
+
+### Combining facts from multiple retrievers with `params.factRetrieverId`
+
+When two retrievers listed in a check's `factIds` publish a fact under the same key, the last-write-wins merge described above hides one value behind the other. To compare both values in the same check, set `params.factRetrieverId` on each condition to the id of the retriever whose value it should read:
+
+```yaml title="app-config.yaml"
+techInsights:
+  factChecker:
+    checks:
+      bothMigrationsComplete:
+        type: json-rules-engine
+        name: Both migrations complete
+        factIds:
+          - migrationStatus.a
+          - migrationStatus.b
+        rule:
+          conditions:
+            all:
+              - fact: completed
+                params:
+                  factRetrieverId: migrationStatus.a
+                operator: equal
+                value: true
+              - fact: completed
+                params:
+                  factRetrieverId: migrationStatus.b
+                operator: equal
+                value: true
+```
+
+Notes:
+
+- `params.factRetrieverId` must reference a retriever listed in the check's `factIds`; otherwise the check fails with a clear error at run time.
+- Conditions without `params.factRetrieverId` keep the legacy merge behaviour, so existing checks are unaffected.
+- If the named retriever did not produce the referenced fact, the check is skipped, the same path as any other missing fact.
 
 ### Adding filter in check
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.test.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.test.ts
@@ -564,6 +564,173 @@ const testChecks: Record<string, TechInsightJsonRuleCheck[]> = {
       },
     },
   ],
+  factRetrieverIdBothPass: [
+    {
+      id: 'factRetrieverIdBothPassCheck',
+      name: 'factRetrieverIdBothPassCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description: 'Both retrievers should satisfy their conditions',
+      factIds: ['test-factretriever', 'test-factretriever-same-fact'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever' },
+              operator: 'equal',
+              value: 3,
+            },
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever-same-fact' },
+              operator: 'equal',
+              value: 3,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  factRetrieverIdOneFails: [
+    {
+      id: 'factRetrieverIdOneFailsCheck',
+      name: 'factRetrieverIdOneFailsCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description:
+        "One retriever's value does not satisfy its qualified condition",
+      factIds: ['test-factretriever', 'test-factretriever-different-fact'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever' },
+              operator: 'equal',
+              value: 3,
+            },
+            {
+              fact: 'testnumberfact',
+              params: {
+                factRetrieverId: 'test-factretriever-different-fact',
+              },
+              operator: 'equal',
+              value: 3,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  factRetrieverIdDistinctValues: [
+    {
+      id: 'factRetrieverIdDistinctValuesCheck',
+      name: 'factRetrieverIdDistinctValuesCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description:
+        'Same fact name resolved against two retrievers yields distinct values',
+      factIds: ['test-factretriever', 'test-factretriever-different-fact'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever' },
+              operator: 'equal',
+              value: 3,
+            },
+            {
+              fact: 'testnumberfact',
+              params: {
+                factRetrieverId: 'test-factretriever-different-fact',
+              },
+              operator: 'equal',
+              value: 1,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  factRetrieverIdUnlistedRetriever: [
+    {
+      id: 'factRetrieverIdUnlistedRetrieverCheck',
+      name: 'factRetrieverIdUnlistedRetrieverCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description: 'References a retriever not listed in factIds',
+      factIds: ['test-factretriever'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever-same-fact' },
+              operator: 'equal',
+              value: 3,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  factRetrieverIdRetrieverMissingFact: [
+    {
+      id: 'factRetrieverIdRetrieverMissingFactCheck',
+      name: 'factRetrieverIdRetrieverMissingFactCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description: 'Named retriever did not produce the referenced fact',
+      factIds: ['test-factretriever', 'test-factretriever-no-fact'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              params: { factRetrieverId: 'test-factretriever-no-fact' },
+              operator: 'equal',
+              value: 3,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
+  factRetrieverIdMixedConditions: [
+    {
+      id: 'factRetrieverIdMixedConditionsCheck',
+      name: 'factRetrieverIdMixedConditionsCheck',
+      type: JSON_RULE_ENGINE_CHECK_TYPE,
+      description: 'Mix qualified and unqualified conditions in the same rule',
+      // Order matters here: the legacy flat-merge reduces in factIds order,
+      // so test-factretriever (value 3) is last and wins for the unqualified
+      // condition. The qualified condition explicitly reads the other
+      // retriever's value (1).
+      factIds: ['test-factretriever-different-fact', 'test-factretriever'],
+      rule: {
+        conditions: {
+          all: [
+            {
+              fact: 'testnumberfact',
+              operator: 'equal',
+              value: 3,
+            },
+            {
+              fact: 'testnumberfact',
+              params: {
+                factRetrieverId: 'test-factretriever-different-fact',
+              },
+              operator: 'equal',
+              value: 1,
+            },
+          ],
+        },
+      },
+    },
+  ],
+
   filterAnnotationMissing: [
     {
       id: 'filterAnnotationMissingCheck',
@@ -1109,6 +1276,55 @@ describe('JsonRulesEngineFactChecker', () => {
       ]);
     });
 
+    describe('params.factRetrieverId', () => {
+      it('passes when each retriever-qualified condition is satisfied', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdBothPass',
+        ]);
+        expect(results).toHaveLength(1);
+        expect(results[0].result).toBe(true);
+      });
+
+      it('fails when one retriever-qualified condition is not satisfied', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdOneFails',
+        ]);
+        expect(results).toHaveLength(1);
+        expect(results[0].result).toBe(false);
+      });
+
+      it('resolves the same fact name to different values per retriever', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdDistinctValues',
+        ]);
+        expect(results).toHaveLength(1);
+        expect(results[0].result).toBe(true);
+      });
+
+      it('skips and does not abort the run when factRetrieverId references a retriever not in factIds', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdUnlistedRetriever',
+          'simple',
+        ]);
+        expect(results.map(r => r.check.id)).toEqual(['simpleTestCheck']);
+      });
+
+      it('skips checks when the named retriever did not produce the fact', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdRetrieverMissingFact',
+        ]);
+        expect(results).toEqual([]);
+      });
+
+      it('mixes qualified and unqualified conditions within one rule', async () => {
+        const results = await factChecker.runChecks('a/a/a', [
+          'factRetrieverIdMixedConditions',
+        ]);
+        expect(results).toHaveLength(1);
+        expect(results[0].result).toBe(true);
+      });
+    });
+
     it('should respond with result, facts, fact schemas and checks with metadatas', async () => {
       const results = await factChecker.runChecks('a/a/a', ['metadata']);
       expect(results).toHaveLength(1);
@@ -1168,6 +1384,24 @@ describe('JsonRulesEngineFactChecker', () => {
         });
       },
     );
+
+    it('should succeed when params.factRetrieverId references a listed retriever', async () => {
+      const validationResponse = await factChecker.validate(
+        testChecks.factRetrieverIdBothPass[0],
+      );
+      expect(validationResponse.valid).toBe(true);
+    });
+
+    it('should fail when params.factRetrieverId references a retriever not in factIds', async () => {
+      const validationResponse = await factChecker.validate(
+        testChecks.factRetrieverIdUnlistedRetriever[0],
+      );
+      expect(validationResponse).toMatchObject({
+        valid: false,
+        message:
+          'Condition references factRetrieverId "test-factretriever-same-fact" which is not in this check\'s factIds list: [test-factretriever]',
+      });
+    });
   });
 
   describe('when filtering checks by entity criteria', () => {

--- a/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
+++ b/workspaces/tech-insights/plugins/tech-insights-backend-module-jsonfc/src/service/JsonRulesEngineFactChecker.ts
@@ -310,10 +310,43 @@ export class JsonRulesEngineFactChecker
     // get list of available fact names
     const factNames = flatten(schemas.map(schema => Object.keys(schema)));
 
-    const factValues = Object.values(facts).reduce(
+    // Per-fact view keyed by retriever id, used for `params.factRetrieverId`
+    // resolution.
+    const valuesByFactByRetriever: Record<string, Record<string, unknown>> = {};
+    for (const [retrieverId, row] of Object.entries(facts)) {
+      for (const [factName, value] of Object.entries(row.facts)) {
+        (valuesByFactByRetriever[factName] ||= {})[retrieverId] = value;
+      }
+    }
+
+    // Legacy flat-merge view, kept as the fallback when a condition does not
+    // set `params.factRetrieverId`. The reduce order matches the previous
+    // implementation bit-for-bit so existing checks see the same value
+    // (including the documented last-write-wins behaviour on key collisions).
+    const legacyFlat: Record<string, unknown> = Object.values(facts).reduce(
       (acc, it) => ({ ...acc, ...it.facts }),
-      {} as FlatTechInsightFact,
+      {} as Record<string, unknown>,
     );
+
+    // Register a handler fact per known fact name. The handler reads
+    // `params.factRetrieverId` from the condition; when set, it returns the
+    // named retriever's value, otherwise it falls back to the legacy merged
+    // value.
+    // Both `valuesByFactByRetriever` and `legacyFlat` are entity-specific, so
+    // handlers (and the engine instance above) must be constructed per call;
+    // they cannot be hoisted onto the class.
+    for (const factName of Object.keys(valuesByFactByRetriever)) {
+      engine.addFact(factName, params => {
+        const retrieverId =
+          params && typeof params.factRetrieverId === 'string'
+            ? params.factRetrieverId
+            : undefined;
+        if (retrieverId !== undefined) {
+          return valuesByFactByRetriever[factName]?.[retrieverId];
+        }
+        return legacyFlat[factName];
+      });
+    }
 
     filteredChecks.forEach(techInsightCheck => {
       const rule = techInsightCheck.rule;
@@ -337,10 +370,39 @@ export class JsonRulesEngineFactChecker
         );
       }
 
-      // Checks if all facts are present in the factValues
-      const hasFacts = usedFacts.every(factId =>
-        factValues.hasOwnProperty(factId),
+      // Each `params.factRetrieverId` must reference a retriever listed in the
+      // check's factIds. `validate()` catches this at registration time;
+      // at runtime we skip the offending check with a warning rather than
+      // abort the whole `runChecks` call, so an unrelated misconfiguration
+      // can never block other checks for the same entity.
+      const qualifiedRefs = this.retrieveQualifiedFactReferences(
+        techInsightCheck.rule.conditions,
       );
+      const unlistedFactRetrieverMessage =
+        this.findUnlistedFactRetrieverMessage(techInsightCheck, qualifiedRefs);
+      if (unlistedFactRetrieverMessage !== undefined) {
+        this.logger.warn(
+          `Skipping ${rule.name}: ${unlistedFactRetrieverMessage}`,
+        );
+        return;
+      }
+
+      // Checks if all referenced facts can be resolved. A condition that
+      // qualifies its fact via `params.factRetrieverId` is only satisfied when
+      // the named retriever actually produced that fact; unqualified
+      // conditions keep the legacy "present in any retriever" semantics.
+      const hasFacts = qualifiedRefs.every(({ fact, factRetrieverId }) => {
+        if (factRetrieverId !== undefined) {
+          return (
+            valuesByFactByRetriever[fact] !== undefined &&
+            Object.prototype.hasOwnProperty.call(
+              valuesByFactByRetriever[fact],
+              factRetrieverId,
+            )
+          );
+        }
+        return Object.prototype.hasOwnProperty.call(legacyFlat, fact);
+      });
       if (hasFacts) {
         engine.addRule({ ...techInsightCheck.rule, event: noopEvent });
       } else {
@@ -355,7 +417,7 @@ export class JsonRulesEngineFactChecker
     });
 
     try {
-      const results = await engine.run(factValues);
+      const results = await engine.run();
       return await this.ruleEngineResultsToCheckResponse(
         results,
         filteredChecks,
@@ -398,12 +460,24 @@ export class JsonRulesEngineFactChecker
       };
     }
 
+    const qualifiedReferences = this.retrieveQualifiedFactReferences(
+      check.rule.conditions,
+    );
+    const unlistedFactRetrieverMessage = this.findUnlistedFactRetrieverMessage(
+      check,
+      qualifiedReferences,
+    );
+    if (unlistedFactRetrieverMessage !== undefined) {
+      this.logger.warn(
+        `Validation failed for check ${check.name}. ${unlistedFactRetrieverMessage}`,
+      );
+      return { valid: false, message: unlistedFactRetrieverMessage };
+    }
+
     const existingSchemas = await this.repository.getLatestSchemas(
       check.factIds,
     );
-    const references = this.retrieveIndividualFactReferences(
-      check.rule.conditions,
-    );
+    const references = qualifiedReferences.map(ref => ref.fact);
     const results = references.map(ref => ({
       ref,
       result: existingSchemas.some(schema => schema.hasOwnProperty(ref)),
@@ -457,6 +531,53 @@ export class JsonRulesEngineFactChecker
       // ignore the ConditionReference type
     } else {
       results.push(condition.fact);
+    }
+    return results;
+  }
+
+  private findUnlistedFactRetrieverMessage(
+    check: TechInsightJsonRuleCheck,
+    qualifiedRefs: Array<{ fact: string; factRetrieverId?: string }>,
+  ): string | undefined {
+    for (const { factRetrieverId } of qualifiedRefs) {
+      if (
+        factRetrieverId !== undefined &&
+        !check.factIds.includes(factRetrieverId)
+      ) {
+        return `Condition references factRetrieverId "${factRetrieverId}" which is not in this check's factIds list: [${check.factIds.join(
+          ', ',
+        )}]`;
+      }
+    }
+    return undefined;
+  }
+
+  private retrieveQualifiedFactReferences(
+    condition:
+      | TopLevelCondition
+      | { fact: string; params?: Record<string, unknown> },
+  ): Array<{ fact: string; factRetrieverId?: string }> {
+    let results: Array<{ fact: string; factRetrieverId?: string }> = [];
+    if ('all' in condition) {
+      results = results.concat(
+        condition.all.flatMap(con => this.retrieveQualifiedFactReferences(con)),
+      );
+    } else if ('any' in condition) {
+      results = results.concat(
+        condition.any.flatMap(con => this.retrieveQualifiedFactReferences(con)),
+      );
+    } else if ('not' in condition) {
+      results = results.concat(
+        this.retrieveQualifiedFactReferences(condition.not),
+      );
+    } else if ('condition' in condition) {
+      // ignore the ConditionReference type
+    } else {
+      const factRetrieverId =
+        condition.params && typeof condition.params.factRetrieverId === 'string'
+          ? condition.params.factRetrieverId
+          : undefined;
+      results.push({ fact: condition.fact, factRetrieverId });
     }
     return results;
   }


### PR DESCRIPTION
When two fact retrievers expose facts under the same name, the previous flat merge made it impossible to author a single check that compares values from specific retrievers. Conditions can now set params.factRetrieverId to pick a retriever explicitly; unqualified conditions keep the legacy merge behaviour unchanged.

The implementation switches engine.run(values) to handler-fact registration so the per-condition params object reaches the resolver. A preflight validates that each factRetrieverId is listed in the check's factIds, and the missing-fact skip path now also fires when the named retriever did not produce the referenced fact. No schema change.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
