### PR TITLE
fix(rbac): retry plugin permission metadata reads during conditional policy reconcile

### DIFF
--- a/workspaces/rbac/.changeset/mighty-wolves-retry.md
+++ b/workspaces/rbac/.changeset/mighty-wolves-retry.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': minor
+---
+
+Conditional policy reconciliation from the conditional policies file now retries plugin permission metadata reads with bounded exponential backoff, so transient startup races (permission metadata routes mounting after RBAC startup) no longer abort the reconcile. The retry window is configurable via `permission.rbac.conditionalMetadataRetry` (`maxAttempts`, `baseDelayMs`, `maxDelayMs`) and defaults to roughly 4 minutes; set `maxAttempts: 1` to restore the previous fail-fast behavior. Metadata reads triggered through the REST API keep failing fast.

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -324,6 +324,32 @@ All values must be positive integers.
 
 If you already use very large conditional payloads or YAML files, raise these limits in config during upgrade rather than relying on defaults.
 
+### Retrying permission metadata reads during conditional policy reconciliation
+
+When conditional policies are applied from `conditionalPoliciesFile`, the RBAC backend reads the permission metadata of every target plugin (for example `catalog`) to map permission actions to permission names. On a fresh boot the permission metadata route of a target plugin can mount later than the RBAC plugin starts, which previously caused the reconciliation to abort until the next file reload or restart.
+
+The RBAC backend now retries these metadata reads with exponential backoff and jitter. The defaults allow roughly 4 minutes of total retry budget (12 attempts, starting at a 2 second delay and capped at 30 seconds per delay). If the metadata endpoint stays unavailable beyond that window, the reconciliation still aborts safely and preserves the stored conditions; it is applied on a later file reload or restart. Reads triggered through the REST API are not retried and keep failing fast.
+
+The retry behavior can be tuned:
+
+```YAML
+permission:
+  enabled: true
+  rbac:
+    conditionalMetadataRetry:
+      maxAttempts: 12
+      baseDelayMs: 2000
+      maxDelayMs: 30000
+```
+
+Field descriptions:
+
+- `permission.rbac.conditionalMetadataRetry.maxAttempts`: Maximum number of read attempts before the reconciliation aborts. Set to `1` to disable retries.
+- `permission.rbac.conditionalMetadataRetry.baseDelayMs`: Initial backoff delay in milliseconds, doubled on every attempt.
+- `permission.rbac.conditionalMetadataRetry.maxDelayMs`: Upper bound in milliseconds for a single backoff delay.
+
+All values must be positive integers.
+
 ### Configuring Database Storage for policies
 
 The RBAC plugin offers the option to store policies in a database. It supports two database storage options:

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -95,6 +95,27 @@ export interface Config {
         }>;
       };
       /**
+       * Optional retry tuning for reading plugin permission metadata while
+       * applying conditional policies from `conditionalPoliciesFile`.
+       * Bounds the wait for permission metadata routes of target plugins
+       * that are not mounted yet during startup.
+       */
+      conditionalMetadataRetry?: {
+        /**
+         * Maximum number of read attempts before conditional policy
+         * reconciliation aborts. Set to 1 to disable retries. Defaults to 12.
+         */
+        maxAttempts?: number;
+        /**
+         * Initial backoff delay in milliseconds. Defaults to 2000.
+         */
+        baseDelayMs?: number;
+        /**
+         * Upper bound in milliseconds for a single backoff delay. Defaults to 30000.
+         */
+        maxDelayMs?: number;
+      };
+      /**
        * Optional validation tuning for conditional policies.
        */
       validation?: {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.test.ts
@@ -34,6 +34,7 @@ import {
   YamlConditionalPoliciesFileWatcher,
 } from './yaml-conditional-file-watcher';
 import { DEFAULT_CONDITION_VALIDATION_LIMITS } from '../validation/condition-validation';
+import type { ConditionalMetadataRetryOptions } from '../helper';
 import { mockAuditorService } from '../../__fixtures__/mock-utils';
 import { expectAuditorLog } from '../../__fixtures__/auditor-test-utils';
 import {
@@ -273,6 +274,26 @@ describe('YamlConditionalFileWatcher', () => {
         maxBytes,
         maxDocuments,
       },
+    );
+  }
+
+  function createWatcherWithMetadataRetry(
+    filePath: string | undefined,
+    metadataRetry: Partial<ConditionalMetadataRetryOptions>,
+  ): YamlConditionalPoliciesFileWatcher {
+    return new YamlConditionalPoliciesFileWatcher(
+      filePath,
+      false,
+      mockLoggerService,
+      conditionalStorageMock as DataBaseConditionalStorage,
+      mockAuditorService,
+      mockAuthService,
+      pluginMetadataCollectorMock as PluginPermissionMetadataCollector,
+      roleMetadataStorageMock,
+      roleEventEmitterMock,
+      DEFAULT_CONDITION_VALIDATION_LIMITS,
+      {},
+      metadataRetry,
     );
   }
 
@@ -767,7 +788,9 @@ describe('YamlConditionalFileWatcher', () => {
       '      - group:default/team-b',
     ].join('\n');
 
-    const watcher = createWatcher(csvFileName);
+    const watcher = createWatcherWithMetadataRetry(csvFileName, {
+      maxAttempts: 1,
+    });
     jest.spyOn(watcher, 'getCurrentContents').mockReturnValue(updatedYaml);
     await watcher.onChange();
 
@@ -775,6 +798,85 @@ describe('YamlConditionalFileWatcher', () => {
     expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
     expect(conditionalStorageMock.updateCondition).not.toHaveBeenCalled();
     expect(mockLoggerService.error).toHaveBeenCalled();
+  });
+
+  describe('conditional metadata retry', () => {
+    let randomSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    });
+
+    afterEach(() => {
+      randomSpy.mockRestore();
+    });
+
+    it('throws InputError when maxAttempts is not a positive integer', () => {
+      expect(() =>
+        createWatcherWithMetadataRetry(csvFileName, { maxAttempts: 0 }),
+      ).toThrow(InputError);
+      expect(() =>
+        createWatcherWithMetadataRetry(csvFileName, { baseDelayMs: -1 }),
+      ).toThrow(
+        `'baseDelayMs' must be a positive integer for 'permission.rbac.conditionalMetadataRetry'`,
+      );
+    });
+
+    it('applies conditions after transient metadata failures during startup', async () => {
+      conditionalStorageMock.filterConditions = jest
+        .fn()
+        .mockImplementation(() => []);
+      roleMetadataStorageMock.filterRoleMetadata = jest
+        .fn()
+        .mockImplementation(() => csvFileRoles);
+      pluginMetadataCollectorMock.getMetadataByPluginId = jest
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValue(testPluginMetadataResp);
+
+      const watcher = createWatcherWithMetadataRetry(csvFileName, {
+        maxAttempts: 3,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+      });
+      await watcher.initialize();
+
+      expect(
+        pluginMetadataCollectorMock.getMetadataByPluginId,
+      ).toHaveBeenCalledTimes(3);
+      expect(conditionalStorageMock.createCondition).toHaveBeenCalledTimes(2);
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Unable to get permission list for plugin catalog, retrying in \d+ms \(attempt 1 of 3\)/,
+        ),
+      );
+    });
+
+    it('preserves stored conditions when metadata stays unavailable after retries', async () => {
+      conditionalStorageMock.filterConditions = jest
+        .fn()
+        .mockImplementation(() => [conditionToRemove]);
+      roleMetadataStorageMock.filterRoleMetadata = jest
+        .fn()
+        .mockImplementation(() => csvFileRoles);
+      pluginMetadataCollectorMock.getMetadataByPluginId = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      const watcher = createWatcherWithMetadataRetry(csvFileName, {
+        maxAttempts: 2,
+        baseDelayMs: 1,
+        maxDelayMs: 2,
+      });
+      await watcher.initialize();
+
+      expect(
+        pluginMetadataCollectorMock.getMetadataByPluginId,
+      ).toHaveBeenCalledTimes(2);
+      expect(conditionalStorageMock.deleteCondition).not.toHaveBeenCalled();
+      expect(conditionalStorageMock.createCondition).not.toHaveBeenCalled();
+      expect(mockLoggerService.error).toHaveBeenCalled();
+    });
   });
 
   test('should merge sibling yaml conditions via update and delete', async () => {

--- a/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/file-permissions/yaml-conditional-file-watcher.ts
@@ -39,12 +39,14 @@ import {
 } from '../database/role-metadata';
 import {
   abortConditionalPolicyReconcile,
+  type ConditionalMetadataRetryOptions,
   deepSortEqual,
   diffConditionalPolicies,
   pendingDeleteIdsFromPlan,
   permissionMappingToActions,
   planConditionalReconcile,
   processConditionMapping,
+  resolveConditionalMetadataRetryOptions,
   toError,
 } from '../helper';
 import { RoleEventEmitter, RoleEvents } from '../service/enforcer-delegate';
@@ -122,6 +124,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
   private readonly maxFileBytes: number;
   private readonly maxFileDocuments: number;
   private readonly conditionValidationLimits: ConditionValidationLimits;
+  private readonly metadataRetryOptions: ConditionalMetadataRetryOptions;
 
   constructor(
     filePath: string | undefined,
@@ -135,6 +138,7 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     private readonly roleEventEmitter: RoleEventEmitter<RoleEvents>,
     conditionValidationLimits: ConditionValidationLimits,
     limits: Partial<ConditionalPoliciesFileLimits> = {},
+    metadataRetry: Partial<ConditionalMetadataRetryOptions> = {},
   ) {
     super(filePath, allowReload, logger);
 
@@ -142,6 +146,8 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
     this.maxFileBytes = resolvedLimits.maxBytes;
     this.maxFileDocuments = resolvedLimits.maxDocuments;
     this.conditionValidationLimits = conditionValidationLimits;
+    this.metadataRetryOptions =
+      resolveConditionalMetadataRetryOptions(metadataRetry);
   }
 
   async initialize(): Promise<void> {
@@ -247,6 +253,10 @@ export class YamlConditionalPoliciesFileWatcher extends AbstractFileWatcher<
             condition,
             this.pluginMetadataCollector,
             this.auth,
+            {
+              metadataRetry: this.metadataRetryOptions,
+              logger: this.logger,
+            },
           ),
         );
       }

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.test.ts
@@ -13,21 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RoleMetadata } from '@backstage-community/plugin-rbac-common';
-import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import {
+  PermissionAction,
+  RoleConditionalPolicyDecision,
+  RoleMetadata,
+} from '@backstage-community/plugin-rbac-common';
+import { mockServices } from '@backstage/backend-test-utils';
+import { InputError } from '@backstage/errors';
+import {
+  AuthorizeResult,
+  type MetadataResponse,
+} from '@backstage/plugin-permission-common';
 import { clearAuditorMock } from '../__fixtures__/auditor-test-utils';
