### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/quiet-maps-dream.md
+++ b/workspaces/quay/.changeset/quiet-maps-dream.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
----
-
-Migrated the Quay plugin and dev app from Material UI to Backstage UI (BUI). Replaced `@material-ui/*` with `@backstage/ui` components and `@remixicon/react` icons. Removed direct MUI dependencies; no breaking API changes to plugin exports.
-
-**Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-quay
 
+## 1.35.0
+
+### Minor Changes
+
+- c58c3c0: Migrated the Quay plugin and dev app from Material UI to Backstage UI (BUI). Replaced `@material-ui/*` with `@backstage/ui` components and `@remixicon/react` icons. Removed direct MUI dependencies; no breaking API changes to plugin exports.
+
+  **Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.
+
 ## 1.34.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.35.0

### Minor Changes

-   c58c3c0: Migrated the Quay plugin and dev app from Material UI to Backstage UI (BUI). Replaced `@material-ui/*` with `@backstage/ui` components and `@remixicon/react` icons. Removed direct MUI dependencies; no breaking API changes to plugin exports.

    **Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.
