### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/migrate-argocd-mui-v5.md
+++ b/workspaces/argocd/.changeset/migrate-argocd-mui-v5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
----
-
-Migrated from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/material`, `@mui/icons-material`). Replaced `makeStyles`/`createStyles` with MUI v5 `styled()` and `sx` prop patterns. Removed `@material-ui/core`, `@material-ui/icons`, `@material-ui/lab`, and `@material-ui/styles` dependencies.

--- a/workspaces/argocd/.changeset/renovate-14240a2.md
+++ b/workspaces/argocd/.changeset/renovate-14240a2.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-Updated dependency `react-use` to `17.6.1`.

--- a/workspaces/argocd/.changeset/renovate-1dd5867.md
+++ b/workspaces/argocd/.changeset/renovate-1dd5867.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-Updated dependency `@playwright/test` to `1.61.1`.

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd
 
+## 2.10.0
+
+### Minor Changes
+
+- 328f198: Migrated from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/material`, `@mui/icons-material`). Replaced `makeStyles`/`createStyles` with MUI v5 `styled()` and `sx` prop patterns. Removed `@material-ui/core`, `@material-ui/icons`, `@material-ui/lab`, and `@material-ui/styles` dependencies.
+
+### Patch Changes
+
+- 12fae1d: Updated dependency `react-use` to `17.6.1`.
+- 6622075: Updated dependency `@playwright/test` to `1.61.1`.
+
 ## 2.9.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.10.0

### Minor Changes

-   328f198: Migrated from Material UI v4 (`@material-ui/*`) to MUI v5 (`@mui/material`, `@mui/icons-material`). Replaced `makeStyles`/`createStyles` with MUI v5 `styled()` and `sx` prop patterns. Removed `@material-ui/core`, `@material-ui/icons`, `@material-ui/lab`, and `@material-ui/styles` dependencies.

### Patch Changes

-   12fae1d: Updated dependency `react-use` to `17.6.1`.
-   6622075: Updated dependency `@playwright/test` to `1.61.1`.