-import { mockAuditorService } from '../__fixtures__/mock-utils';
+import {
+  mockAuditorService,
+  mockAuthService,
+} from '../__fixtures__/mock-utils';
 import { ADMIN_ROLE_AUTHOR } from './admin-permissions/admin-creation';
 import { RoleMetadataDao } from './database/role-metadata';
 import {
+  computeConditionalMetadataBackoffDelayMs,
   deepSortedEqual,
+  DEFAULT_CONDITIONAL_METADATA_RETRY_OPTIONS,
   isPermissionAction,
   matches,
   mergeRoleMetadata,
   metadataStringToPolicy,
   policiesToString,
   policyToString,
+  processConditionMapping,
+  readConditionalMetadataRetryOptionsFromConfig,
   removeTheDifference,
+  resolveConditionalMetadataRetryOptions,
   syncRolePolicies,
   conditionalActionsOverlap,
   permissionMappingToActions,
@@ -43,6 +60,7 @@ import {
 import { RBACFilters } from './permissions';
 // Import the function to test
 import { EnforcerDelegate } from './service/enforcer-delegate';
+import { PluginPermissionMetadataCollector } from './service/plugin-endpoints';
 
 const modifiedBy = 'user:default/some-user';
 
@@ -960,5 +978,206 @@ describe('toError', () => {
     const error = toError('failed');
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe('failed');
+  });
+});
+
+describe('resolveConditionalMetadataRetryOptions', () => {
+  it('returns defaults when no overrides are provided', () => {
+    expect(resolveConditionalMetadataRetryOptions()).toEqual({
+      maxAttempts: 12,
+      baseDelayMs: 2000,
+      maxDelayMs: 30000,
+    });
+  });
+
+  it('merges partial overrides with defaults', () => {
+    expect(resolveConditionalMetadataRetryOptions({ maxAttempts: 3 })).toEqual({
+      maxAttempts: 3,
+      baseDelayMs: 2000,
+      maxDelayMs: 30000,
+    });
+  });
+
+  it.each(['maxAttempts', 'baseDelayMs', 'maxDelayMs'] as const)(
+    'throws InputError when %s is not a positive integer',
+    field => {
+      expect(() =>
+        resolveConditionalMetadataRetryOptions({ [field]: 0 }),
+      ).toThrow(InputError);
+      expect(() =>
+        resolveConditionalMetadataRetryOptions({ [field]: 1.5 }),
+      ).toThrow(
+        `'${field}' must be a positive integer for 'permission.rbac.conditionalMetadataRetry'`,
+      );
+    },
+  );
+});
+
+describe('readConditionalMetadataRetryOptionsFromConfig', () => {
+  it('reads only defined values from config', () => {
+    const data: Record<string, number> = {
+      'permission.rbac.conditionalMetadataRetry.maxAttempts': 5,
+      'permission.rbac.conditionalMetadataRetry.maxDelayMs': 10000,
+    };
+    expect(
+      readConditionalMetadataRetryOptionsFromConfig({
+        getOptionalNumber: key => data[key],
+      }),
+    ).toEqual({ maxAttempts: 5, maxDelayMs: 10000 });
+  });
+
+  it('returns an empty object when nothing is configured', () => {
+    expect(
+      readConditionalMetadataRetryOptionsFromConfig({
+        getOptionalNumber: () => undefined,
+      }),
+    ).toEqual({});
+  });
+});
+
+describe('computeConditionalMetadataBackoffDelayMs', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('grows exponentially and caps at maxDelayMs without jitter', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const options = DEFAULT_CONDITIONAL_METADATA_RETRY_OPTIONS;
+    expect(computeConditionalMetadataBackoffDelayMs(1, options)).toBe(2000);
+    expect(computeConditionalMetadataBackoffDelayMs(2, options)).toBe(4000);
+    expect(computeConditionalMetadataBackoffDelayMs(3, options)).toBe(8000);
+    expect(computeConditionalMetadataBackoffDelayMs(5, options)).toBe(30000);
+    expect(computeConditionalMetadataBackoffDelayMs(10, options)).toBe(30000);
+  });
+
+  it('never exceeds maxDelayMs even with maximum jitter', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.999999);
+    const options = DEFAULT_CONDITIONAL_METADATA_RETRY_OPTIONS;
+    for (const attempt of [1, 2, 5, 10]) {
+      expect(
+        computeConditionalMetadataBackoffDelayMs(attempt, options),
+      ).toBeLessThanOrEqual(options.maxDelayMs);
+    }
+  });
+});
+
+describe('processConditionMapping', () => {
+  const roleConditionPolicy: RoleConditionalPolicyDecision<PermissionAction> = {
+    id: 1,
+    result: AuthorizeResult.CONDITIONAL,
+    roleEntityRef: 'role:default/test',
+    pluginId: 'catalog',
+    resourceType: 'catalog-entity',
+    permissionMapping: ['read'],
+    conditions: {
+      rule: 'IS_ENTITY_OWNER',
+      resourceType: 'catalog-entity',
+      params: { claims: ['group:default/team-a'] },
+    },
+  };
+
+  const metadata: MetadataResponse = {
+    permissions: [
+      {
+        type: 'resource',
+        name: 'catalog.entity.read',
+        attributes: { action: 'read' },
+        resourceType: 'catalog-entity',
+      },
+    ],
+    rules: [],
+  };
+
+  const loggerMock = mockServices.logger.mock();
+  let getMetadataByPluginId: jest.Mock;
+  let collector: PluginPermissionMetadataCollector;
+
+  beforeEach(() => {
+    getMetadataByPluginId = jest.fn();
+    collector = {
+      getMetadataByPluginId,
+    } as unknown as PluginPermissionMetadataCollector;
+    (loggerMock.warn as jest.Mock).mockClear();
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('maps permission actions to permission names', async () => {
+    getMetadataByPluginId.mockResolvedValue(metadata);
+
+    const result = await processConditionMapping(
+      roleConditionPolicy,
+      collector,
+      mockAuthService,
+    );
+
+    expect(result.permissionMapping).toEqual([
+      { name: 'catalog.entity.read', action: 'read' },
+    ]);
+    expect(getMetadataByPluginId).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails fast without retry options when metadata is unavailable', async () => {
+    getMetadataByPluginId.mockResolvedValue(undefined);
+
+    await expect(
+      processConditionMapping(roleConditionPolicy, collector, mockAuthService),
+    ).rejects.toThrow('Unable to get permission list for plugin catalog');
+    expect(getMetadataByPluginId).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until metadata becomes available when retry options are provided', async () => {
+    getMetadataByPluginId
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ rules: [] })
+      .mockResolvedValue(metadata);
+
+    const result = await processConditionMapping(
+      roleConditionPolicy,
+      collector,
+      mockAuthService,
+      {
+        metadataRetry: { maxAttempts: 5, baseDelayMs: 1, maxDelayMs: 2 },
+        logger: loggerMock,
+      },
+    );
+
+    expect(result.permissionMapping).toEqual([
+      { name: 'catalog.entity.read', action: 'read' },
+    ]);
+    expect(getMetadataByPluginId).toHaveBeenCalledTimes(3);
+    expect(loggerMock.warn).toHaveBeenCalledTimes(2);
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Unable to get permission list for plugin catalog, retrying in \d+ms \(attempt 1 of 5\)/,
+      ),
+    );
+  });
+
+  it('throws after exhausting retry attempts', async () => {
+    getMetadataByPluginId.mockResolvedValue(undefined);
+
+    await expect(
+      processConditionMapping(roleConditionPolicy, collector, mockAuthService, {
+        metadataRetry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 2 },
+      }),
+    ).rejects.toThrow('Unable to get permission list for plugin catalog');
+    expect(getMetadataByPluginId).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry mapping failures once metadata was fetched', async () => {
+    getMetadataByPluginId.mockResolvedValue({ permissions: [], rules: [] });
+
+    await expect(
+      processConditionMapping(roleConditionPolicy, collector, mockAuthService, {
+        metadataRetry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 2 },
+      }),
+    ).rejects.toThrow(
+      `Unable to find permission to get permission name for resource type 'catalog-entity' and action "read"`,
+    );
+    expect(getMetadataByPluginId).toHaveBeenCalledTimes(1);
   });
 });

