### PR TITLE
fix(github-issues): batch repo queries to avoid GitHub resource limits

### DIFF
--- a/workspaces/github/.changeset/github-issues-null-nodes.md
+++ b/workspaces/github/.changeset/github-issues-null-nodes.md
@@ -3,7 +3,3 @@
 ---
 
 Fixed the GitHub Issues card failing with `Cannot read properties of null (reading 'updatedAt')` / repeated "Resource limits for this query exceeded." errors on entities (typically groups) that own many repositories.
-
-- Repositories are now fetched in smaller batches instead of a single large GraphQL query, which was exceeding GitHub's per-request resource limit and causing GitHub to return `null` issue nodes.
-- Trimmed the issues query to only what the UI renders: `assignees` is fetched with `first: 1` (only the first assignee is displayed) and the unused `participants` field was removed. Both were nested fields contributing to the resource-limit failures.
-- Null issue nodes returned in partial responses are now filtered out before sorting/rendering, so a partial failure no longer crashes the card.

--- a/workspaces/github/.changeset/github-issues-null-nodes.md
+++ b/workspaces/github/.changeset/github-issues-null-nodes.md
@@ -1,0 +1,9 @@
+---
+'@backstage-community/plugin-github-issues': patch
+---
+
+Fixed the GitHub Issues card failing with `Cannot read properties of null (reading 'updatedAt')` / repeated "Resource limits for this query exceeded." errors on entities (typically groups) that own many repositories.
+
+- Repositories are now fetched in smaller batches instead of a single large GraphQL query, which was exceeding GitHub's per-request resource limit and causing GitHub to return `null` issue nodes.
+- Trimmed the issues query to only what the UI renders: `assignees` is fetched with `first: 1` (only the first assignee is displayed) and the unused `participants` field was removed. Both were nested fields contributing to the resource-limit failures.
+- Null issue nodes returned in partial responses are now filtered out before sorting/rendering, so a partial failure no longer crashes the card.

--- a/workspaces/github/plugins/github-issues/README.md
+++ b/workspaces/github/plugins/github-issues/README.md
@@ -37,6 +37,9 @@ app:
 
 **Issues are sorted from the recently updated DESC order (the plugin might not render all issues from a single repo next to each other).**
 
+> [!Note]
+> When an Entity owns many repositories, the plugin fetches issues from GitHub in several smaller batched requests instead of a single large query. This keeps each request within GitHub's GraphQL [per-request resource limit](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api) — a single query spanning many repositories would otherwise fail with `RESOURCE_LIMITS_EXCEEDED`. If GitHub still returns a partial response for a batch, the issues that were fetched successfully are shown and the rest are skipped, rather than failing the whole card.
+
 ## Screenshots
 
 ### Card View
@@ -96,7 +99,7 @@ Both `GithubIssuesPage` and `GithubIssuesCard` provide default configuration. It
 However, you can configure the plugin with props:
 
 - `itemsPerPage: number = 10` - Issues in the list are paginated, number of issues on a single page is controlled with this prop
-- `itemsPerRepo: number = 40` - the plugin doesn't download all Issues available on GitHub. By default, it will get at most 40 Issues - this prop controls this behaviour
+- `itemsPerRepo: number = 40` - the plugin doesn't download all Issues available on GitHub. By default, it will get at most 40 Issues **per repository** - this prop controls this behaviour
 - `filterBy: object` - the plugin can be configured to filter the query by `assignee`, `createdBy`, `labels`, `states`, `mentioned` or `milestone`.
 - `orderBy: object = { field: 'UPDATED_AT', direction: 'DESC' }` - The ordering that the issues are returned can be configured by the `orderBy` field.
 

--- a/workspaces/github/plugins/github-issues/README.md
+++ b/workspaces/github/plugins/github-issues/README.md
@@ -38,7 +38,7 @@ app:
 **Issues are sorted from the recently updated DESC order (the plugin might not render all issues from a single repo next to each other).**
 
 > [!Note]
