### PR TITLE
Version Packages (tekton)

### DIFF
--- a/workspaces/tekton/.changeset/migrate-tekton-mui-v5.md
+++ b/workspaces/tekton/.changeset/migrate-tekton-mui-v5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Migrated the Tekton plugin UI from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/*`). Replaced `makeStyles`/`withStyles` usage with `sx` prop styling and added `TektonStylesProvider` with a class name seed to avoid CSS collisions with the host app. No breaking API changes.

--- a/workspaces/tekton/.changeset/renovate-1dd5867.md
+++ b/workspaces/tekton/.changeset/renovate-1dd5867.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Updated dependency `@playwright/test` to `1.61.1`.

--- a/workspaces/tekton/.changeset/replace-mui-styles-with-emotion.md
+++ b/workspaces/tekton/.changeset/replace-mui-styles-with-emotion.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-tekton': patch
----
-
-Replaced legacy `@mui/styles` `StylesProvider` with Emotion `CacheProvider` in `TektonStylesProvider` to scope sx/styled class names and avoid CSS collisions with the host app. Removed the `@mui/styles` and unused `@mui/lab` dependencies in favor of `@emotion/cache` and `@emotion/react`. Fixed the pipeline run output dialog layout so expanded output sections scroll inside the dialog instead of overflowing its border. Declared `mobx-react` as a direct dependency for pipeline topology components. No breaking API changes.

--- a/workspaces/tekton/.changeset/version-bump-1-52-0.md
+++ b/workspaces/tekton/.changeset/version-bump-1-52-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-tekton': minor
-'@backstage-community/plugin-tekton-common': minor
-'@backstage-community/plugin-tekton-react': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tekton-common
 
+## 1.23.0
+
+### Minor Changes
+
+- 3ad9785: Backstage version bump to v1.52.0
+
 ## 1.22.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton-common/package.json
+++ b/workspaces/tekton/plugins/tekton-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-tekton-common",
   "description": "Common functionalities for the tekton plugin",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/tekton/plugins/tekton-react/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-tekton-react
 
+## 0.8.0
+
+### Minor Changes
+
+- 3ad9785: Backstage version bump to v1.52.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton-react/package.json
+++ b/workspaces/tekton/plugins/tekton-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton-react",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "description": "Web library for the tekton plugin",
   "main": "src/index.ts",

--- a/workspaces/tekton/plugins/tekton/CHANGELOG.md
+++ b/workspaces/tekton/plugins/tekton/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-tekton
 
+## 3.40.0
+
+### Minor Changes
+
+- 3ad9785: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 9ec30ec: Migrated the Tekton plugin UI from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/*`). Replaced `makeStyles`/`withStyles` usage with `sx` prop styling and added `TektonStylesProvider` with a class name seed to avoid CSS collisions with the host app. No breaking API changes.
+- 6622075: Updated dependency `@playwright/test` to `1.61.1`.
+- 0aa5613: Replaced legacy `@mui/styles` `StylesProvider` with Emotion `CacheProvider` in `TektonStylesProvider` to scope sx/styled class names and avoid CSS collisions with the host app. Removed the `@mui/styles` and unused `@mui/lab` dependencies in favor of `@emotion/cache` and `@emotion/react`. Fixed the pipeline run output dialog layout so expanded output sections scroll inside the dialog instead of overflowing its border. Declared `mobx-react` as a direct dependency for pipeline topology components. No breaking API changes.
+- Updated dependencies [3ad9785]
+  - @backstage-community/plugin-tekton-common@1.23.0
+  - @backstage-community/plugin-tekton-react@0.8.0
+
 ## 3.39.0
 
 ### Minor Changes

--- a/workspaces/tekton/plugins/tekton/package.json
+++ b/workspaces/tekton/plugins/tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-tekton",
-  "version": "3.39.0",
+  "version": "3.40.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-tekton@3.40.0

### Minor Changes

-   3ad9785: Backstage version bump to v1.52.0

### Patch Changes

-   9ec30ec: Migrated the Tekton plugin UI from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/*`). Replaced `makeStyles`/`withStyles` usage with `sx` prop styling and added `TektonStylesProvider` with a class name seed to avoid CSS collisions with the host app. No breaking API changes.
-   6622075: Updated dependency `@playwright/test` to `1.61.1`.
-   0aa5613: Replaced legacy `@mui/styles` `StylesProvider` with Emotion `CacheProvider` in `TektonStylesProvider` to scope sx/styled class names and avoid CSS collisions with the host app. Removed the `@mui/styles` and unused `@mui/lab` dependencies in favor of `@emotion/cache` and `@emotion/react`. Fixed the pipeline run output dialog layout so expanded output sections scroll inside the dialog instead of overflowing its border. Declared `mobx-react` as a direct dependency for pipeline topology components. No breaking API changes.
-   Updated dependencies [3ad9785]
    -   @backstage-community/plugin-tekton-common@1.23.0
    -   @backstage-community/plugin-tekton-react@0.8.0

## @backstage-community/plugin-tekton-common@1.23.0

### Minor Changes

-   3ad9785: Backstage version bump to v1.52.0

## @backstage-community/plugin-tekton-react@0.8.0

### Minor Changes

-   3ad9785: Backstage version bump to v1.52.0
