### PR TITLE
fix(rbac): preserve stored conditions when conditional reconcile fails

### DIFF
--- a/workspaces/rbac/.changeset/beige-timers-marry.md
+++ b/workspaces/rbac/.changeset/beige-timers-marry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Conditional policy reconciliation no longer deletes stored conditions when validation or permission metadata lookup fails during reload. Pending additions are staged first; removals apply only after all additions succeed.

--- a/workspaces/rbac/.changeset/beige-timers-marry.md
+++ b/workspaces/rbac/.changeset/beige-timers-marry.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-rbac-backend': patch
 ---
 
-Conditional policy reconciliation no longer deletes stored conditions when validation or permission metadata lookup fails during reload. Pending additions are staged first; removals apply only after all additions succeed.
+Conditional policy reconciliation no longer deletes stored conditions when validation or permission metadata lookup fails during reload. Pending additions are staged first; overlapping replacements are applied with updateCondition; net-new creates and pure deletes run only after updates/creates succeed.

--- a/workspaces/rbac/plugins/rbac-backend/docs/audit-log.md
+++ b/workspaces/rbac/plugins/rbac-backend/docs/audit-log.md
@@ -131,12 +131,12 @@ Failed events contain `error` information.
   **Permission Event meta for `policy-write`:**
 
   - source: string (source emitting the event, `rest`, `csv-file`, `configuration`, `externalProviderPluginId`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
 
   **Permission Event fail/success meta for `policy-write`:**
 
   - source: string (source emitting the event, `rest`, `csv-file`, `configuration`, `externalProviderPluginId`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
   - policies: string[][] (modified permissions)
 
   Filter on `actionType`.
@@ -178,12 +178,12 @@ Failed events contain `error` information.
   **Condition Event meta for `condition-write`:**
 
   - source?: string (source emitting the event, `rest` or not included for conditions from `yaml-conditional-file`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
 
   **Condition Event fail/success meta for `condition-write`:**
 
   - source?: string (source emitting the event, `rest` or not included for conditions from `yaml-conditional-file`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
   - condition: RoleConditionalPolicyDecision<"create" | "read" | "update" | "delete" | "use">
 
   Filter on `actionType`.
@@ -191,6 +191,14 @@ Failed events contain `error` information.
   - **`create`**: Creates conditions. (POST `/roles/conditions`, extension point `applyPermissions`)
   - **`update`**: Updates conditions. (PUT `/roles/conditions`)
   - **`delete`**: Deletes conditions. (DELETE `/roles/conditions`, extension point `applyPermissions`)
+  - **`reconcile_abort`**: Provider conditional reconcile failed before completion; stored conditions preserved. (extension point `applyConditionalPermissions`)
+
+    **Condition Event fail meta for `reconcile_abort`:**
+
+    - source: string (provider id)
+    - pendingAdds: number
+    - pendingRemoves: number
+    - pluginIds: string[]
 
 - **`condition-read`**: Reads conditions. (GET `/roles/conditions`)
 

--- a/workspaces/rbac/plugins/rbac-backend/src/auditor/auditor.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/auditor/auditor.ts
@@ -33,6 +33,7 @@ export const ActionType = {
   CREATE_OR_UPDATE: 'create_or_update',
   UPDATE: 'update',
   DELETE: 'delete',
+  RECONCILE_ABORT: 'reconcile_abort',
 };
 
 export const RoleEvents = {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -458,7 +458,7 @@ describe('YamlConditionalFileWatcher', () => {
     const watcher = createWatcher(csvFileName);
     await watcher.initialize();
 
-    expect(conditionalStorageMock.createCondition).toHaveBeenCalled();
+    expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
     expectAuditorLog([
       {
         event: {
@@ -472,12 +472,22 @@ describe('YamlConditionalFileWatcher', () => {
       },
       {
         event: {
-          eventId: ConditionEvents.CONDITION_WRITE,
-          meta: { actionType: ActionType.CREATE },
+          eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 2,
+            pendingRemoves: 0,
+            pluginIds: ['catalog'],
+          },
         },
         fail: {
-          error: new Error('unknown error message 2'),
-          ...mappedConditionMeta(conditionToStore2),
+          error: new Error('unknown error message 1'),
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 2,
+            pendingRemoves: 0,
+            pluginIds: ['catalog'],
+          },
         },
       },
     ]);
@@ -729,6 +739,58 @@ describe('YamlConditionalFileWatcher', () => {
         },
       },
     ]);
+  });
+
+  test('should preserve existing conditions when catalog metadata is unavailable during reload (#9429)', async () => {
+    const storedCondition = {
+      id: 1,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [{ name: 'catalog.entity.read', action: 'read' }],
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: {
+          claims: ['group:default/team-a'],
+        },
+      },
+    };
+
+    conditionalStorageMock.filterConditions = jest
+      .fn()
+      .mockImplementation(() => [storedCondition]);
+    roleMetadataStorageMock.filterRoleMetadata = jest
+      .fn()
+      .mockImplementation(() => csvFileRoles);
+    pluginMetadataCollectorMock.getMetadataByPluginId = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    const updatedYaml = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+      '      - group:default/team-b',
+    ].join('\n');
+
+    const watcher = createWatcher(csvFileName);
+    jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(updatedYaml);
+    await watcher.onChange();
+
+    expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+    expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+    expect(mockLoggerService.error).toHaveBeenCalled();
   });
 
   test('should clean up conditions if conditional file was not specified', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -25,6 +25,7 @@ import { omit } from 'lodash';
 
 import type {
   PermissionAction,
+  PermissionInfo,
   RoleConditionalPolicyDecision,
 } from '@backstage-community/plugin-rbac-common';
 
@@ -33,7 +34,11 @@ import fs from 'fs';
 import { ActionType, ConditionEvents } from '../auditor/auditor';
 import { ConditionalStorage } from '../database/conditional-storage';
 import { RoleMetadataStorage } from '../database/role-metadata';
-import { deepSortEqual, processConditionMapping } from '../helper';
+import {
+  abortConditionalPolicyReconcile,
+  deepSortEqual,
+  processConditionMapping,
+} from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
 import {
@@ -268,65 +273,116 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   }
 
   private async handleFileChanges(): Promise<void> {
-    await this.removeConditions();
-    await this.addConditions();
-  }
+    const { addedConditions, removedConditions } = this.conditionsDiff;
 
-  private async addConditions(): Promise<void> {
-    for (const condition of this.conditionsDiff.addedConditions) {
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.CREATE },
-      });
+    if (addedConditions.length === 0 && removedConditions.length === 0) {
+      return;
+    }
 
-      try {
-        const conditionToCreate = await processConditionMapping(
-          condition,
-          this.pluginMetadataCollector,
-          this.auth,
+    // Map and persist all additions before any removals so a failed add does not
+    // delete stored conditions (for example when permission metadata is unavailable).
+    try {
+      const stagedAdditions: RoleConditionalPolicyDecision<PermissionInfo>[] =
+        [];
+      for (const condition of addedConditions) {
+        stagedAdditions.push(
+          await processConditionMapping(
+            condition,
+            this.pluginMetadataCollector,
+            this.auth,
+          ),
         );
-
-        await this.conditionalStorage.createCondition(conditionToCreate);
-        await auditorEvent.success({
-          meta: { condition },
-        });
-      } catch (error) {
-        await auditorEvent.fail({ error, meta: { condition } });
       }
-    }
 
-    this.conditionsDiff.addedConditions = [];
+      for (const conditionToCreate of stagedAdditions) {
+        await this.persistConditionAddition(conditionToCreate);
+      }
+
+      for (const condition of removedConditions) {
+        await this.persistConditionRemoval(condition);
+      }
+
+      this.conditionsDiff = {
+        addedConditions: [],
+        removedConditions: [],
+      };
+    } catch (error) {
+      await abortConditionalPolicyReconcile({
+        logger: this.logger,
+        auditor: this.auditor,
+        source: 'conditional-policies-file',
+        abortEventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+        pendingAdds: addedConditions.length,
+        pendingRemoves: removedConditions.length,
+        pluginIds: [...new Set(addedConditions.map(c => c.pluginId))],
+        error,
+      });
+    }
   }
 
-  private async removeConditions(): Promise<void> {
-    for (const condition of this.conditionsDiff.removedConditions) {
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.DELETE },
+  private async persistConditionAddition(
+    conditionToCreate: RoleConditionalPolicyDecision<PermissionInfo>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.CREATE },
+    });
+
+    try {
+      await this.conditionalStorage.createCondition(conditionToCreate);
+      await auditorEvent.success({
+        meta: {
+          condition: {
+            ...conditionToCreate,
+            permissionMapping: conditionToCreate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
       });
-
-      try {
-        const conditionToDelete = (
-          await this.conditionalStorage.filterConditions(
-            condition.roleEntityRef,
-            condition.pluginId,
-            condition.resourceType,
-            condition.permissionMapping,
-          )
-        )[0];
-        await this.conditionalStorage.deleteCondition(conditionToDelete.id!);
-        await auditorEvent.success({ meta: { condition } });
-      } catch (error) {
-        await auditorEvent.fail({
-          error,
-          meta: { condition },
-        });
-      }
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: {
+          condition: {
+            ...conditionToCreate,
+            permissionMapping: conditionToCreate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+      throw error;
     }
+  }
 
-    this.conditionsDiff.removedConditions = [];
+  private async persistConditionRemoval(
+    condition: RoleConditionalPolicyDecision<PermissionAction>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.DELETE },
+    });
+
+    try {
+      const conditionToDelete = (
+        await this.conditionalStorage.filterConditions(
+          condition.roleEntityRef,
+          condition.pluginId,
+          condition.resourceType,
+          condition.permissionMapping,
+        )
+      )[0];
+      await this.conditionalStorage.deleteCondition(conditionToDelete.id!);
+      await auditorEvent.success({ meta: { condition } });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: { condition },
+      });
+    }
   }
 
   async cleanUpConditionalPolicies(): Promise<void> {
@@ -343,6 +399,9 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
       };
     });
     this.conditionsDiff.removedConditions = existedFileConds;
