### PR TITLE
fix(rbac): make conditional policy reconcile non-destructive and support sibling merges

### DIFF
--- a/workspaces/rbac/.changeset/fuzzy-pugs-search.md
+++ b/workspaces/rbac/.changeset/fuzzy-pugs-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': patch
+---
+
+Conditional policy reconciliation preserves stored conditions when staging or persistence fails, and correctly merges sibling conditions for the same role and resource without conflict errors during reload.

--- a/workspaces/rbac/plugins/rbac-backend/docs/audit-log.md
+++ b/workspaces/rbac/plugins/rbac-backend/docs/audit-log.md
@@ -177,20 +177,32 @@ Failed events contain `error` information.
 
   **Condition Event meta for `condition-write`:**
 
-  - source?: string (source emitting the event, `rest` or not included for conditions from `yaml-conditional-file`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
+  - source?: string (source emitting the event, `rest`, external provider id from extension point sync, or omitted for conditions from the conditional policies YAML file)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
 
   **Condition Event fail/success meta for `condition-write`:**
 
-  - source?: string (source emitting the event, `rest` or not included for conditions from `yaml-conditional-file`)
-  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`)
-  - condition: RoleConditionalPolicyDecision<"create" | "read" | "update" | "delete" | "use">
+  - source?: string (source emitting the event, `rest`, external provider id from extension point sync, or omitted for conditions from the conditional policies YAML file)
+  - actionType: string (further specifies type of modify action, `create`, `update`, `delete`, `reconcile_abort`)
+  - condition: RoleConditionalPolicyDecision<"create" | "read" | "update" | "delete" | "use"> (not present when `actionType` is `reconcile_abort`)
 
   Filter on `actionType`.
 
-  - **`create`**: Creates conditions. (POST `/roles/conditions`, extension point `applyPermissions`)
-  - **`update`**: Updates conditions. (PUT `/roles/conditions`)
-  - **`delete`**: Deletes conditions. (DELETE `/roles/conditions`, extension point `applyPermissions`)
+  - **`create`**: Creates conditions. (POST `/roles/conditions`, extension point `applyConditionalPermissions`, conditional policies YAML file reload)
+  - **`update`**: Updates conditions. (PUT `/roles/conditions`, conditional policies YAML file reload, extension point `applyConditionalPermissions`)
+  - **`delete`**: Deletes conditions. (DELETE `/roles/conditions`, conditional policies YAML file reload, extension point `applyConditionalPermissions`)
+  - **`reconcile_abort`**: Batch conditional policy reconcile failed after staging; stored conditions were left unchanged. (extension point `applyConditionalPermissions` only — emitted as a failed `condition-write` event, not per-row create/update/delete)
+
+    **Condition Event fail meta for `reconcile_abort` (`condition-write` only):**
+
+    - source: string (provider id emitting the event)
+    - actionType: `reconcile_abort`
+    - pendingAdds: number (conditions in the pending add set when reconcile aborted)
+    - pendingRemoves: number (conditions in the pending remove set when reconcile aborted)
+    - pluginIds: string[] (plugin ids from the pending add set)
+    - error: Error (staging or persist failure that aborted the batch)
+
+    Operational logs also emit `event: "conditional_reconcile_aborted"` with the same fields for alerting.
 
 - **`condition-read`**: Reads conditions. (GET `/roles/conditions`)
 
@@ -222,7 +234,17 @@ Failed events contain `error` information.
 
 - **`conditional-policies-file-not-found`**: Conditional policies file was not found.
 
-- **`conditional-policies-file-change`**: Conditional policies file changed.
+- **`conditional-policies-file-change`**: Conditional policies file changed or batch reconcile from the file failed.
+
+  **Conditional file Event fail meta for batch reconcile abort** (YAML reload staging or persist failure; stored conditions unchanged):
+
+  - source: `conditional-policies-file`
+  - pendingAdds: number
+  - pendingRemoves: number
+  - pluginIds: string[]
+  - error: Error
+
+  Per-row `condition-write` events (`create`, `update`, `delete`) may precede a batch abort when failure occurs mid-persist. Operational logs also emit `event: "conditional_reconcile_aborted"` with the same fields for alerting.
 
 ### Permission Evaluation Events
 

--- a/workspaces/rbac/plugins/rbac-backend/src/auditor/auditor.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/auditor/auditor.ts
@@ -33,6 +33,8 @@ export const ActionType = {
   CREATE_OR_UPDATE: 'create_or_update',
   UPDATE: 'update',
   DELETE: 'delete',
+  /** Batch conditional reconcile aborted; see audit-log.md (`condition-write` / `conditional-policies-file-change`). */
+  RECONCILE_ABORT: 'reconcile_abort',
 };
 
 export const RoleEvents = {

--- a/workspaces/rbac/plugins/rbac-backend/src/database/conditional-storage.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/conditional-storage.test.ts
@@ -560,6 +560,38 @@ describe('DataBaseConditionalStorage', () => {
     );
 
     it.each(databases.eachSupportedId())(
+      'should update when idsToExclude includes pending sibling delete',
+      async databasesId => {
+        const { knex, db } = await createDatabase(databasesId);
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert(
+          conditionDao1,
+        );
+        await knex<ConditionalPolicyDecisionDAO>(CONDITIONAL_TABLE).insert({
+          ...conditionDao1,
+          permissions: '[{"action":"delete","name":"catalog.entity.delete"}]',
+        });
+
+        const updateCondition: RoleConditionalPolicyDecision<PermissionInfo> = {
+          ...condition1,
+          permissionMapping: [
+            { name: 'catalog.entity.read', action: 'read' },
+            { name: 'catalog.entity.delete', action: 'delete' },
+          ],
+        };
+
+        await db.updateCondition(1, updateCondition, undefined, new Set([2]));
+
+        const condition = await knex
+          .table(CONDITIONAL_TABLE)
+          .select<ConditionalPolicyDecisionDAO[]>()
+          .where('id', 1);
+        expect(condition[0].permissions).toBe(
+          '[{"name":"catalog.entity.read","action":"read"},{"name":"catalog.entity.delete","action":"delete"}]',
+        );
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
       'should update condition with removed one action',
       async databasesId => {
         const { knex, db } = await createDatabase(databasesId);

--- a/workspaces/rbac/plugins/rbac-backend/src/database/conditional-storage.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/database/conditional-storage.ts
@@ -47,6 +47,7 @@ export interface ConditionalStorage {
   ): Promise<RoleConditionalPolicyDecision<PermissionInfo>[]>;
   createCondition(
     conditionalDecision: RoleConditionalPolicyDecision<PermissionInfo>,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<number>;
   checkConflictedConditions(
     roleEntityRef: string,
@@ -54,6 +55,8 @@ export interface ConditionalStorage {
     pluginId: string,
     queryPermissionNames: string[],
     idToExclude?: number,
+    trx?: Knex.Transaction | Knex,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<void>;
   getCondition(
     id: number,
@@ -64,6 +67,7 @@ export interface ConditionalStorage {
     id: number,
     conditionalDecision: RoleConditionalPolicyDecision<PermissionInfo>,
     trx?: Knex.Transaction,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<void>;
 }
 
@@ -125,12 +129,16 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
 
   async createCondition(
     conditionalDecision: RoleConditionalPolicyDecision<PermissionInfo>,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<number> {
     await this.checkConflictedConditions(
       conditionalDecision.roleEntityRef,
       conditionalDecision.resourceType,
       conditionalDecision.pluginId,
       conditionalDecision.permissionMapping.map(permInfo => permInfo.action),
+      undefined,
+      undefined,
+      idsToExclude,
     );
 
     const conditionRaw = this.toDAO(conditionalDecision);
@@ -152,6 +160,7 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
     queryConditionActions: PermissionAction[],
     idToExclude?: number,
     trx?: Knex.Transaction | Knex,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<void> {
     const db = trx ?? this.knex;
     let conditionsForTheSameResource = await this.filterConditions(
@@ -163,7 +172,11 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
       db,
     );
     conditionsForTheSameResource = conditionsForTheSameResource.filter(
-      c => c.id !== idToExclude,
+      c =>
+        c.id !== idToExclude &&
+        (idsToExclude === undefined ||
+          c.id === undefined ||
+          !idsToExclude.has(c.id)),
     );
 
     if (conditionsForTheSameResource) {
@@ -217,6 +230,7 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
     id: number,
     conditionalDecision: RoleConditionalPolicyDecision<PermissionInfo>,
     trx?: Knex.Transaction,
+    idsToExclude?: ReadonlySet<number>,
   ): Promise<void> {
     const db = trx ?? this.knex;
     const condition = await this.getCondition(id, db);
@@ -231,6 +245,7 @@ export class DataBaseConditionalStorage implements ConditionalStorage {
       conditionalDecision.permissionMapping.map(perm => perm.action),
       id,
       db,
+      idsToExclude,
     );
 
     const conditionRaw = this.toDAO(conditionalDecision);

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -839,6 +839,58 @@ describe('YamlConditionalFileWatcher', () => {
     expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
   });
 
+  test('should not reconcile when only array element order differs', async () => {
+    const storedWithReorderedArrays = {
+      id: 2,
+      ...conditionToStore2,
+      permissionMapping: [
+        { name: 'catalog.entity.delete', action: 'delete' },
+        { name: 'catalog.entity.read', action: 'read' },
+      ],
+      conditions: {
+        ...conditionToStore2.conditions,
+        params: {
+          claims: ['group:default/team-b', 'group:default/team-a'],
+        },
+      },
+    };
+
+    conditionalStorageMock.filterConditions = jest
+      .fn()
+      .mockImplementation(() => [storedWithReorderedArrays]);
+    roleMetadataStorageMock.filterRoleMetadata = jest
+      .fn()
+      .mockImplementation(() => csvFileRoles);
+
+    const yamlWithCanonicalOrder = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      '  - delete',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+      '      - group:default/team-b',
+    ].join('\n');
+
+    const watcher = createWatcher(csvFileName);
+    jest
+      .spyOn(watcher, 'getCurrentContents')
+      .mockReturnValue(yamlWithCanonicalOrder);
+    await watcher.onChange();
+
+    expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+    expect(conditionalStorageMock.updateCondition).not.toHaveBeenCalled();
+    expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+    expectAuditorLog([]);
+  });
+
   test('should handle error on delete condition', async () => {
     conditionalStorageMock.filterConditions = jest
       .fn()

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -229,6 +229,10 @@ describe('YamlConditionalFileWatcher', () => {
 
     conditionalStorageMock.createCondition = jest.fn().mockImplementation();
     conditionalStorageMock.deleteCondition = jest.fn().mockImplementation();
+    conditionalStorageMock.updateCondition = jest.fn().mockImplementation();
+    pluginMetadataCollectorMock.getMetadataByPluginId = jest
+      .fn()
+      .mockImplementation(async () => testPluginMetadataResp);
     jest.clearAllMocks();
   });
 
@@ -458,7 +462,8 @@ describe('YamlConditionalFileWatcher', () => {
     const watcher = createWatcher(csvFileName);
     await watcher.initialize();
 
-    expect(conditionalStorageMock.createCondition).toHaveBeenCalled();
+    expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+    expect(mockLoggerService.error).toHaveBeenCalled();
     expectAuditorLog([
       {
         event: {
@@ -467,17 +472,34 @@ describe('YamlConditionalFileWatcher', () => {
         },
         fail: {
           error: new Error('unknown error message 1'),
-          ...mappedConditionMeta(conditionToStore1),
+          meta: {
+            condition: {
+              ...conditionToStore1,
+              permissionMapping: conditionToStore1.permissionMapping.map(
+                pm => pm.action,
+              ),
+            },
+          },
         },
       },
       {
         event: {
-          eventId: ConditionEvents.CONDITION_WRITE,
-          meta: { actionType: ActionType.CREATE },
+          eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 2,
+            pendingRemoves: 0,
+            pluginIds: ['catalog'],
+          },
         },
         fail: {
-          error: new Error('unknown error message 2'),
-          ...mappedConditionMeta(conditionToStore2),
+          error: new Error('unknown error message 1'),
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 2,
+            pendingRemoves: 0,
+            pluginIds: ['catalog'],
+          },
         },
       },
     ]);
@@ -496,9 +518,11 @@ describe('YamlConditionalFileWatcher', () => {
 
     expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
       conditionToStore1,
+      expect.any(Set),
     );
     expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
       conditionToStore2,
+      expect.any(Set),
     );
     expectAuditorLog([
       {
@@ -598,9 +622,11 @@ describe('YamlConditionalFileWatcher', () => {
 
     expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
       expectedCondition1,
+      expect.any(Set),
     );
     expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
       expectedCondition2,
+      expect.any(Set),
     );
     expectAuditorLog([
       {
@@ -698,6 +724,121 @@ describe('YamlConditionalFileWatcher', () => {
     expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledWith(2);
   });
 
+  test('should preserve existing conditions when catalog metadata is unavailable during reload (#9429)', async () => {
+    const storedCondition = {
+      id: 1,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [{ name: 'catalog.entity.read', action: 'read' }],
+      conditions: {
+        rule: 'IS_ENTITY_OWNER',
+        resourceType: 'catalog-entity',
+        params: {
+          claims: ['group:default/team-a'],
+        },
+      },
+    };
+
+    conditionalStorageMock.filterConditions = jest
+      .fn()
+      .mockImplementation(() => [storedCondition]);
+    roleMetadataStorageMock.filterRoleMetadata = jest
+      .fn()
+      .mockImplementation(() => csvFileRoles);
+    pluginMetadataCollectorMock.getMetadataByPluginId = jest
+      .fn()
+      .mockResolvedValue(undefined);
+
+    const updatedYaml = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+      '      - group:default/team-b',
+    ].join('\n');
+
+    const watcher = createWatcher(csvFileName);
+    jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(updatedYaml);
+    await watcher.onChange();
+
+    expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+    expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+    expect(conditionalStorageMock.updateCondition).not.toHaveBeenCalled();
+    expect(mockLoggerService.error).toHaveBeenCalled();
+  });
+
+  test('should merge sibling yaml conditions via update and delete', async () => {
+    const storedRead = {
+      id: 1,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [{ name: 'catalog.entity.read', action: 'read' }],
+      conditions: conditionToStore1.conditions,
+    };
+    const storedDelete = {
+      id: 2,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: 'role:default/test',
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      permissionMapping: [{ name: 'catalog.entity.delete', action: 'delete' }],
+      conditions: conditionToStore1.conditions,
+    };
+
+    conditionalStorageMock.filterConditions = jest
+      .fn()
+      .mockImplementation(() => [storedRead, storedDelete]);
+    roleMetadataStorageMock.filterRoleMetadata = jest
+      .fn()
+      .mockImplementation(() => csvFileRoles);
+
+    const mergedYaml = [
+      'result: CONDITIONAL',
+      'roleEntityRef: role:default/test',
+      'pluginId: catalog',
+      'resourceType: catalog-entity',
+      'permissionMapping:',
+      '  - read',
+      '  - delete',
+      'conditions:',
+      '  rule: IS_ENTITY_OWNER',
+      '  resourceType: catalog-entity',
+      '  params:',
+      '    claims:',
+      '      - group:default/team-a',
+    ].join('\n');
+
+    const watcher = createWatcher(csvFileName);
+    jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(mergedYaml);
+    await watcher.onChange();
+
+    expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        permissionMapping: expect.arrayContaining([
+          expect.objectContaining({ action: 'read' }),
+          expect.objectContaining({ action: 'delete' }),
+        ]),
+      }),
+      undefined,
+      new Set([2]),
+    );
+    expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledWith(2);
+    expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+  });
+
   test('should handle error on delete condition', async () => {
     conditionalStorageMock.filterConditions = jest
       .fn()
@@ -726,6 +867,26 @@ describe('YamlConditionalFileWatcher', () => {
         fail: {
           error: new NotFoundError('Condition was not found'),
           ...mappedConditionMeta(conditionToRemove),
+        },
+      },
+      {
+        event: {
+          eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 0,
+            pendingRemoves: 1,
+            pluginIds: [],
+          },
+        },
+        fail: {
+          error: new NotFoundError('Condition was not found'),
+          meta: {
+            source: 'conditional-policies-file',
+            pendingAdds: 0,
+            pendingRemoves: 1,
+            pluginIds: [],
+          },
         },
       },
     ]);

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -21,10 +21,11 @@ import type {
 import { InputError } from '@backstage/errors';
 
 import yaml from 'js-yaml';
-import { omit } from 'lodash';
+import { isEqual, omit } from 'lodash';
 
 import type {
   PermissionAction,
+  PermissionInfo,
   RoleConditionalPolicyDecision,
 } from '@backstage-community/plugin-rbac-common';
 
@@ -32,8 +33,19 @@ import fs from 'fs';
 
 import { ActionType, ConditionEvents } from '../auditor/auditor';
 import { ConditionalStorage } from '../database/conditional-storage';
-import { RoleMetadataStorage } from '../database/role-metadata';
-import { deepSortEqual, processConditionMapping } from '../helper';
+import {
+  RoleMetadataDao,
+  RoleMetadataStorage,
+} from '../database/role-metadata';
+import {
+  abortConditionalPolicyReconcile,
+  diffConditionalPolicies,
+  pendingDeleteIdsFromPlan,
+  permissionMappingToActions,
+  planConditionalReconcile,
+  processConditionMapping,
+  toError,
+} from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
 import {
@@ -41,11 +53,6 @@ import {
   validateRoleCondition,
 } from '../validation/condition-validation';
 import { AbstractFileWatcher } from './file-watcher';
-
-type ConditionalPoliciesDiff = {
-  addedConditions: RoleConditionalPolicyDecision<PermissionAction>[];
-  removedConditions: RoleConditionalPolicyDecision<PermissionAction>[];
-};
 
 export type ConditionalPoliciesFileLimits = {
   maxBytes: number;
@@ -97,10 +104,20 @@ export function resolveConditionalPoliciesFileLimits(
   return resolved;
 }
 
+function yamlConditionEquals(
+  stored: RoleConditionalPolicyDecision<PermissionInfo>,
+  desired: RoleConditionalPolicyDecision<PermissionAction>,
+): boolean {
+  const storedComparable = {
+    ...omit(stored, ['id']),
+    permissionMapping: permissionMappingToActions(stored.permissionMapping),
+  };
+  return isEqual(storedComparable, omit(desired, ['id']));
+}
+
 export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   RoleConditionalPolicyDecision<PermissionAction>[]
 > {
-  private conditionsDiff: ConditionalPoliciesDiff;
   private readonly maxFileBytes: number;
   private readonly maxFileDocuments: number;
   private readonly conditionValidationLimits: ConditionValidationLimits;
@@ -120,10 +137,6 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   ) {
     super(filePath, allowReload, logger);
 
-    this.conditionsDiff = {
-      addedConditions: [],
-      removedConditions: [],
-    };
     const resolvedLimits = resolveConditionalPoliciesFileLimits(limits);
     this.maxFileBytes = resolvedLimits.maxBytes;
     this.maxFileDocuments = resolvedLimits.maxDocuments;
@@ -156,69 +169,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
 
   async onChange(): Promise<void> {
     try {
-      const newConds = this.parse();
-
-      const addedConds: RoleConditionalPolicyDecision<PermissionAction>[] = [];
-      const removedConds: RoleConditionalPolicyDecision<PermissionAction>[] =
-        [];
-
-      const csvFileRoles =
-        await this.roleMetadataStorage.filterRoleMetadata('csv-file');
-      const existedFileConds = (
-        await this.conditionalStorage.filterConditions(
-          csvFileRoles.map(role => role.roleEntityRef),
-        )
-      ).map(condition => {
-        return {
-          ...condition,
-          permissionMapping: condition.permissionMapping.map(pm => pm.action),
-        };
-      });
-
-      // Find added conditions
-      for (const condition of newConds) {
-        const roleMetadata = csvFileRoles.find(
-          role => condition.roleEntityRef === role.roleEntityRef,
-        );
-        if (!roleMetadata) {
-          this.logger.warn(
-            `skip to add condition for role '${condition.roleEntityRef}'. The role either does not exist or was not created from a CSV file.`,
-          );
-          continue;
-        }
-        if (roleMetadata.source !== 'csv-file') {
-          this.logger.warn(
-            `skip to add condition for role '${condition.roleEntityRef}'. Role is not from csv-file`,
-          );
-          continue;
-        }
-
-        const existingCondition = existedFileConds.find(c =>
-          deepSortEqual(omit(c, ['id']), omit(condition, ['id'])),
-        );
-
-        if (!existingCondition) {
-          addedConds.push(condition);
-        }
-      }
-
-      // Find removed conditions
-      for (const condition of existedFileConds) {
-        if (
-          !newConds.find(c =>
-            deepSortEqual(omit(c, ['id']), omit(condition, ['id'])),
-          )
-        ) {
-          removedConds.push(condition);
-        }
-      }
-
-      this.conditionsDiff = {
-        addedConditions: addedConds,
-        removedConditions: removedConds,
-      };
-
-      await this.handleFileChanges();
+      await this.syncYamlConditionalPoliciesFile();
     } catch (error) {
       const auditorEvent = await this.auditor.createEvent({
         eventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
@@ -267,82 +218,235 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     return parsedDocuments;
   }
 
-  private async handleFileChanges(): Promise<void> {
-    await this.removeConditions();
-    await this.addConditions();
-  }
+  private async syncYamlConditionalPoliciesFile(): Promise<void> {
+    const parsed = this.parse();
+    const csvFileSourcedRoles =
+      await this.roleMetadataStorage.filterRoleMetadata('csv-file');
+    const fileDesired = this.filterParsedToCsvFileSourcedRoles(
+      parsed,
+      csvFileSourcedRoles,
+    );
+    const stored = await this.loadStoredConditionsForRoles(csvFileSourcedRoles);
+    const diff = diffConditionalPolicies(
+      stored,
+      fileDesired,
+      yamlConditionEquals,
+    );
 
-  private async addConditions(): Promise<void> {
-    for (const condition of this.conditionsDiff.addedConditions) {
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.CREATE },
-      });
+    if (diff.toAdd.length === 0 && diff.toRemove.length === 0) {
+      return;
+    }
 
-      try {
-        const conditionToCreate = await processConditionMapping(
-          condition,
-          this.pluginMetadataCollector,
-          this.auth,
+    try {
+      const stagedAdditions: RoleConditionalPolicyDecision<PermissionInfo>[] =
+        [];
+      for (const condition of diff.toAdd) {
+        stagedAdditions.push(
+          await processConditionMapping(
+            condition,
+            this.pluginMetadataCollector,
+            this.auth,
+          ),
         );
-
-        await this.conditionalStorage.createCondition(conditionToCreate);
-        await auditorEvent.success({
-          meta: { condition },
-        });
-      } catch (error) {
-        await auditorEvent.fail({ error, meta: { condition } });
       }
-    }
 
-    this.conditionsDiff.addedConditions = [];
+      const plan = planConditionalReconcile(
+        stagedAdditions,
+        diff.toRemove,
+        item => permissionMappingToActions(item.permissionMapping),
+      );
+      const pendingDeleteIds = pendingDeleteIdsFromPlan(plan);
+
+      for (const { stored: storedRow, desired } of plan.updates) {
+        await this.persistConditionUpdate(
+          storedRow.id!,
+          desired,
+          pendingDeleteIds,
+        );
+      }
+
+      for (const conditionToCreate of plan.creates) {
+        await this.persistConditionCreate(conditionToCreate, pendingDeleteIds);
+      }
+
+      for (const condition of plan.deletes) {
+        await this.persistConditionDelete(condition);
+      }
+    } catch (error) {
+      await abortConditionalPolicyReconcile({
+        logger: this.logger,
+        auditor: this.auditor,
+        source: 'conditional-policies-file',
+        abortEventId: ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+        pendingAdds: diff.toAdd.length,
+        pendingRemoves: diff.toRemove.length,
+        pluginIds: [...new Set(diff.toAdd.map(c => c.pluginId))],
+        error: toError(error),
+      });
+    }
   }
 
-  private async removeConditions(): Promise<void> {
-    for (const condition of this.conditionsDiff.removedConditions) {
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.DELETE },
-      });
+  private filterParsedToCsvFileSourcedRoles(
+    parsed: RoleConditionalPolicyDecision<PermissionAction>[],
+    csvFileSourcedRoles: RoleMetadataDao[],
+  ): RoleConditionalPolicyDecision<PermissionAction>[] {
+    const fileDesired: RoleConditionalPolicyDecision<PermissionAction>[] = [];
 
-      try {
-        const conditionToDelete = (
-          await this.conditionalStorage.filterConditions(
-            condition.roleEntityRef,
-            condition.pluginId,
-            condition.resourceType,
-            condition.permissionMapping,
-          )
-        )[0];
-        await this.conditionalStorage.deleteCondition(conditionToDelete.id!);
-        await auditorEvent.success({ meta: { condition } });
-      } catch (error) {
-        await auditorEvent.fail({
-          error,
-          meta: { condition },
-        });
+    for (const condition of parsed) {
+      const roleMetadata = csvFileSourcedRoles.find(
+        role => condition.roleEntityRef === role.roleEntityRef,
+      );
+      if (!roleMetadata) {
+        this.logger.warn(
+          `skip to add condition for role '${condition.roleEntityRef}'. The role either does not exist or was not created from a CSV file.`,
+        );
+        continue;
       }
+      if (roleMetadata.source !== 'csv-file') {
+        this.logger.warn(
+          `skip to add condition for role '${condition.roleEntityRef}'. Role is not from csv-file`,
+        );
+        continue;
+      }
+      fileDesired.push(condition);
     }
 
-    this.conditionsDiff.removedConditions = [];
+    return fileDesired;
+  }
+
+  private async loadStoredConditionsForRoles(
+    csvFileSourcedRoles: RoleMetadataDao[],
+  ): Promise<RoleConditionalPolicyDecision<PermissionInfo>[]> {
+    return this.conditionalStorage.filterConditions(
+      csvFileSourcedRoles.map(role => role.roleEntityRef),
+    );
+  }
+
+  private async persistConditionUpdate(
+    id: number,
+    conditionToUpdate: RoleConditionalPolicyDecision<PermissionInfo>,
+    pendingDeleteIds: ReadonlySet<number>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.UPDATE },
+    });
+
+    try {
+      await this.conditionalStorage.updateCondition(
+        id,
+        conditionToUpdate,
+        undefined,
+        pendingDeleteIds,
+      );
+      await auditorEvent.success({
+        meta: {
+          condition: {
+            ...conditionToUpdate,
+            permissionMapping: conditionToUpdate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: {
+          condition: {
+            ...conditionToUpdate,
+            permissionMapping: conditionToUpdate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+      throw error;
+    }
+  }
+
+  private async persistConditionCreate(
+    conditionToCreate: RoleConditionalPolicyDecision<PermissionInfo>,
+    pendingDeleteIds: ReadonlySet<number>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.CREATE },
+    });
+
+    try {
+      await this.conditionalStorage.createCondition(
+        conditionToCreate,
+        pendingDeleteIds,
+      );
+      await auditorEvent.success({
+        meta: {
+          condition: {
+            ...conditionToCreate,
+            permissionMapping: conditionToCreate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: {
+          condition: {
+            ...conditionToCreate,
+            permissionMapping: conditionToCreate.permissionMapping.map(
+              pm => pm.action,
+            ),
+          },
+        },
+      });
+      throw error;
+    }
+  }
+
+  private async persistConditionDelete(
+    condition: RoleConditionalPolicyDecision<PermissionInfo>,
+  ): Promise<void> {
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.DELETE },
+    });
+
+    const deleteMeta = {
+      condition: {
+        ...condition,
+        permissionMapping: condition.permissionMapping.map(pm => pm.action),
+      },
+    };
+
+    try {
+      if (condition.id === undefined) {
+        throw new InputError(
+          `Cannot delete conditional policy without stored id for role '${condition.roleEntityRef}'`,
+        );
+      }
+      await this.conditionalStorage.deleteCondition(condition.id);
+      await auditorEvent.success({ meta: deleteMeta });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: deleteMeta,
+      });
+      throw error;
+    }
   }
 
   async cleanUpConditionalPolicies(): Promise<void> {
     const csvFileRoles =
       await this.roleMetadataStorage.filterRoleMetadata('csv-file');
-    const existedFileConds = (
-      await this.conditionalStorage.filterConditions(
-        csvFileRoles.map(role => role.roleEntityRef),
-      )
-    ).map(condition => {
-      return {
-        ...condition,
-        permissionMapping: condition.permissionMapping.map(pm => pm.action),
-      };
-    });
-    this.conditionsDiff.removedConditions = existedFileConds;
-    await this.removeConditions();
+    const existedFileConds =
+      await this.loadStoredConditionsForRoles(csvFileRoles);
+    for (const condition of existedFileConds) {
+      await this.persistConditionDelete(condition);
+    }
   }
 }

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -21,7 +21,7 @@ import type {
 import { InputError } from '@backstage/errors';
 
 import yaml from 'js-yaml';
-import { isEqual, omit } from 'lodash';
+import { omit } from 'lodash';
 
 import type {
   PermissionAction,
@@ -39,6 +39,7 @@ import {
 } from '../database/role-metadata';
 import {
   abortConditionalPolicyReconcile,
+  deepSortEqual,
   diffConditionalPolicies,
   pendingDeleteIdsFromPlan,
   permissionMappingToActions,
@@ -112,7 +113,7 @@ function yamlConditionEquals(
     ...omit(stored, ['id']),
     permissionMapping: permissionMappingToActions(stored.permissionMapping),
   };
-  return isEqual(storedComparable, omit(desired, ['id']));
+  return deepSortEqual(storedComparable, omit(desired, ['id']));
 }
 
 export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { RoleMetadata } from '@backstage-community/plugin-rbac-common';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { clearAuditorMock } from '../__fixtures__/auditor-test-utils';
 import { mockAuditorService } from '../__fixtures__/mock-utils';
 import { ADMIN_ROLE_AUTHOR } from './admin-permissions/admin-creation';
@@ -28,6 +29,11 @@ import {
   policyToString,
   removeTheDifference,
   syncRolePolicies,
+  conditionalActionsOverlap,
+  permissionMappingToActions,
+  planConditionalReconcile,
+  pendingDeleteIdsFromPlan,
+  toError,
   transformArrayToPolicy,
   transformPolicyGroupToLowercase,
   transformRolesGroupToLowercase,
@@ -838,5 +844,121 @@ describe('mergeRoleMetadata', () => {
     expect(result.description).toEqual(newMetadata.description);
     expect(result.roleEntityRef).toEqual(newMetadata.roleEntityRef);
     expect(result.source).toEqual(newMetadata.source);
+  });
+});
+
+describe('planConditionalReconcile', () => {
+  const stored = {
+    id: 1,
+    result: AuthorizeResult.CONDITIONAL,
+    roleEntityRef: 'role:default/test',
+    pluginId: 'catalog',
+    resourceType: 'catalog-entity',
+    permissionMapping: [
+      { name: 'catalog.entity.read', action: 'read' as const },
+    ],
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'catalog-entity',
+      params: { claims: ['group:default/team-a'] },
+    },
+  };
+
+  it('routes overlapping replacements to updates', () => {
+    const desired = {
+      ...stored,
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' as const },
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+    };
+
+    const plan = planConditionalReconcile([desired], [stored], item =>
+      permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.updates[0].stored.id).toBe(1);
+    expect(plan.creates).toHaveLength(0);
+    expect(plan.deletes).toHaveLength(0);
+  });
+
+  it('merges sibling rows into update and delete', () => {
+    const siblingDelete = {
+      id: 2,
+      result: AuthorizeResult.CONDITIONAL,
+      roleEntityRef: stored.roleEntityRef,
+      pluginId: stored.pluginId,
+      resourceType: stored.resourceType,
+      permissionMapping: [
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+      conditions: stored.conditions,
+    };
+    const desired = {
+      roleEntityRef: stored.roleEntityRef,
+      pluginId: stored.pluginId,
+      resourceType: stored.resourceType,
+      permissionMapping: [
+        { name: 'catalog.entity.read', action: 'read' as const },
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+      conditions: stored.conditions,
+    };
+
+    const plan = planConditionalReconcile(
+      [desired],
+      [stored, siblingDelete],
+      item => permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(1);
+    expect(plan.updates[0].stored.id).toBe(1);
+    expect(plan.creates).toHaveLength(0);
+    expect(plan.deletes).toHaveLength(1);
+    expect(plan.deletes[0].id).toBe(2);
+    expect(pendingDeleteIdsFromPlan(plan)).toEqual(new Set([2]));
+  });
+
+  it('routes non-overlapping replacement to create and delete', () => {
+    const desired = {
+      roleEntityRef: stored.roleEntityRef,
+      pluginId: stored.pluginId,
+      resourceType: stored.resourceType,
+      permissionMapping: [
+        { name: 'catalog.entity.delete', action: 'delete' as const },
+      ],
+    };
+
+    const plan = planConditionalReconcile([desired], [stored], item =>
+      permissionMappingToActions(item.permissionMapping),
+    );
+
+    expect(plan.updates).toHaveLength(0);
+    expect(plan.creates).toHaveLength(1);
+    expect(plan.deletes).toHaveLength(1);
+  });
+});
+
+describe('conditionalActionsOverlap', () => {
+  it('returns true when action sets intersect', () => {
+    expect(conditionalActionsOverlap(['read'], ['read', 'delete'])).toBe(true);
+  });
+
+  it('returns false when action sets are disjoint', () => {
+    expect(conditionalActionsOverlap(['read'], ['delete'])).toBe(false);
+  });
+});
+
+describe('toError', () => {
+  it('returns Error instances unchanged', () => {
+    const error = new Error('failed');
+    expect(toError(error)).toBe(error);
+  });
+
+  it('wraps non-Error values', () => {
+    const error = toError('failed');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('failed');
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AuditorService, AuthService } from '@backstage/backend-plugin-api';
+import {
+  AuditorService,
+  AuthService,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
 import type { MetadataResponse } from '@backstage/plugin-permission-common';
 
 import {
@@ -36,7 +40,7 @@ import {
   Source,
 } from '@backstage-community/plugin-rbac-common';
 
-import { ActionType, RoleEvents } from './auditor/auditor';
+import { ActionType, ConditionEvents, RoleEvents } from './auditor/auditor';
 import { RoleMetadataDao, RoleMetadataStorage } from './database/role-metadata';
 import { EnforcerDelegate } from './service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from './service/plugin-endpoints';
@@ -81,6 +85,205 @@ export function metadataStringToPolicy(policy: string): string[] {
  */
 function policyArraysEqual(a: string[], b: string[]): boolean {
   return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+export type ConditionalPolicyDiff<TAdd> = {
+  toAdd: TAdd[];
+  toRemove: RoleConditionalPolicyDecision<PermissionInfo>[];
+};
+
+export type ConditionalResourceKey = {
+  roleEntityRef: string;
+  pluginId: string;
+  resourceType: string;
+};
+
+export type ConditionalPolicyReplacement<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+> = {
+  stored: TRemove;
+  desired: TAdd;
+};
+
+export type ConditionalPolicyReconcilePlan<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+> = {
+  updates: ConditionalPolicyReplacement<TAdd, TRemove>[];
+  creates: TAdd[];
+  deletes: TRemove[];
+};
+
+export type ConditionalPolicyReconcileAbortContext = {
+  logger: LoggerService;
+  auditor: AuditorService;
+  source: string;
+  abortEventId?: string;
+  pendingAdds: number;
+  pendingRemoves: number;
+  pluginIds: string[];
+  error: Error;
+};
+
+function serializeErrorForLog(error: Error): {
+  name: string;
+  message: string;
+  stack?: string;
+} {
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+}
+
+export function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+/**
+ * Computes additions and removals between stored and desired conditional policies.
+ */
+export function diffConditionalPolicies<TAdd>(
+  stored: RoleConditionalPolicyDecision<PermissionInfo>[],
+  desired: TAdd[],
+  equals: (
+    storedItem: RoleConditionalPolicyDecision<PermissionInfo>,
+    desiredItem: TAdd,
+  ) => boolean,
+): ConditionalPolicyDiff<TAdd> {
+  const toAdd = desired.filter(
+    desiredItem => !stored.some(storedItem => equals(storedItem, desiredItem)),
+  );
+  const toRemove = stored.filter(
+    storedItem => !desired.some(desiredItem => equals(storedItem, desiredItem)),
+  );
+  return { toAdd, toRemove };
+}
+
+export function permissionMappingToActions(
+  mapping: PermissionInfo[] | PermissionAction[],
+): PermissionAction[] {
+  return mapping.map(entry =>
+    typeof entry === 'string' ? entry : entry.action,
+  );
+}
+
+export function sameConditionalResource(
+  a: ConditionalResourceKey,
+  b: ConditionalResourceKey,
+): boolean {
+  return (
+    a.roleEntityRef === b.roleEntityRef &&
+    a.pluginId === b.pluginId &&
+    a.resourceType === b.resourceType
+  );
+}
+
+export function conditionalActionsOverlap(
+  actionsA: PermissionAction[],
+  actionsB: PermissionAction[],
+): boolean {
+  return actionsA.some(action => actionsB.includes(action));
+}
+
+/**
+ * Splits a conditional diff into in-place updates, net-new creates, and pure
+ * deletes. Overlapping add/remove pairs for the same role/plugin/resourceType
+ * are treated as updates so createCondition is not called while the stored row
+ * still exists.
+ */
+export function planConditionalReconcile<
+  TAdd extends ConditionalResourceKey,
+  TRemove extends ConditionalResourceKey & { id?: number },
+>(
+  toAdd: TAdd[],
+  toRemove: TRemove[],
+  getActions: (item: TAdd | TRemove) => PermissionAction[],
+): ConditionalPolicyReconcilePlan<TAdd, TRemove> {
+  const matchedRemoveIds = new Set<number>();
+  const updates: ConditionalPolicyReplacement<TAdd, TRemove>[] = [];
+  const creates: TAdd[] = [];
+
+  for (const desired of toAdd) {
+    const stored = toRemove.find(
+      item =>
+        item.id !== undefined &&
+        !matchedRemoveIds.has(item.id) &&
+        sameConditionalResource(item, desired) &&
+        conditionalActionsOverlap(getActions(item), getActions(desired)),
+    );
+
+    if (stored?.id !== undefined) {
+      matchedRemoveIds.add(stored.id);
+      updates.push({ stored, desired });
+    } else {
+      creates.push(desired);
+    }
+  }
+
+  const deletes = toRemove.filter(
+    item => item.id === undefined || !matchedRemoveIds.has(item.id),
+  );
+
+  return { updates, creates, deletes };
+}
+
+export function pendingDeleteIdsFromPlan(plan: {
+  deletes: ReadonlyArray<{ id?: number }>;
+}): ReadonlySet<number> {
+  const ids = plan.deletes
+    .map(item => item.id)
+    .filter((id): id is number => id !== undefined);
+  return new Set(ids);
+}
+
+/**
+ * Logs and audits a failed conditional reconcile. Callers must finish staging
+ * and validation for all pending additions, then persist updates/creates before
+ * deletes. Invoke from a catch block when that persist phase throws so stored
+ * conditions are not deleted.
+ */
+export async function abortConditionalPolicyReconcile(
+  context: ConditionalPolicyReconcileAbortContext,
+): Promise<void> {
+  const {
+    logger,
+    auditor,
+    source,
+    abortEventId = ConditionEvents.CONDITIONAL_POLICIES_FILE_CHANGE,
+    pendingAdds,
+    pendingRemoves,
+    pluginIds,
+    error,
+  } = context;
+
+  const abortMeta = {
+    source,
+    pendingAdds,
+    pendingRemoves,
+    pluginIds,
+    ...(abortEventId === ConditionEvents.CONDITION_WRITE
+      ? { actionType: ActionType.RECONCILE_ABORT }
+      : {}),
+  };
+
+  logger.error(
+    'Conditional policy reconcile aborted; stored conditions preserved. Retry reconciliation once the add failure is resolved.',
+    {
+      event: 'conditional_reconcile_aborted',
+      ...abortMeta,
+      error: serializeErrorForLog(error),
+    },
+  );
+
+  const auditorEvent = await auditor.createEvent({
+    eventId: abortEventId,
+    severityLevel: 'medium',
+    meta: abortMeta,
+  });
+  await auditorEvent.fail({ error, meta: abortMeta });
 }
 
 /**

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -270,7 +270,7 @@ export async function abortConditionalPolicyReconcile(
   };
 
   logger.error(
-    'Conditional policy reconcile aborted; stored conditions preserved. Retry reconciliation once the add failure is resolved.',
+    'Conditional policy reconcile aborted; stored conditions preserved. Retry reconciliation once the underlying staging or persistence failure is resolved.',
     {
       event: 'conditional_reconcile_aborted',
       ...abortMeta,

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.test.ts
@@ -597,14 +597,19 @@ describe('Connection', () => {
 
   describe('applyConditionalPermissions', () => {
     beforeEach(() => {
+      (conditionalStorageMock.filterConditions as jest.Mock).mockImplementation(
+        () => existingConditionalPermission,
+      );
       (conditionalStorageMock.createCondition as jest.Mock).mockReset();
       (conditionalStorageMock.deleteCondition as jest.Mock).mockReset();
+      (conditionalStorageMock.updateCondition as jest.Mock).mockReset();
     });
 
     afterEach(() => {
       (mockLoggerService.warn as jest.Mock).mockReset();
       (conditionalStorageMock.createCondition as jest.Mock).mockReset();
       (conditionalStorageMock.deleteCondition as jest.Mock).mockReset();
+      (conditionalStorageMock.updateCondition as jest.Mock).mockReset();
     });
 
     it('should create conditional permissions', async () => {
@@ -627,7 +632,8 @@ describe('Connection', () => {
       ];
       await provider.applyConditionalPermissions(policies);
       expect(conditionalStorageMock.createCondition).toHaveBeenCalledWith(
-        ...policies,
+        policies[0],
+        expect.any(Set),
       );
     });
 
@@ -706,8 +712,15 @@ describe('Connection', () => {
       ];
 
       await provider.applyConditionalPermissions(policies);
-      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
-      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+        existingConditionalPermission[0].id,
+        policies[0],
+        undefined,
+        expect.any(Set),
+      );
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     });
     it('should replace permissions with changed condition', async () => {
       const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
@@ -732,9 +745,116 @@ describe('Connection', () => {
       ];
 
       await provider.applyConditionalPermissions(policies);
-      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
-      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+        existingConditionalPermission[0].id,
+        policies[0],
+        undefined,
+        expect.any(Set),
+      );
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     });
+
+    it('should create then delete when replacement actions do not overlap', async () => {
+      const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
+        {
+          id: existingConditionalPermission[0].id,
+          result: existingConditionalPermission[0].result,
+          roleEntityRef: existingConditionalPermission[0].roleEntityRef,
+          pluginId: existingConditionalPermission[0].pluginId,
+          resourceType: existingConditionalPermission[0].resourceType,
+          permissionMapping: [{ name: 'delete', action: 'delete' }],
+          conditions: existingConditionalPermission[0].conditions,
+        },
+      ];
+
+      await provider.applyConditionalPermissions(policies);
+      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.updateCondition).not.toHaveBeenCalled();
+    });
+
+    it('should merge sibling conditional policies via update and delete', async () => {
+      const siblingConditions: RoleConditionalPolicyDecision<PermissionInfo>[] =
+        [
+          {
+            id: 1,
+            result: 'CONDITIONAL',
+            roleEntityRef: 'role:default/team',
+            pluginId: 'catalog',
+            resourceType: 'catalog-entity',
+            permissionMapping: [{ name: 'read', action: 'read' }],
+            conditions: existingConditionalPermission[0].conditions,
+          },
+          {
+            id: 2,
+            result: 'CONDITIONAL',
+            roleEntityRef: 'role:default/team',
+            pluginId: 'catalog',
+            resourceType: 'catalog-entity',
+            permissionMapping: [{ name: 'delete', action: 'delete' }],
+            conditions: existingConditionalPermission[0].conditions,
+          },
+        ];
+      (conditionalStorageMock.filterConditions as jest.Mock).mockImplementation(
+        () => siblingConditions,
+      );
+
+      const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
+        {
+          id: 1,
+          result: 'CONDITIONAL',
+          roleEntityRef: 'role:default/team',
+          pluginId: 'catalog',
+          resourceType: 'catalog-entity',
+          permissionMapping: [
+            { name: 'read', action: 'read' },
+            { name: 'delete', action: 'delete' },
+          ],
+          conditions: existingConditionalPermission[0].conditions,
+        },
+      ];
+
+      await provider.applyConditionalPermissions(policies);
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledWith(
+        1,
+        policies[0],
+        undefined,
+        new Set([2]),
+      );
+      expect(conditionalStorageMock.deleteCondition).toHaveBeenCalledWith(2);
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+    });
+
+    it('should preserve existing conditional policies when replacement update fails (#9429)', async () => {
+      (conditionalStorageMock.updateCondition as jest.Mock).mockImplementation(
+        () => {
+          throw new Error('update failed');
+        },
+      );
+
+      const policies: RoleConditionalPolicyDecision<PermissionInfo>[] = [
+        {
+          id: existingConditionalPermission[0].id,
+          result: existingConditionalPermission[0].result,
+          roleEntityRef: existingConditionalPermission[0].roleEntityRef,
+          pluginId: existingConditionalPermission[0].pluginId,
+          resourceType: existingConditionalPermission[0].resourceType,
+          permissionMapping: [
+            { name: 'read', action: 'read' },
+            { name: 'delete', action: 'delete' },
+          ],
+          conditions: existingConditionalPermission[0].conditions,
+        },
+      ];
+
+      await provider.applyConditionalPermissions(policies);
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.updateCondition).toHaveBeenCalledTimes(1);
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+    });
+
     it('should reject policies from an invalid source', async () => {
       const anotherProvider = new Connection(
         'another-provider',
@@ -769,14 +889,24 @@ describe('Connection', () => {
         {
           event: {
             eventId: ConditionEvents.CONDITION_WRITE,
-            meta: { actionType: ActionType.CREATE, source: 'another-provider' },
+            meta: {
+              source: 'another-provider',
+              actionType: ActionType.RECONCILE_ABORT,
+              pendingAdds: 1,
+              pendingRemoves: 0,
+              pluginIds: ['catalog'],
+            },
           },
           fail: {
             error: new Error(
               `source does not match originating role role:default/existing-provider-role, consider making changes to the 'TEST'`,
             ),
             meta: {
-              policies: [policies[0]],
+              source: 'another-provider',
+              actionType: ActionType.RECONCILE_ABORT,
+              pendingAdds: 1,
+              pendingRemoves: 0,
+              pluginIds: ['catalog'],
             },
           },
         },

--- a/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/providers/connect-providers.ts
@@ -38,6 +38,12 @@ import {
 } from '../auditor/auditor';
 import { RoleMetadataStorage } from '../database/role-metadata';
 import {
+  abortConditionalPolicyReconcile,
+  diffConditionalPolicies,
+  pendingDeleteIdsFromPlan,
+  permissionMappingToActions,
+  planConditionalReconcile,
+  toError,
   transformArrayToPolicy,
   transformRolesGroupToLowercase,
   typedPoliciesToString,
@@ -123,45 +129,68 @@ export class Connection implements RBACProviderConnection {
   async applyConditionalPermissions(
     conditionalPermissions: RoleConditionalPolicyDecision<PermissionInfo>[],
   ): Promise<void> {
+    const providerRoles = await this.getProviderRoles();
     const storedConditionalPermissions =
-      await this.conditionStorage.filterConditions();
+      await this.conditionStorage.filterConditions(providerRoles);
 
-    const conditionsToBeAdded: RoleConditionalPolicyDecision<PermissionInfo>[] =
-      conditionalPermissions.filter(
-        conditionalPermission =>
-          !storedConditionalPermissions.some(
-            stored =>
-              conditionalPermission.roleEntityRef === stored.roleEntityRef &&
-              conditionalPermission.pluginId === stored.pluginId &&
-              conditionalPermission.resourceType === stored.resourceType &&
-              isEqual(
-                conditionalPermission.permissionMapping,
-                stored.permissionMapping,
-              ) &&
-              isEqual(conditionalPermission.conditions, stored.conditions),
-          ),
+    const diff = diffConditionalPolicies(
+      storedConditionalPermissions,
+      conditionalPermissions,
+      (stored, desired) =>
+        stored.roleEntityRef === desired.roleEntityRef &&
+        stored.pluginId === desired.pluginId &&
+        stored.resourceType === desired.resourceType &&
+        isEqual(stored.permissionMapping, desired.permissionMapping) &&
+        isEqual(stored.conditions, desired.conditions),
+    );
+
+    if (diff.toAdd.length === 0 && diff.toRemove.length === 0) {
+      return;
+    }
+
+    try {
+      for (const condition of diff.toAdd) {
+        const metadata = await this.roleMetadataStorage.findRoleMetadata(
+          condition.roleEntityRef,
+        );
+        const err = await validateSource(this.id, metadata);
+        if (err) {
+          throw err;
+        }
+      }
+
+      const plan = planConditionalReconcile(diff.toAdd, diff.toRemove, item =>
+        permissionMappingToActions(item.permissionMapping),
       );
+      const pendingDeleteIds = pendingDeleteIdsFromPlan(plan);
 
-    // Updated policies fails the 'some' check due to permissionMapping differences
-    const conditionsToBeRemoved: RoleConditionalPolicyDecision<PermissionInfo>[] =
-      storedConditionalPermissions.filter(
-        stored =>
-          !conditionalPermissions.some(
-            conditionalPermission =>
-              stored.roleEntityRef === conditionalPermission.roleEntityRef &&
-              stored.pluginId === conditionalPermission.pluginId &&
-              stored.resourceType === conditionalPermission.resourceType &&
-              isEqual(
-                stored.permissionMapping,
-                conditionalPermission.permissionMapping,
-              ) &&
-              isEqual(stored.conditions, conditionalPermission.conditions),
-          ),
-      );
+      for (const { stored, desired } of plan.updates) {
+        await this.persistConditionalUpdate(
+          stored.id!,
+          desired,
+          pendingDeleteIds,
+        );
+      }
 
-    await this.removeConditionalPermissions(conditionsToBeRemoved);
+      for (const condition of plan.creates) {
+        await this.persistConditionalAddition(condition, pendingDeleteIds);
+      }
 
-    await this.addConditionalPermissions(conditionsToBeAdded);
+      for (const condition of plan.deletes) {
+        await this.persistConditionalRemoval(condition);
+      }
+    } catch (error) {
+      await abortConditionalPolicyReconcile({
+        logger: this.logger,
+        auditor: this.auditor,
+        source: this.id,
+        abortEventId: ConditionEvents.CONDITION_WRITE,
+        pendingAdds: diff.toAdd.length,
+        pendingRemoves: diff.toRemove.length,
+        pluginIds: [...new Set(diff.toAdd.map(c => c.pluginId))],
+        error: toError(error),
+      });
+    }
   }
 
   private async addRoles(roles: string[][]): Promise<void> {
@@ -338,65 +367,87 @@ export class Connection implements RBACProviderConnection {
     }
   }
 
-  private async addConditionalPermissions(
-    conditionalPermissions: RoleConditionalPolicyDecision<PermissionInfo>[],
+  private async persistConditionalUpdate(
+    id: number,
+    condition: RoleConditionalPolicyDecision<PermissionInfo>,
+    pendingDeleteIds: ReadonlySet<number>,
   ): Promise<void> {
-    for (const condition of conditionalPermissions) {
-      const auditorMeta = {
-        policies: [condition],
-      };
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: {
-          actionType: ActionType.CREATE,
-          source: this.id,
-        },
-      });
-      try {
-        const metadata = await this.roleMetadataStorage.findRoleMetadata(
-          condition.roleEntityRef,
-        );
-        const err = await validateSource(this.id, metadata);
-        if (err) {
-          throw err;
-        }
-        await this.conditionStorage.createCondition(condition);
-        await auditorEvent.success({ meta: auditorMeta });
-      } catch (error) {
-        await auditorEvent.fail({ error, meta: auditorMeta });
-      }
+    const auditorMeta = {
+      policies: [condition],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: {
+        actionType: ActionType.UPDATE,
+        source: this.id,
+      },
+    });
+    try {
+      await this.conditionStorage.updateCondition(
+        id,
+        condition,
+        undefined,
+        pendingDeleteIds,
+      );
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({ error, meta: auditorMeta });
+      throw error;
     }
   }
 
-  private async removeConditionalPermissions(
-    conditionalPermissions: RoleConditionalPolicyDecision<PermissionInfo>[],
+  private async persistConditionalAddition(
+    condition: RoleConditionalPolicyDecision<PermissionInfo>,
+    pendingDeleteIds: ReadonlySet<number>,
   ): Promise<void> {
-    for (const conditionalPermission of conditionalPermissions) {
-      const auditorMeta = {
-        policies: [conditionalPermission],
-      };
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: ConditionEvents.CONDITION_WRITE,
-        severityLevel: 'medium',
-        meta: { actionType: ActionType.DELETE, source: this.id },
-      });
-      try {
-        const metadata = await this.roleMetadataStorage.findRoleMetadata(
-          conditionalPermission.roleEntityRef,
-        );
-        const err = await validateSource(this.id, metadata);
-        if (err) {
-          throw err;
-        }
-        await this.conditionStorage.deleteCondition(conditionalPermission.id);
-        await auditorEvent.success({ meta: auditorMeta });
-      } catch (error) {
-        await auditorEvent.fail({
-          error,
-          meta: auditorMeta,
-        });
+    const auditorMeta = {
+      policies: [condition],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: {
+        actionType: ActionType.CREATE,
+        source: this.id,
+      },
+    });
+    try {
+      await this.conditionStorage.createCondition(condition, pendingDeleteIds);
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({ error, meta: auditorMeta });
+      throw error;
+    }
+  }
+
+  private async persistConditionalRemoval(
+    conditionalPermission: RoleConditionalPolicyDecision<PermissionInfo>,
+  ): Promise<void> {
+    const auditorMeta = {
+      policies: [conditionalPermission],
+    };
+    const auditorEvent = await this.auditor.createEvent({
+      eventId: ConditionEvents.CONDITION_WRITE,
+      severityLevel: 'medium',
+      meta: { actionType: ActionType.DELETE, source: this.id },
+    });
+    try {
+      const metadata = await this.roleMetadataStorage.findRoleMetadata(
+        conditionalPermission.roleEntityRef,
+      );
+      const err = await validateSource(this.id, metadata);
+      if (err) {
+        throw err;
       }
+      await this.conditionStorage.deleteCondition(conditionalPermission.id!);
+      await auditorEvent.success({ meta: auditorMeta });
+    } catch (error) {
+      await auditorEvent.fail({
+        error,
+        meta: auditorMeta,
+      });
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a regression where conditional policy reload could wipe stored conditions when Catalog metadata was unavailable or when persistence failed partway through a reconcile.

Previously, the YAML file watcher and provider sync paths would remove conditions up front and then re-add them. If staging (metadata lookup) or a later create/update failed, the deletes had already landed and operators could end up with fewer conditions than before the reload.

This change makes reconcile non-destructive: we diff desired vs stored state, validate only pending additions, then apply updates, creates, and deletes in that order. If anything fails, we abort and leave the database as-is. Related conditions for the same role/resource (sibling merges) are handled by excluding pending deletes from conflict checks during create/update.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
