### PR TITLE
Migrate todo plugin table from MUI to BUI

### DIFF
--- a/workspaces/todo/.changeset/migrate-todo-mui-to-bui.md
+++ b/workspaces/todo/.changeset/migrate-todo-mui-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-todo': patch
+---
+
+Migrated the TODO table from Material UI to Backstage UI (`@backstage/ui`), including the table, tooltips, links, and filter fields. Backstage UI is required and has been included as part of Backstage since `1.41.0`.

--- a/workspaces/todo/.changeset/migrate-todo-mui-to-bui.md
+++ b/workspaces/todo/.changeset/migrate-todo-mui-to-bui.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-todo': patch
+'@backstage-community/plugin-todo': major
 ---
 
-Migrated the TODO table from Material UI to Backstage UI (`@backstage/ui`), including the table, tooltips, links, and filter fields. Backstage UI is required and has been included as part of Backstage since `1.41.0`.
+Migrated the TODO plugin UI from Material UI to Backstage UI (`@backstage/ui`). The TODO table, links, text display, and filter fields now use BUI components. Backstage UI is required and has been included as part of Backstage since `1.41.0`.

--- a/workspaces/todo/plugins/todo/README.md
+++ b/workspaces/todo/plugins/todo/README.md
@@ -3,7 +3,7 @@
 This plugin lists `// TODO` comments in source code. It currently exports a single component extension for use on entity pages.
 
 > [!Note]
-> Backstage UI (BUI) is now required for the Todo plugin to function, BUI has been included as part of Backstage since `1.41.0` which means you're very likely to already have it installed. The [BUI documentation](https://ui.backstage.io/) has details on installation if needed and the Backstage [User Interface documentation](https://backstage.io/docs/conf/user-interface/) has details on creating a custom BUI theme.
+> Backstage UI (BUI) is now required for the Todo plugin to function. It has been included as part of Backstage since `1.41.0`, which means you're very likely to already have it installed. The [BUI documentation](https://ui.backstage.io/) has details on installation if needed, and the Backstage [User Interface documentation](https://backstage.io/docs/conf/user-interface/) has details on creating a custom BUI theme.
 
 ## Prerequisite
 

--- a/workspaces/todo/plugins/todo/README.md
+++ b/workspaces/todo/plugins/todo/README.md
@@ -2,6 +2,9 @@
 
 This plugin lists `// TODO` comments in source code. It currently exports a single component extension for use on entity pages.
 
+> [!Note]
+> Backstage UI (BUI) is now required for the Todo plugin to function, BUI has been included as part of Backstage since `1.41.0` which means you're very likely to already have it installed. The [BUI documentation](https://ui.backstage.io/) has details on installation if needed and the Backstage [User Interface documentation](https://backstage.io/docs/conf/user-interface/) has details on creating a custom BUI theme.
+
 ## Prerequisite
 
 For this plugin to work, you must first install and configure the [Todo Backend plugin](../todo-backend).

--- a/workspaces/todo/plugins/todo/dev/index.tsx
+++ b/workspaces/todo/plugins/todo/dev/index.tsx
@@ -17,8 +17,6 @@
 import { Entity, ANNOTATION_LOCATION } from '@backstage/catalog-model';
 import { createDevApp } from '@backstage/dev-utils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
-import OnlineIcon from '@material-ui/icons/Cloud';
-import OfflineIcon from '@material-ui/icons/Storage';
 import { EntityTodoContent, todoApiRef, todoPlugin } from '../src';
 
 import { Content, Header, HeaderLabel, Page } from '@backstage/core-components';
@@ -73,7 +71,6 @@ createDevApp()
       </TestApiProvider>
     ),
     title: 'Entity Todo Content',
-    icon: OfflineIcon,
   })
   .addPage({
     element: (
@@ -89,6 +86,5 @@ createDevApp()
       </EntityProvider>
     ),
     title: 'Backend Connected',
-    icon: OnlineIcon,
   })
   .render();