-    await this.removeConditions();
+    for (const condition of this.conditionsDiff.removedConditions) {
+      await this.persistConditionRemoval(condition);
+    }
+    this.conditionsDiff.removedConditions = [];
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -37,6 +37,8 @@ import { RoleMetadataStorage } from '../database/role-metadata';
 import {
   abortConditionalPolicyReconcile,
   deepSortEqual,
+  permissionMappingToActions,
+  planConditionalReconcile,
   processConditionMapping,
 } from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
@@ -279,8 +281,8 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
       return;
     }
 
-    // Map and persist all additions before any removals so a failed add does not
-    // delete stored conditions (for example when permission metadata is unavailable).
+    // Map all additions, then apply updates/creates before deletes so a failed
+    // persist does not delete stored conditions (#9429).
     try {
       const stagedAdditions: RoleConditionalPolicyDecision<PermissionInfo>[] =
         [];
@@ -294,11 +296,21 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
         );
       }
 
-      for (const conditionToCreate of stagedAdditions) {
+      const plan = planConditionalReconcile(
+        stagedAdditions,
+        removedConditions,
+        item => permissionMappingToActions(item.permissionMapping),
+      );
+
+      for (const { stored, desired } of plan.updates) {
+        await this.persistConditionUpdate(stored.id!, desired);
+      }
+
+      for (const conditionToCreate of plan.creates) {
         await this.persistConditionAddition(conditionToCreate);
       }
 
-      for (const condition of removedConditions) {
+      for (const condition of plan.deletes) {
         await this.persistConditionRemoval(condition);
       }
 
@@ -317,6 +329,44 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
         pluginIds: [...new Set(addedConditions.map(c => c.pluginId))],
         error,
       });
