### PR TITLE
fix(copilot): fix enterprise v2 parser, error handler, and ingestion false-success

### DIFF
--- a/workspaces/copilot/.changeset/soft-games-check.md
+++ b/workspaces/copilot/.changeset/soft-games-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': patch
+---
+
+Fix enterprise v2 metrics ingestion: correct MiddlewareFactory.error() invocation, handle flat V2EnterpriseDayTotal response shape from GitHub 2026-03-10 report API, and prevent false-success log entry when 0 rows are parsed

--- a/workspaces/copilot/plugins/copilot-backend/src/service/router.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/service/router.ts
@@ -557,6 +557,6 @@ async function createRouter(
     },
   );
 
-  router.use(MiddlewareFactory.create({ config, logger }).error);
+  router.use(MiddlewareFactory.create({ config, logger }).error());
   return router;
 }

--- a/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagementV2.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagementV2.test.ts
@@ -331,6 +331,52 @@ describe('TaskManagementV2', () => {
   });
 });
 
+it('ingestTotals returns partial status when downloaded document yields 0 parsed rows', async () => {
+  // Regression test for: https://github.com/backstage/community-plugins/issues/9458
+  // Before the fix, ingestTotals always returned true even when 0 rows were parsed,
+  // causing the ingestion log to record status='success' and getMissingDays to
+  // permanently skip those days on future runs.
+  const db = createDbMock();
+  const api = createApiMock();
+  const config = createConfigMock({
+    'copilot.enterprise': 'ent-1',
+    'copilot.backfillFromDate': '2026-05-10',
+    'copilot.backfillDelayMs': 0,
+    'copilot.ingestTeams': false,
+  });
+  const logger = createLoggerMock();
+
+  db.getMissingDays.mockResolvedValue(['2026-05-10']);
+  api.fetchEnterpriseReportLinks.mockResolvedValue({
+    download_links: ['https://downloads.github.com/report.json'],
+  });
+  // Return a payload that is structurally valid (an object) but has no 'day' field,
+  // so parseEnterpriseDocument produces 0 dailyTotals rows.
+  api.downloadDocument.mockResolvedValueOnce({ not_a_day: 'malformed' });
+
+  const task = TaskManagementV2.create({
+    db: db as unknown as DatabaseHandlerV2,
+    api: api as unknown as GithubClientV2,
+    config,
+    logger,
+  });
+
+  await task.runAsync();
+
+  // Should NOT be logged as success — totals component was not loaded
+  expect(db.upsertIngestionLog).toHaveBeenCalledWith(
+    expect.objectContaining({
+      day: '2026-05-10',
+      metrics_type: 'enterprise',
+      entity_id: 'ent-1',
+      status: 'partial',
+    }),
+  );
+  expect(db.upsertIngestionLog).not.toHaveBeenCalledWith(
+    expect.objectContaining({ status: 'success' }),
+  );
+});
+
 function createDbMock() {
   return {
     getMissingDays: jest.fn(),

--- a/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagementV2.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/task/TaskManagementV2.ts
@@ -207,6 +207,8 @@ export class TaskManagementV2 {
       return false;
     }
 
+    let totalRowsParsed = 0;
+
     for (const url of totalLinks) {
       const document = await api.downloadDocument(url);
       const parsed =
@@ -222,6 +224,15 @@ export class TaskManagementV2 {
       await db.insertByModelFeature(parsed.byModelFeature);
       await db.insertByLanguageModel(parsed.byLanguageModel);
       await db.insertByCli(parsed.byCli);
+
+      totalRowsParsed += parsed.dailyTotals.length;
+    }
+
+    if (totalRowsParsed === 0) {
+      logger.warn(
+        `[TaskManagementV2] Parsed 0 daily rows for ${metricsType} totals on ${day} — not marking as success.`,
+      );
+      return false;
     }
 
     return true;

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.test.ts
@@ -220,6 +220,65 @@ describe('reportParser', () => {
       expect(result.byIde).toEqual([]);
       expect(result.byLanguageFeature).toEqual([]);
     });
+    it('parses a flat V2EnterpriseDayTotal object (GitHub 2026-03-10 API shape)', () => {
+      // Regression test for: https://github.com/backstage/community-plugins/issues/9458
+      // GitHub's report API returns a single flat object per download URL, not a
+      // V2EnterpriseDocument wrapper with a day_totals array.
+      const doc = {
+        day: '2026-06-22',
+        enterprise_id: '1',
+        daily_active_users: 120,
+        weekly_active_users: 530,
+        monthly_active_users: 1400,
+        daily_active_cli_users: 5,
+        monthly_active_agent_users: 10,
+        monthly_active_chat_users: 50,
+        code_acceptance_activity_count: 80,
+        code_generation_activity_count: 200,
+        loc_added_sum: 500,
+        loc_deleted_sum: 100,
+        loc_suggested_to_add_sum: 700,
+        loc_suggested_to_delete_sum: 150,
+        user_initiated_interaction_count: 300,
+        totals_by_ide: [
+          {
+            ide: 'vscode',
+            code_acceptance_activity_count: 40,
+            code_generation_activity_count: 100,
+            loc_added_sum: 250,
+            loc_deleted_sum: 50,
+            loc_suggested_to_add_sum: 350,
+            loc_suggested_to_delete_sum: 75,
+            user_initiated_interaction_count: 150,
+          },
+        ],
+      };
+
+      const result = parseEnterpriseDocument(doc, 'enterprise', 'ent-1');
+
+      expect(result.dailyTotals).toHaveLength(1);
+      expect(result.dailyTotals[0]).toEqual(
+        expect.objectContaining({
+          day: '2026-06-22',
+          metrics_type: 'enterprise',
+          entity_id: 'ent-1',
+          team_slug: '',
+          daily_active_users: 120,
+          weekly_active_users: 530,
+          monthly_active_users: 1400,
+          user_initiated_interaction_count: 300,
+        }),
+      );
+      expect(result.byIde).toHaveLength(1);
+      expect(result.byIde[0]).toEqual(
+        expect.objectContaining({
+          day: '2026-06-22',
+          metrics_type: 'enterprise',
+          entity_id: 'ent-1',
+          ide: 'vscode',
+        }),
+      );
+    });
   });
 
   describe('parseOrganizationDocument', () => {

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
@@ -16,7 +16,6 @@
 
 import {
   V2DailyTotal,
-  V2EnterpriseDocument,
   V2MetricsByCliRow,
   V2MetricsByFeatureRow,
   V2MetricsByIdeRow,
@@ -124,8 +123,10 @@ function toStringValue(value: unknown): string | null {
 }
 
 /**
- * Parse an enterprise or org report document (array of EnterpriseDocument items).
- * The document is the downloaded JSON from a signed enterprise-1-day or organization-1-day URL.
+ * Parse an enterprise report document downloaded from a signed enterprise-1-day URL.
+ * The GitHub report API (2026-03-10) returns a single flat V2EnterpriseDayTotal object
+ * per file. Both flat objects and legacy V2EnterpriseDocument arrays (with a day_totals
+ * wrapper) are accepted for robustness.
  */
 export function parseEnterpriseDocument(
   doc: unknown,
@@ -143,28 +144,41 @@ export function parseEnterpriseDocument(
     byCli: [],
   };
 
-  if (!Array.isArray(doc)) {
-    logWarn('Expected enterprise document array, received non-array payload.');
+  // Normalize: the GitHub report API (2026-03-10) downloads a single flat
+  // V2EnterpriseDayTotal object per file — not a V2EnterpriseDocument with a
+  // day_totals wrapper. Accept both shapes for robustness.
+  const rawDocs: unknown[] = Array.isArray(doc)
+    ? doc
+    : isRecord(doc)
+    ? [doc]
+    : [];
+
+  if (rawDocs.length === 0) {
+    logWarn('Expected enterprise document object, received invalid payload.');
     return parsed;
   }
 
-  for (const enterpriseDoc of doc as V2EnterpriseDocument[]) {
-    if (!isRecord(enterpriseDoc) || !Array.isArray(enterpriseDoc.day_totals)) {
-      logWarn(
-        'Skipping enterprise document item with missing day_totals array.',
-      );
-      continue;
-    }
+  for (const rawDoc of rawDocs) {
+    // Unwrap V2EnterpriseDocument (day_totals wrapper) if present;
+    // otherwise treat the item itself as the day's metrics object.
+    const dayTotals: unknown[] =
+      isRecord(rawDoc) && Array.isArray(rawDoc.day_totals)
+        ? (rawDoc.day_totals as unknown[])
+        : isRecord(rawDoc)
+        ? [rawDoc]
+        : [];
 
-    for (const dayTotal of enterpriseDoc.day_totals) {
+    for (const dayTotal of dayTotals) {
       if (!isRecord(dayTotal)) {
-        logWarn('Skipping day_totals item because it is not an object.');
+        logWarn(
+          'Skipping enterprise document item because it is not an object.',
+        );
         continue;
       }
 
       const day = toStringValue(dayTotal.day);
       if (!day) {
-        logWarn('Skipping day_totals item with missing day field.');
+        logWarn('Skipping enterprise document item with missing day field.');
         continue;
       }
 

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
@@ -154,7 +154,9 @@ export function parseEnterpriseDocument(
     : [];
 
   if (rawDocs.length === 0) {
-    logWarn('Expected enterprise document object, received invalid payload.');
+    logWarn(
+      'Expected enterprise document object or array, received invalid or empty payload.',
+    );
     return parsed;
   }
 

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
@@ -163,12 +163,14 @@ export function parseEnterpriseDocument(
   for (const rawDoc of rawDocs) {
     // Unwrap V2EnterpriseDocument (day_totals wrapper) if present;
     // otherwise treat the item itself as the day's metrics object.
-    const dayTotals: unknown[] =
-      isRecord(rawDoc) && Array.isArray(rawDoc.day_totals)
-        ? (rawDoc.day_totals as unknown[])
-        : isRecord(rawDoc)
-        ? [rawDoc]
-        : [];
+    if (!isRecord(rawDoc)) {
+      logWarn('Skipping enterprise document item because it is not an object.');
+      continue;
+    }
+
+    const dayTotals: unknown[] = Array.isArray(rawDoc.day_totals)
+      ? (rawDoc.day_totals as unknown[])
+      : [rawDoc];
 
     for (const dayTotal of dayTotals) {
       if (!isRecord(dayTotal)) {

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
@@ -271,7 +271,7 @@ export function parseEnterpriseDocument(
             metrics_type: metricsType,
             entity_id: entityId,
             team_slug: '',
-            feature: row.feature,
+            feature: toStringValue(row.feature)!,
             code_acceptance_activity_count: toNumber(
               row.code_acceptance_activity_count,
             ),
@@ -303,7 +303,7 @@ export function parseEnterpriseDocument(
             metrics_type: metricsType,
             entity_id: entityId,
             team_slug: '',
-            ide: row.ide,
+            ide: toStringValue(row.ide)!,
             code_acceptance_activity_count: toNumber(
               row.code_acceptance_activity_count,
             ),
@@ -341,8 +341,8 @@ export function parseEnterpriseDocument(
             metrics_type: metricsType,
             entity_id: entityId,
             team_slug: '',
-            language: row.language,
-            feature: row.feature,
+            language: toStringValue(row.language)!,
+            feature: toStringValue(row.feature)!,
             code_acceptance_activity_count: toNumber(
               row.code_acceptance_activity_count,
             ),


### PR DESCRIPTION
What this PR does / why we need it:
Fixes three bugs in the Copilot plugin's v2 enterprise metrics ingestion pipeline introduced with the GitHub report-based API (X-GitHub-Api-Version: 2026-03-10):

Bug 1 — Error handler not installed: MiddlewareFactory.create(...).error was passed as a method reference instead of being called. Express received the function object rather than the middleware it produces, causing this to be null and crashing on any router error.
Bug 2 — Enterprise parser rejects GitHub's actual response shape: The GitHub report API returns a single flat V2EnterpriseDayTotal object per download URL. parseEnterpriseDocument expected a V2EnterpriseDocument array with a day_totals wrapper and rejected the flat object immediately, silently returning 0 rows parsed for every enterprise ingestion.
Bug 3 — Failed ingestion logged as success: Even when 0 rows were parsed (due to Bug 2), ingestTotals returned true, causing ingestDay to write a status='success' entry to copilot_ingestion_log. Since getMissingDays skips days marked success, those days were permanently skipped on all future runs with no error raised.

Fixes #9458
Which issue(s) this PR fixes:
Fixes #9458

parseEnterpriseDocument now accepts both the new flat V2EnterpriseDayTotal shape and the legacy V2EnterpriseDocument array (with day_totals wrapper) for robustness.
V2EnterpriseDocument import removed from reportParser.ts as it is no longer referenced in code (only in comments).
A regression test was added to reportParser.test.ts that would have failed against the old code.

Does this PR introduce a breaking change?
No.
AI assistance disclosure:
This fix was developed with AI assistance (Claude by Anthropic). All changes were reviewed, understood, and verified by the author including manual test runs (120 tests passing).