### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/version-bump-1-51-0.md
+++ b/workspaces/jenkins/.changeset/version-bump-1-51-0.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-jenkins': minor
-'@backstage-community/plugin-jenkins-backend': minor
-'@backstage-community/plugin-jenkins-common': minor
-'@backstage-community/plugin-scaffolder-backend-module-jenkins': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/jenkins/.changeset/version-bump-1-52-0.md
+++ b/workspaces/jenkins/.changeset/version-bump-1-52-0.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-jenkins': minor
-'@backstage-community/plugin-jenkins-backend': minor
-'@backstage-community/plugin-jenkins-common': minor
-'@backstage-community/plugin-scaffolder-backend-module-jenkins': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.29.0
+
+### Minor Changes
+
+- cdc918c: Backstage version bump to v1.51.0
+- 26a0c8f: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [cdc918c]
+- Updated dependencies [26a0c8f]
+  - @backstage-community/plugin-jenkins-common@0.20.0
+
 ## 0.28.1
 
 ### Patch Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-jenkins-common
 
+## 0.20.0
+
+### Minor Changes
+
+- cdc918c: Backstage version bump to v1.51.0
+- 26a0c8f: Backstage version bump to v1.52.0
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins-common/package.json
+++ b/workspaces/jenkins/plugins/jenkins-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-common",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "backstage": {
     "role": "common-library",
     "pluginId": "jenkins",

--- a/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-jenkins
 
+## 0.32.0
+
+### Minor Changes
+
+- cdc918c: Backstage version bump to v1.51.0
+- 26a0c8f: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [cdc918c]
+- Updated dependencies [26a0c8f]
+  - @backstage-community/plugin-jenkins-common@0.20.0
+
 ## 0.31.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins/package.json
+++ b/workspaces/jenkins/plugins/jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "A Backstage plugin that integrates towards Jenkins",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-scaffolder-backend-module-jenkins
 
+## 0.22.0
+
+### Minor Changes
+
+- cdc918c: Backstage version bump to v1.51.0
+- 26a0c8f: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [cdc918c]
+- Updated dependencies [26a0c8f]
+  - @backstage-community/plugin-jenkins-common@0.20.0
+
 ## 0.21.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-jenkins",
   "description": "Scaffolder plugin for Jenkins",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins@0.32.0

### Minor Changes

-   cdc918c: Backstage version bump to v1.51.0
-   26a0c8f: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [cdc918c]
-   Updated dependencies [26a0c8f]
    -   @backstage-community/plugin-jenkins-common@0.20.0

## @backstage-community/plugin-jenkins-backend@0.29.0

### Minor Changes

-   cdc918c: Backstage version bump to v1.51.0
-   26a0c8f: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [cdc918c]
-   Updated dependencies [26a0c8f]
    -   @backstage-community/plugin-jenkins-common@0.20.0

## @backstage-community/plugin-jenkins-common@0.20.0

### Minor Changes

-   cdc918c: Backstage version bump to v1.51.0
-   26a0c8f: Backstage version bump to v1.52.0

## @backstage-community/plugin-scaffolder-backend-module-jenkins@0.22.0

### Minor Changes

-   cdc918c: Backstage version bump to v1.51.0
-   26a0c8f: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [cdc918c]
-   Updated dependencies [26a0c8f]
    -   @backstage-community/plugin-jenkins-common@0.20.0
