### PR TITLE
feat(azure-devops): auto-detect README.md from source-location when readme-path annotation is absent

### DIFF
--- a/workspaces/azure-devops/.changeset/rich-comics-complain.md
+++ b/workspaces/azure-devops/.changeset/rich-comics-complain.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops-common': patch
+---
+
+Add auto-detection of README.md from backstage.io/source-location when dev.azure.com/readme-path annotation is absent

--- a/workspaces/azure-devops/.changeset/rich-comics-complain.md
+++ b/workspaces/azure-devops/.changeset/rich-comics-complain.md
@@ -1,5 +1,6 @@
 ---
 '@backstage-community/plugin-azure-devops-common': patch
+'@backstage-community/plugin-azure-devops': patch
 ---
 
-Add auto-detection of README.md from backstage.io/source-location when dev.azure.com/readme-path annotation is absent
+Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent

--- a/workspaces/azure-devops/.changeset/rich-comics-complain.md
+++ b/workspaces/azure-devops/.changeset/rich-comics-complain.md
@@ -3,4 +3,4 @@
 '@backstage-community/plugin-azure-devops': patch
 ---
 
-Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent
+Added auto-detection of `README.md` from `backstage.io/managed-by-location` when `dev.azure.com/readme-path` annotation is absent

--- a/workspaces/azure-devops/.changeset/rich-comics-complain.md
+++ b/workspaces/azure-devops/.changeset/rich-comics-complain.md
@@ -3,4 +3,4 @@
 '@backstage-community/plugin-azure-devops': patch
 ---
 
-Added auto-detection of `README.md` from `backstage.io/managed-by-location` when `dev.azure.com/readme-path` annotation is absent
+Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent

--- a/workspaces/azure-devops/.changeset/shy-bulldogs-grow.md
+++ b/workspaces/azure-devops/.changeset/shy-bulldogs-grow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-azure-devops': patch
+---
+
+Add documentation for automatic README path detection from backstage.io/source-location

--- a/workspaces/azure-devops/.changeset/shy-bulldogs-grow.md
+++ b/workspaces/azure-devops/.changeset/shy-bulldogs-grow.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-azure-devops': patch
----
-
-Add documentation for automatic README path detection from backstage.io/source-location

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -535,15 +535,15 @@ describe('getAnnotationValuesFromEntity', () => {
       });
     });
   });
-  describe('readme path auto-detection from managed-by-location (#9188)', () => {
+  describe('readme path auto-detection from source-location (#9188)', () => {
     it('returns explicit readme-path annotation when both annotations are present', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
             'dev.azure.com/readme-path': '/explicit/README.md',
-            'backstage.io/managed-by-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fsvc%2Fcatalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fsvc',
           },
         },
       } as unknown as Entity;
@@ -552,13 +552,13 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/explicit/README.md');
     });
 
-    it('derives readme path when managed-by-location points to a catalog file', () => {
+    it('derives readme path when source-location points to a subfolder (monorepo)', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc',
           },
         },
       } as unknown as Entity;
@@ -567,13 +567,13 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('derives readme path when managed-by-location path has a trailing slash', () => {
+    it('derives readme path when source-location path has a trailing slash', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml%2F',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2F',
           },
         },
       } as unknown as Entity;
@@ -582,13 +582,13 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('derives readme path at repo root when managed-by-location has no subdirectory', () => {
+    it('derives readme path at repo root when source-location has no subfolder', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fcatalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2F',
           },
         },
       } as unknown as Entity;
@@ -597,7 +597,7 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/README.md');
     });
 
