### PR TITLE
fix(jfrog-artifactory): paginate tag queries

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/four-waves-fetch.md
+++ b/workspaces/jfrog-artifactory/.changeset/four-waves-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jfrog-artifactory': patch
+---
+
+Fetch all JFrog Artifactory tags up to the configured `pageLimit`, including when the result spans multiple API pages.

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/__fixtures__/mockTags.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/__fixtures__/mockTags.ts
@@ -396,6 +396,10 @@ export const mockTags = {
           },
         },
       ],
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: null,
+      },
     },
   },
 };

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/api/index.test.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/api/index.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ConfigApi,
+  DiscoveryApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
+
+import { Edge, TagsResponse } from '../types';
+import { JfrogArtifactoryApiClient } from './index';
+
+const edge = (name: string) => ({ node: { name } } as Edge);
+
+const page = (
+  names: string[],
+  hasNextPage: boolean,
+  endCursor: string | null,
+): TagsResponse => ({
+  data: {
+    versions: {
+      edges: names.map(edge),
+      pageInfo: { hasNextPage, endCursor },
+    },
+  },
+});
+
+describe('JfrogArtifactoryApiClient', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('paginates through the API up to the configured page limit', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify(
+            page(
+              Array.from({ length: 200 }, (_, index) => `tag-${index}`),
+              true,
+              'cursor-1',
+            ),
+          ),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify(
+            page(
+              Array.from({ length: 200 }, (_, index) => `tag-${index + 200}`),
+              true,
+              'cursor-2',
+            ),
+          ),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify(
+            page(
+              Array.from({ length: 50 }, (_, index) => `tag-${index + 400}`),
+              false,
+              null,
+            ),
+          ),
+        ),
+      );
+    const client = new JfrogArtifactoryApiClient({
+      discoveryApi: {
+        getBaseUrl: jest
+          .fn()
+          .mockResolvedValue('https://backstage.example/api/proxy'),
+      } as unknown as DiscoveryApi,
+      configApi: {
+        getOptionalString: jest.fn(),
+        getOptionalNumber: jest.fn().mockReturnValue(450),
+      } as unknown as ConfigApi,
+      identityApi: {
+        getCredentials: jest.fn().mockResolvedValue({ token: 'token' }),
+      } as unknown as IdentityApi,
+    });
+
+    const response = await client.getTags('example/image');
+
+    expect(response.data.versions.edges).toHaveLength(450);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const variables = fetchMock.mock.calls.map(call =>
+      JSON.parse(call[1]?.body as string),
+    );
+    expect(variables.map(body => body.variables.first)).toEqual([200, 200, 50]);
+    expect(variables.map(body => body.variables.after)).toEqual([
+      undefined,
+      'cursor-1',
+      'cursor-2',
+    ]);
+  });
+});

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/api/index.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/api/index.ts
@@ -20,9 +20,10 @@ import {
   IdentityApi,
 } from '@backstage/core-plugin-api';
 
-import { TagsResponse } from '../types';
+import { Edge, PageInfo, TagsResponse } from '../types';
 
 const DEFAULT_PROXY_PATH = '/jfrog-artifactory/api';
