### PR TITLE
test(pingidentity): expand auth and catalog coverage and add contributor dev guides

### DIFF
--- a/workspaces/pingidentity/.changeset/shaggy-timers-buy.md
+++ b/workspaces/pingidentity/.changeset/shaggy-timers-buy.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-auth-backend-module-pingfederate-provider': patch
+'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
+---
+
+Added contributor development guides and dev harness `app-config.yaml` files for both plugins. Expanded automated test coverage for PingFederate sign-in resolvers and auth module wiring, and for PingOne catalog module extension points and entity provider registration.

--- a/workspaces/pingidentity/README.md
+++ b/workspaces/pingidentity/README.md
@@ -1,14 +1,8 @@
-# [Backstage](https://backstage.io)
+# Ping Identity workspace
 
-This is your newly scaffolded Backstage App, Good Luck!
+Publishable plugins in this workspace:
 
-To start the app, run:
+- [@backstage-community/plugin-auth-backend-module-pingfederate-provider](./plugins/auth-backend-module-pingfederate-provider/) — operator docs: [README](./plugins/auth-backend-module-pingfederate-provider/README.md); contributors: [CONTRIBUTING](./plugins/auth-backend-module-pingfederate-provider/CONTRIBUTING.md)
+- [@backstage-community/plugin-catalog-backend-module-pingidentity](./plugins/catalog-backend-module-pingidentity/) — operator docs: [README](./plugins/catalog-backend-module-pingidentity/README.md); contributors: [CONTRIBUTING](./plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md)
 
