### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/migrate-quay-to-nfs.md
+++ b/workspaces/quay/.changeset/migrate-quay-to-nfs.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
----
-
-Migrate Quay plugin to the new frontend system (NFS). Legacy (OFS) exports remain available from the main entry point.

--- a/workspaces/quay/.changeset/renovate-1dd5867.md
+++ b/workspaces/quay/.changeset/renovate-1dd5867.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@playwright/test` to `1.61.1`.

--- a/workspaces/quay/.changeset/renovate-2aae059.md
+++ b/workspaces/quay/.changeset/renovate-2aae059.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `start-server-and-test` to `3.0.11`.

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay
 
+## 1.37.0
+
+### Minor Changes
+
+- 07a0064: Migrate Quay plugin to the new frontend system (NFS). Legacy (OFS) exports remain available from the main entry point.
+
+### Patch Changes
+
+- 6622075: Updated dependency `@playwright/test` to `1.61.1`.
+- dc80f66: Updated dependency `start-server-and-test` to `3.0.11`.
+
 ## 1.36.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.37.0

### Minor Changes

-   07a0064: Migrate Quay plugin to the new frontend system (NFS). Legacy (OFS) exports remain available from the main entry point.

### Patch Changes

-   6622075: Updated dependency `@playwright/test` to `1.61.1`.
-   dc80f66: Updated dependency `start-server-and-test` to `3.0.11`.
