### PR TITLE
Version Packages (github)

### DIFF
--- a/workspaces/github/.changeset/github-issues-group-host-resolution.md
+++ b/workspaces/github/.changeset/github-issues-group-host-resolution.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-github-issues': patch
----
-
-Fixed the GitHub Issues card crashing with `TypeError: Failed to construct 'URL': Invalid URL` for `Group` and `User` entities whose `backstage.io/source-location` / `backstage.io/managed-by-location` is not a parseable URL (for example entities registered from a `file:` location, or with no location at all).
-
-For owner entities (`Group`/`User`) the card now resolves the GitHub host from the configured `integrations.github` instead of the owner entity's location annotation — the same approach used by the `github-pull-requests-board` plugin — so a team simply sees the open issues of every repository it owns. `getHostnameFromEntity` is now non-throwing, and repositories whose host cannot be determined are no longer silently dropped.

--- a/workspaces/github/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-github-issues
 
+## 1.2.1
+
+### Patch Changes
+
+- 99ab95f: Fixed the GitHub Issues card crashing with `TypeError: Failed to construct 'URL': Invalid URL` for `Group` and `User` entities whose `backstage.io/source-location` / `backstage.io/managed-by-location` is not a parseable URL (for example entities registered from a `file:` location, or with no location at all).
+
+  For owner entities (`Group`/`User`) the card now resolves the GitHub host from the configured `integrations.github` instead of the owner entity's location annotation — the same approach used by the `github-pull-requests-board` plugin — so a team simply sees the open issues of every repository it owns. `getHostnameFromEntity` is now non-throwing, and repositories whose host cannot be determined are no longer silently dropped.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-issues/package.json
+++ b/workspaces/github/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "github-issues",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-issues@1.2.1

### Patch Changes

-   99ab95f: Fixed the GitHub Issues card crashing with `TypeError: Failed to construct 'URL': Invalid URL` for `Group` and `User` entities whose `backstage.io/source-location` / `backstage.io/managed-by-location` is not a parseable URL (for example entities registered from a `file:` location, or with no location at all).

    For owner entities (`Group`/`User`) the card now resolves the GitHub host from the configured `integrations.github` instead of the owner entity's location annotation — the same approach used by the `github-pull-requests-board` plugin — so a team simply sees the open issues of every repository it owns. `getHostnameFromEntity` is now non-throwing, and repositories whose host cannot be determined are no longer silently dropped.