--- a/workspaces/rbac/plugins/rbac-backend/src/helper.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/helper.ts
@@ -18,6 +18,7 @@ import {
   AuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
 import type { MetadataResponse } from '@backstage/plugin-permission-common';
 
 import {
@@ -459,26 +460,159 @@ export function mergeRoleMetadata(
   return mergedMetaData;
 }
 
+export type ConditionalMetadataRetryOptions = {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+};
+
+/**
+ * With a 2s base delay, exponential backoff and a 30s cap, 12 attempts give a
+ * total retry budget of roughly 4 minutes, which covers slow cold-start mounts
+ * of permission metadata routes without retrying forever.
+ */
+export const DEFAULT_CONDITIONAL_METADATA_RETRY_OPTIONS: ConditionalMetadataRetryOptions =
+  {
+    maxAttempts: 12,
+    baseDelayMs: 2 * 1000,
+    maxDelayMs: 30 * 1000,
+  };
+
+/** Minimal config surface for reading optional metadata retry options. */
+export type ConditionalMetadataRetryConfig = {
+  getOptionalNumber(key: string): number | undefined;
+};
+
+export function readConditionalMetadataRetryOptionsFromConfig(
+  config: ConditionalMetadataRetryConfig,
+): Partial<ConditionalMetadataRetryOptions> {
+  const baseKey = 'permission.rbac.conditionalMetadataRetry';
+  const optionKeys: (keyof ConditionalMetadataRetryOptions)[] = [
+    'maxAttempts',
+    'baseDelayMs',
+    'maxDelayMs',
+  ];
+  const options: Partial<ConditionalMetadataRetryOptions> = {};
+  for (const key of optionKeys) {
+    const value = config.getOptionalNumber(`${baseKey}.${key}`);
+    if (value !== undefined) {
+      options[key] = value;
+    }
+  }
+  return options;
+}
+
+/**
+ * Merges optional overrides with defaults and validates all options are
+ * positive integers.
+ */
+export function resolveConditionalMetadataRetryOptions(
+  partial: Partial<ConditionalMetadataRetryOptions> = {},
+): ConditionalMetadataRetryOptions {
+  const resolved: ConditionalMetadataRetryOptions = {
+    ...DEFAULT_CONDITIONAL_METADATA_RETRY_OPTIONS,
+    ...partial,
+  };
+  assertPositiveIntegerRetryOption(resolved.maxAttempts, 'maxAttempts');
+  assertPositiveIntegerRetryOption(resolved.baseDelayMs, 'baseDelayMs');
+  assertPositiveIntegerRetryOption(resolved.maxDelayMs, 'maxDelayMs');
+  return resolved;
+}
+
+function assertPositiveIntegerRetryOption(
+  value: number,
+  fieldName: string,
+): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new InputError(
+      `'${fieldName}' must be a positive integer for 'permission.rbac.conditionalMetadataRetry'`,
+    );
+  }
+}
+
+export function computeConditionalMetadataBackoffDelayMs(
+  attempt: number,
+  options: ConditionalMetadataRetryOptions,
+): number {
+  const exponential = Math.min(
+    options.maxDelayMs,
+    options.baseDelayMs * 2 ** Math.max(0, attempt - 1),
+  );
+  const jitter = Math.floor(Math.random() * Math.max(250, exponential * 0.2));
+  return Math.min(options.maxDelayMs, exponential + jitter);
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+const SINGLE_ATTEMPT: ConditionalMetadataRetryOptions = {
+  maxAttempts: 1,
+  baseDelayMs: 0,
+  maxDelayMs: 0,
+};
+
+type MetadataWithPermissions = MetadataResponse & {
+  permissions: NonNullable<MetadataResponse['permissions']>;
+};
+
+/**
+ * On fresh boot the permission metadata route of a target plugin can mount
+ * later than RBAC startup. The metadata collector swallows transient failures
+ * (network errors, 5xx) and returns a response without permissions, so a
+ * missing permission list is what gets retried here, with exponential backoff
+ * bounding the total wait.
+ */
+async function getPluginPermissionMetadataWithRetry(
+  pluginPermMetaData: PluginPermissionMetadataCollector,
+  pluginId: string,
+  token: string | undefined,
+  retry: ConditionalMetadataRetryOptions,
+  logger?: LoggerService,
+): Promise<MetadataWithPermissions> {
+  for (let attempt = 1; ; attempt++) {
+    const metadata: MetadataResponse | undefined =
+      await pluginPermMetaData.getMetadataByPluginId(pluginId, token);
+    if (metadata?.permissions) {
+      return { ...metadata, permissions: metadata.permissions };
+    }
+    if (attempt >= retry.maxAttempts) {
+      throw new Error(`Unable to get permission list for plugin ${pluginId}`);
+    }
+    const delayMs = computeConditionalMetadataBackoffDelayMs(attempt, retry);
+    logger?.warn(
+      `Unable to get permission list for plugin ${pluginId}, retrying in ${delayMs}ms (attempt ${attempt} of ${retry.maxAttempts})`,
+    );
+    await sleep(delayMs);
+  }
+}
+
+export type ProcessConditionMappingOptions = {
+  /**
+   * Retry tuning for the permission metadata read. Defaults to a single
+   * attempt so interactive callers such as the REST API keep failing fast.
+   */
+  metadataRetry?: ConditionalMetadataRetryOptions;
+  logger?: LoggerService;
+};
+
 export async function processConditionMapping(
   roleConditionPolicy: RoleConditionalPolicyDecision<PermissionAction>,
   pluginPermMetaData: PluginPermissionMetadataCollector,
   auth: AuthService,
+  options?: ProcessConditionMappingOptions,
 ): Promise<RoleConditionalPolicyDecision<PermissionInfo>> {
   const { token } = await auth.getPluginRequestToken({
     onBehalfOf: await auth.getOwnServiceCredentials(),
     targetPluginId: roleConditionPolicy.pluginId,
   });
 
-  const rule: MetadataResponse | undefined =
-    await pluginPermMetaData.getMetadataByPluginId(
-      roleConditionPolicy.pluginId,
-      token,
-    );
-  if (!rule?.permissions) {
-    throw new Error(
-      `Unable to get permission list for plugin ${roleConditionPolicy.pluginId}`,
-    );
-  }
+  const rule = await getPluginPermissionMetadataWithRetry(
+    pluginPermMetaData,
+    roleConditionPolicy.pluginId,
+    token,
+    options?.metadataRetry ?? SINGLE_ATTEMPT,
+    options?.logger,
+  );
 
   const permInfo: PermissionInfo[] = [];
   for (const action of roleConditionPolicy.permissionMapping) {

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -59,6 +59,7 @@ import {
   resolveConditionalPoliciesFileLimits,
   YamlConditionalPoliciesFileWatcher,
 } from '../file-permissions/yaml-conditional-file-watcher';
+import { readConditionalMetadataRetryOptionsFromConfig } from '../helper';
 import { EnforcerDelegate } from '../service/enforcer-delegate';
 import { PluginPermissionMetadataCollector } from '../service/plugin-endpoints';
 import {
@@ -165,6 +166,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       enforcerDelegate,
       resolvedConditionValidationLimits,
       conditionalFileLimits,
+      readConditionalMetadataRetryOptionsFromConfig(configApi),
     );
     await conditionalFile.initialize();
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### What

Conditional policy reconciliation from `permission.rbac.conditionalPoliciesFile` reads the permission metadata of every target plugin (e.g. `catalog`) to map permission actions to permission names. On a fresh boot, the permission metadata route of a target plugin can mount later than the RBAC backend starts. The metadata collector reports these transient failures (network errors, 5xx) as a missing permission list, so staging failed, and since #9731 the reconcile aborts safely — but the conditions from the file are still not applied until a later file reload or restart.

This PR adds a bounded retry with exponential backoff and jitter around the permission metadata reads in the conditional-policies-file reconcile path:

- Defaults: 12 attempts, 2s base delay, 30s max delay — roughly a 4-minute retry budget that covers slow cold-start mounts of permission metadata routes without retrying forever.
- Configurable via `permission.rbac.conditionalMetadataRetry` (`maxAttempts`, `baseDelayMs`, `maxDelayMs`); `maxAttempts: 1` restores the previous fail-fast behavior.
- Each retry logs a warning with the attempt number and delay.
- Reads triggered through the REST API (`POST`/`PUT /roles/conditions`) are **not** retried and keep failing fast — the retry only applies to the file watcher path, where startup blocks while other plugins continue mounting.
- If the metadata endpoint stays unavailable beyond the retry budget, the reconcile still aborts safely (`conditional_reconcile_aborted`) and stored conditions are preserved, as introduced in #9731.

We have been running this behavior in production as a local patch on top of `@backstage-community/plugin-rbac-backend` 7.16.0 to eliminate startup races where the `catalog` metadata fetch failed during staging.

### How

- `helper.ts`: `processConditionMapping` accepts optional `{ metadataRetry, logger }`; new `resolveConditionalMetadataRetryOptions` / `readConditionalMetadataRetryOptionsFromConfig` / `computeConditionalMetadataBackoffDelayMs` following the existing `ConditionValidationLimits` / `ConditionalPoliciesFileLimits` patterns (defaults + validated overrides, `InputError` on non-positive-integer values).
- `yaml-conditional-file-watcher.ts`: accepts optional retry overrides in the constructor and passes them (plus its logger) to `processConditionMapping`.
- `permission-policy.ts`: reads the config and wires it into the watcher.
- `config.d.ts`: schema for `permission.rbac.conditionalMetadataRetry`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — n/a, backend only
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