--- a/workspaces/todo/plugins/todo/package.json
+++ b/workspaces/todo/plugins/todo/package.json
@@ -59,13 +59,14 @@
     "@backstage/errors": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/icons": "^4.9.1",
+    "@backstage/ui": "backstage:^",
     "@types/react": "^16.13.1 || ^17.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
+    "@material-ui/icons": "^4.9.1",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",

--- a/workspaces/todo/plugins/todo/package.json
+++ b/workspaces/todo/plugins/todo/package.json
@@ -60,23 +60,22 @@
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/ui": "backstage:^",
-    "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+    "@types/react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",
     "@backstage/dev-utils": "backstage:^",
     "@backstage/test-utils": "backstage:^",
-    "@material-ui/icons": "^4.9.1",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^15.0.0",
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   }
 }

--- a/workspaces/todo/plugins/todo/package.json
+++ b/workspaces/todo/plugins/todo/package.json
@@ -60,7 +60,7 @@
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/ui": "backstage:^",
-    "@types/react": "^16.13.1 || ^17.0.0"
+    "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "backstage:^",

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.test.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.test.tsx
@@ -50,6 +50,12 @@ const renderTodoList = (mockApi: jest.Mocked<TodoApi>) =>
     </TestApiProvider>,
   );
 
+const flushPendingTimers = async () => {
+  await act(async () => {
+    jest.runOnlyPendingTimers();
+  });
+};
+
 describe('TodoList', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -94,9 +100,7 @@ describe('TodoList', () => {
       target: { value: 'Rugvip' },
     });
 
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+    await flushPendingTimers();
 
     await screen.findByText('FIXME');
 
@@ -123,9 +127,7 @@ describe('TodoList', () => {
 
     fireEvent.click(screen.getByRole('columnheader', { name: 'Author' }));
 
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+    await flushPendingTimers();
 
     await screen.findByText('FIXME');
 
@@ -139,9 +141,7 @@ describe('TodoList', () => {
 
     fireEvent.click(screen.getByRole('columnheader', { name: 'Author' }));
 
-    await act(async () => {
-      jest.advanceTimersByTime(300);
-    });
+    await flushPendingTimers();
 
     await screen.findByText('FIXME');
 

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.test.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.test.tsx
@@ -17,39 +17,140 @@
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { TodoApi, todoApiRef } from '../../api';
 import { TodoList } from './TodoList';
 
+const mockEntity = {
+  metadata: { name: 'mock' },
+  kind: 'MockKind',
+} as Entity;
+
+const mockListResult = {
+  items: [
+    {
+      text: 'My TODO',
+      tag: 'FIXME',
+      author: 'Rugvip',
+      viewUrl: 'https://example.com',
+      repoFilePath: '/my-file.js',
+    },
+  ],
+  totalCount: 1,
+  limit: 10,
+  offset: 0,
+};
+
+const renderTodoList = (mockApi: jest.Mocked<TodoApi>) =>
+  renderInTestApp(
+    <TestApiProvider apis={[[todoApiRef, mockApi]]}>
+      <EntityProvider entity={mockEntity}>
+        <TodoList />
+      </EntityProvider>
+    </TestApiProvider>,
+  );
+
 describe('TodoList', () => {
-  it('should render', async () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should render and request todos for the entity', async () => {
     const mockApi: jest.Mocked<TodoApi> = {
-      listTodos: jest.fn().mockResolvedValue({
-        items: [
-          {
-            text: 'My TODO',
-            tag: 'FIXME',
-            viewUrl: 'https://example.com',
-            repoFilePath: '/my-file.js',
-          },
-        ],
-        totalCount: 1,
-        limit: 10,
-        offset: 0,
-      }),
+      listTodos: jest.fn().mockResolvedValue(mockListResult),
     };
-    const mockEntity = {
-      metadata: { name: 'mock' },
-      kind: 'MockKind',
-    } as Entity;
 
-    const rendered = await renderInTestApp(
-      <TestApiProvider apis={[[todoApiRef, mockApi]]}>
-        <EntityProvider entity={mockEntity}>
-          <TodoList />
-        </EntityProvider>
-      </TestApiProvider>,
-    );
+    await renderTodoList(mockApi);
 
-    await expect(rendered.findByText('FIXME')).resolves.toBeInTheDocument();
+    await expect(screen.findByText('FIXME')).resolves.toBeInTheDocument();
+    expect(mockApi.listTodos).toHaveBeenCalledWith({
+      entity: mockEntity,
+      offset: 0,
+      limit: 10,
+      orderBy: undefined,
+      filters: undefined,
+    });
+  });
+
+  it('translates filter inputs into wildcard server-side filters', async () => {
+    const mockApi: jest.Mocked<TodoApi> = {
+      listTodos: jest.fn().mockResolvedValue(mockListResult),
+    };
+
+    await renderTodoList(mockApi);
+    await screen.findByText('FIXME');
+
+    fireEvent.change(screen.getByLabelText('Filter by text'), {
+      target: { value: '  pagination  ' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter by file'), {
+      target: { value: 'TodoList' },
+    });
+    fireEvent.change(screen.getByLabelText('Filter by author'), {
+      target: { value: 'Rugvip' },
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await screen.findByText('FIXME');
+
+    expect(mockApi.listTodos).toHaveBeenLastCalledWith({
+      entity: mockEntity,
+      offset: 0,
+      limit: 10,
+      orderBy: undefined,
+      filters: [
+        { field: 'text', value: '*pagination*' },
+        { field: 'repoFilePath', value: '*TodoList*' },
+        { field: 'author', value: '*Rugvip*' },
+      ],
+    });
+  });
+
+  it('translates table sort into server-side orderBy', async () => {
+    const mockApi: jest.Mocked<TodoApi> = {
+      listTodos: jest.fn().mockResolvedValue(mockListResult),
+    };
+
+    await renderTodoList(mockApi);
+    await screen.findByText('FIXME');
+
+    fireEvent.click(screen.getByRole('columnheader', { name: 'Author' }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await screen.findByText('FIXME');
+
+    expect(mockApi.listTodos).toHaveBeenLastCalledWith({
+      entity: mockEntity,
+      offset: 0,
+      limit: 10,
+      orderBy: { field: 'author', direction: 'asc' },
+      filters: undefined,
+    });
+
+    fireEvent.click(screen.getByRole('columnheader', { name: 'Author' }));
+
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+
+    await screen.findByText('FIXME');
+
+    expect(mockApi.listTodos).toHaveBeenLastCalledWith({
+      entity: mockEntity,
+      offset: 0,
+      limit: 10,
+      orderBy: { field: 'author', direction: 'desc' },
+      filters: undefined,
+    });
   });
 });

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -92,6 +92,7 @@ const columns: (ColumnConfig<TodoRow> & { id: TodoListFields })[] = [
           <Link
             href={item.viewUrl}
             target="_blank"
+            rel="noopener noreferrer"
             truncate
             title={item.repoFilePath ? item.repoFilePath : '-'}
           >
@@ -212,6 +213,7 @@ export const TodoList = () => {
         <Table<TodoRow>
           columnConfig={columns}
           {...tableProps}
+          aria-label="TODOs"
           emptyState={
             <Text variant="body-medium">
               {hasActiveFilter

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -46,11 +46,17 @@ const columnWidths = {
 
 type TodoRow = TodoItem & { id: string };
 
-const toRow = (item: TodoItem, index: number): TodoRow => ({
+const toRowId = (item: TodoItem): string => {
+  const repoFilePath = item.repoFilePath ?? 'unknown';
+  const lineNumber =
+    item.lineNumber !== undefined ? String(item.lineNumber) : 'n';
+
+  return `${repoFilePath}:${lineNumber}:${item.tag}:${item.text}`;
+};
+
+const toRow = (item: TodoItem): TodoRow => ({
   ...item,
-  id: `${item.repoFilePath ? item.repoFilePath : 'unknown'}:${
-    item.lineNumber ? item.lineNumber : 'n'
-  }:${item.tag}:${index}`,
+  id: toRowId(item),
 });
 
 type TodoFilters = {

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -37,13 +37,6 @@ import { useApi } from '@backstage/core-plugin-api';
 
 const PAGE_SIZE = 10;
 
-const columnWidths = {
-  tag: '10%',
-  text: '55%',
-  repoFilePath: '25%',
-  author: '10%',
-} as const;
-
 type TodoRow = TodoItem & { id: string };
 
 const toRowId = (item: TodoItem): string => {
@@ -69,14 +62,14 @@ const columns: (ColumnConfig<TodoRow> & { id: TodoListFields })[] = [
   {
     id: 'tag',
     label: 'Tag',
-    width: columnWidths.tag,
+    width: '10%',
     isSortable: true,
     cell: item => <CellText title={item.tag} />,
   },
   {
     id: 'text',
     label: 'Text',
-    width: columnWidths.text,
+    width: '55%',
     isRowHeader: true,
     isSortable: true,
     cell: item => (
@@ -90,7 +83,7 @@ const columns: (ColumnConfig<TodoRow> & { id: TodoListFields })[] = [
   {
     id: 'repoFilePath',
     label: 'File',
-    width: columnWidths.repoFilePath,
+    width: '25%',
     isSortable: true,
     cell: item =>
       item.viewUrl ? (
@@ -112,7 +105,7 @@ const columns: (ColumnConfig<TodoRow> & { id: TodoListFields })[] = [
   {
     id: 'author',
     label: 'Author',
-    width: columnWidths.author,
+    width: '10%',
     isSortable: true,
     cell: item => <CellText title={item.author ? item.author : '-'} />,
   },
@@ -183,8 +176,8 @@ export const TodoList = () => {
           TODOs
         </Text>
         <Flex>
-          <div style={{ width: columnWidths.tag }} />
-          <div style={{ width: columnWidths.text }}>
+          <div style={{ width: '10%' }} />
+          <div style={{ width: '55%' }}>
             <SearchField
               aria-label="Filter by text"
               value={filter.value?.text ? filter.value.text : ''}
@@ -193,7 +186,7 @@ export const TodoList = () => {
               }
             />
           </div>
-          <div style={{ width: columnWidths.repoFilePath }}>
+          <div style={{ width: '25%' }}>
             <SearchField
               aria-label="Filter by file"
               value={
@@ -204,7 +197,7 @@ export const TodoList = () => {
               }
             />
           </div>
-          <div style={{ width: columnWidths.author }}>
+          <div style={{ width: '10%' }}>
             <SearchField
               aria-label="Filter by author"
               value={filter.value?.author ? filter.value.author : ''}

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -54,9 +54,9 @@ const toRowId = (item: TodoItem): string => {
   return `${repoFilePath}:${lineNumber}:${item.tag}:${item.text}`;
 };
 
-const toRow = (item: TodoItem): TodoRow => ({
+const toRow = (item: TodoItem, offset: number, index: number): TodoRow => ({
   ...item,
-  id: toRowId(item),
+  id: `${toRowId(item)}:${offset}:${index}`,
 });
 
 type TodoFilters = {
@@ -156,7 +156,7 @@ export const TodoList = () => {
         });
 
         return {
-          data: result.items.map(toRow),
+          data: result.items.map((item, index) => toRow(item, offset, index)),
           totalCount: result.totalCount,
         };
       } catch (loadingError) {

--- a/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
+++ b/workspaces/todo/plugins/todo/src/components/TodoList/TodoList.tsx
@@ -17,51 +17,97 @@
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { useState } from 'react';
 import { todoApiRef } from '../../api';
-import { TodoItem, TodoListOptions } from '../../api/types';
-
+import { TodoItem, TodoListFields, TodoListOptions } from '../../api/types';
+import { ResponseErrorPanel } from '@backstage/core-components';
 import {
-  Table,
-  TableColumn,
-  OverflowTooltip,
+  Card,
+  CardBody,
+  CardHeader,
+  Cell,
+  CellText,
   Link,
-  ResponseErrorPanel,
-} from '@backstage/core-components';
+  SearchField,
+  Table,
+  Text,
+  Flex,
+  useTable,
+  type ColumnConfig,
+} from '@backstage/ui';
 import { useApi } from '@backstage/core-plugin-api';
 
 const PAGE_SIZE = 10;
 
-const columns: TableColumn<TodoItem>[] = [
+const columnWidths = {
+  tag: '10%',
+  text: '55%',
+  repoFilePath: '25%',
+  author: '10%',
+} as const;
+
+type TodoRow = TodoItem & { id: string };
+
+const toRow = (item: TodoItem, index: number): TodoRow => ({
+  ...item,
+  id: `${item.repoFilePath ? item.repoFilePath : 'unknown'}:${
+    item.lineNumber ? item.lineNumber : 'n'
+  }:${item.tag}:${index}`,
+});
+
+type TodoFilters = {
+  text?: string;
+  repoFilePath?: string;
+  author?: string;
+};
+
+const columns: (ColumnConfig<TodoRow> & { id: TodoListFields })[] = [
   {
-    title: 'Tag',
-    field: 'tag',
-    width: '10%',
-    filtering: false,
+    id: 'tag',
+    label: 'Tag',
+    width: columnWidths.tag,
+    isSortable: true,
+    cell: item => <CellText title={item.tag} />,
   },
   {
-    title: 'Text',
-    field: 'text',
-    width: '55%',
-    highlight: true,
-    render: ({ text }) => <OverflowTooltip text={text} />,
+    id: 'text',
+    label: 'Text',
+    width: columnWidths.text,
+    isRowHeader: true,
+    isSortable: true,
+    cell: item => (
+      <Cell>
+        <Text variant="body-medium" weight="bold" truncate title={item.text}>
+          {item.text}
+        </Text>
+      </Cell>
+    ),
   },
   {
-    title: 'File',
-    field: 'repoFilePath',
-    width: '25%',
-    render: ({ viewUrl, repoFilePath }) =>
-      viewUrl ? (
-        <Link to={viewUrl} target="_blank">
-          <OverflowTooltip text={repoFilePath} />
-        </Link>
+    id: 'repoFilePath',
+    label: 'File',
+    width: columnWidths.repoFilePath,
+    isSortable: true,
+    cell: item =>
+      item.viewUrl ? (
+        <Cell>
+          <Link
+            href={item.viewUrl}
+            target="_blank"
+            truncate
+            title={item.repoFilePath ? item.repoFilePath : '-'}
+          >
+            {item.repoFilePath ? item.repoFilePath : '-'}
+          </Link>
+        </Cell>
       ) : (
-        <OverflowTooltip text={repoFilePath} />
+        <CellText title={item.repoFilePath ? item.repoFilePath : '-'} />
       ),
   },
   {
-    title: 'Author',
-    field: 'author',
-    width: '10%',
-    render: ({ author }) => <OverflowTooltip text={author} />,
+    id: 'author',
+    label: 'Author',
+    width: columnWidths.author,
+    isSortable: true,
+    cell: item => <CellText title={item.author ? item.author : '-'} />,
   },
 ];
 
@@ -70,54 +116,111 @@ export const TodoList = () => {
   const todoApi = useApi(todoApiRef);
   const [error, setError] = useState<Error>();
 
+  const { tableProps, filter } = useTable<TodoRow, TodoFilters>({
+    mode: 'offset',
+    paginationOptions: { pageSize: PAGE_SIZE },
+    getData: async ({ offset, pageSize, sort, filter: activeFilter }) => {
+      try {
+        const filters: TodoListOptions['filters'] = [];
+        const text = activeFilter?.text?.trim();
+        if (text) {
+          filters.push({ field: 'text', value: `*${text}*` });
+        }
+        const repoFilePath = activeFilter?.repoFilePath?.trim();
+        if (repoFilePath) {
+          filters.push({ field: 'repoFilePath', value: `*${repoFilePath}*` });
+        }
+        const author = activeFilter?.author?.trim();
+        if (author) {
+          filters.push({ field: 'author', value: `*${author}*` });
+        }
+
+        const result = await todoApi.listTodos({
+          entity,
+          offset,
+          limit: pageSize,
+          orderBy: sort
+            ? {
+                field: sort.column as TodoListFields,
+                direction: sort.direction === 'ascending' ? 'asc' : 'desc',
+              }
+            : undefined,
+          filters: filters.length ? filters : undefined,
+        });
+
+        return {
+          data: result.items.map(toRow),
+          totalCount: result.totalCount,
+        };
+      } catch (loadingError) {
+        setError(loadingError as Error);
+        return { data: [], totalCount: 0 };
+      }
+    },
+  });
+
+  const hasActiveFilter = Boolean(
+    filter.value?.text?.trim() ||
+      filter.value?.repoFilePath?.trim() ||
+      filter.value?.author?.trim(),
+  );
+
   if (error) {
     return <ResponseErrorPanel error={error} />;
   }
 
   return (
-    <Table<TodoItem>
-      title="TODOs"
-      options={{
-        search: false,
-        pageSize: PAGE_SIZE,
-        padding: 'dense',
-        sorting: true,
-        draggable: false,
-        paging: true,
-        filtering: true,
-        debounceInterval: 500,
-        filterCellStyle: { padding: '0 16px 0 20px' },
-      }}
-      columns={columns}
-      data={async query => {
-        try {
-          const page = query?.page ?? 0;
-          const pageSize = query?.pageSize ?? PAGE_SIZE;
-          const result = await todoApi.listTodos({
-            entity,
-            offset: page * pageSize,
-            limit: pageSize,
-            orderBy:
-              query?.orderBy &&
-              ({
-                field: query.orderBy.field,
-                direction: query.orderDirection,
-              } as TodoListOptions['orderBy']),
-            filters: query?.filters?.map(filter => ({
-              field: filter.column.field!,
-              value: `*${filter.value}*`,
-            })) as TodoListOptions['filters'],
-          });
-          return {
-            data: result.items,
-            totalCount: result.totalCount,
-            page: Math.floor(result.offset / result.limit),
-          };
-        } catch (loadingError) {
-          setError(loadingError);
-          return { data: [], totalCount: 0, page: 0 };
-        }
-      }}
-    />
+    <Card>
+      <CardHeader>
+        <Text as="h2" variant="title-medium">
+          TODOs
+        </Text>
+        <Flex>
+          <div style={{ width: columnWidths.tag }} />
+          <div style={{ width: columnWidths.text }}>
+            <SearchField
+              aria-label="Filter by text"
+              value={filter.value?.text ? filter.value.text : ''}
+              onChange={value =>
+                filter.onChange({ ...filter.value, text: value })
+              }
+            />
+          </div>
+          <div style={{ width: columnWidths.repoFilePath }}>
+            <SearchField
+              aria-label="Filter by file"
+              value={
+                filter.value?.repoFilePath ? filter.value.repoFilePath : ''
+              }
+              onChange={value =>
+                filter.onChange({ ...filter.value, repoFilePath: value })
+              }
+            />
+          </div>
+          <div style={{ width: columnWidths.author }}>
+            <SearchField
+              aria-label="Filter by author"
+              value={filter.value?.author ? filter.value.author : ''}
+              onChange={value =>
+                filter.onChange({ ...filter.value, author: value })
+              }
+            />
+          </div>
+        </Flex>
+      </CardHeader>
+      <CardBody>
+        <Table<TodoRow>
+          columnConfig={columns}
+          {...tableProps}
+          emptyState={
+            <Text variant="body-medium">
+              {hasActiveFilter
+                ? 'No TODOs match the current filters.'
+                : 'No TODOs found.'}
+            </Text>
+          }
+        />
+      </CardBody>
+    </Card>
   );
 };

--- a/workspaces/todo/yarn.lock
+++ b/workspaces/todo/yarn.lock
@@ -2059,13 +2059,13 @@ __metadata:
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
-    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    "@types/react": "npm:^17.0.0 || ^18.0.0"
+    react: "npm:^17.0.0 || ^18.0.0"
+    react-dom: "npm:^17.0.0 || ^18.0.0"
     react-router-dom: "npm:6.0.0-beta.0 || ^6.3.0"
   peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
   languageName: unknown
   linkType: soft
@@ -22827,15 +22827,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^16.13.1 || ^17.0.0 || ^18.0.0":
-  version: 18.2.0
-  resolution: "react-dom@npm:18.2.0"
+"react-dom@npm:^17.0.0 || ^18.0.0":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.0"
+    scheduler: "npm:^0.23.2"
   peerDependencies:
-    react: ^18.2.0
-  checksum: 10/ca5e7762ec8c17a472a3605b6f111895c9f87ac7d43a610ab7024f68cd833d08eda0625ce02ec7178cc1f3c957cf0b9273cdc17aa2cd02da87544331c43b1d21
+    react: ^18.3.1
+  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
   languageName: node
   linkType: hard
 
@@ -23130,12 +23130,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^16.13.1 || ^17.0.0 || ^18.0.0":
-  version: 18.2.0
-  resolution: "react@npm:18.2.0"
+"react@npm:^17.0.0 || ^18.0.0":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/b9214a9bd79e99d08de55f8bef2b7fc8c39630be97c4e29d7be173d14a9a10670b5325e94485f74cd8bff4966ef3c78ee53c79a7b0b9b70cba20aa8973acc694
+  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
   languageName: node
   linkType: hard
 
@@ -24015,12 +24015,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.0":
-  version: 0.23.0
-  resolution: "scheduler@npm:0.23.0"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: "npm:^1.1.0"
-  checksum: 10/0c4557aa37bafca44ff21dc0ea7c92e2dbcb298bc62eae92b29a39b029134f02fb23917d6ebc8b1fa536b4184934314c20d8864d156a9f6357f3398aaf7bfda8
+  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
   languageName: node
   linkType: hard
 

--- a/workspaces/todo/yarn.lock
+++ b/workspaces/todo/yarn.lock
@@ -2060,7 +2060,7 @@ __metadata:
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
-    "@types/react": "npm:^16.13.1 || ^17.0.0"
+    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-router-dom: "npm:6.0.0-beta.0 || ^6.3.0"

--- a/workspaces/todo/yarn.lock
+++ b/workspaces/todo/yarn.lock
@@ -2056,7 +2056,6 @@ __metadata:
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
     "@backstage/ui": "backstage:^"
-    "@material-ui/icons": "npm:^4.9.1"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"

--- a/workspaces/todo/yarn.lock
+++ b/workspaces/todo/yarn.lock
@@ -2055,6 +2055,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
+    "@backstage/ui": "backstage:^"
     "@material-ui/icons": "npm:^4.9.1"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
@@ -3432,7 +3433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.0":
+"@backstage/ui@backstage:^::backstage=1.53.0&npm=0.17.0, @backstage/ui@npm:^0.17.0":
   version: 0.17.0
   resolution: "@backstage/ui@npm:0.17.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated the `@backstage-community/plugin-todo` from Material UI / `@backstage/core-components` to Backstage UI (`@backstage/ui`). Filtering, sorting, and server-side pagination behavior are preserved.

https://github.com/user-attachments/assets/a874eda0-b91f-4527-968a-532aac00ed92
 
#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Video attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Summary

- Replaced the Material UI components with BUI `Card`, `Table`, `SearchField`, `Link`, and `useTable` in `TodoList`
- Added `@backstage/ui` as a direct dependency
- Documented the BUI requirement in the plugin README (Backstage ≥ 1.41)
- Kept `ResponseErrorPanel` from `@backstage/core-components` (no BUI equivalent)

## Notes

- `ResponseErrorPanel` is kept as it is and it matches other BUI migrations (e.g. Azure DevOps)
- No public API changes — API reports not expected to change

## Test plan

- [x] `yarn tsc` passes in `workspaces/todo`
- [x] `yarn lint` passes in `workspaces/todo`
- [x] `yarn test plugins/todo/src/components/TodoList` passes
- [x] Manual UI verification in plugin dev app (pagination, filters, sort, empty states)

Closes #7531