+    }
+  }
+
+  private async persistConditionUpdate(
+    id: number,
+    conditionToUpdate: RoleConditionalPolicyDecision<PermissionInfo>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.UPDATE },
+    });
+
+    try {
+      await this.conditionalStorage.updateCondition(id, conditionToUpdate);
+      await auditorEvent.success({
+        meta: {
+          condition: {
+            ...conditionToUpdate,
+            permissionMapping: conditionToUpdate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: {
+          condition: {
+            ...conditionToUpdate,
+            permissionMapping: conditionToUpdate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+      throw error;
     }
   }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -40,6 +40,7 @@ import {
   permissionMappingToActions,
   planConditionalReconcile,
   processConditionMapping,
+  toError,
 } from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
@@ -327,7 +328,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
         pendingAdds: addedConditions.length,
         pendingRemoves: removedConditions.length,
         pluginIds: [...new Set(addedConditions.map(c => c.pluginId))],
-        error,
+        error: toError(error),
       });
     }
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 import { RoleMetadata } from '@backstage-community/plugin-rbac-common';
+import { mockServices } from '@backstage/backend-test-utils';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { clearAuditorMock } from '../__fixtures__/auditor-test-utils';
 import { mockAuditorService } from '../__fixtures__/mock-utils';
 import { ADMIN_ROLE_AUTHOR } from './admin-permissions/admin-creation';
 import { RoleMetadataDao } from './database/role-metadata';
 import {
+  abortConditionalPolicyReconcile,
   deepSortedEqual,
+  diffConditionalPolicies,
   isPermissionAction,
   matches,
   mergeRoleMetadata,
@@ -838,5 +842,83 @@ describe('mergeRoleMetadata', () => {
     expect(result.description).toEqual(newMetadata.description);
     expect(result.roleEntityRef).toEqual(newMetadata.roleEntityRef);
     expect(result.source).toEqual(newMetadata.source);
+  });
+});
+
+describe('diffConditionalPolicies', () => {
+  const stored = [
+    {
+      id: 1,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' as const },
+      ],
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: { claims: ['group:default/team-a'] },
+      },
+    },
+  ];
+
+  it('returns empty diff when stored matches desired', () => {
+    const diff = diffConditionalPolicies(
+      stored,
+      stored,
+      (a, b) => a.id === b.id,
+    );
+    expect(diff.toAdd).toHaveLength(0);
+    expect(diff.toRemove).toHaveLength(0);
+  });
+
+  it('returns additions and removals for replace diff', () => {
+    const desired = [
+      {
+        ...stored[0],
+        permissionMapping: [
+          { name: 'catalog.entity.read', action: 'read' as const },
+          { name: 'catalog.entity.delete', action: 'delete' as const },
+        ],
+      },
+    ];
+    const diff = diffConditionalPolicies(
+      stored,
+      desired,
+      (a, b) =>
+        a.roleEntityRef === b.roleEntityRef &&
+        a.pluginId === b.pluginId &&
+        a.resourceType === b.resourceType &&
+        JSON.stringify(a.permissionMapping) ===
+          JSON.stringify(b.permissionMapping) &&
+        JSON.stringify(a.conditions) === JSON.stringify(b.conditions),
+    );
+    expect(diff.toAdd).toHaveLength(1);
+    expect(diff.toRemove).toHaveLength(1);
+  });
+});
+
+describe('abortConditionalPolicyReconcile', () => {
+  const mockLogger = mockServices.logger.mock();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearAuditorMock();
+  });
+
+  it('logs and audits a batch abort without mutating storage', async () => {
+    await abortConditionalPolicyReconcile({
+      logger: mockLogger,
+      auditor: mockAuditorService,
+      source: 'test',
+      pendingAdds: 1,
+      pendingRemoves: 1,
+      pluginIds: ['catalog'],
+      error: new Error('metadata unavailable'),
+    });
+
+    expect(mockLogger.error).toHaveBeenCalled();
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -22,10 +22,13 @@ import { ADMIN_ROLE_AUTHOR } from './admin-permissions/admin-creation';
 import { RoleMetadataDao } from './database/role-metadata';
 import {
   abortConditionalPolicyReconcile,
+  conditionalActionsOverlap,
   deepSortedEqual,
   diffConditionalPolicies,
   isPermissionAction,
   matches,
+  permissionMappingToActions,
+  planConditionalReconcile,
   mergeRoleMetadata,
   metadataStringToPolicy,
   policiesToString,
@@ -897,6 +900,91 @@ describe('diffConditionalPolicies', () => {
     );
     expect(diff.toAdd).toHaveLength(1);
     expect(diff.toRemove).toHaveLength(1);
+  });
+});
+
+describe('planConditionalReconcile', () => {
+  const stored = {
+    id: 1,
+    result: AuthorizeResult.CONDITIONAL,
+    roleEntityRef: 'role:default/test',
+    pluginId: 'catalog',
+    resourceType: 'catalog-entity',
+    permissionMapping: [
+      { name: 'catalog.entity.read', action: 'read' as const },
+    ],
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'catalog-entity',
+      params: { claims: ['group:default/team-a'] },
+    },
+  };
+
+  it('routes overlapping replacements to updates', () => {
+    const desired = {
+      ...stored,
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' as const },
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+    };
+
+    const plan = planConditionalReconcile([desired], [stored], item =>
+      permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.updates[0].stored.id).toBe(1);
+    expect(plan.creates).toHaveLength(0);
+    expect(plan.deletes).toHaveLength(0);
+  });
+
+  it('routes non-overlapping replacement to create and delete', () => {
+    const desired = {
+      roleEntityRef: stored.roleEntityRef,
+      pluginId: stored.pluginId,
+      resourceType: stored.resourceType,
+      permissionMapping: [
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+    };
+
+    const plan = planConditionalReconcile([desired], [stored], item =>
+      permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.creates).toHaveLength(1);
+    expect(plan.deletes).toHaveLength(1);
+  });
+
+  it('routes net-new additions to creates only', () => {
+    const desired = {
+      roleEntityRef: 'role:default/other',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' as const },
+      ],
+    };
+
+    const plan = planConditionalReconcile([desired], [stored], item =>
+      permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.creates).toHaveLength(1);
+    expect(plan.deletes).toHaveLength(1);
+  });
+});
+
+describe('conditionalActionsOverlap', () => {
+  it('returns true when action sets intersect', () => {
+    expect(conditionalActionsOverlap(['read'], ['read', 'delete'])).toBe(true);
+  });
+
+  it('returns false when action sets are disjoint', () => {
+    expect(conditionalActionsOverlap(['read'], ['delete'])).toBe(false);
   });
 });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -16,8 +16,12 @@
 import { RoleMetadata } from '@backstage-community/plugin-rbac-common';
 import { mockServices } from '@backstage/backend-test-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
