### PR TITLE
Version Packages (acr)

### DIFF
--- a/workspaces/acr/.changeset/migrate-acr-mui-to-bui.md
+++ b/workspaces/acr/.changeset/migrate-acr-mui-to-bui.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': patch
----
-
-Migrated from Material UI (`@mui/material`) to Backstage UI (`@backstage/ui`). Replaced `Box` and `Chip` components with BUI equivalents (`Box`, `Flex`, `Tag`, `TagGroup`). Removed `@mui/material` and `@backstage/theme` dependencies.

--- a/workspaces/acr/.changeset/version-bump-1-51-0.md
+++ b/workspaces/acr/.changeset/version-bump-1-51-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': minor
----
-
-Backstage version bump to v1.51.0

--- a/workspaces/acr/.changeset/version-bump-1-52-0.md
+++ b/workspaces/acr/.changeset/version-bump-1-52-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-acr': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/acr/plugins/acr/CHANGELOG.md
+++ b/workspaces/acr/plugins/acr/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-acr
 
+## 1.26.0
+
+### Minor Changes
+
+- 94f9df2: Backstage version bump to v1.51.0
+- 35d5828: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 7201af5: Migrated from Material UI (`@mui/material`) to Backstage UI (`@backstage/ui`). Replaced `Box` and `Chip` components with BUI equivalents (`Box`, `Flex`, `Tag`, `TagGroup`). Removed `@mui/material` and `@backstage/theme` dependencies.
+
 ## 1.25.2
 
 ### Patch Changes

--- a/workspaces/acr/plugins/acr/package.json
+++ b/workspaces/acr/plugins/acr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-acr",
   "description": "A Backstage plugin that displays information about your container images available in the Azure Container Registry",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-acr@1.26.0

### Minor Changes

-   94f9df2: Backstage version bump to v1.51.0
-   35d5828: Backstage version bump to v1.52.0

### Patch Changes

-   7201af5: Migrated from Material UI (`@mui/material`) to Backstage UI (`@backstage/ui`). Replaced `Box` and `Chip` components with BUI equivalents (`Box`, `Flex`, `Tag`, `TagGroup`). Removed `@mui/material` and `@backstage/theme` dependencies.
