### PR TITLE
Version Packages (mcp-chat)

### DIFF
--- a/workspaces/mcp-chat/.changeset/renovate-b4eb8d6.md
+++ b/workspaces/mcp-chat/.changeset/renovate-b4eb8d6.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat': patch
----
-
-Updated dependency `react-router` to `^6.30.4`.

--- a/workspaces/mcp-chat/.changeset/version-bump-1-52-0.md
+++ b/workspaces/mcp-chat/.changeset/version-bump-1-52-0.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-mcp-chat': minor
-'@backstage-community/plugin-mcp-chat-backend': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-mcp-chat-backend
 
+## 0.12.0
+
+### Minor Changes
+
+- cacdbba: Backstage version bump to v1.52.0
+
 ## 0.11.0
 
 ### Minor Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-mcp-chat-backend",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
+++ b/workspaces/mcp-chat/plugins/mcp-chat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-mcp-chat
 
+## 0.8.0
+
+### Minor Changes
+
+- cacdbba: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- 4e8bd66: Updated dependency `react-router` to `^6.30.4`.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/workspaces/mcp-chat/plugins/mcp-chat/package.json
+++ b/workspaces/mcp-chat/plugins/mcp-chat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-mcp-chat",
   "description": "A Backstage plugin that provides a chat interface for interacting with the MCP Servers.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-mcp-chat@0.8.0

### Minor Changes

-   cacdbba: Backstage version bump to v1.52.0

### Patch Changes

-   4e8bd66: Updated dependency `react-router` to `^6.30.4`.

## @backstage-community/plugin-mcp-chat-backend@0.12.0

### Minor Changes

-   cacdbba: Backstage version bump to v1.52.0