-```sh
-yarn install
-yarn start
-```
-
-### To learn more about the plugins included:
-
-- [Ping Identity Backend Plugin](./plugins/catalog-backend-module-pingidentity/README.md)
+The `packages/app` and `packages/backend` apps are optional workspace scaffolding (`yarn start` from this directory). Day-to-day plugin work uses each package's `dev/` harness — see the contributor guides above.

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CONTRIBUTING.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing — PingFederate auth backend module
+
+Developer guide for `@backstage-community/plugin-auth-backend-module-pingfederate-provider`. For operator install and configuration, see [README.md](./README.md).
+
+## Prerequisites
+
+- Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
+- Yarn (workspace uses the community-plugins monorepo lockfile)
+
+## Development harness
+
+Start this module in isolation:
+
+```bash
+yarn workspace @backstage-community/plugin-auth-backend-module-pingfederate-provider start
+```
+
+This runs a minimal backend with `@backstage/plugin-auth-backend` and the PingFederate provider module. Use it for OAuth flow, authenticator, and resolver work.
+
+Only one plugin `dev/` harness should run on port **7007** at a time. To work on the PingOne catalog module instead, stop this process and start the [catalog module harness](../catalog-backend-module-pingidentity/CONTRIBUTING.md).
+
+### Environment setup
+
+Export these variables in your shell before starting the harness. Use local-only placeholder values for development — do not commit secrets.
+
+| Variable                     | Purpose                                                                |
+| ---------------------------- | ---------------------------------------------------------------------- |
+| `PINGFEDERATE_BASE_URL`      | PingFederate OIDC issuer base URL                                      |
+| `PINGFEDERATE_CLIENT_ID`     | OAuth client ID                                                        |
+| `PINGFEDERATE_CLIENT_SECRET` | OAuth client secret                                                    |
+| `AUTH_SESSION_SECRET`        | Backstage auth session signing secret (any long random string locally) |
+| `BACKSTAGE_DEV_STATIC_TOKEN` | Static bearer token for authenticated `curl` calls to the dev backend  |
+
+Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
+
+### API authentication for `curl`
+
+The dev [`app-config.yaml`](./app-config.yaml) registers a **static** backend access token (see [service-to-service auth](https://backstage.io/docs/auth/service-to-service-auth)):
+
+```yaml
+backend:
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+```
+
+Use the same value you exported for `BACKSTAGE_DEV_STATIC_TOKEN` as a Bearer token when a route requires authentication:
+
+```bash
+curl -H "Authorization: Bearer ${BACKSTAGE_DEV_STATIC_TOKEN}" \
+  "http://localhost:7007/api/catalog/entities?limit=1"
+```
+
+The auth-only harness does not run the catalog plugin, so that example may return an empty list or a routing error — it is included to show the header shape. Prefer the smoke commands below for this package.
+
+**OAuth sign-in smoke** does not use the static Bearer token; it relies on redirects and session cookies instead.
+
+## Validation commands
+
+From the workspace root (`workspaces/pingidentity`):
+
+```bash
+yarn workspace @backstage-community/plugin-auth-backend-module-pingfederate-provider test
+yarn workspace @backstage-community/plugin-auth-backend-module-pingfederate-provider lint
+yarn tsc
+```
+
+## What automated tests cover
+
+CI exercises:
+
+- **Sign-in resolvers** — dual-claim security (`sub`, LDAP UUID) between userinfo and ID token
+- **Authenticator** — OIDC token exchange, refresh, and revocation paths (MSW)
+- **Module wiring** — provider registration and OAuth redirect/cookie flow via `startTestBackend`
+
+CI does **not** replace reading [Backstage release notes](https://github.com/backstage/backstage/releases) for the `@backstage/*` packages this module depends on. After a dependency bump, review those notes and decide whether additional validation is warranted.
+
+## Optional manual smoke checklist
+
+Use when you change auth integration code or are reviewing a Backstage version bump:
+
+1. Export the [environment variables](#environment-setup) and start this harness.
+2. OAuth start (no `Authorization` header):
+
+   ```bash
+   curl -i "http://localhost:7007/api/auth/pingfederate/start?env=development"
+   ```
+
+   Expect `302` with a `Location` header pointing at your PingFederate authorize URL.
+
+3. Full interactive sign-in and resolver pairing with catalog users requires a Backstage deployment that also runs the catalog module — not covered by this harness alone.
+
+## Related packages
+
+- [Ping Identity catalog module](../catalog-backend-module-pingidentity/CONTRIBUTING.md) — PingOne entity ingestion (separate `dev/` harness)

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/README.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/README.md
@@ -4,6 +4,8 @@ This module provides a PingFederate auth provider implementation for `@backstage
 
 The provider uses OIDC authentication and includes PingFederate-specific sign-in resolvers for matching users via LDAP UUID and Ping Identity user IDs.
 
+**Contributors:** see [CONTRIBUTING.md](./CONTRIBUTING.md) for development harnesses, tests, and bump-review guidance.
+
 > **Note:** This provider has only been tested with LDAP catalog provider (`@backstage/plugin-catalog-backend-module-ldap`). It has not been tested with the PingOne catalog provider (`@backstage-community/plugin-catalog-backend-module-pingidentity`), though it should work with appropriate resolver configuration.
 
 ## Installation

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/app-config.yaml
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/app-config.yaml
@@ -1,0 +1,24 @@
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+
+auth:
+  environment: development
+  session:
+    secret: ${AUTH_SESSION_SECRET}
+  providers:
+    pingfederate:
+      development:
+        baseUrl: ${PINGFEDERATE_BASE_URL}
+        clientId: ${PINGFEDERATE_CLIENT_ID}
+        clientSecret: ${PINGFEDERATE_CLIENT_SECRET}
+        signIn:
+          resolvers:
+            - resolver: subClaimMatchingPingIdentityUserId

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/module.test.ts
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/module.test.ts
@@ -71,15 +71,10 @@ describe('authModulePingFederateProvider', () => {
             ctx.json(issuerMetadata),
           ),
       ),
-      rest.get(
-        'https://oidc.test/oauth2/authorize',
-        async (req, _res, _ctx) => {
-          nonce =
-            new URL(req.url).searchParams.get('nonce') ??
-            'nonceGeneratedByAuthServer';
-        },
-      ),
       rest.get('https://oidc.test/oauth2/authorize', async (req, res, ctx) => {
+        nonce =
+          new URL(req.url).searchParams.get('nonce') ??
+          'nonceGeneratedByAuthServer';
         const callbackUrl = new URL(req.url.searchParams.get('redirect_uri')!);
         callbackUrl.searchParams.set('code', 'authorization_code');
         callbackUrl.searchParams.set(
@@ -217,15 +212,21 @@ describe('authModulePingFederateProvider', () => {
   });
 
   it('#authenticate exchanges authorization code for a access_token', async () => {
-    const agent = request.agent('');
+    const agent = request.agent(backstageServer);
     const startResponse = await agent.get(
-      `${appUrl}/api/auth/pingfederate/start?env=development`,
+      `/api/auth/pingfederate/start?env=development`,
     );
-    const authorizationResponse = await agent.get(
-      startResponse.header.location,
-    );
+    expect(startResponse.status).toBe(302);
+
+    const authorizeUrl = startResponse.get('location')!;
+    const authorizationResponse = await fetch(authorizeUrl, {
+      redirect: 'manual',
+    });
+    expect(authorizationResponse.status).toBe(302);
+
+    const callbackUrl = new URL(authorizationResponse.headers.get('location')!);
     const handlerResponse = await agent.get(
-      authorizationResponse.header.location,
+      `${callbackUrl.pathname}${callbackUrl.search}`,
     );
 
     expect(handlerResponse.text).toContain(

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/module.test.ts
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/module.test.ts
@@ -211,7 +211,7 @@ describe('authModulePingFederateProvider', () => {
     });
   });
 
-  it('#authenticate exchanges authorization code for a access_token', async () => {
+  it('#authenticate exchanges authorization code for an access_token', async () => {
     const agent = request.agent(backstageServer);
     const startResponse = await agent.get(
       `/api/auth/pingfederate/start?env=development`,

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/resolvers.test.ts
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/src/resolvers.test.ts
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SignJWT } from 'jose';
+import type { TokenSet, UserinfoResponse } from 'openid-client';
+import {
+  AuthResolverContext,
+  commonSignInResolvers,
+  type OAuthAuthenticatorResult,
+  type SignInInfo,
+} from '@backstage/plugin-auth-node';
+import type { PingFederateAuthResult } from './authenticator';
+import { pingfederateSignInResolvers } from './resolvers';
+
+type PingFederateSignInInfo = SignInInfo<
+  OAuthAuthenticatorResult<PingFederateAuthResult>
+>;
+
+const createMockContext = (): jest.Mocked<AuthResolverContext> => ({
+  issueToken: jest.fn(),
+  findCatalogUser: jest.fn(),
+  signInWithCatalogUser: jest.fn().mockResolvedValue({ token: 'test-token' }),
+  resolveOwnershipEntityRefs: jest.fn(),
+});
+
+const signTestIdToken = async (payload: Record<string, unknown>) => {
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .sign(new TextEncoder().encode('unit-test-secret'));
+};
+
+const createInfo = (
+  userinfo: UserinfoResponse | Record<string, unknown>,
+  idToken?: string,
+): PingFederateSignInInfo => ({
+  profile: {},
+  result: {
+    fullProfile: {
+      userinfo: userinfo as UserinfoResponse,
+      tokenset: (idToken !== undefined
+        ? { id_token: idToken }
+        : {}) as TokenSet,
+    },
+    session: {
+      accessToken: 'test-access-token',
+      tokenType: 'bearer',
+      scope: 'openid profile email',
+    },
+  },
+});
+
+describe('pingfederateSignInResolvers', () => {
+  describe('subClaimMatchingPingIdentityUserId', () => {
+    it('signs in using pingidentity.org/id annotation when userinfo and id token sub match', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        pingfederateSignInResolvers.subClaimMatchingPingIdentityUserId();
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const idToken = await signTestIdToken({ sub });
+      const info = createInfo({ sub }, idToken);
+
+      const result = await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'pingidentity.org/id': sub } },
+        { dangerousEntityRefFallback: undefined },
+      );
+      expect(result).toEqual({ token: 'test-token' });
+    });
+
+    it('throws when sub is missing from userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        pingfederateSignInResolvers.subClaimMatchingPingIdentityUserId();
+      const idToken = await signTestIdToken({
+        sub: '9cf51b5d-e066-4ed8-940c-dc6da77f81a5',
+      });
+      const info = createInfo({ email: 'user@example.com' }, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(
+        /missing a 'sub' claim/,
+      );
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token is missing', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        pingfederateSignInResolvers.subClaimMatchingPingIdentityUserId();
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const info = createInfo({ sub });
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ID token/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token sub does not match userinfo sub', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        pingfederateSignInResolvers.subClaimMatchingPingIdentityUserId();
+      const idToken = await signTestIdToken({
+        sub: '11111111-1111-1111-1111-111111111111',
+      });
+      const info = createInfo(
+        { sub: '9cf51b5d-e066-4ed8-940c-dc6da77f81a5' },
+        idToken,
+      );
+
+      await expect(resolver(info, ctx)).rejects.toThrow(
+        /mismatching 'sub' claim/,
+      );
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('passes dangerousEntityRefFallback when enabled', async () => {
+      const ctx = createMockContext();
+      const resolver =
+        pingfederateSignInResolvers.subClaimMatchingPingIdentityUserId({
+          dangerouslyAllowSignInWithoutUserInCatalog: true,
+        });
+      const sub = '9cf51b5d-e066-4ed8-940c-dc6da77f81a5';
+      const idToken = await signTestIdToken({ sub });
+      const info = createInfo({ sub }, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'pingidentity.org/id': sub } },
+        { dangerousEntityRefFallback: { entityRef: sub } },
+      );
+    });
+  });
+
+  describe('ldapUuidMatchingAnnotation', () => {
+    it('signs in using backstage.io/ldap-uuid when userinfo and id token ldap_uuid match', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: ldapUuid,
+      });
+      const info = createInfo({ ldap_uuid: ldapUuid }, idToken);
+
+      const result = await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': ldapUuid } },
+        { dangerousEntityRefFallback: undefined },
+      );
+      expect(result).toEqual({ token: 'test-token' });
+    });
+
+    it('uses ldapUuidKey when provided', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation({
+        ldapUuidKey: 'directory_id',
+      });
+      const uuid = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        directory_id: uuid,
+      });
+      const info = createInfo({ directory_id: uuid }, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': uuid } },
+        { dangerousEntityRefFallback: undefined },
+      );
+    });
+
+    it('throws when the configured claim is missing from userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      });
+      const info = createInfo({ email: 'u@example.com' }, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ldap_uuid/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when userinfo claim is not a valid UUID string', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      });
+      const info = createInfo({ ldap_uuid: 'not-a-uuid' }, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/valid UUID string/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token is missing', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const info = createInfo({ ldap_uuid: ldapUuid });
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/ID token/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token claim is not a valid UUID string', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const validUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: 'not-a-uuid',
+      });
+      const info = createInfo({ ldap_uuid: validUuid }, idToken);
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/valid UUID string/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('throws when id token claim does not match userinfo', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation();
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: '11111111-1111-1111-1111-111111111111',
+      });
+      const info = createInfo(
+        { ldap_uuid: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' },
+        idToken,
+      );
+
+      await expect(resolver(info, ctx)).rejects.toThrow(/mismatching UUID/);
+      expect(ctx.signInWithCatalogUser).not.toHaveBeenCalled();
+    });
+
+    it('passes dangerousEntityRefFallback when enabled', async () => {
+      const ctx = createMockContext();
+      const resolver = pingfederateSignInResolvers.ldapUuidMatchingAnnotation({
+        dangerouslyAllowSignInWithoutUserInCatalog: true,
+      });
+      const ldapUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+      const idToken = await signTestIdToken({
+        sub: 'user-sub',
+        ldap_uuid: ldapUuid,
+      });
+      const info = createInfo({ ldap_uuid: ldapUuid }, idToken);
+
+      await resolver(info, ctx);
+
+      expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith(
+        { annotations: { 'backstage.io/ldap-uuid': ldapUuid } },
+        { dangerousEntityRefFallback: { entityRef: ldapUuid } },
+      );
+    });
+  });
+
+  describe('common resolver delegation', () => {
+    it('delegates emailMatchingUserEntityProfileEmail to commonSignInResolvers', () => {
+      expect(
+        pingfederateSignInResolvers.emailMatchingUserEntityProfileEmail,
+      ).toBe(commonSignInResolvers.emailMatchingUserEntityProfileEmail);
+    });
+
+    it('delegates emailLocalPartMatchingUserEntityName to commonSignInResolvers', () => {
+      expect(
+        pingfederateSignInResolvers.emailLocalPartMatchingUserEntityName,
+      ).toBe(commonSignInResolvers.emailLocalPartMatchingUserEntityName);
+    });
+  });
+});

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
@@ -32,8 +32,6 @@ Export these variables in your shell before starting the harness. Use local-only
 | `PING_IDENTITY_CLIENT_SECRET` | OAuth client secret                                                   |
 | `BACKSTAGE_DEV_STATIC_TOKEN`  | Static bearer token for authenticated `curl` calls to the dev backend |
 
-Example (replace placeholders with your PingOne values):
-
 Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
 
 ### API authentication for `curl`

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing — Ping Identity catalog backend module
+
+Developer guide for `@backstage-community/plugin-catalog-backend-module-pingidentity`. For operator install and configuration, see [README.md](./README.md).
+
+## Prerequisites
+
+- Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
+- Yarn (workspace uses the community-plugins monorepo lockfile)
+
+## Development harness
+
+Start this module in isolation:
+
+```bash
+yarn workspace @backstage-community/plugin-catalog-backend-module-pingidentity start
+```
+
+This runs a minimal backend with `@backstage/plugin-catalog-backend` and the Ping Identity entity provider module. Use it for ingestion, transformers, and PingOne API client work.
+
+Only one plugin `dev/` harness should run on port **7007** at a time. To work on the PingFederate auth module instead, stop this process and start the [auth module harness](../auth-backend-module-pingfederate-provider/CONTRIBUTING.md).
+
+### Environment setup
+
+Export these variables in your shell before starting the harness. Use local-only placeholder values for development — do not commit secrets.
+
+| Variable                      | Purpose                                                               |
+| ----------------------------- | --------------------------------------------------------------------- |
+| `PING_IDENTITY_API_PATH`      | PingOne API base path (e.g. `https://api.pingone.com/v1`)             |
+| `PING_IDENTITY_AUTH_PATH`     | PingOne auth base path (e.g. `https://auth.pingone.com`)              |
+| `PING_IDENTITY_ENV_ID`        | PingOne environment ID                                                |
+| `PING_IDENTITY_CLIENT_ID`     | OAuth client ID for PingOne Management API                            |
+| `PING_IDENTITY_CLIENT_SECRET` | OAuth client secret                                                   |
+| `BACKSTAGE_DEV_STATIC_TOKEN`  | Static bearer token for authenticated `curl` calls to the dev backend |
+
+Example (replace placeholders with your PingOne values):
+
+Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
+
+### API authentication for `curl`
+
+The dev [`app-config.yaml`](./app-config.yaml) registers a **static** backend access token (see [service-to-service auth](https://backstage.io/docs/auth/service-to-service-auth)):
+
+```yaml
+backend:
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+```
+
+Authenticated catalog API requests must send that token:
+
+```bash
+curl -H "Authorization: Bearer ${BACKSTAGE_DEV_STATIC_TOKEN}" \
+  "http://localhost:7007/api/catalog/entities?filter=kind=User"
+```
+
+Requests without a valid `Authorization: Bearer …` header are rejected when the default auth policy applies.
+
+## Validation commands
+
+From the workspace root (`workspaces/pingidentity`):
+
+```bash
+yarn workspace @backstage-community/plugin-catalog-backend-module-pingidentity test
+yarn workspace @backstage-community/plugin-catalog-backend-module-pingidentity lint
+yarn tsc
+```
+
+## What automated tests cover
+
+CI exercises:
+
+- **Module wiring** — catalog extension-point registration and zero-config behavior
+- **Transformer extension point** — double-set guards and custom transformer wiring
+- **Config contract** — provider config parsing and validation
+- **HTTP client** — PingOne API error paths (MSW)
+- **Entity provider** — read/schedule paths and mutations
+
+CI does **not** replace reading [Backstage release notes](https://github.com/backstage/backstage/releases) for the `@backstage/*` packages this module depends on. After a dependency bump, review those notes and decide whether additional validation is warranted.
+
+## Optional manual smoke checklist
+
+Use when you change catalog integration code or are reviewing a Backstage version bump:
+
+1. Export the [environment variables](#environment-setup) and start this harness.
+2. List ingested users (requires Bearer token):
+
+   ```bash
+   curl -H "Authorization: Bearer ${BACKSTAGE_DEV_STATIC_TOKEN}" \
+     "http://localhost:7007/api/catalog/entities?filter=kind=User"
+   ```
+
+   Expect users after the provider refresh runs (may take one schedule cycle).
+
+3. Testing auth resolver pairing (`subClaimMatchingPingIdentityUserId`, `ldapUuidMatchingAnnotation`) requires a Backstage instance that also runs the PingFederate auth module — not covered by this harness alone.
+
+## Related packages
+
+- [PingFederate auth module](../auth-backend-module-pingfederate-provider/CONTRIBUTING.md) — OIDC sign-in (separate `dev/` harness)

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/README.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/README.md
@@ -2,6 +2,8 @@
 
 The PingOne backend plugin ingests organization data (users and groups) from Ping Identity's cloud offering, PingOne, into Backstage.
 
+**Contributors:** see [CONTRIBUTING.md](./CONTRIBUTING.md) for development harnesses, tests, and bump-review guidance.
+
 # Capabilities
 
 The Ping Identity backend plugin has the following capabilities:

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/app-config.yaml
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/app-config.yaml
@@ -1,0 +1,23 @@
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+
+catalog:
+  providers:
+    pingIdentityOrg:
+      default:
+        apiPath: ${PING_IDENTITY_API_PATH}
+        authPath: ${PING_IDENTITY_AUTH_PATH}
+        envId: ${PING_IDENTITY_ENV_ID}
+        clientId: ${PING_IDENTITY_CLIENT_ID}
+        clientSecret: ${PING_IDENTITY_CLIENT_SECRET}
+        schedule:
+          frequency: { minutes: 30 }
+          timeout: { minutes: 3 }

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/src/module/catalogModulePingIdentityEntityProvider.test.ts
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/src/module/catalogModulePingIdentityEntityProvider.test.ts
@@ -20,12 +20,32 @@ import { catalogModulePingIdentityEntityProvider } from './catalogModulePingIden
 import { PingIdentityEntityProvider } from '../providers/PingIdentityEntityProvider';
 
 describe('catalogModulePingIdentityEntityProvider', () => {
+  it('should register zero providers when config is absent', async () => {
+    let addedProviders: PingIdentityEntityProvider[] | undefined;
+
+    const extensionPoint = {
+      addEntityProvider: (providers: PingIdentityEntityProvider[]) => {
+        addedProviders = providers;
+      },
+    };
+
+    await startTestBackend({
+      extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
+      features: [
+        catalogModulePingIdentityEntityProvider,
+        mockServices.rootConfig.factory({ data: {} }),
+      ],
+    });
+
+    expect(addedProviders).toEqual([]);
+  });
+
   it('should register provider at the catalog extension point', async () => {
-    let addedProviders: Array<PingIdentityEntityProvider> | undefined;
+    let addedProviders: PingIdentityEntityProvider[] | undefined;
     let usedSchedule: SchedulerServiceTaskScheduleDefinitionConfig | undefined;
 
     const extensionPoint = {
-      addEntityProvider: (providers: any) => {
+      addEntityProvider: (providers: PingIdentityEntityProvider[]) => {
         addedProviders = providers;
       },
     };

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/src/module/extensions.test.ts
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/src/module/extensions.test.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { UserEntity } from '@backstage/catalog-model';
+import {
+  catalogProcessingExtensionPoint,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import { pingIdentityTransformerExtensionPoint } from '../extensions';
+import { readPingIdentity } from '../lib/read';
+import { PING_IDENTITY_ID_ANNOTATION } from '../lib/constants';
+import type { UserTransformer } from '../lib/types';
+import { catalogModulePingIdentityEntityProvider } from './catalogModulePingIdentityEntityProvider';
+import { PingIdentityEntityProvider } from '../providers/PingIdentityEntityProvider';
+
+jest.mock('../lib/read', () => ({
+  ...jest.requireActual('../lib/read'),
+  readPingIdentity: jest.fn(),
+}));
+
+const readPingIdentityMock = readPingIdentity as jest.MockedFunction<
+  typeof readPingIdentity
+>;
+
+const CUSTOM_TRANSFORMER_MARKER = 'custom-transformer-wired';
+
+const customUserTransformer: UserTransformer = async (
+  entity,
+  _pingIdentityUser,
+  _envId,
+  _groups,
+) => {
+  entity.metadata.annotations = {
+    ...entity.metadata.annotations,
+    'pingidentity.test/wired': CUSTOM_TRANSFORMER_MARKER,
+  };
+  return entity;
+};
+
+const providerConfig = {
+  catalog: {
+    providers: {
+      pingIdentityOrg: {
+        default: {
+          apiPath: 'https://api.test',
+          authPath: 'https://auth.test',
+          envId: 'envId',
+          clientId: 'clientId',
+          clientSecret: 'clientSecret',
+          schedule: {
+            frequency: { minutes: 30 },
+            timeout: { minutes: 3 },
+          },
+        },
+      },
+    },
+  },
+};
+
+const createDoubleSetUserTransformerModule = () =>
+  createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'pingidentity-test-double-set-user',
+    register(reg) {
+      reg.registerInit({
+        deps: { transformers: pingIdentityTransformerExtensionPoint },
+        async init({ transformers }) {
+          transformers.setUserTransformer(async entity => entity);
+          transformers.setUserTransformer(async entity => entity);
+        },
+      });
+    },
+  });
+
+const createDoubleSetGroupTransformerModule = () =>
+  createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'pingidentity-test-double-set-group',
+    register(reg) {
+      reg.registerInit({
+        deps: { transformers: pingIdentityTransformerExtensionPoint },
+        async init({ transformers }) {
+          transformers.setGroupTransformer(async entity => entity);
+          transformers.setGroupTransformer(async entity => entity);
+        },
+      });
+    },
+  });
+
+const createCustomUserTransformerModule = () =>
+  createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'pingidentity-test-custom-transformer',
+    register(reg) {
+      reg.registerInit({
+        deps: { transformers: pingIdentityTransformerExtensionPoint },
+        async init({ transformers }) {
+          transformers.setUserTransformer(customUserTransformer);
+        },
+      });
+    },
+  });
+
+const scheduler = mockServices.scheduler.mock({
+  createScheduledTaskRunner() {
+    return { run: jest.fn() };
+  },
+});
+
+describe('pingIdentityTransformerExtensionPoint', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when setUserTransformer is called twice', async () => {
+    await expect(
+      startTestBackend({
+        extensionPoints: [
+          [catalogProcessingExtensionPoint, { addEntityProvider: jest.fn() }],
+        ],
+        features: [
+          catalogModulePingIdentityEntityProvider,
+          createDoubleSetUserTransformerModule(),
+          mockServices.rootConfig.factory({ data: providerConfig }),
+          scheduler.factory,
+        ],
+      }),
+    ).rejects.toThrow('User transformer may only be set once');
+  });
+
+  it('throws when setGroupTransformer is called twice', async () => {
+    await expect(
+      startTestBackend({
+        extensionPoints: [
+          [catalogProcessingExtensionPoint, { addEntityProvider: jest.fn() }],
+        ],
+        features: [
+          catalogModulePingIdentityEntityProvider,
+          createDoubleSetGroupTransformerModule(),
+          mockServices.rootConfig.factory({ data: providerConfig }),
+          scheduler.factory,
+        ],
+      }),
+    ).rejects.toThrow('Group transformer may only be set once');
+  });
+
+  it('applies a custom user transformer registered via the extension point', async () => {
+    let addedProviders: PingIdentityEntityProvider[] = [];
+    const extensionPoint = {
+      addEntityProvider: (providers: PingIdentityEntityProvider[]) => {
+        addedProviders = providers;
+      },
+    };
+
+    readPingIdentityMock.mockImplementation(async (_client, options) => {
+      const baseUser: UserEntity = {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'User',
+        metadata: {
+          name: 'u1',
+          annotations: {
+            [PING_IDENTITY_ID_ANNOTATION]: 'uid1',
+          },
+        },
+        spec: { memberOf: [] },
+      };
+
+      const userTransformer = options?.userTransformer;
+      const transformed = userTransformer
+        ? await userTransformer(
+            baseUser,
+            {
+              id: 'uid1',
+              username: 'u1',
+            } as Parameters<UserTransformer>[1],
+            'envId',
+            [],
+          )
+        : baseUser;
+
+      return {
+        users: transformed ? [transformed] : [],
+        groups: [],
+      };
+    });
+
+    await startTestBackend({
+      extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
+      features: [
+        createCustomUserTransformerModule(),
+        catalogModulePingIdentityEntityProvider,
+        mockServices.rootConfig.factory({ data: providerConfig }),
+        scheduler.factory,
+      ],
+    });
+
+    const provider = addedProviders[0];
+    const connection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+
+    await provider.connect(connection);
+    await provider.read();
+
+    expect(connection.applyMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({
+                annotations: expect.objectContaining({
+                  'pingidentity.test/wired': CUSTOM_TRANSFORMER_MARKER,
+                }),
+              }),
+            }),
+          }),
+        ],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aims to increase the test coverage for the pingidentity plugins, with a focus on Backstage integration. 

It also adds a contributor guide with steps for running the plugin dev/ harness, running the usual package/workspace validation commands, and a short manual smoke checklist.

Removing the full workspace Backstage app (packages/app / packages/backend) can be a follow-up once this workflow is settled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
