### PR TITLE
Version Packages (acr)

### DIFF
--- a/workspaces/acr/.changeset/little-trees-deny.md
+++ b/workspaces/acr/.changeset/little-trees-deny.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': patch
----
-
-Migrated MUI-v4 references to MUI-v5. Replaced `@material-ui/core` with `@mui/material` and `@material-ui/icons` with `@mui/icons-material`. Replaced `makeStyles` with `sx` prop and `styled()`. No breaking API changes.

--- a/workspaces/acr/plugins/acr/CHANGELOG.md
+++ b/workspaces/acr/plugins/acr/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-acr
 
+## 1.25.2
+
+### Patch Changes
+
+- aba159f: Migrated MUI-v4 references to MUI-v5. Replaced `@material-ui/core` with `@mui/material` and `@material-ui/icons` with `@mui/icons-material`. Replaced `makeStyles` with `sx` prop and `styled()`. No breaking API changes.
+
 ## 1.25.1
 
 ### Patch Changes

--- a/workspaces/acr/plugins/acr/package.json
+++ b/workspaces/acr/plugins/acr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-acr",
   "description": "A Backstage plugin that displays information about your container images available in the Azure Container Registry",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acr@1.25.2

### Patch Changes

-   aba159f: Migrated MUI-v4 references to MUI-v5. Replaced `@material-ui/core` with `@mui/material` and `@material-ui/icons` with `@mui/icons-material`. Replaced `makeStyles` with `sx` prop and `styled()`. No breaking API changes.
