### PR TITLE
Version Packages (healert)

### DIFF
--- a/workspaces/healert/.changeset/orange-cycles-pick.md
+++ b/workspaces/healert/.changeset/orange-cycles-pick.md
@@ -1,9 +1,0 @@
----
-'@backstage-community/plugin-healert': minor
----
-
-Add @backstage-community/plugin-healert - Friction Intelligence Platform.
-Surfaces Kubernetes audit log friction events per Backstage catalog entity
-as Friction Scores and Heatmaps. Detects kubectl-exec, pipeline-skip,
-config-drift, port-forward, and emergency-access events. Uses exponential
-time decay scoring so recent events weigh more than old ones.

--- a/workspaces/healert/plugins/healert/CHANGELOG.md
+++ b/workspaces/healert/plugins/healert/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @backstage-community/plugin-healert
+
+## 0.1.0
+
+### Minor Changes
+
+- 10cf821: Add @backstage-community/plugin-healert - Friction Intelligence Platform.
+  Surfaces Kubernetes audit log friction events per Backstage catalog entity
+  as Friction Scores and Heatmaps. Detects kubectl-exec, pipeline-skip,
+  config-drift, port-forward, and emergency-access events. Uses exponential
+  time decay scoring so recent events weigh more than old ones.

--- a/workspaces/healert/plugins/healert/package.json
+++ b/workspaces/healert/plugins/healert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-healert",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Healert Friction Intelligence Platform Plugin for Backstage — surfaces Kubernetes bypass events and friction scores per service",
   "main": "dist/index.cjs.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-healert@0.1.0

### Minor Changes

-   10cf821: Add @backstage-community/plugin-healert - Friction Intelligence Platform.
    Surfaces Kubernetes audit log friction events per Backstage catalog entity
    as Friction Scores and Heatmaps. Detects kubectl-exec, pipeline-skip,
    config-drift, port-forward, and emergency-access events. Uses exponential
    time decay scoring so recent events weigh more than old ones.
