### PR TITLE
fix(i18n): update RBAC German header

### DIFF
--- a/workspaces/rbac/.changeset/i18n-updated-rbac.md
+++ b/workspaces/rbac/.changeset/i18n-updated-rbac.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Update German translation for accessible plugins header.

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
@@ -35,7 +35,7 @@ const rbacTranslationDe = createTranslationMessages({
     'table.titleWithCount': 'Alle Rollen ({{count}})',
     'table.headers.name': 'Name',
     'table.headers.usersAndGroups': 'Benutzer und Gruppen',
-    'table.headers.accessiblePlugins': 'Barrierefreie Plugins',
+    'table.headers.accessiblePlugins': 'Zugängliche Plugins',
     'table.headers.actions': 'Aktionen',
     'table.defaultRoleUsersAndGroups': 'Alle Benutzer und alle Gruppen',
     'table.emptyContent': 'Keine Datensätze gefunden',


### PR DESCRIPTION
## Summary
- correct German label for the accessible plugins header in RBAC
- add changeset for the translation update

## Test plan
- not run (translation change)

Made with [Cursor](https://cursor.com)