### PR TITLE
feat(announcements): add dynamic banner color based on until_date

### DIFF
--- a/workspaces/announcements/.changeset/eight-points-doubt.md
+++ b/workspaces/announcements/.changeset/eight-points-doubt.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': minor
+---
+
+Add dynamic color to NewAnnouncementBanner based on until_date proximity. Banner status changes from blue (info) to yellow (warning) at 3 days, red (danger) at 1–2 days, and green (success) when past due. Maintenance and release category banners default to yellow and are non-dismissible. A category badge and per-category icon are shown on each banner.

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -33,6 +33,8 @@ import { useSignal } from '@backstage/plugin-signals-react';
 import {
   RiCloseLine,
   RiMegaphoneLine,
+  RiWrenchLine,
+  RiAlertLine,
   RiExternalLinkLine,
 } from '@remixicon/react';
 
@@ -47,6 +49,25 @@ type CardOptions = {
 type AnnouncementBannerProps = {
   announcement: Announcement;
   cardOptions?: CardOptions;
+};
+
+const getAlertStatus = (
+  until_date?: string | null,
+  categorySlug?: string,
+): 'info' | 'warning' | 'danger' | 'success' => {
+  const isPersistent =
+    categorySlug === 'maintenance' || categorySlug === 'release';
+  if (!until_date) return isPersistent ? 'warning' : 'info';
+
+  const daysUntil = DateTime.fromISO(until_date).diff(
+    DateTime.now(),
+    'days',
+  ).days;
+
+  if (daysUntil < 0) return 'success';
+  if (daysUntil <= 2) return 'danger';
+  if (daysUntil <= 3) return 'warning';
+  return isPersistent ? 'warning' : 'info';
 };
 
 const floatingStyle: React.CSSProperties = {
@@ -71,6 +92,9 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
   const { t } = useAnnouncementsTranslation();
   const [bannerOpen, setBannerOpen] = useState(true);
   const announcement = props.announcement;
+  const isPersistent =
+    announcement.category?.slug === 'maintenance' ||
+    announcement.category?.slug === 'release';
   const titleLength = props.cardOptions?.titleLength;
   const excerptLength = props.cardOptions?.excerptLength;
 
@@ -89,7 +113,9 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
       },
     });
 
-    markSeen();
+    if (!isPersistent) {
+      markSeen();
+    }
   };
 
   const handleDismiss = () => {
@@ -112,6 +138,19 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
 
   const bannerTitle = (
     <Box>
+      {announcement.category && (
+        <Box
+          as="span"
+          style={{
+            fontWeight: 'bold',
+            marginRight: 8,
+            textTransform: 'uppercase',
+            fontSize: '0.75em',
+          }}
+        >
+          {announcement.category.title}
+        </Box>
+      )}
       {title}
       <Link
         href={viewAnnouncementLink({ id: announcement.id })}
@@ -149,14 +188,24 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
     return null;
   }
 
+  let icon = <RiMegaphoneLine />;
+  if (announcement.category?.slug === 'maintenance') {
+    icon = <RiWrenchLine />;
+  } else if (announcement.category?.slug === 'release') {
+    icon = <RiAlertLine />;
+  }
+
   return (
     <Alert
       style={floatingStyle}
-      status="info"
-      icon={<RiMegaphoneLine />}
+      status={getAlertStatus(
+        announcement.until_date,
+        announcement.category?.slug,
+      )}
+      icon={icon}
       title={bannerTitle}
       description={excerpt}
-      customActions={closeButton}
+      customActions={isPersistent ? undefined : closeButton}
       mb="4"
     />
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds dynamic color-changing behavior to the `NewAnnouncementBanner` based on how close the announcement's `until_date` is. Previously the banner was always static blue (`status="info"`). Now:

- **Blue** — 4+ days away or no `until_date`
- **Yellow** — 3 days away
- **Red** — 1–2 days away
- **Green** — past due but still active

Maintenance and release category banners always default to at least yellow and are non-dismissible, since they represent critical notices. A category text badge and per-category icon (wrench for maintenance, alert for release, megaphone for general) are also shown on each banner.

Closes #7546

<img width="2266" height="1168" alt="on-dismissable-banner" src="https://github.com/user-attachments/assets/ecffe994-bd79-45c6-b657-00d61ea5559c" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))