### PR TITLE
Remove deprecated components and update frontend-plugin-api resolution

### DIFF
--- a/workspaces/cost-insights/.changeset/healthy-radios-shake.md
+++ b/workspaces/cost-insights/.changeset/healthy-radios-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cost-insights': patch
+---
+
+Removed NavItemBlueprint that was removed in Backstage 1.51.0

--- a/workspaces/cost-insights/package.json
+++ b/workspaces/cost-insights/package.json
@@ -47,7 +47,6 @@
     "typescript": "~5.8.0"
   },
   "resolutions": {
-    "@backstage/frontend-plugin-api": "0.16.1",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "csstype@npm:^3.0.2": "3.0.9",

--- a/workspaces/cost-insights/plugins/cost-insights/report-alpha.api.md
+++ b/workspaces/cost-insights/plugins/cost-insights/report-alpha.api.md
@@ -10,7 +10,6 @@ import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
-import { IconComponent } from '@backstage/frontend-plugin-api';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
@@ -38,31 +37,6 @@ const _default: OverridableFrontendPlugin<
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
       ) => ExtensionBlueprintParams<AnyApiFactory>;
-    }>;
-    'nav-item:cost-insights': OverridableExtensionDefinition<{
-      kind: 'nav-item';
-      name: undefined;
-      config: {
-        title: string | undefined;
-      };
-      configInput: {
-        title?: string | undefined;
-      };
-      output: ExtensionDataRef<
-        {
-          title: string;
-          icon: IconComponent;
-          routeRef: RouteRef<undefined>;
-        },
-        'core.nav-item.target',
-        {}
-      >;
-      inputs: {};
-      params: {
-        title: string;
-        icon: IconComponent;
-        routeRef: RouteRef<undefined>;
-      };
     }>;
     'page:cost-insights': OverridableExtensionDefinition<{
       kind: 'page';

--- a/workspaces/cost-insights/plugins/cost-insights/src/alpha/plugin.tsx
+++ b/workspaces/cost-insights/plugins/cost-insights/src/alpha/plugin.tsx
@@ -16,7 +16,6 @@
 
 import {
   PageBlueprint,
-  NavItemBlueprint,
   createFrontendPlugin,
   ApiBlueprint,
 } from '@backstage/frontend-plugin-api';
@@ -45,6 +44,7 @@ export const CostInsightsApi = ApiBlueprint.make({
 export const CostInsightsPage = PageBlueprint.make({
   params: {
     path: '/cost-insights',
+    icon: <MoneyIcon />,
     routeRef: convertLegacyRouteRef(rootRouteRef),
     loader: () =>
       import('./router').then(m => compatWrapper(<m.CostInsightsRouter />)),
@@ -64,20 +64,9 @@ export const EntityCostInsightsContent = EntityContentBlueprint.make({
   },
 });
 
-/**
- * @alpha
- */
-export const CostInsightsNavItem = NavItemBlueprint.make({
-  params: {
-    title: 'Cost Insights',
-    routeRef: convertLegacyRouteRef(rootRouteRef),
-    icon: MoneyIcon,
-  },
-});
-
 export default createFrontendPlugin({
   pluginId: 'cost-insights',
-  extensions: [CostInsightsApi, CostInsightsPage, CostInsightsNavItem],
+  extensions: [CostInsightsApi, CostInsightsPage],
   routes: convertLegacyRouteRefs({
     root: rootRouteRef,
   }),

--- a/workspaces/cost-insights/plugins/cost-insights/src/alpha/plugin.tsx
+++ b/workspaces/cost-insights/plugins/cost-insights/src/alpha/plugin.tsx
@@ -44,6 +44,7 @@ export const CostInsightsApi = ApiBlueprint.make({
 export const CostInsightsPage = PageBlueprint.make({
   params: {
     path: '/cost-insights',
+    title: 'Cost Insights',
     icon: <MoneyIcon />,
     routeRef: convertLegacyRouteRef(rootRouteRef),
     loader: () =>

--- a/workspaces/cost-insights/yarn.lock
+++ b/workspaces/cost-insights/yarn.lock
@@ -1117,7 +1117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.3.0, @backstage/errors@npm:^1.3.1":
+"@backstage/errors@npm:^1.3.1":
   version: 1.3.1
   resolution: "@backstage/errors@npm:1.3.1"
   dependencies:
@@ -1137,7 +1137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/filter-predicates@npm:^0.1.2, @backstage/filter-predicates@npm:^0.1.3":
+"@backstage/filter-predicates@npm:^0.1.3":
   version: 0.1.3
   resolution: "@backstage/filter-predicates@npm:0.1.3"
   dependencies:
@@ -1150,16 +1150,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.16.1":
-  version: 0.16.1
-  resolution: "@backstage/frontend-plugin-api@npm:0.16.1"
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.52.0&npm=0.17.2, @backstage/frontend-plugin-api@npm:^0.17.2":
+  version: 0.17.2
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.2"
   dependencies:
-    "@backstage/errors": "npm:^1.3.0"
-    "@backstage/filter-predicates": "npm:^0.1.2"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.3"
     "@backstage/types": "npm:^1.2.2"
     "@backstage/version-bridge": "npm:^1.0.12"
     "@standard-schema/spec": "npm:^1.1.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -1169,7 +1170,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b994f5a174eee8f4ee033cb0815ac24bf60aeac07d671ac30d6e761aba3e3e198a42a349398e96796df78d7e7ad90253b2e11c07942615d5b1b5d6997b590e0c
+  checksum: 10/b8991723a01e057dafd37aa412c1253948837dd529cf9edd09bab544fd7c9496659f14299d5060f4bcf39f8fb97023238394d86b9385febf60ce0ddddf64e96d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After recently upgrading our own Backstage instance to 1.52.1 we noticed that the cost-insights plugin was giving us some errors. That feld weird because the most recent release of that plugin explicitly stated that it added support for Backstage 1.52.

Investigating this I found that there was an explicit resolution for the `@backstage/frontend-plugin-api` package in the `package.json` for an older version. Thus I removed this and then made the fix for the breaking change introduced there by removing the `NavItemBlueprint` and moving the icon over to the Page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