-> When an Entity owns many repositories, the plugin fetches issues from GitHub in several smaller batched requests instead of a single large query. This keeps each request within GitHub's GraphQL [per-request resource limit](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api) — a single query spanning many repositories would otherwise fail with `RESOURCE_LIMITS_EXCEEDED`. If GitHub still returns a partial response for a batch, the issues that were fetched successfully are shown and the rest are skipped, rather than failing the whole card.
+> When an Entity owns many repositories, the plugin fetches issues from GitHub in several smaller batched requests instead of a single large query. This keeps each request within GitHub's GraphQL [per-request resource limit](https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api) — a single query spanning many repositories would otherwise fail with `RESOURCE_LIMITS_EXCEEDED`. If GitHub still returns a partial response for a batch, the issues that were fetched successfully are shown and the rest are skipped, rather than failing the whole card. When this happens, the card footer notes how many issues couldn't be loaded so a partial result isn't mistaken for the full set.
 
 ## Screenshots
 

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -56,7 +56,7 @@ function getFragment(
     '        totalCount\n' +
     '        edges {\n' +
     '          node {\n' +
-    '            assignees(first: 10) {\n' +
+    '            assignees(first: 1) {\n' +
     '              edges {\n' +
     '                node {\n' +
     '                  avatarUrl\n' +
@@ -72,9 +72,6 @@ function getFragment(
     '            }\n' +
     '            title\n' +
     '            url\n' +
-    '            participants {\n' +
-    '              totalCount\n' +
-    '            }\n' +
     '            updatedAt\n' +
     '            createdAt\n' +
     '            comments(last: 1) {\n' +
@@ -201,6 +198,17 @@ describe('githubIssuesApi', () => {
       );
     });
 
+    it('should split repositories into multiple queries to stay within GitHub resource limits', async () => {
+      const repos = Array.from({ length: 12 }, (_, i) =>
+        entityRepository(`mrwolny/repo-${i}`),
+      );
+
+      await api.fetchIssuesByRepoFromGithub(repos, 10, 'github.com');
+
+      // 12 repositories with a batch size of 5 => 3 GraphQL requests.
+      expect(mockGraphQLQuery).toHaveBeenCalledTimes(3);
+    });
+
     describe('filterBy', () => {
       const cases: [GithubIssuesFilters | undefined, string][] = [
         [{}, ''],
@@ -297,6 +305,101 @@ describe('githubIssuesApi', () => {
       'mrwolny/yo-yo': {
         issues: {
           totalCount: 1,
+          edges: [
+            {
+              node: {
+                assignees: {
+                  edges: [],
+                },
+                author: {
+                  login: 'mrwolny',
+                },
+                repository: {
+                  nameWithOwner: 'mrwolny/yo-yo',
+                },
+                title: "It's the ISSUE!",
+                url: 'https://github.com/mrwolny/yo-yo/issues/1',
+                participants: {
+                  totalCount: 1,
+                },
+                updatedAt: '2022-07-04T18:47:33Z',
+                createdAt: '2022-06-23T18:14:26Z',
+                comments: {
+                  totalCount: 4,
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should drop null issue nodes returned in partial data (e.g. resource limits exceeded)', async () => {
+    mockGraphQLQuery.mockImplementationOnce(() =>
+      Promise.reject({
+        data: {
+          yoyo: {
+            issues: {
+              totalCount: 2,
+              edges: [
+                {
+                  node: {
+                    assignees: {
+                      edges: [],
+                    },
+                    author: {
+                      login: 'mrwolny',
+                    },
+                    repository: {
+                      nameWithOwner: 'mrwolny/yo-yo',
+                    },
+                    title: "It's the ISSUE!",
+                    url: 'https://github.com/mrwolny/yo-yo/issues/1',
+                    participants: {
+                      totalCount: 1,
+                    },
+                    updatedAt: '2022-07-04T18:47:33Z',
+                    createdAt: '2022-06-23T18:14:26Z',
+                    comments: {
+                      totalCount: 4,
+                    },
+                  },
+                },
+                // GitHub returns `null` nodes for the issues it could not
+                // resolve within the query's resource budget.
+                { node: null },
+              ],
+            },
+          },
+        },
+        errors: [
+          {
+            type: 'MAX_NODE_LIMIT_EXCEEDED',
+            message: 'Resource limits for this query exceeded.',
+          },
+        ],
+      }),
+    );
+
+    const api = githubIssuesApi(
+      { getCredentials: jest.fn().mockResolvedValue({ token: mockToken }) },
+      {
+        getOptionalConfigArray: jest.fn(),
+      } as unknown as ConfigApi,
+      { post: jest.fn() } as unknown as ErrorApi,
+    );
+
+    const data = await api.fetchIssuesByRepoFromGithub(
+      [entityRepository('mrwolny/yo-yo')],
+      10,
+      'github.com',
+    );
+
+    expect(data).toEqual({
+      'mrwolny/yo-yo': {
+        issues: {
+          totalCount: 2,
           edges: [
             {
               node: {

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -209,6 +209,58 @@ describe('githubIssuesApi', () => {
       expect(mockGraphQLQuery).toHaveBeenCalledTimes(3);
     });
 
+    it('should not exceed the concurrent request limit', async () => {
+      const flush = () => new Promise<void>(resolve => setTimeout(resolve, 0));
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const resolvers: Array<() => void> = [];
+
+      try {
+        mockGraphQLQuery.mockImplementation(
+          () =>
+            new Promise(resolve => {
+              inFlight += 1;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              resolvers.push(() => {
+                inFlight -= 1;
+                resolve({});
+              });
+            }),
+        );
+
+        const repos = Array.from({ length: 30 }, (_, i) =>
+          entityRepository(`mrwolny/repo-${i}`),
+        );
+        // 30 repositories / 5 per query => 6 batches, at most 4 in flight.
+
+        const resultPromise = api.fetchIssuesByRepoFromGithub(
+          repos,
+          10,
+          'github.com',
+        );
+
+        await flush();
+        // Only the concurrency limit's worth of requests should have started.
+        expect(inFlight).toBe(4);
+
+        // Release requests one at a time; each frees a worker to start the
+        // next batch until all batches have run.
+        while (resolvers.length > 0) {
+          resolvers.shift()!();
+          await flush();
+        }
+
+        await resultPromise;
+
+        expect(maxInFlight).toBe(4);
+        expect(mockGraphQLQuery).toHaveBeenCalledTimes(6);
+      } finally {
+        // Restore the default implementation so it doesn't leak into other
+        // tests (the shared afterEach only clears calls, not implementations).
+        mockGraphQLQuery.mockImplementation(() => ({}));
+      }
+    });
+
     describe('filterBy', () => {
       const cases: [GithubIssuesFilters | undefined, string][] = [
         [{}, ''],
@@ -255,9 +307,6 @@ describe('githubIssuesApi', () => {
                     },
                     title: "It's the ISSUE!",
                     url: 'https://github.com/mrwolny/yo-yo/issues/1',
-                    participants: {
-                      totalCount: 1,
-                    },
                     updatedAt: '2022-07-04T18:47:33Z',
                     createdAt: '2022-06-23T18:14:26Z',
                     comments: {
@@ -319,9 +368,6 @@ describe('githubIssuesApi', () => {
                 },
                 title: "It's the ISSUE!",
                 url: 'https://github.com/mrwolny/yo-yo/issues/1',
-                participants: {
-                  totalCount: 1,
-                },
                 updatedAt: '2022-07-04T18:47:33Z',
                 createdAt: '2022-06-23T18:14:26Z',
                 comments: {
@@ -356,9 +402,6 @@ describe('githubIssuesApi', () => {
                     },
                     title: "It's the ISSUE!",
                     url: 'https://github.com/mrwolny/yo-yo/issues/1',
-                    participants: {
-                      totalCount: 1,
-                    },
                     updatedAt: '2022-07-04T18:47:33Z',
                     createdAt: '2022-06-23T18:14:26Z',
                     comments: {
@@ -414,9 +457,6 @@ describe('githubIssuesApi', () => {
                 },
                 title: "It's the ISSUE!",
                 url: 'https://github.com/mrwolny/yo-yo/issues/1',
-                participants: {
-                  totalCount: 1,
-                },
                 updatedAt: '2022-07-04T18:47:33Z',
                 createdAt: '2022-06-23T18:14:26Z',
                 comments: {

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -53,9 +53,6 @@ export type Issue = {
   };
   title: string;
   url: string;
-  participants: {
-    totalCount: number;
-  };
   createdAt: string;
   updatedAt: string;
   comments: {
@@ -108,6 +105,19 @@ export interface GithubIssuesByRepoOptions {
 export const githubIssuesApiRef = createApiRef<GithubIssuesApi>().with({
   id: 'plugin.githubissues.service',
 });
+
+// Maximum number of repositories requested in a single GraphQL query. Keeping
+// this small avoids GitHub's per-request resource limit (`RESOURCE_LIMITS_EXCEEDED`)
+// when an entity owns many repositories.
+const REPOS_PER_QUERY = 5;
+
+function chunk<T>(items: Array<T>, size: number): Array<Array<T>> {
+  const chunks: Array<Array<T>> = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
 
 /** @internal */
 export const githubIssuesApi = (
@@ -177,27 +187,60 @@ export const githubIssuesApi = (
       });
 
     let issuesByRepo: IssuesByRepo = {};
-    try {
-      if (repositories.length === 0) {
-        throw new Error(`No repositories found for ${host}`);
-      }
-      issuesByRepo = await octokit.graphql(
-        createIssueByRepoQuery(repositories, itemsPerRepo, {
-          filterBy,
-          orderBy,
+    if (repositories.length === 0) {
+      errorApi.post(
+        new ForwardedError(
+          'GitHub Issues Plugin failure',
+          new Error(`No repositories found for ${host}`),
+        ),
+      );
+    } else {
+      // GitHub's GraphQL API enforces a per-request resource/complexity limit.
+      // Requesting many repositories (each with nested issue and assignee
+      // connections) in a single query can exceed it, in which case GitHub
+      // responds with `RESOURCE_LIMITS_EXCEEDED` errors and `null` nodes for
+      // every issue. Split the repositories into smaller batches so each
+      // request stays within the limit, then merge the results.
+      const batches = chunk(repositories, REPOS_PER_QUERY);
+
+      const batchResults = await Promise.all(
+        batches.map(async batch => {
+          try {
+            return (await octokit.graphql(
+              createIssueByRepoQuery(batch, itemsPerRepo, {
+                filterBy,
+                orderBy,
+              }),
+            )) as IssuesByRepo;
+          } catch (e) {
+            errorApi.post(
+              new ForwardedError('GitHub Issues Plugin failure', e),
+            );
+            // GitHub may still return partial data for the batch alongside the
+            // errors; keep whatever resolved successfully.
+            return (e.data ?? {}) as IssuesByRepo;
+          }
         }),
       );
-    } catch (e) {
-      if (e.data) {
-        issuesByRepo = e.data;
-      }
 
-      errorApi.post(new ForwardedError('GitHub Issues Plugin failure', e));
+      issuesByRepo = Object.assign({}, ...batchResults);
     }
 
     return repositories.reduce((acc, { safeName, name, owner }) => {
-      if (issuesByRepo[safeName]) {
-        acc[`${owner}/${name}`] = issuesByRepo[safeName];
+      const repoIssues = issuesByRepo[safeName];
+      if (repoIssues) {
+        acc[`${owner}/${name}`] = {
+          ...repoIssues,
+          issues: {
+            ...repoIssues.issues,
+            totalCount: repoIssues.issues?.totalCount ?? 0,
+            // When GitHub responds with partial data alongside errors (e.g.
+            // "Resource limits for this query exceeded"), some edges can come
+            // back with a `null` node. Drop those here so downstream consumers
+            // never read properties off a null node.
+            edges: (repoIssues.issues?.edges ?? []).filter(edge => edge?.node),
+          },
+        };
       }
 
       return acc;
@@ -255,7 +298,7 @@ function createIssueByRepoQuery(
         totalCount
         edges {
           node {
-            assignees(first: 10) {
+            assignees(first: 1) {
               edges {
                 node {
                   avatarUrl
@@ -271,9 +314,6 @@ function createIssueByRepoQuery(
             }
             title
             url
-            participants {
-              totalCount
-            }
             updatedAt
             createdAt
             comments(last: 1) {

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -111,12 +111,41 @@ export const githubIssuesApiRef = createApiRef<GithubIssuesApi>().with({
 // when an entity owns many repositories.
 const REPOS_PER_QUERY = 5;
 
+// Maximum number of batched GraphQL queries executed at the same time. Bounding
+// the concurrency avoids firing a large burst of parallel requests for entities
+// that own many repositories, which could trip GitHub's secondary rate limits.
+const MAX_CONCURRENT_QUERIES = 4;
+
 function chunk<T>(items: Array<T>, size: number): Array<Array<T>> {
   const chunks: Array<Array<T>> = [];
   for (let i = 0; i < items.length; i += size) {
     chunks.push(items.slice(i, i + size));
   }
   return chunks;
+}
+
+// Runs `fn` over `items` with at most `limit` invocations in flight at once,
+// preserving input order in the returned results.
+async function mapWithConcurrency<T, R>(
+  items: Array<T>,
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<Array<R>> {
+  const results: Array<R> = new Array(items.length);
+  let cursor = 0;
+
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index]);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+
+  return results;
 }
 
 /** @internal */
@@ -203,8 +232,10 @@ export const githubIssuesApi = (
       // request stays within the limit, then merge the results.
       const batches = chunk(repositories, REPOS_PER_QUERY);
 
-      const batchResults = await Promise.all(
-        batches.map(async batch => {
+      const batchResults = await mapWithConcurrency(
+        batches,
+        MAX_CONCURRENT_QUERIES,
+        async batch => {
           try {
             return (await octokit.graphql(
               createIssueByRepoQuery(batch, itemsPerRepo, {
@@ -220,7 +251,7 @@ export const githubIssuesApi = (
             // errors; keep whatever resolved successfully.
             return (e.data ?? {}) as IssuesByRepo;
           }
-        }),
+        },
       );
 
       issuesByRepo = Object.assign({}, ...batchResults);

--- a/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
+++ b/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
@@ -46,9 +46,6 @@ const getTestIssue = (overwrites: Partial<Issue> = {}): { node: Issue } => ({
       },
       title: 'quasi labore qui',
       url: 'http://flowery-muscatel.net',
-      participants: {
-        totalCount: 3,
-      },
       updatedAt: '2022-05-02T09:46:35.885Z',
       createdAt: '2022-06-03T07:11:22.320Z',
       comments: {

--- a/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
+++ b/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.test.tsx
@@ -408,4 +408,71 @@ describe('GithubIssues', () => {
       );
     });
   });
+
+  describe('partially loaded issues', () => {
+    it('warns in the card footer when GitHub reports more issues than were returned', async () => {
+      const testIssue = getTestIssue();
+
+      // `totalCount` is 3 but only a single issue node made it back (e.g. the
+      // rest came back as `null` nodes in a `RESOURCE_LIMITS_EXCEEDED` partial
+      // response and were dropped), so 2 issues could not be loaded.
+      const mockApi: GithubIssuesApi = {
+        fetchIssuesByRepoFromGithub: async () => ({
+          backstage: {
+            issues: {
+              totalCount: 3,
+              edges: [testIssue],
+            },
+          },
+        }),
+      } as GithubIssuesApi;
+
+      const apis = [
+        [githubIssuesApiRef, mockApi],
+        [catalogApiRef, mockCatalogApi],
+      ] as const;
+
+      const { getByText } = await renderInTestApp(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={makeEntityWithKind('Component')}>
+            <GithubIssues />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+
+      expect(
+        getByText(`2 issues couldn't be loaded and were skipped.`),
+      ).toBeInTheDocument();
+    });
+
+    it('does not warn when every issue GitHub reported was returned', async () => {
+      const testIssue = getTestIssue();
+
+      const mockApi: GithubIssuesApi = {
+        fetchIssuesByRepoFromGithub: async () => ({
+          backstage: {
+            issues: {
+              totalCount: 1,
+              edges: [testIssue],
+            },
+          },
+        }),
+      } as GithubIssuesApi;
+
+      const apis = [
+        [githubIssuesApiRef, mockApi],
+        [catalogApiRef, mockCatalogApi],
+      ] as const;
+
+      const { queryByText } = await renderInTestApp(
+        <TestApiProvider apis={apis}>
+          <EntityProvider entity={makeEntityWithKind('Component')}>
+            <GithubIssues />
+          </EntityProvider>
+        </TestApiProvider>,
+      );
+
+      expect(queryByText(/couldn't be loaded/)).toBeNull();
+    });
+  });
 });

--- a/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.tsx
+++ b/workspaces/github/plugins/github-issues/src/components/GithubIssues/GithubIssues.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import {
   Text,
   Flex,
@@ -22,8 +23,9 @@ import {
   Card,
   CardHeader,
   CardBody,
+  CardFooter,
 } from '@backstage/ui';
-import { RiRefreshLine } from '@remixicon/react';
+import { RiRefreshLine, RiErrorWarningLine } from '@remixicon/react';
 import { Progress } from '@backstage/core-components';
 import { useEntityGithubRepositories } from '../../hooks/useEntityGithubRepositories';
 import { useGetIssuesByRepoFromGithub } from '../../hooks/useGetIssuesByRepoFromGithub';
@@ -58,6 +60,24 @@ export const GithubIssues = (props: GithubIssuesProps) => {
     orderBy,
   });
 
+  // Number of issues GitHub reported (via `totalCount`) but did not return.
+  // This happens when a batched query only partially succeeds — e.g. a
+  // `RESOURCE_LIMITS_EXCEEDED` response comes back with `null` issue nodes that
+  // are dropped downstream. `totalCount` counts every open issue, but we only
+  // request `itemsPerRepo` per repo, so the expected count is capped there;
+  // anything below that expectation is a genuinely missing (skipped) issue
+  // rather than one we simply never asked for.
+  const unloadedIssuesCount = useMemo(() => {
+    if (!issuesByRepository) {
+      return 0;
+    }
+
+    return Object.values(issuesByRepository).reduce((acc, { issues }) => {
+      const expected = Math.min(itemsPerRepo, issues.totalCount);
+      return acc + Math.max(0, expected - issues.edges.length);
+    }, 0);
+  }, [issuesByRepository, itemsPerRepo]);
+
   if (!repositories.length) {
     return <NoRepositoriesInfo />;
   }
@@ -85,6 +105,18 @@ export const GithubIssues = (props: GithubIssuesProps) => {
           itemsPerPage={itemsPerPage}
         />
       </CardBody>
+      {unloadedIssuesCount > 0 && (
+        <CardFooter>
+          <Flex align="center" gap="2">
+            <RiErrorWarningLine size={16} color="var(--bui-fg-warning)" />
+            <Text variant="body-small" color="warning">
+              {unloadedIssuesCount === 1
+                ? `1 issue couldn't be loaded and was skipped.`
+                : `${unloadedIssuesCount} issues couldn't be loaded and were skipped.`}
+            </Text>
+          </Flex>
+        </CardFooter>
+      )}
     </Card>
   );
 };

--- a/workspaces/github/plugins/github-issues/src/components/GithubIssues/IssuesList/IssuesList.tsx
+++ b/workspaces/github/plugins/github-issues/src/components/GithubIssues/IssuesList/IssuesList.tsx
@@ -89,6 +89,10 @@ export const IssuesList = ({
         ? Object.values(filteredRepos)
             .map(({ issues: { edges } }) => edges)
             .flat()
+            // Guard against `null` nodes that GitHub can return in partial
+            // responses (e.g. "Resource limits for this query exceeded"), which
+            // would otherwise crash the sort/render below.
+            .filter(edge => edge?.node)
             .sort((a, b) => {
               if (a.node.updatedAt > b.node.updatedAt) {
                 return -1;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The card queried every repository owned by a Group/User in a single GraphQL request. For owners with many repositories this exceeded GitHub's per-request resource limit, so GitHub returned RESOURCE_LIMITS_EXCEEDED errors with null issue nodes, and the card crashed with "Cannot read properties of null (reading 'updatedAt')".

- Fetch repositories in batches of 5 per GraphQL request so a single query stays within GitHub's resource limit.
- Trim the issues query to what the UI renders: request assignees with `first: 1` (only the first assignee is shown) and drop the unused `participants` field. Both were nested fields driving the failures.
- Filter out null issue nodes from partial responses so a partial failure no longer crashes the card.
- Add tests for the batching behaviour and null-node handling.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