+const MAX_PAGE_SIZE = 200;
 
 export interface JfrogArtifactoryApiV1 {
   getTags(
@@ -65,7 +66,7 @@ export class JfrogArtifactoryApiClient implements JfrogArtifactoryApiV1 {
     }`;
   }
 
-  private async fetcher(url: string, query: string) {
+  private async fetcher<T>(url: string, query: string): Promise<T> {
     const { token: idToken } = await this.identityApi.getCredentials();
     const response = await fetch(url, {
       headers: {
@@ -80,7 +81,7 @@ export class JfrogArtifactoryApiClient implements JfrogArtifactoryApiV1 {
         `failed to fetch data, status ${response.status}: ${response.statusText}`,
       );
     }
-    return await response.json();
+    return (await response.json()) as T;
   }
 
   private getSortField(): string {
@@ -109,6 +110,7 @@ export class JfrogArtifactoryApiClient implements JfrogArtifactoryApiV1 {
 
   async getTags(image: string, target?: string, repoFilter?: string) {
     const proxyUrl = await this.getBaseUrl(target);
+    const pageLimit = this.getPageLimit();
 
     const filter: any = {
       packageId: `docker://${image}`,
@@ -123,22 +125,35 @@ export class JfrogArtifactoryApiClient implements JfrogArtifactoryApiV1 {
       };
     }
 
-    const tagQuery = {
-      query:
-        'query ($filter: VersionFilter!, $first: Int, $orderBy: VersionOrder) { versions (filter: $filter, first: $first, orderBy: $orderBy) { edges { node { name, created, modified, package { id }, repos { name, type, leadFilePath }, licenses { name, source }, size, stats { downloadCount }, vulnerabilities { critical, high, medium, low, info, unknown, skipped }, files { name, lead, size, md5, sha1, sha256, mimeType } } } } }',
-      variables: {
-        filter,
-        first: this.getPageLimit(),
-        orderBy: {
-          field: this.getSortField(),
-          direction: 'DESC',
-        },
-      },
-    };
+    const edges: Edge[] = [];
+    let pageInfo: PageInfo = { hasNextPage: false, endCursor: null };
+    let after: string | undefined;
 
-    return (await this.fetcher(
-      `${proxyUrl}/metadata/api/v1/query`,
-      JSON.stringify(tagQuery),
-    )) as TagsResponse;
+    do {
+      const tagQuery = {
+        query:
+          'query ($filter: VersionFilter!, $first: Int, $after: ID, $orderBy: VersionOrder) { versions (filter: $filter, first: $first, after: $after, orderBy: $orderBy) { edges { node { name, created, modified, package { id }, repos { name, type, leadFilePath }, licenses { name, source }, size, stats { downloadCount }, vulnerabilities { critical, high, medium, low, info, unknown, skipped }, files { name, lead, size, md5, sha1, sha256, mimeType } } } pageInfo { hasNextPage, endCursor } } }',
+        variables: {
+          filter,
+          first: Math.min(MAX_PAGE_SIZE, pageLimit - edges.length),
+          after,
+          orderBy: {
+            field: this.getSortField(),
+            direction: 'DESC',
+          },
+        },
+      };
+
+      const response = await this.fetcher<TagsResponse>(
+        `${proxyUrl}/metadata/api/v1/query`,
+        JSON.stringify(tagQuery),
+      );
+      const remaining = pageLimit - edges.length;
+      edges.push(...response.data.versions.edges.slice(0, remaining));
+      pageInfo = response.data.versions.pageInfo;
+      after = pageInfo.endCursor ?? undefined;
+    } while (edges.length < pageLimit && pageInfo.hasNextPage && after);
+
+    return { data: { versions: { edges, pageInfo } } };
   }
 }

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/types.ts
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/src/types.ts
@@ -23,6 +23,12 @@ export interface Data {
 
 export interface Versions {
   edges: Edge[];
+  pageInfo: PageInfo;
+}
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  endCursor: string | null;
 }
 
 export interface Edge {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #9771

JFrog's metadata service caps a single GraphQL response at 200 versions, so sending a larger configured `pageLimit` still silently truncated repositories. This change treats `pageLimit` as the total requested result count and follows the service's Relay cursor in pages of at most 200 until that count is reached or no results remain.

The regression test exercises a 450-tag request across three responses and verifies both page sizes and cursors. This PR was created with AI assistance; I reviewed the implementation and ran the checks listed below.

Validation:

- `yarn test --runInBand` (2 suites, 2 tests)
- `yarn tsc:full`
- `yarn lint --fix` (31 files checked)
- `yarn prettier --write <changed files>`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not a UI change)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
