### PR TITLE
Version Packages (scaffolder-backend-module-annotator)

### DIFF
--- a/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-51-0.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-51-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-annotator': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-annotator
 
+## 2.17.0
+
+### Minor Changes
+
+- 83264d5: Backstage version bump to v1.51.0
+
 ## 2.16.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-annotator",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-annotator@2.17.0

### Minor Changes

-   83264d5: Backstage version bump to v1.51.0
