### PR TITLE
fix(copilot): normalize postgres date outputs and add defensive front…

### DIFF
--- a/workspaces/copilot/.changeset/poor-plants-yell.md
+++ b/workspaces/copilot/.changeset/poor-plants-yell.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+'@backstage-community/plugin-copilot': minor
+---
+
+Fix V2 dashboard 'Invalid Date' bug on PostgreSQL by normalizing date API outputs and adding defensive frontend parsing.

--- a/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.test.ts
@@ -166,7 +166,8 @@ describe('DatabaseHandlerV2', () => {
 
       const logs = await handler.getIngestionLog('organization', 'org-1');
       expect(logs).toHaveLength(1);
-      expect(normalizeDate(logs[0].day)).toBe('2026-05-10');
+      expect(typeof logs[0].day).toBe('string');
+      expect(logs[0].day).toBe('2026-05-10');
       expect(logs[0].status).toBe('success');
       expect(logs[0].components_loaded).toBe('["totals","users"]');
     });
@@ -227,11 +228,31 @@ describe('DatabaseHandlerV2', () => {
       );
 
       expect(rows).toHaveLength(2);
-      expect(rows.map(r => normalizeDate(r.day))).toEqual([
-        '2026-05-01',
-        '2026-05-02',
-      ]);
+      expect(rows.every(r => typeof r.day === 'string')).toBe(true);
+      expect(rows.map(r => r.day)).toEqual(['2026-05-01', '2026-05-02']);
       expect(rows.every(r => r.team_slug === 'team-a')).toBe(true);
+    });
+
+    it('getDailyTotals always returns day as a plain YYYY-MM-DD string, regardless of database driver (regression test for #9540)', async () => {
+      // On Postgres, Knex deserializes a `date` column as a JS Date object.
+      // Before the fix, that Date was returned as-is and serialized by
+      // res.json() into a full ISO timestamp, breaking the frontend's
+      // formatDay() parsing. This test guards against that regression on
+      // every database backend the suite runs against, including Postgres.
+      await handler.insertDailyTotals([
+        buildDailyTotal({ day: '2026-05-26', team_slug: '' }),
+      ]);
+
+      const rows = await handler.getDailyTotals(
+        'organization',
+        'org-1',
+        '2026-05-26',
+        '2026-05-26',
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(typeof rows[0].day).toBe('string');
+      expect(rows[0].day).toBe('2026-05-26');
     });
 
     it('getPeriodRange returns min/max day from daily totals', async () => {
@@ -379,14 +400,6 @@ function buildDailyTotal(overrides: Partial<V2DailyTotal> = {}): V2DailyTotal {
     user_initiated_interaction_count: 33,
     ...overrides,
   };
-}
-
-function normalizeDate(day: string | Date): string {
-  if (day instanceof Date) {
-    return day.toISOString().split('T')[0];
-  }
-
-  return /^\d{4}-\d{2}-\d{2}/.exec(day)?.[0] ?? day;
 }
 
 function buildUserTeam(overrides: Partial<V2UserTeamRow> = {}): V2UserTeamRow {

--- a/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { DatabaseService } from '@backstage/backend-plugin-api';
 import {
   PeriodRange,
@@ -294,7 +293,11 @@ export class DatabaseHandlerV2 {
       query.where('day', '<=', to);
     }
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getDailyTotals(
@@ -311,7 +314,11 @@ export class DatabaseHandlerV2 {
 
     query.where('team_slug', teamSlug ?? '');
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getPrMetrics(
@@ -328,7 +335,11 @@ export class DatabaseHandlerV2 {
 
     query.where('team_slug', teamSlug ?? '');
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getByFeature(
@@ -345,7 +356,11 @@ export class DatabaseHandlerV2 {
 
     query.where('team_slug', teamSlug ?? '');
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getByIde(
@@ -362,7 +377,11 @@ export class DatabaseHandlerV2 {
 
     query.where('team_slug', teamSlug ?? '');
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getByLanguageFeature(
@@ -386,7 +405,11 @@ export class DatabaseHandlerV2 {
       query.where('feature', feature);
     }
 
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getByModelFeature(
@@ -403,7 +426,11 @@ export class DatabaseHandlerV2 {
       .where('entity_id', entityId)
       .whereBetween('day', [from, to]);
     query.where('team_slug', teamSlug ?? '');
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getByLanguageModel(
@@ -420,7 +447,11 @@ export class DatabaseHandlerV2 {
       .where('entity_id', entityId)
       .whereBetween('day', [from, to]);
     query.where('team_slug', teamSlug ?? '');
-    return query.orderBy('day', 'asc').select('*');
+    const rows = await query.orderBy('day', 'asc').select('*');
+    return rows.map(row => ({
+      ...row,
+      day: this.normalizeDay(row.day) as string,
+    }));
   }
 
   async getDashboardData(

--- a/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/db/DatabaseHandlerV2.ts
@@ -296,7 +296,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -317,7 +317,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -338,7 +338,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -359,7 +359,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -380,7 +380,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -408,7 +408,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -429,7 +429,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -450,7 +450,7 @@ export class DatabaseHandlerV2 {
     const rows = await query.orderBy('day', 'asc').select('*');
     return rows.map(row => ({
       ...row,
-      day: this.normalizeDay(row.day) as string,
+      day: this.normalizeRequiredDay(row.day),
     }));
   }
 
@@ -561,6 +561,23 @@ export class DatabaseHandlerV2 {
     }
 
     return null;
+  }
+  /**
+   * Like normalizeDay, but throws if the value can't be normalized.
+   * Use this for DB columns that are NOT NULL — if this ever throws,
+   * it means the data violates an invariant we assume elsewhere
+   * (e.g. the frontend requires a valid day string to render charts).
+   */
+  private normalizeRequiredDay(value: unknown): string {
+    const normalized = this.normalizeDay(value);
+    if (normalized === null) {
+      throw new Error(
+        `Expected a valid 'day' value from the database but got: ${JSON.stringify(
+          value,
+        )}`,
+      );
+    }
+    return normalized;
   }
 
   private hasRequiredComponents(

--- a/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.test.ts
@@ -17,12 +17,23 @@
 import {
   filterChatRows,
   filterLocRowsByMode,
+  formatDay,
   getChatModelTotals,
   getMostUsedChatModel,
   isAgentCodeChangeFeature,
 } from './chartUtils';
 
 describe('chartUtils', () => {
+  describe('formatDay', () => {
+    it('formats a plain YYYY-MM-DD string', () => {
+      expect(formatDay('2026-05-26')).toBe('May 26');
+    });
+
+    it('formats a full ISO timestamp string as returned by an unnormalized Postgres date column (regression test for #9540)', () => {
+      expect(formatDay('2026-05-26T00:00:00.000Z')).toBe('May 26');
+    });
+  });
+
   it('classifies agent code change features consistently', () => {
     expect(isAgentCodeChangeFeature('agent_edit')).toBe(true);
     expect(isAgentCodeChangeFeature('chat_panel_edit_mode')).toBe(true);

--- a/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
@@ -36,9 +36,23 @@ export function compactNumber(v: number | null): string {
 
 /**
  * Formats a YYYY-MM-DD date string as "Month Day" e.g. "May 22".
+ *
+ * TEMPORARILY REVERTED to the original, buggy implementation to reproduce
+ * https://github.com/backstage/community-plugins/issues/9540 (Postgres
+ * returns `day` as a full ISO timestamp, e.g. "2026-05-26T00:00:00.000Z",
+ * which breaks this string interpolation and produces "Invalid Date").
+ * The fix is commented out below — restore it once the bug has been
+ * confirmed locally.
  */
+// export function formatDay(day: string): string {
+//   const date = new Date(`${day}T00:00:00`);
+//   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+// }
+
+// --- Fix for #9540 (restore this and delete the function above once verified) ---
 export function formatDay(day: string): string {
-  const date = new Date(`${day}T00:00:00`);
+  const dateStr = day.slice(0, 10);
+  const date = new Date(`${dateStr}T00:00:00`);
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 

--- a/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
@@ -35,21 +35,10 @@ export function compactNumber(v: number | null): string {
 }
 
 /**
- * Formats a YYYY-MM-DD date string as "Month Day" e.g. "May 22".
- *
- * TEMPORARILY REVERTED to the original, buggy implementation to reproduce
- * https://github.com/backstage/community-plugins/issues/9540 (Postgres
- * returns `day` as a full ISO timestamp, e.g. "2026-05-26T00:00:00.000Z",
- * which breaks this string interpolation and produces "Invalid Date").
- * The fix is commented out below — restore it once the bug has been
- * confirmed locally.
+ * Safely formats a date string into 'MMM D' (e.g., "May 26").
+ * Slices the first 10 characters to gracefully handle both standard "YYYY-MM-DD" 
+ * inputs and full ISO 8601 timestamps returned by Postgres databases.
  */
-// export function formatDay(day: string): string {
-//   const date = new Date(`${day}T00:00:00`);
-//   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-// }
-
-// --- Fix for #9540 (restore this and delete the function above once verified) ---
 export function formatDay(day: string): string {
   const dateStr = day.slice(0, 10);
   const date = new Date(`${dateStr}T00:00:00`);

--- a/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
+++ b/workspaces/copilot/plugins/copilot/src/components/V2Dashboard/charts/chartUtils.ts
@@ -36,7 +36,7 @@ export function compactNumber(v: number | null): string {
 
 /**
  * Safely formats a date string into 'MMM D' (e.g., "May 26").
- * Slices the first 10 characters to gracefully handle both standard "YYYY-MM-DD" 
+ * Slices the first 10 characters to gracefully handle both standard "YYYY-MM-DD"
  * inputs and full ISO 8601 timestamps returned by Postgres databases.
  */
 export function formatDay(day: string): string {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Fixes issue #9540**

### What this PR does / why we need it:
This PR fixes a bug where V2 dashboard charts display "Invalid Date" on the X-axis and in tooltips when Backstage is connected to a PostgreSQL database. 

When using Postgres, the `pg` driver deserializes `DATE` columns into JavaScript `Date` objects. Express serializes these to full ISO 8601 strings (e.g., `2026-05-26T00:00:00.000Z`) instead of the `YYYY-MM-DD` format the frontend expects, causing `formatDay` to produce an `Invalid Date`.

This PR implements a "Defense in Depth" approach to solve the issue permanently:
1. **Backend (Root Cause):** Mapped over the row results in the `DatabaseHandlerV2` getter methods to call the existing `this.normalizeDay()` helper. This ensures the API reliably outputs `YYYY-MM-DD` strings, preventing the `pg` driver from leaking full ISO timestamps.
2. **Frontend (Defensive Safeguard):** Updated `formatDay` in `chartUtils.ts` to slice the first 10 characters of the date string. This ensures the UI remains resilient and parses correctly regardless of whether it receives a short date string or a full ISO timestamp.

### Testing
Added a regression test to `chartUtils.test.ts` to prove `formatDay` safely handles full ISO timestamps. Verified the fix locally.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. 
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. 