### PR TITLE
Version Packages (linkerd)

### DIFF
--- a/workspaces/linkerd/.changeset/version-bump-1-52-0.md
+++ b/workspaces/linkerd/.changeset/version-bump-1-52-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-linkerd': minor
-'@backstage-community/plugin-linkerd-backend': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/linkerd/packages/app/CHANGELOG.md
+++ b/workspaces/linkerd/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.28
+
+### Patch Changes
+
+- Updated dependencies [cdefd56]
+  - @backstage-community/plugin-linkerd@0.21.0
+
 ## 0.0.27
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/app/package.json
+++ b/workspaces/linkerd/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/linkerd/packages/backend/CHANGELOG.md
+++ b/workspaces/linkerd/packages/backend/CHANGELOG.md
@@ -1,5 +1,13 @@
 # backend
 
+## 0.0.32
+
+### Patch Changes
+
+- Updated dependencies [cdefd56]
+  - @backstage-community/plugin-linkerd-backend@0.21.0
+  - app@0.0.28
+
 ## 0.0.31
 
 ### Patch Changes

--- a/workspaces/linkerd/packages/backend/package.json
+++ b/workspaces/linkerd/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd-backend
 
+## 0.21.0
+
+### Minor Changes
+
+- cdefd56: Backstage version bump to v1.52.0
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd-backend/package.json
+++ b/workspaces/linkerd/plugins/linkerd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd-backend",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
+++ b/workspaces/linkerd/plugins/linkerd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linkerd
 
+## 0.21.0
+
+### Minor Changes
+
+- cdefd56: Backstage version bump to v1.52.0
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/linkerd/plugins/linkerd/package.json
+++ b/workspaces/linkerd/plugins/linkerd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-linkerd",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-linkerd@0.21.0

### Minor Changes

-   cdefd56: Backstage version bump to v1.52.0

## @backstage-community/plugin-linkerd-backend@0.21.0

### Minor Changes

-   cdefd56: Backstage version bump to v1.52.0

## app@0.0.28

### Patch Changes

-   Updated dependencies [cdefd56]
    -   @backstage-community/plugin-linkerd@0.21.0

## backend@0.0.32

### Patch Changes

-   Updated dependencies [cdefd56]
    -   @backstage-community/plugin-linkerd-backend@0.21.0
    -   app@0.0.28
