### PR TITLE
Version Packages (jaeger)

### DIFF
--- a/workspaces/jaeger/.changeset/version-bump-1-51-0.md
+++ b/workspaces/jaeger/.changeset/version-bump-1-51-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jaeger': minor
-'@backstage-community/plugin-jaeger-common': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/jaeger/.changeset/version-bump-1-52-0.md
+++ b/workspaces/jaeger/.changeset/version-bump-1-52-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-jaeger': minor
-'@backstage-community/plugin-jaeger-common': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-jaeger-common
 
+## 0.17.0
+
+### Minor Changes
+
+- b055771: Backstage version bump to v1.51.0
+- e97f430: Backstage version bump to v1.52.0
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/jaeger/plugins/jaeger-common/package.json
+++ b/workspaces/jaeger/plugins/jaeger-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-jaeger-common",
   "description": "Common functionalities for the jaeger plugin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-jaeger
 
+## 0.17.0
+
+### Minor Changes
+
+- b055771: Backstage version bump to v1.51.0
+- e97f430: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [b055771]
+- Updated dependencies [e97f430]
+  - @backstage-community/plugin-jaeger-common@0.17.0
+
 ## 0.16.0
 
 ### Minor Changes

--- a/workspaces/jaeger/plugins/jaeger/package.json
+++ b/workspaces/jaeger/plugins/jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jaeger",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jaeger@0.17.0

### Minor Changes

-   b055771: Backstage version bump to v1.51.0
-   e97f430: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [b055771]
-   Updated dependencies [e97f430]
    -   @backstage-community/plugin-jaeger-common@0.17.0

## @backstage-community/plugin-jaeger-common@0.17.0

### Minor Changes

-   b055771: Backstage version bump to v1.51.0
-   e97f430: Backstage version bump to v1.52.0
