### PR TITLE
Version Packages (copilot)

### DIFF
--- a/workspaces/copilot/.changeset/poor-plants-yell.md
+++ b/workspaces/copilot/.changeset/poor-plants-yell.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-copilot-backend': minor
-'@backstage-community/plugin-copilot': minor
----
-
-Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.

--- a/workspaces/copilot/.changeset/renovate-b4eb8d6.md
+++ b/workspaces/copilot/.changeset/renovate-b4eb8d6.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-copilot': patch
----
-
-Updated dependency `react-router` to `^6.30.4`.

--- a/workspaces/copilot/.changeset/soft-games-check.md
+++ b/workspaces/copilot/.changeset/soft-games-check.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-copilot-backend': patch
----
-
-Fix enterprise v2 metrics ingestion: correct MiddlewareFactory.error() invocation, handle flat V2EnterpriseDayTotal response shape from GitHub 2026-03-10 report API, and prevent false-success log entry when 0 rows are parsed

--- a/workspaces/copilot/.changeset/version-bump-1-52-0.md
+++ b/workspaces/copilot/.changeset/version-bump-1-52-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-copilot': minor
-'@backstage-community/plugin-copilot-backend': minor
-'@backstage-community/plugin-copilot-common': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-copilot-backend
 
+## 1.1.0
+
+### Minor Changes
+
+- 20bcf3c: Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.
+- 7a4ea48: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- fca2146: Fix enterprise v2 metrics ingestion: correct MiddlewareFactory.error() invocation, handle flat V2EnterpriseDayTotal response shape from GitHub 2026-03-10 report API, and prevent false-success log entry when 0 rows are parsed
+- Updated dependencies [7a4ea48]
+  - @backstage-community/plugin-copilot-common@1.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/copilot/plugins/copilot-backend/package.json
+++ b/workspaces/copilot/plugins/copilot-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "homepage": "https://backstage.io",
   "license": "Apache-2.0",
   "main": "src/index.ts",

--- a/workspaces/copilot/plugins/copilot-common/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-copilot-common
 
+## 1.1.0
+
+### Minor Changes
+
+- 7a4ea48: Backstage version bump to v1.52.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/workspaces/copilot/plugins/copilot-common/package.json
+++ b/workspaces/copilot/plugins/copilot-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-copilot-common",
   "description": "Common functionalities for the copilot plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/copilot/plugins/copilot/CHANGELOG.md
+++ b/workspaces/copilot/plugins/copilot/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-copilot
 
+## 1.2.0
+
+### Minor Changes
+
+- 20bcf3c: Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.
+- 7a4ea48: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 4e8bd66: Updated dependency `react-router` to `^6.30.4`.
+- Updated dependencies [7a4ea48]
+  - @backstage-community/plugin-copilot-common@1.1.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/workspaces/copilot/plugins/copilot/package.json
+++ b/workspaces/copilot/plugins/copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-copilot",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-copilot@1.2.0

### Minor Changes

-   20bcf3c: Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.
-   7a4ea48: Backstage version bump to v1.52.0

### Patch Changes

-   4e8bd66: Updated dependency `react-router` to `^6.30.4`.
-   Updated dependencies [7a4ea48]
    -   @backstage-community/plugin-copilot-common@1.1.0

## @backstage-community/plugin-copilot-backend@1.1.0

### Minor Changes

-   20bcf3c: Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.
-   7a4ea48: Backstage version bump to v1.52.0

### Patch Changes

-   fca2146: Fix enterprise v2 metrics ingestion: correct MiddlewareFactory.error() invocation, handle flat V2EnterpriseDayTotal response shape from GitHub 2026-03-10 report API, and prevent false-success log entry when 0 rows are parsed
-   Updated dependencies [7a4ea48]
    -   @backstage-community/plugin-copilot-common@1.1.0

## @backstage-community/plugin-copilot-common@1.1.0

### Minor Changes

-   7a4ea48: Backstage version bump to v1.52.0
