### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/mui-v5-servicenow.md
+++ b/workspaces/servicenow/.changeset/mui-v5-servicenow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-servicenow': patch
----
-
-Migrate ServiceNow frontend plugin from Material UI v4 to Material UI v5, replacing `makeStyles` with `sx` props and removing `@material-ui/*` imports.

--- a/workspaces/servicenow/.changeset/version-bump-1-51-0.md
+++ b/workspaces/servicenow/.changeset/version-bump-1-51-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/servicenow/.changeset/version-bump-1-52-0.md
+++ b/workspaces/servicenow/.changeset/version-bump-1-52-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.13.0
+
+### Minor Changes
+
+- 2603949: Backstage version bump to v1.51.0
+- 2e296d0: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [2603949]
+- Updated dependencies [2e296d0]
+  - @backstage-community/plugin-servicenow-common@1.12.0
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-servicenow-common
 
+## 1.12.0
+
+### Minor Changes
+
+- 2603949: Backstage version bump to v1.51.0
+- 2e296d0: Backstage version bump to v1.52.0
+
 ## 1.11.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-common/package.json
+++ b/workspaces/servicenow/plugins/servicenow-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-common",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the servicenow plugin",
   "main": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-servicenow
 
+## 1.13.0
+
+### Minor Changes
+
+- 2603949: Backstage version bump to v1.51.0
+- 2e296d0: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- fc0ec09: Migrate ServiceNow frontend plugin from Material UI v4 to Material UI v5, replacing `makeStyles` with `sx` props and removing `@material-ui/*` imports.
+- Updated dependencies [2603949]
+- Updated dependencies [2e296d0]
+  - @backstage-community/plugin-servicenow-common@1.12.0
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.13.0

### Minor Changes

-   2603949: Backstage version bump to v1.51.0
-   2e296d0: Backstage version bump to v1.52.0

### Patch Changes

-   fc0ec09: Migrate ServiceNow frontend plugin from Material UI v4 to Material UI v5, replacing `makeStyles` with `sx` props and removing `@material-ui/*` imports.
-   Updated dependencies [2603949]
-   Updated dependencies [2e296d0]
    -   @backstage-community/plugin-servicenow-common@1.12.0

## @backstage-community/plugin-servicenow-backend@1.13.0

### Minor Changes

-   2603949: Backstage version bump to v1.51.0
-   2e296d0: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [2603949]
-   Updated dependencies [2e296d0]
    -   @backstage-community/plugin-servicenow-common@1.12.0

## @backstage-community/plugin-servicenow-common@1.12.0

### Minor Changes

-   2603949: Backstage version bump to v1.51.0
-   2e296d0: Backstage version bump to v1.52.0