-import { clearAuditorMock } from '../__fixtures__/auditor-test-utils';
+import {
+  clearAuditorMock,
+  expectAuditorLog,
+} from '../__fixtures__/auditor-test-utils';
 import { mockAuditorService } from '../__fixtures__/mock-utils';
+import { ActionType, ConditionEvents } from './auditor/auditor';
 import { ADMIN_ROLE_AUTHOR } from './admin-permissions/admin-creation';
 import { RoleMetadataDao } from './database/role-metadata';
 import {
@@ -1008,5 +1012,43 @@ describe('abortConditionalPolicyReconcile', () => {
     });
 
     expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  it('includes reconcile_abort actionType for condition-write aborts', async () => {
+    await abortConditionalPolicyReconcile({
+      logger: mockLogger,
+      auditor: mockAuditorService,
+      source: 'test-provider',
+      abortEventId: ConditionEvents.CONDITION_WRITE,
+      pendingAdds: 2,
+      pendingRemoves: 1,
+      pluginIds: ['catalog'],
+      error: new Error('reconcile failed'),
+    });
+
+    expectAuditorLog([
+      {
+        event: {
+          eventId: ConditionEvents.CONDITION_WRITE,
+          meta: {
+            source: 'test-provider',
+            actionType: ActionType.RECONCILE_ABORT,
+            pendingAdds: 2,
+            pendingRemoves: 1,
+            pluginIds: ['catalog'],
+          },
+        },
+        fail: {
+          error: new Error('reconcile failed'),
+          meta: {
+            source: 'test-provider',
+            actionType: ActionType.RECONCILE_ABORT,
+            pendingAdds: 2,
+            pendingRemoves: 1,
+            pluginIds: ['catalog'],
+          },
+        },
+      },
+    ]);
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -33,6 +33,7 @@ import {
   matches,
   permissionMappingToActions,
   planConditionalReconcile,
+  toError,
   mergeRoleMetadata,
   metadataStringToPolicy,
   policiesToString,
@@ -992,6 +993,19 @@ describe('conditionalActionsOverlap', () => {
   });
 });
 
+describe('toError', () => {
+  it('returns Error instances unchanged', () => {
+    const error = new Error('failed');
+    expect(toError(error)).toBe(error);
+  });
+
+  it('wraps non-Error values', () => {
+    const error = toError('failed');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('failed');
+  });
+});
+
 describe('abortConditionalPolicyReconcile', () => {
   const mockLogger = mockServices.logger.mock();
 
@@ -1001,6 +1015,8 @@ describe('abortConditionalPolicyReconcile', () => {
   });
 
   it('logs and audits a batch abort without mutating storage', async () => {
+    const reconcileError = new Error('metadata unavailable');
+
     await abortConditionalPolicyReconcile({
       logger: mockLogger,
       auditor: mockAuditorService,
@@ -1008,10 +1024,20 @@ describe('abortConditionalPolicyReconcile', () => {
       pendingAdds: 1,
       pendingRemoves: 1,
       pluginIds: ['catalog'],
-      error: new Error('metadata unavailable'),
+      error: reconcileError,
     });
 
-    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        event: 'conditional_reconcile_aborted',
+        error: {
+          name: reconcileError.name,
+          message: reconcileError.message,
+          stack: reconcileError.stack,
+        },
+      }),
+    );
   });
 
   it('includes reconcile_abort actionType for condition-write aborts', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -239,6 +239,9 @@ export async function abortConditionalPolicyReconcile(
     pendingAdds,
     pendingRemoves,
     pluginIds,
+    ...(abortEventId === ConditionEvents.CONDITION_WRITE
+      ? { actionType: ActionType.RECONCILE_ABORT }
+      : {}),
   };
 
   logger.error(

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -92,6 +92,29 @@ export type ConditionalPolicyDiff<TAdd> = {
   toRemove: RoleConditionalPolicyDecision<PermissionInfo>[];
 };
 
+export type ConditionalResourceKey = {
+  roleEntityRef: string;
+  pluginId: string;
+  resourceType: string;
+};
+
+export type ConditionalPolicyReplacement<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+> = {
+  stored: TRemove;
+  desired: TAdd;
+};
+
+export type ConditionalPolicyReconcilePlan<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+> = {
+  updates: ConditionalPolicyReplacement<TAdd, TRemove>[];
+  creates: TAdd[];
+  deletes: TRemove[];
+};
+
 export type ConditionalPolicyReconcileAbortContext = {
   logger: LoggerService;
   auditor: AuditorService;
@@ -123,11 +146,79 @@ export function diffConditionalPolicies<TAdd>(
   return { toAdd, toRemove };
 }
 
+export function permissionMappingToActions(
+  mapping: PermissionInfo[] | PermissionAction[],
+): PermissionAction[] {
+  return mapping.map(entry =>
+    typeof entry === 'string' ? entry : entry.action,
+  );
+}
+
+export function sameConditionalResource(
+  a: ConditionalResourceKey,
+  b: ConditionalResourceKey,
+): boolean {
+  return (
+    a.roleEntityRef === b.roleEntityRef &&
+    a.pluginId === b.pluginId &&
+    a.resourceType === b.resourceType
+  );
+}
+
+export function conditionalActionsOverlap(
+  actionsA: PermissionAction[],
+  actionsB: PermissionAction[],
+): boolean {
+  return actionsA.some(action => actionsB.includes(action));
+}
+
 /**
- * Logs and audits a failed conditional reconcile. Callers must complete the full
- * add path (validation, metadata mapping, and createCondition) before running
- * removals, and invoke this from a catch block when that add path throws so
- * stored conditions are not deleted.
+ * Splits a conditional diff into in-place updates, net-new creates, and pure
+ * deletes. Overlapping add/remove pairs for the same role/plugin/resourceType
+ * are treated as updates so createCondition is not called while the stored row
+ * still exists.
+ */
+export function planConditionalReconcile<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+>(
+  toAdd: TAdd[],
+  toRemove: TRemove[],
+  getActions: (item: TAdd | TRemove) => PermissionAction[],
+): ConditionalPolicyReconcilePlan<TAdd, TRemove> {
+  const matchedRemoveIds = new Set<number>();
+  const updates: ConditionalPolicyReplacement<TAdd, TRemove>[] = [];
+  const creates: TAdd[] = [];
+
+  for (const desired of toAdd) {
+    const stored = toRemove.find(
+      item =>
+        item.id !== undefined &&
+        !matchedRemoveIds.has(item.id) &&
+        sameConditionalResource(item, desired) &&
+        conditionalActionsOverlap(getActions(item), getActions(desired)),
+    );
+
+    if (stored?.id !== undefined) {
+      matchedRemoveIds.add(stored.id);
+      updates.push({ stored, desired });
+    } else {
+      creates.push(desired);
+    }
+  }
+
+  const deletes = toRemove.filter(
+    item => item.id === undefined || !matchedRemoveIds.has(item.id),
+  );
+
+  return { updates, creates, deletes };
+}
+
+/**
+ * Logs and audits a failed conditional reconcile. Callers must finish staging
+ * and validation for all pending additions, then persist updates/creates before
+ * deletes. Invoke from a catch block when that persist phase throws so stored
+ * conditions are not deleted.
  */
 export async function abortConditionalPolicyReconcile(
   context: ConditionalPolicyReconcileAbortContext,

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuditorService, AuthService } from '@backstage/backend-plugin-api';
+import {
+  AuditorService,
+  AuthService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
 import type { MetadataResponse } from '@backstage/plugin-permission-common';
 
 import {
@@ -36,7 +40,7 @@ import {
   Source,
 } from '@backstage-community/plugin-rbac-common';
 
-import { ActionType, RoleEvents } from './auditor/auditor';
+import { ActionType, ConditionEvents, RoleEvents } from './auditor/auditor';
 import { RoleMetadataDao, RoleMetadataStorage } from './database/role-metadata';
 import { EnforcerDelegate } from './service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from './service/plugin-endpoints';
@@ -81,6 +85,86 @@ export function metadataStringToPolicy(policy: string): string[] {
  */
 function policyArraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+export type ConditionalPolicyDiff<TAdd> = {
+  toAdd: TAdd[];
+  toRemove: RoleConditionalPolicyDecision<PermissionInfo>[];
+};
+
+export type ConditionalPolicyReconcileAbortContext = {
+  logger: LoggerService;
+  auditor: AuditorService;
+  source: string;
+  abortEventId?: string;
+  pendingAdds: number;
+  pendingRemoves: number;
+  pluginIds: string[];
+  error: unknown;
+};
+
+/**
+ * Computes additions and removals between stored and desired conditional policies.
+ */
+export function diffConditionalPolicies<TAdd>(
+  stored: RoleConditionalPolicyDecision<PermissionInfo>[],
+  desired: TAdd[],
+  equals: (
+    storedItem: RoleConditionalPolicyDecision<PermissionInfo>,
+    desiredItem: TAdd,
+  ) => boolean,
+): ConditionalPolicyDiff<TAdd> {
+  const toAdd = desired.filter(
+    desiredItem => !stored.some(storedItem => equals(storedItem, desiredItem)),
+  );
+  const toRemove = stored.filter(
+    storedItem => !desired.some(desiredItem => equals(storedItem, desiredItem)),
+  );
+  return { toAdd, toRemove };
+}
+
+/**
+ * Logs and audits a failed conditional reconcile. Callers must complete the full
+ * add path (validation, metadata mapping, and createCondition) before running
+ * removals, and invoke this from a catch block when that add path throws so
+ * stored conditions are not deleted.
+ */
+export async function abortConditionalPolicyReconcile(
+  context: ConditionalPolicyReconcileAbortContext,
+): Promise<void> {
+  const {
+    logger,
+    auditor,
+    source,
+    abortEventId = ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+    pendingAdds,
+    pendingRemoves,
+    pluginIds,
+    error,
+  } = context;
+
+  const abortMeta = {
+    source,
+    pendingAdds,
+    pendingRemoves,
+    pluginIds,
+  };
+
+  logger.error(
+    'Conditional policy reconcile aborted; stored conditions preserved. Retry reconciliation once the add failure is resolved.',
+    {
+      event: 'conditional_reconcile_aborted',
+      ...abortMeta,
+      error: String(error),
+    },
+  );
+
+  const auditorEvent = await auditor.createEvent({
+    eventId: abortEventId,
+    severityLevel: 'medium',
+    meta: abortMeta,
+  });
+  await auditorEvent.fail({ error, meta: abortMeta });
 }
 
 /**

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -123,8 +123,24 @@ export type ConditionalPolicyReconcileAbortContext = {
   pendingAdds: number;
   pendingRemoves: number;
   pluginIds: string[];
-  error: unknown;
+  error: Error;
 };
+
+function serializeErrorForLog(error: Error): {
+  name: string;
+  message: string;
+  stack?: string;
+} {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+}
+
+export function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
 
 /**
  * Computes additions and removals between stored and desired conditional policies.
@@ -249,7 +265,7 @@ export async function abortConditionalPolicyReconcile(
     {
       event: 'conditional_reconcile_aborted',
       ...abortMeta,
-      error: String(error),
+      error: serializeErrorForLog(error),
     },
   );
 

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -599,12 +599,14 @@ describe('Connection', () => {
     beforeEach(() => {
       (conditionalStorageMock.createCondition as jest.Mock).mockReset();
       (conditionalStorageMock.deleteCondition as jest.Mock).mockReset();
+      (conditionalStorageMock.updateCondition as jest.Mock).mockReset();
     });
 
     afterEach(() => {
       (mockLoggerService.warn as jest.Mock).mockReset();
       (conditionalStorageMock.createCondition as jest.Mock).mockReset();
       (conditionalStorageMock.deleteCondition as jest.Mock).mockReset();
+      (conditionalStorageMock.updateCondition as jest.Mock).mockReset();
     });
 
     it('should create conditional permissions', async () => {
@@ -706,8 +708,13 @@ describe('Connection', () => {
       ];
 
       await provider.applyConditionalPermissions(policies);
-      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
-      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+        existingConditionalPermission[0].id,
+        policies[0],
+      );
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     });
     it('should replace permissions with changed condition', async () => {
       const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
@@ -732,14 +739,38 @@ describe('Connection', () => {
       ];
 
       await provider.applyConditionalPermissions(policies);
-      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
-      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+        existingConditionalPermission[0].id,
+        policies[0],
+      );
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     });
 
-    it('should preserve existing conditional policies when replacement add fails (#9429)', async () => {
-      (conditionalStorageMock.createCondition as jest.Mock).mockImplementation(
+    it('should create then delete when replacement actions do not overlap', async () => {
+      const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
+        {
+          id: existingConditionalPermission[0].id,
+          result: existingConditionalPermission[0].result,
+          roleEntityRef: existingConditionalPermission[0].roleEntityRef,
+          pluginId: existingConditionalPermission[0].pluginId,
+          resourceType: existingConditionalPermission[0].resourceType,
+          permissionMapping: [{ name: 'delete', action: 'delete' }],
+          conditions: existingConditionalPermission[0].conditions,
+        },
+      ];
+
+      await provider.applyConditionalPermissions(policies);
+      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).not.toHaveBeenCalled();
+    });
+
+    it('should preserve existing conditional policies when replacement update fails (#9429)', async () => {
+      (conditionalStorageMock.updateCondition as jest.Mock).mockImplementation(
         () => {
-          throw new Error('create failed');
+          throw new Error('update failed');
         },
       );
 
@@ -760,7 +791,8 @@ describe('Connection', () => {
 
       await provider.applyConditionalPermissions(policies);
       expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
-      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     });
 
     it('should reject policies from an invalid source', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -831,6 +831,7 @@ describe('Connection', () => {
             eventId: ConditionEvents.CONDITION_WRITE,
             meta: {
               source: 'another-provider',
+              actionType: ActionType.RECONCILE_ABORT,
               pendingAdds: 1,
               pendingRemoves: 0,
               pluginIds: ['catalog'],
@@ -842,6 +843,7 @@ describe('Connection', () => {
             ),
             meta: {
               source: 'another-provider',
+              actionType: ActionType.RECONCILE_ABORT,
               pendingAdds: 1,
               pendingRemoves: 0,
               pluginIds: ['catalog'],

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -735,6 +735,34 @@ describe('Connection', () => {
       expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
       expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
     });
+
+    it('should preserve existing conditional policies when replacement add fails (#9429)', async () => {
+      (conditionalStorageMock.createCondition as jest.Mock).mockImplementation(
+        () => {
+          throw new Error('create failed');
+        },
+      );
+
+      const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
+        {
+          id: existingConditionalPermission[0].id,
+          result: existingConditionalPermission[0].result,
+          roleEntityRef: existingConditionalPermission[0].roleEntityRef,
+          pluginId: existingConditionalPermission[0].pluginId,
+          resourceType: existingConditionalPermission[0].resourceType,
+          permissionMapping: [
+            { name: 'read', action: 'read' },
+            { name: 'delete', action: 'delete' },
+          ],
+          conditions: existingConditionalPermission[0].conditions,
+        },
+      ];
+
+      await provider.applyConditionalPermissions(policies);
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+    });
+
     it('should reject policies from an invalid source', async () => {
       const anotherProvider = new Connection(
         'another-provider',
@@ -769,14 +797,22 @@ describe('Connection', () => {
         {
           event: {
             eventId: ConditionEvents.CONDITION_WRITE,
-            meta: { actionType: ActionType.CREATE, source: 'another-provider' },
+            meta: {
+              source: 'another-provider',
+              pendingAdds: 1,
+              pendingRemoves: 0,
+              pluginIds: ['catalog'],
+            },
           },
           fail: {
             error: new Error(
               `source does not match originating role role:default/existing-provider-role, consider making changes to the 'TEST'`,
             ),
             meta: {
-              policies: [policies[0]],
+              source: 'another-provider',
+              pendingAdds: 1,
+              pendingRemoves: 0,
+              pluginIds: ['catalog'],
             },
           },
         },

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -41,6 +41,8 @@ import {
   transformArrayToPolicy,
   transformRolesGroupToLowercase,
   typedPoliciesToString,
+  abortConditionalPolicyReconcile,
+  diffConditionalPolicies,
 } from '../helper';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { MODEL } from '../service/permission-model';
@@ -126,42 +128,50 @@ export class Connection implements RBACProviderConnection {
     const storedConditionalPermissions =
       await this.conditionStorage.filterConditions();
 
-    const conditionsToBeAdded: RoleConditionalPolicyDecision<PermissionInfo>[] =
-      conditionalPermissions.filter(
-        conditionalPermission =>
-          !storedConditionalPermissions.some(
-            stored =>
-              conditionalPermission.roleEntityRef === stored.roleEntityRef &&
-              conditionalPermission.pluginId === stored.pluginId &&
-              conditionalPermission.resourceType === stored.resourceType &&
-              isEqual(
-                conditionalPermission.permissionMapping,
-                stored.permissionMapping,
-              ) &&
-              isEqual(conditionalPermission.conditions, stored.conditions),
-          ),
-      );
+    const diff = diffConditionalPolicies(
+      storedConditionalPermissions,
+      conditionalPermissions,
+      (stored, desired) =>
+        stored.roleEntityRef === desired.roleEntityRef &&
+        stored.pluginId === desired.pluginId &&
+        stored.resourceType === desired.resourceType &&
+        isEqual(stored.permissionMapping, desired.permissionMapping) &&
+        isEqual(stored.conditions, desired.conditions),
+    );
 
-    // Updated policies fails the 'some' check due to permissionMapping differences
-    const conditionsToBeRemoved: RoleConditionalPolicyDecision<PermissionInfo>[] =
-      storedConditionalPermissions.filter(
-        stored =>
-          !conditionalPermissions.some(
-            conditionalPermission =>
-              stored.roleEntityRef === conditionalPermission.roleEntityRef &&
-              stored.pluginId === conditionalPermission.pluginId &&
-              stored.resourceType === conditionalPermission.resourceType &&
-              isEqual(
-                stored.permissionMapping,
-                conditionalPermission.permissionMapping,
-              ) &&
-              isEqual(stored.conditions, conditionalPermission.conditions),
-          ),
-      );
+    if (diff.toAdd.length === 0 && diff.toRemove.length === 0) {
+      return;
+    }
 
-    await this.removeConditionalPermissions(conditionsToBeRemoved);
+    // Validate and persist all additions before any removals so a failed add does not
+    // delete stored conditions.
+    try {
+      for (const condition of diff.toAdd) {
+        const metadata = await this.roleMetadataStorage.findRoleMetadata(
+          condition.roleEntityRef,
+        );
+        const err = await validateSource(this.id, metadata);
+        if (err) {
+          throw err;
+        }
+        await this.persistConditionalAddition(condition);
+      }
 
-    await this.addConditionalPermissions(conditionsToBeAdded);
+      for (const condition of diff.toRemove) {
+        await this.persistConditionalRemoval(condition);
+      }
+    } catch (error) {
+      await abortConditionalPolicyReconcile({
+        logger: this.logger,
+        auditor: this.auditor,
+        source: this.id,
+        abortEventId: ConditionEvents.CONDITION_WRITE,
+        pendingAdds: diff.toAdd.length,
+        pendingRemoves: diff.toRemove.length,
+        pluginIds: [...new Set(diff.toAdd.map(c => c.pluginId))],
+        error,
+      });
+    }
   }
 
   private async addRoles(roles: string[][]): Promise<void> {
@@ -338,65 +348,55 @@ export class Connection implements RBACProviderConnection {
     }
   }
 
-  private async addConditionalPermissions(
-    conditionalPermissions: RoleConditionalPolicyDecision<PermissionInfo>[],
+  private async persistConditionalAddition(
+    condition: RoleConditionalPolicyDecision<PermissionInfo>,
   ): Promise<void> {
-    for (const condition of conditionalPermissions) {
-      const auditorMeta = {
-        policies: [condition],
-      };
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: {
-          actionType: ActionType.CREATE,
-          source: this.id,
-        },
-      });
-      try {
-        const metadata = await this.roleMetadataStorage.findRoleMetadata(
-          condition.roleEntityRef,
-        );
-        const err = await validateSource(this.id, metadata);
-        if (err) {
-          throw err;
-        }
-        await this.conditionStorage.createCondition(condition);
-        await auditorEvent.success({ meta: auditorMeta });
-      } catch (error) {
-        await auditorEvent.fail({ error, meta: auditorMeta });
-      }
+    const auditorMeta = {
+      policies: [condition],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: {
+        actionType: ActionType.CREATE,
+        source: this.id,
+      },
+    });
+    try {
+      await this.conditionStorage.createCondition(condition);
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({ error, meta: auditorMeta });
+      throw error;
     }
   }
 
-  private async removeConditionalPermissions(
-    conditionalPermissions: RoleConditionalPolicyDecision<PermissionInfo>[],
+  private async persistConditionalRemoval(
+    conditionalPermission: RoleConditionalPolicyDecision<PermissionInfo>,
   ): Promise<void> {
-    for (const conditionalPermission of conditionalPermissions) {
-      const auditorMeta = {
-        policies: [conditionalPermission],
-      };
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.DELETE, source: this.id },
-      });
-      try {
-        const metadata = await this.roleMetadataStorage.findRoleMetadata(
-          conditionalPermission.roleEntityRef,
-        );
-        const err = await validateSource(this.id, metadata);
-        if (err) {
-          throw err;
-        }
-        await this.conditionStorage.deleteCondition(conditionalPermission.id);
-        await auditorEvent.success({ meta: auditorMeta });
-      } catch (error) {
-        await auditorEvent.fail({
-          error,
-          meta: auditorMeta,
-        });
+    const auditorMeta = {
+      policies: [conditionalPermission],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.DELETE, source: this.id },
+    });
+    try {
+      const metadata = await this.roleMetadataStorage.findRoleMetadata(
+        conditionalPermission.roleEntityRef,
+      );
+      const err = await validateSource(this.id, metadata);
+      if (err) {
+        throw err;
       }
+      await this.conditionStorage.deleteCondition(conditionalPermission.id!);
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: auditorMeta,
+      });
     }
   }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -45,6 +45,7 @@ import {
   diffConditionalPolicies,
   permissionMappingToActions,
   planConditionalReconcile,
+  toError,
 } from '../helper';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { MODEL } from '../service/permission-model';
@@ -182,7 +183,7 @@ export class Connection implements RBACProviderConnection {
         pendingAdds: diff.toAdd.length,
         pendingRemoves: diff.toRemove.length,
         pluginIds: [...new Set(diff.toAdd.map(c => c.pluginId))],
-        error,
+        error: toError(error),
       });
     }
   }

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -43,6 +43,8 @@ import {
   typedPoliciesToString,
   abortConditionalPolicyReconcile,
   diffConditionalPolicies,
+  permissionMappingToActions,
+  planConditionalReconcile,
 } from '../helper';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { MODEL } from '../service/permission-model';
@@ -143,8 +145,8 @@ export class Connection implements RBACProviderConnection {
       return;
     }
 
-    // Validate and persist all additions before any removals so a failed add does not
-    // delete stored conditions.
+    // Stage all additions, then apply updates/creates before deletes so a failed
+    // persist does not delete stored conditions (#9429).
     try {
       for (const condition of diff.toAdd) {
         const metadata = await this.roleMetadataStorage.findRoleMetadata(
@@ -154,10 +156,21 @@ export class Connection implements RBACProviderConnection {
         if (err) {
           throw err;
         }
+      }
+
+      const plan = planConditionalReconcile(diff.toAdd, diff.toRemove, item =>
+        permissionMappingToActions(item.permissionMapping),
+      );
+
+      for (const { stored, desired } of plan.updates) {
+        await this.persistConditionalUpdate(stored.id!, desired);
+      }
+
+      for (const condition of plan.creates) {
         await this.persistConditionalAddition(condition);
       }
 
-      for (const condition of diff.toRemove) {
+      for (const condition of plan.deletes) {
         await this.persistConditionalRemoval(condition);
       }
     } catch (error) {
@@ -345,6 +358,30 @@ export class Connection implements RBACProviderConnection {
           });
         }
       }
+    }
+  }
+
+  private async persistConditionalUpdate(
+    id: number,
+    condition: RoleConditionalPolicyDecision<PermissionInfo>,
+  ): Promise<void> {
+    const auditorMeta = {
+      policies: [condition],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: {
+        actionType: ActionType.UPDATE,
+        source: this.id,
+      },
+    });
+    try {
+      await this.conditionStorage.updateCondition(id, condition);
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({ error, meta: auditorMeta });
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Conditional policy reload used remove-then-add ordering, so when adds failed (e.g. Catalog permission metadata 503), stored conditions were already deleted.

Reconciliation now stages and persists all additions before any removals. On add-phase failure, stored conditions are preserved and a batch abort is logged/audited via abortConditionalPolicyReconcile in helper.ts.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
