### PR TITLE
Version Packages (entity-validation)

### DIFF
--- a/workspaces/entity-validation/.changeset/fix-entity-validation-null-safety.md
+++ b/workspaces/entity-validation/.changeset/fix-entity-validation-null-safety.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-entity-validation': patch
----
-
-Handle missing `kind` and `metadata` without crashing when validating entities. Previously the plugin crashed on entities missing these fields, hiding the underlying validation errors from the user. The plugin now surfaces those errors and labels which field is missing (for example `component:<missing name>`) in the results list.

--- a/workspaces/entity-validation/plugins/entity-validation/CHANGELOG.md
+++ b/workspaces/entity-validation/plugins/entity-validation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-validation
 
+## 0.21.1
+
+### Patch Changes
+
+- 086eec6: Handle missing `kind` and `metadata` without crashing when validating entities. Previously the plugin crashed on entities missing these fields, hiding the underlying validation errors from the user. The plugin now surfaces those errors and labels which field is missing (for example `component:<missing name>`) in the results list.
+
 ## 0.21.0
 
 ### Minor Changes

--- a/workspaces/entity-validation/plugins/entity-validation/package.json
+++ b/workspaces/entity-validation/plugins/entity-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-validation",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "entity-validation",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-validation@0.21.1

### Patch Changes

-   086eec6: Handle missing `kind` and `metadata` without crashing when validating entities. Previously the plugin crashed on entities missing these fields, hiding the underlying validation errors from the user. The plugin now surfaces those errors and labels which field is missing (for example `component:<missing name>`) in the results list.