-    it('returns undefined when neither readme-path nor managed-by-location annotation is present', () => {
+    it('returns undefined when neither readme-path nor source-location annotation is present', () => {
       const entity = {
         metadata: {
           annotations: {
@@ -610,13 +610,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
-    it('returns undefined when managed-by-location URL has no path query parameter (e.g. GitHub-style URLs)', () => {
+    it('returns undefined when source-location URL has no path query parameter (e.g. GitHub-style URLs)', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://github.com/org/repo/blob/main/catalog-info.yaml',
+            'backstage.io/source-location': 'url:https://github.com/org/repo',
           },
         },
       } as unknown as Entity;
@@ -630,8 +629,8 @@ describe('getAnnotationValuesFromEntity', () => {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://github.com/org/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo?path=%2Fservices%2Fmy-svc',
           },
         },
       } as unknown as Entity;
@@ -659,8 +658,8 @@ describe('getAnnotationValuesFromEntity', () => {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
-              'url:https://azuredevops.mycompany.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+            'backstage.io/source-location':
+              'url:https://azuredevops.mycompany.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc',
           },
         },
       } as unknown as Entity;
@@ -669,12 +668,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('returns undefined when managed-by-location Azure DevOps URL has no path query parameter', () => {
+    it('returns undefined when source-location Azure DevOps URL has no path query parameter', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location':
+            'backstage.io/source-location':
               'url:https://dev.azure.com/org/proj/_git/repo',
           },
         },
@@ -684,12 +683,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
-    it('returns undefined gracefully when managed-by-location is a malformed URL', () => {
+    it('returns undefined gracefully when source-location is a malformed URL', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/managed-by-location': 'not-a-valid-url',
+            'backstage.io/source-location': 'not-a-valid-url',
           },
         },
       } as unknown as Entity;

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -535,4 +535,124 @@ describe('getAnnotationValuesFromEntity', () => {
       });
     });
   });
+
+  describe('readme path auto-detection from source-location (#9188)', () => {
+    it('returns explicit readme-path annotation when both annotations are present', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'dev.azure.com/readme-path': '/explicit/README.md',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fsvc%2Fcatalog-info.yaml',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('/explicit/README.md');
+    });
+
+    it('derives readme path when source-location points to a catalog file', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('/services/my-svc/README.md');
+    });
+
+    it('derives readme path when source-location points to a directory (no filename)', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('/services/my-svc/README.md');
+    });
+
+    it('derives readme path when source-location path has a trailing slash', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2F',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('/services/my-svc/README.md');
+    });
+
+    it('returns undefined when neither readme-path nor source-location annotation is present', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBeUndefined();
+    });
+
+    it('returns undefined when source-location is a non-Azure DevOps URL', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo/blob/main/catalog-info.yaml',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBeUndefined();
+    });
+
+    it('returns undefined when source-location Azure DevOps URL has no path query parameter', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://dev.azure.com/org/proj/_git/repo',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBeUndefined();
+    });
+
+    it('returns undefined gracefully when source-location is a malformed URL', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location': 'not-a-valid-url',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBeUndefined();
+    });
+  });
 });

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -611,7 +611,7 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
-    it('returns undefined when source-location is a non-Azure DevOps URL', () => {
+    it('returns undefined when source-location URL has no path query parameter (e.g. GitHub-style URLs)', () => {
       const entity = {
         metadata: {
           annotations: {
@@ -624,6 +624,21 @@ describe('getAnnotationValuesFromEntity', () => {
 
       const result = getAnnotationValuesFromEntity(entity);
       expect(result.readmePath).toBeUndefined();
+    });
+
+    it('derives readme path for on-prem Azure DevOps Server URLs (non dev.azure.com hostname)', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://azuredevops.mycompany.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
     it('returns undefined when source-location Azure DevOps URL has no path query parameter', () => {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -535,15 +535,14 @@ describe('getAnnotationValuesFromEntity', () => {
       });
     });
   });
-
-  describe('readme path auto-detection from source-location (#9188)', () => {
+  describe('readme path auto-detection from managed-by-location (#9188)', () => {
     it('returns explicit readme-path annotation when both annotations are present', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
             'dev.azure.com/readme-path': '/explicit/README.md',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fsvc%2Fcatalog-info.yaml',
           },
         },
@@ -553,12 +552,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/explicit/README.md');
     });
 
-    it('derives readme path when source-location points to a catalog file', () => {
+    it('derives readme path when managed-by-location points to a catalog file', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
           },
         },
@@ -568,13 +567,13 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('derives readme path when source-location points to a directory (no filename)', () => {
+    it('derives readme path when managed-by-location path has a trailing slash', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc',
+            'backstage.io/managed-by-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml%2F',
           },
         },
       } as unknown as Entity;
@@ -583,22 +582,22 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('derives readme path when source-location path has a trailing slash', () => {
+    it('derives readme path at repo root when managed-by-location has no subdirectory', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
-              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2F',
+            'backstage.io/managed-by-location':
+              'url:https://dev.azure.com/org/proj/_git/repo?path=%2Fcatalog-info.yaml',
           },
         },
       } as unknown as Entity;
 
       const result = getAnnotationValuesFromEntity(entity);
-      expect(result.readmePath).toBe('/services/my-svc/README.md');
+      expect(result.readmePath).toBe('/README.md');
     });
 
-    it('returns undefined when neither readme-path nor source-location annotation is present', () => {
+    it('returns undefined when neither readme-path nor managed-by-location annotation is present', () => {
       const entity = {
         metadata: {
           annotations: {
@@ -611,12 +610,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
-    it('returns undefined when source-location URL has no path query parameter (e.g. GitHub-style URLs)', () => {
+    it('returns undefined when managed-by-location URL has no path query parameter (e.g. GitHub-style URLs)', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://github.com/org/repo/blob/main/catalog-info.yaml',
           },
         },
@@ -631,7 +630,7 @@ describe('getAnnotationValuesFromEntity', () => {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://github.com/org/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
           },
         },
@@ -660,7 +659,7 @@ describe('getAnnotationValuesFromEntity', () => {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://azuredevops.mycompany.com/org/proj/_git/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
           },
         },
@@ -670,12 +669,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBe('/services/my-svc/README.md');
     });
 
-    it('returns undefined when source-location Azure DevOps URL has no path query parameter', () => {
+    it('returns undefined when managed-by-location Azure DevOps URL has no path query parameter', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location':
+            'backstage.io/managed-by-location':
               'url:https://dev.azure.com/org/proj/_git/repo',
           },
         },
@@ -685,12 +684,12 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
-    it('returns undefined gracefully when source-location is a malformed URL', () => {
+    it('returns undefined gracefully when managed-by-location is a malformed URL', () => {
       const entity = {
         metadata: {
           annotations: {
             'dev.azure.com/project-repo': 'myproject/myrepo',
-            'backstage.io/source-location': 'not-a-valid-url',
+            'backstage.io/managed-by-location': 'not-a-valid-url',
           },
         },
       } as unknown as Entity;

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.test.ts
@@ -626,6 +626,35 @@ describe('getAnnotationValuesFromEntity', () => {
       expect(result.readmePath).toBeUndefined();
     });
 
+    it('returns undefined for non-Azure DevOps URLs even when they have a path query parameter', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo?path=%2Fservices%2Fmy-svc%2Fcatalog-info.yaml',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBeUndefined();
+    });
+
+    it('returns empty string when the explicit readme-path annotation is an empty string', () => {
+      const entity = {
+        metadata: {
+          annotations: {
+            'dev.azure.com/project-repo': 'myproject/myrepo',
+            'dev.azure.com/readme-path': '',
+          },
+        },
+      } as unknown as Entity;
+
+      const result = getAnnotationValuesFromEntity(entity);
+      expect(result.readmePath).toBe('');
+    });
+
     it('derives readme path for on-prem Azure DevOps Server URLs (non dev.azure.com hostname)', () => {
       const entity = {
         metadata: {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { Entity, ANNOTATION_SOURCE_LOCATION } from '@backstage/catalog-model';
 import {
   AZURE_DEVOPS_PROJECT_ANNOTATION,
   AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
@@ -38,8 +38,20 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
     entity.metadata.annotations?.[AZURE_DEVOPS_PROJECT_ANNOTATION];
   const definition =
     entity.metadata.annotations?.[AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION];
-  const readmePath =
-    entity.metadata.annotations?.[AZURE_DEVOPS_README_ANNOTATION];
+  const readmePath = (() => {
+    const explicit =
+      entity.metadata.annotations?.[AZURE_DEVOPS_README_ANNOTATION];
+    if (explicit) return explicit;
+
+    // Auto-detect README.md from backstage.io/source-location (#9188)
+    const sourceLocation =
+      entity.metadata.annotations?.[ANNOTATION_SOURCE_LOCATION];
+    if (!sourceLocation) return undefined;
+
+    // TODO(#9188): parse URL, extract path param, replace catalog-info.yaml
+    // with README.md — full implementation in Phase III
+    return undefined;
+  })();
 
   if (definition) {
     if (project) {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -48,9 +48,36 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
       entity.metadata.annotations?.[ANNOTATION_SOURCE_LOCATION];
     if (!sourceLocation) return undefined;
 
-    // TODO(#9188): parse URL, extract path param, replace catalog-info.yaml
-    // with README.md — full implementation in Phase III
-    return undefined;
+    try {
+      // source-location values are prefixed with "url:" per Backstage convention
+      const rawUrl = sourceLocation.startsWith('url:')
+        ? sourceLocation.slice(4)
+        : sourceLocation;
+
+      const parsed = new URL(rawUrl);
+
+      // Only derive paths for Azure DevOps URLs
+      if (!parsed.hostname.includes('dev.azure.com')) return undefined;
+
+      // "path" query param holds the repo-relative path (URL-decoded by the URL API)
+      const pathParam = parsed.searchParams.get('path');
+      if (!pathParam) return undefined;
+
+      // Strip trailing slash, then get the directory of the catalog file
+      const cleanPath = pathParam.replace(/\/$/, '');
+      const lastSlash = cleanPath.lastIndexOf('/');
+      const lastSegment = cleanPath.slice(lastSlash + 1);
+
+      // If the last segment looks like a file (has a dot), use its parent dir
+      const dir = lastSegment.includes('.')
+        ? cleanPath.slice(0, lastSlash)
+        : cleanPath;
+
+      return `${dir}/README.md`;
+    } catch {
+      // Malformed URL — fail gracefully
+      return undefined;
+    }
   })();
 
   if (definition) {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -57,7 +57,7 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
       const parsed = new URL(rawUrl);
 
       // Only derive paths for Azure DevOps URLs
-      if (!parsed.hostname.includes('dev.azure.com')) return undefined;
+      if (parsed.hostname !== 'dev.azure.com') return undefined;
 
       // "path" query param holds the repo-relative path (URL-decoded by the URL API)
       const pathParam = parsed.searchParams.get('path');
@@ -70,7 +70,9 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
 
       // If the last segment looks like a file (has a dot), use its parent dir
       const dir = lastSegment.includes('.')
-        ? cleanPath.slice(0, lastSlash)
+        ? lastSlash >= 0
+          ? cleanPath.slice(0, lastSlash)
+          : ''
         : cleanPath;
 
       return `${dir}/README.md`;

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, ANNOTATION_LOCATION } from '@backstage/catalog-model';
+import { Entity, ANNOTATION_SOURCE_LOCATION } from '@backstage/catalog-model';
 import {
   AZURE_DEVOPS_PROJECT_ANNOTATION,
   AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
@@ -84,10 +84,10 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
 /**
  * Resolves the README path for an entity, preferring the explicit
  * dev.azure.com/readme-path annotation, and falling back to deriving
- * it from backstage.io/managed-by-location when that annotation is
- * absent (#9188). managed-by-location always points at the exact file
- * (e.g. catalog-info.yaml) used to register the entity, so the README
- * is resolved in that file's parent directory.
+ * it from backstage.io/source-location when that annotation is absent
+ * (#9188). source-location points at the folder containing the
+ * entity's actual source code (repo root, or a subfolder in a
+ * monorepo) — the README is resolved directly in that folder.
  * @public
  */
 export function getReadmePath(
@@ -96,31 +96,27 @@ export function getReadmePath(
   const explicit = annotations?.[AZURE_DEVOPS_README_ANNOTATION];
   if (explicit !== undefined) return explicit;
 
-  // Auto-detect README.md from backstage.io/managed-by-location (#9188)
-  const managedByLocation = annotations?.[ANNOTATION_LOCATION];
-  if (!managedByLocation) return undefined;
+  // Auto-detect README.md from backstage.io/source-location (#9188)
+  const sourceLocation = annotations?.[ANNOTATION_SOURCE_LOCATION];
+  if (!sourceLocation) return undefined;
 
   try {
-    // managed-by-location values are prefixed with "url:" per Backstage convention
-    const rawUrl = managedByLocation.startsWith('url:')
-      ? managedByLocation.slice(4)
-      : managedByLocation;
+    // source-location values are prefixed with "url:" per Backstage convention
+    const rawUrl = sourceLocation.startsWith('url:')
+      ? sourceLocation.slice(4)
+      : sourceLocation;
 
     const parsed = new URL(rawUrl);
 
     // Only attempt auto-detection for Azure DevOps repo URLs (Cloud or Server)
     if (!parsed.pathname.includes('/_git/')) return undefined;
 
-    // "path" query param holds the repo-relative path to the file that
-    // defines this entity (URL-decoded by the URL API)
+    // "path" query param already points at the folder containing the
+    // source code — no filename to strip, unlike managed-by-location
     const pathParam = parsed.searchParams.get('path');
     if (!pathParam) return undefined;
 
-    // managed-by-location always points at a file, so the README lives
-    // in that file's parent directory
-    const cleanPath = pathParam.replace(/\/$/, '');
-    const lastSlash = cleanPath.lastIndexOf('/');
-    const dir = lastSlash >= 0 ? cleanPath.slice(0, lastSlash) : '';
+    const dir = pathParam.replace(/\/$/, '');
 
     return `${dir}/README.md`;
   } catch {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -91,7 +91,7 @@ export function getReadmePath(
   annotations?: Record<string, string>,
 ): string | undefined {
   const explicit = annotations?.[AZURE_DEVOPS_README_ANNOTATION];
-  if (explicit) return explicit;
+  if (explicit !== undefined) return explicit;
 
   // Auto-detect README.md from backstage.io/source-location (#9188)
   const sourceLocation = annotations?.[ANNOTATION_SOURCE_LOCATION];
@@ -105,6 +105,9 @@ export function getReadmePath(
 
     const parsed = new URL(rawUrl);
 
+    // Only attempt auto-detection for Azure DevOps repo URLs (Cloud or Server)
+    if (!parsed.pathname.includes('/_git/')) return undefined;
+
     // "path" query param holds the repo-relative path (URL-decoded by the URL API)
     const pathParam = parsed.searchParams.get('path');
     if (!pathParam) return undefined;
@@ -114,8 +117,12 @@ export function getReadmePath(
     const lastSlash = cleanPath.lastIndexOf('/');
     const lastSegment = cleanPath.slice(lastSlash + 1);
 
-    // If the last segment looks like a file (has a dot), use its parent dir
-    const dir = lastSegment.includes('.')
+    // Only known catalog file names are treated as files; otherwise assume
+    // the path already points to a directory (dots in directory names, e.g.
+    // "services/my.service", should not be mistaken for a file extension)
+    const isCatalogFile =
+      lastSegment === 'catalog-info.yaml' || lastSegment === 'catalog-info.yml';
+    const dir = isCatalogFile
       ? lastSlash >= 0
         ? cleanPath.slice(0, lastSlash)
         : ''

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -38,49 +38,7 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
     entity.metadata.annotations?.[AZURE_DEVOPS_PROJECT_ANNOTATION];
   const definition =
     entity.metadata.annotations?.[AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION];
-  const readmePath = (() => {
-    const explicit =
-      entity.metadata.annotations?.[AZURE_DEVOPS_README_ANNOTATION];
-    if (explicit) return explicit;
-
-    // Auto-detect README.md from backstage.io/source-location (#9188)
-    const sourceLocation =
-      entity.metadata.annotations?.[ANNOTATION_SOURCE_LOCATION];
-    if (!sourceLocation) return undefined;
-
-    try {
-      // source-location values are prefixed with "url:" per Backstage convention
-      const rawUrl = sourceLocation.startsWith('url:')
-        ? sourceLocation.slice(4)
-        : sourceLocation;
-
-      const parsed = new URL(rawUrl);
-
-      // Only derive paths for Azure DevOps URLs
-      if (parsed.hostname !== 'dev.azure.com') return undefined;
-
-      // "path" query param holds the repo-relative path (URL-decoded by the URL API)
-      const pathParam = parsed.searchParams.get('path');
-      if (!pathParam) return undefined;
-
-      // Strip trailing slash, then get the directory of the catalog file
-      const cleanPath = pathParam.replace(/\/$/, '');
-      const lastSlash = cleanPath.lastIndexOf('/');
-      const lastSegment = cleanPath.slice(lastSlash + 1);
-
-      // If the last segment looks like a file (has a dot), use its parent dir
-      const dir = lastSegment.includes('.')
-        ? lastSlash >= 0
-          ? cleanPath.slice(0, lastSlash)
-          : ''
-        : cleanPath;
-
-      return `${dir}/README.md`;
-    } catch {
-      // Malformed URL — fail gracefully
-      return undefined;
-    }
-  })();
+  const readmePath = getReadmePath(entity.metadata.annotations);
 
   if (definition) {
     if (project) {
@@ -121,6 +79,53 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
   }
 
   throw new Error('Expected "dev.azure.com" annotations were not found');
+}
+
+/**
+ * Resolves the README path for an entity, preferring the explicit
+ * dev.azure.com/readme-path annotation, and falling back to deriving
+ * it from backstage.io/source-location when that annotation is absent (#9188).
+ * @public
+ */
+export function getReadmePath(
+  annotations?: Record<string, string>,
+): string | undefined {
+  const explicit = annotations?.[AZURE_DEVOPS_README_ANNOTATION];
+  if (explicit) return explicit;
+
+  // Auto-detect README.md from backstage.io/source-location (#9188)
+  const sourceLocation = annotations?.[ANNOTATION_SOURCE_LOCATION];
+  if (!sourceLocation) return undefined;
+
+  try {
+    // source-location values are prefixed with "url:" per Backstage convention
+    const rawUrl = sourceLocation.startsWith('url:')
+      ? sourceLocation.slice(4)
+      : sourceLocation;
+
+    const parsed = new URL(rawUrl);
+
+    // "path" query param holds the repo-relative path (URL-decoded by the URL API)
+    const pathParam = parsed.searchParams.get('path');
+    if (!pathParam) return undefined;
+
+    // Strip trailing slash, then get the directory of the catalog file
+    const cleanPath = pathParam.replace(/\/$/, '');
+    const lastSlash = cleanPath.lastIndexOf('/');
+    const lastSegment = cleanPath.slice(lastSlash + 1);
+
+    // If the last segment looks like a file (has a dot), use its parent dir
+    const dir = lastSegment.includes('.')
+      ? lastSlash >= 0
+        ? cleanPath.slice(0, lastSlash)
+        : ''
+      : cleanPath;
+
+    return `${dir}/README.md`;
+  } catch {
+    // Malformed URL — fail gracefully
+    return undefined;
+  }
 }
 
 function getProjectRepo(annotations?: Record<string, string>): {

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -88,9 +88,8 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
  * (#9188). source-location points at the folder containing the
  * entity's actual source code (repo root, or a subfolder in a
  * monorepo) — the README is resolved directly in that folder.
- * @public
  */
-export function getReadmePath(
+function getReadmePath(
   annotations?: Record<string, string>,
 ): string | undefined {
   const explicit = annotations?.[AZURE_DEVOPS_README_ANNOTATION];

--- a/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
+++ b/workspaces/azure-devops/plugins/azure-devops-common/src/utils/getAnnotationValuesFromEntity.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity, ANNOTATION_SOURCE_LOCATION } from '@backstage/catalog-model';
+import { Entity, ANNOTATION_LOCATION } from '@backstage/catalog-model';
 import {
   AZURE_DEVOPS_PROJECT_ANNOTATION,
   AZURE_DEVOPS_BUILD_DEFINITION_ANNOTATION,
@@ -84,7 +84,10 @@ export function getAnnotationValuesFromEntity(entity: Entity): {
 /**
  * Resolves the README path for an entity, preferring the explicit
  * dev.azure.com/readme-path annotation, and falling back to deriving
- * it from backstage.io/source-location when that annotation is absent (#9188).
+ * it from backstage.io/managed-by-location when that annotation is
+ * absent (#9188). managed-by-location always points at the exact file
+ * (e.g. catalog-info.yaml) used to register the entity, so the README
+ * is resolved in that file's parent directory.
  * @public
  */
 export function getReadmePath(
@@ -93,40 +96,31 @@ export function getReadmePath(
   const explicit = annotations?.[AZURE_DEVOPS_README_ANNOTATION];
   if (explicit !== undefined) return explicit;
 
-  // Auto-detect README.md from backstage.io/source-location (#9188)
-  const sourceLocation = annotations?.[ANNOTATION_SOURCE_LOCATION];
-  if (!sourceLocation) return undefined;
+  // Auto-detect README.md from backstage.io/managed-by-location (#9188)
+  const managedByLocation = annotations?.[ANNOTATION_LOCATION];
+  if (!managedByLocation) return undefined;
 
   try {
-    // source-location values are prefixed with "url:" per Backstage convention
-    const rawUrl = sourceLocation.startsWith('url:')
-      ? sourceLocation.slice(4)
-      : sourceLocation;
+    // managed-by-location values are prefixed with "url:" per Backstage convention
+    const rawUrl = managedByLocation.startsWith('url:')
+      ? managedByLocation.slice(4)
+      : managedByLocation;
 
     const parsed = new URL(rawUrl);
 
     // Only attempt auto-detection for Azure DevOps repo URLs (Cloud or Server)
     if (!parsed.pathname.includes('/_git/')) return undefined;
 
-    // "path" query param holds the repo-relative path (URL-decoded by the URL API)
+    // "path" query param holds the repo-relative path to the file that
+    // defines this entity (URL-decoded by the URL API)
     const pathParam = parsed.searchParams.get('path');
     if (!pathParam) return undefined;
 
-    // Strip trailing slash, then get the directory of the catalog file
+    // managed-by-location always points at a file, so the README lives
+    // in that file's parent directory
     const cleanPath = pathParam.replace(/\/$/, '');
     const lastSlash = cleanPath.lastIndexOf('/');
-    const lastSegment = cleanPath.slice(lastSlash + 1);
-
-    // Only known catalog file names are treated as files; otherwise assume
-    // the path already points to a directory (dots in directory names, e.g.
-    // "services/my.service", should not be mistaken for a file extension)
-    const isCatalogFile =
-      lastSegment === 'catalog-info.yaml' || lastSegment === 'catalog-info.yml';
-    const dir = isCatalogFile
-      ? lastSlash >= 0
-        ? cleanPath.slice(0, lastSlash)
-        : ''
-      : cleanPath;
+    const dir = lastSlash >= 0 ? cleanPath.slice(0, lastSlash) : '';
 
     return `${dir}/README.md`;
   } catch {

--- a/workspaces/azure-devops/plugins/azure-devops/README.md
+++ b/workspaces/azure-devops/plugins/azure-devops/README.md
@@ -121,14 +121,14 @@ dev.azure.com/readme-path: /<path-to>/<my-readme-file>.md
 
 > Note: this annotation does not support relative paths as the API we use from Azure DevOps to power this feature does not support relative paths. If you use something like this `dev.azure.com/readme-path: ./docs/index.md` the frontend will throw an error with details about why.
 
-If the `dev.azure.com/readme-path` annotation is not set, the plugin will automatically try to detect the README using the `backstage.io/managed-by-location` annotation. This annotation always points to the exact file (e.g. `catalog-info.yaml`) used to register the entity in the catalog, so the plugin resolves `README.md` in that file's parent directory — no extra configuration needed.
+If the `dev.azure.com/readme-path` annotation is not set, the plugin will automatically try to detect the README using the `backstage.io/source-location` annotation. This annotation points at the folder containing the entity's source code (the repo root, or a subfolder in a monorepo), so the plugin resolves `README.md` directly in that folder — no extra configuration needed.
 
-This is especially handy in monorepo setups. For example, if your entity's `catalog-info.yaml` is registered from:
+This is especially handy in monorepo setups. For example, if your entity's source code lives at:
 
 ```yaml
 metadata:
   annotations:
-    backstage.io/managed-by-location: url:https://dev.azure.com/org/project/_git/repo?path=%2Fservices%2Fmy-service%2Fcatalog-info.yaml
+    backstage.io/source-location: url:https://dev.azure.com/org/project/_git/repo?path=%2Fservices%2Fmy-service
 ```
 
 The plugin will automatically render `/services/my-service/README.md`.

--- a/workspaces/azure-devops/plugins/azure-devops/README.md
+++ b/workspaces/azure-devops/plugins/azure-devops/README.md
@@ -121,14 +121,14 @@ dev.azure.com/readme-path: /<path-to>/<my-readme-file>.md
 
 > Note: this annotation does not support relative paths as the API we use from Azure DevOps to power this feature does not support relative paths. If you use something like this `dev.azure.com/readme-path: ./docs/index.md` the frontend will throw an error with details about why.
 
-If the `dev.azure.com/readme-path` annotation is not set, the plugin will automatically try to detect the README using the `backstage.io/source-location` annotation. When this annotation points to an Azure DevOps URL, the plugin resolves `README.md` in the same directory as the `catalog-info.yaml` file, so no extra configuration is needed.
+If the `dev.azure.com/readme-path` annotation is not set, the plugin will automatically try to detect the README using the `backstage.io/managed-by-location` annotation. This annotation always points to the exact file (e.g. `catalog-info.yaml`) used to register the entity in the catalog, so the plugin resolves `README.md` in that file's parent directory — no extra configuration needed.
 
-This is especially handy in monorepo setups. For example, if your entity has:
+This is especially handy in monorepo setups. For example, if your entity's `catalog-info.yaml` is registered from:
 
 ```yaml
 metadata:
   annotations:
-    backstage.io/source-location: url:https://dev.azure.com/org/project/_git/repo?path=%2Fservices%2Fmy-service%2Fcatalog-info.yaml
+    backstage.io/managed-by-location: url:https://dev.azure.com/org/project/_git/repo?path=%2Fservices%2Fmy-service%2Fcatalog-info.yaml
 ```
 
 The plugin will automatically render `/services/my-service/README.md`.

--- a/workspaces/azure-devops/plugins/azure-devops/README.md
+++ b/workspaces/azure-devops/plugins/azure-devops/README.md
@@ -121,6 +121,18 @@ dev.azure.com/readme-path: /<path-to>/<my-readme-file>.md
 
 > Note: this annotation does not support relative paths as the API we use from Azure DevOps to power this feature does not support relative paths. If you use something like this `dev.azure.com/readme-path: ./docs/index.md` the frontend will throw an error with details about why.
 
+If the `dev.azure.com/readme-path` annotation is not set, the plugin will automatically try to detect the README using the `backstage.io/source-location` annotation. When this annotation points to an Azure DevOps URL, the plugin resolves `README.md` in the same directory as the `catalog-info.yaml` file, so no extra configuration is needed.
+
+This is especially handy in monorepo setups. For example, if your entity has:
+
+```yaml
+metadata:
+  annotations:
+    backstage.io/source-location: url:https://dev.azure.com/org/project/_git/repo?path=%2Fservices%2Fmy-service%2Fcatalog-info.yaml
+```
+
+The plugin will automatically render `/services/my-service/README.md`.
+
 #### Pipeline in different project to repo
 
 If your pipeline is in a different project to the source code, you will need to specify this in the project annotation.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds automatic README.md detection for the `azure-devops-readme` plugin
when the `dev.azure.com/readme-path` annotation is not set. Closes #9188.

In monorepo setups it's common for components to have `backstage.io/source-location`
set by the discovery processor but no explicit `readme-path` annotation. Previously
the plugin would just render nothing. Now it derives the README path from the
source-location URL by extracting the `path` query parameter and resolving
`README.md` in the same directory as the catalog file.

Non-Azure URLs, missing path params, and malformed values all fall back to
`undefined` gracefully - existing behavior is completely unchanged.

> **AI Assistance Disclosure:** I used an AI coding assistant to help explore
> the codebase and draft parts of this implementation. I have reviewed, tested,
> and take full responsibility for all code in this PR, per the project's AI Use Policy.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) - not applicable, no UI changes
- [x] All your commits have a `Signed-off-by` line in the message.