### PR TITLE
fix(sentry): clarify sentry issues graph subtitle

### DIFF
--- a/workspaces/sentry/.changeset/clarify-sentry-graph-subtitle.md
+++ b/workspaces/sentry/.changeset/clarify-sentry-graph-subtitle.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-sentry': patch
+---
+
+Clarified the Sentry issues table subtitle. It previously read "Stats for 24h" and misleadingly looked tied to the time-range dropdown. It now reads "Graph shows the last 24h" to make clear it describes the sparkline graph's stats period, not the dropdown's row filter.

--- a/workspaces/sentry/.changeset/clarify-sentry-graph-subtitle.md
+++ b/workspaces/sentry/.changeset/clarify-sentry-graph-subtitle.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-sentry': patch
 ---
 
-Clarified the Sentry issues table subtitle. It previously read "Stats for 24h" and misleadingly looked tied to the time-range dropdown. It now reads "Graph shows the last 24h" to make clear it describes the sparkline graph's stats period, not the dropdown's row filter.
+Clarified the Sentry Issues table subtitle to describe the sparkline graph's stats period, not the dropdown filter.

--- a/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
+++ b/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.test.tsx
@@ -106,6 +106,8 @@ describe('SentryIssuesTable', () => {
         }}
       />,
     );
-    expect(await table.findByText('Stats for 24h')).toBeInTheDocument();
+    expect(
+      await table.findByText('Graph shows the last 24h'),
+    ).toBeInTheDocument();
   });
 });

--- a/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
+++ b/workspaces/sentry/plugins/sentry/src/components/SentryIssuesTable/SentryIssuesTable.tsx
@@ -121,7 +121,7 @@ const SentryIssuesTable = (props: SentryIssuesTableProps) => {
             </Grid>
           </Grid>
         }
-        subtitle={statsFor ? `Stats for ${statsFor}` : undefined}
+        subtitle={statsFor ? `Graph shows the last ${statsFor}` : undefined}
         data={filteredIssues}
       />
     </>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves #8372. I believe the "All" crash is already fixed by "fix(sentry): use useMemo for issue filtering to sync with async data (#7523)" on main. This PR fixes the label issue described in the issue instead. 

The Sentry issues table showed a subtitle reading **"Stats for 24h"**, which made it look like the label should update when you change the dropdown. The two are actually unrelated:

- `statsFor` (the subtitle's source prop) controls the **sparkline graph's** stats period. It's passed to the Sentry API as `statsPeriod` and is currently hardcoded as '24hr'.
- The dropdown is an independent **client-side row filter** on each issue's `lastSeen`; it never updates/touches `statsFor` and does not seem to be related to it.

I reworded the subtitle to **"Graph shows the last 24h"** so it clearly describes the graph rather than implying its related to the dropdown. Let me know if this was the intended functionality or not!

<img width="1512" height="752" alt="image" src="https://github.com/user-attachments/assets/4b007641-0c78-4f2a-a921-d8476378711b" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
