### PR TITLE
Version Packages (ocm)

### DIFF
--- a/workspaces/ocm/.changeset/renovate-3775a9b.md
+++ b/workspaces/ocm/.changeset/renovate-3775a9b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.38.0`.

--- a/workspaces/ocm/.changeset/renovate-8dee988.md
+++ b/workspaces/ocm/.changeset/renovate-8dee988.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-ocm-backend': patch
----
-
-Updated dependency `@openapitools/openapi-generator-cli` to `2.39.1`.

--- a/workspaces/ocm/.changeset/version-bump-1-52-0.md
+++ b/workspaces/ocm/.changeset/version-bump-1-52-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-ocm': minor
-'@backstage-community/plugin-ocm-backend': minor
-'@backstage-community/plugin-ocm-common': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-ocm-backend
 
+## 5.20.0
+
+### Minor Changes
+
+- ac55ecf: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 75f3b26: Updated dependency `@openapitools/openapi-generator-cli` to `2.38.0`.
+- b0e8b86: Updated dependency `@openapitools/openapi-generator-cli` to `2.39.1`.
+- Updated dependencies [ac55ecf]
+  - @backstage-community/plugin-ocm-common@3.23.0
+
 ## 5.19.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-backend/package.json
+++ b/workspaces/ocm/plugins/ocm-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm-backend",
-  "version": "5.19.0",
+  "version": "5.20.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## @backstage-community/plugin-ocm-common [3.3.0](https://github.com/janus-idp/backstage-plugins/compare/@backstage-community/plugin-ocm-common@3.2.0...@backstage-community/plugin-ocm-common@3.3.0) (2024-07-26)
 
+## 3.23.0
+
+### Minor Changes
+
+- ac55ecf: Backstage version bump to v1.52.0
+
 ## 3.22.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm-common/package.json
+++ b/workspaces/ocm/plugins/ocm-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-ocm-common",
   "description": "Common functionalities for the Open Cluster Management plugin",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/ocm/plugins/ocm/CHANGELOG.md
+++ b/workspaces/ocm/plugins/ocm/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-ocm
 
+## 5.19.0
+
+### Minor Changes
+
+- ac55ecf: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [ac55ecf]
+  - @backstage-community/plugin-ocm-common@3.23.0
+
 ## 5.18.0
 
 ### Minor Changes

--- a/workspaces/ocm/plugins/ocm/package.json
+++ b/workspaces/ocm/plugins/ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-ocm",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-ocm@5.19.0

### Minor Changes

-   ac55ecf: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [ac55ecf]
    -   @backstage-community/plugin-ocm-common@3.23.0

## @backstage-community/plugin-ocm-backend@5.20.0

### Minor Changes

-   ac55ecf: Backstage version bump to v1.52.0

### Patch Changes

-   75f3b26: Updated dependency `@openapitools/openapi-generator-cli` to `2.38.0`.
-   b0e8b86: Updated dependency `@openapitools/openapi-generator-cli` to `2.39.1`.
-   Updated dependencies [ac55ecf]
    -   @backstage-community/plugin-ocm-common@3.23.0

## @backstage-community/plugin-ocm-common@3.23.0

### Minor Changes

-   ac55ecf: Backstage version bump to v1.52.0
