### PR TITLE
Version Packages (nexus-repository-manager)

### DIFF
--- a/workspaces/nexus-repository-manager/.changeset/quiet-foxes-swim.md
+++ b/workspaces/nexus-repository-manager/.changeset/quiet-foxes-swim.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Fixed nested interactive controls accessibility violation in artifact table by disabling column dragging

--- a/workspaces/nexus-repository-manager/.changeset/renovate-1dd5867.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-1dd5867.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@playwright/test` to `1.61.1`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-5467892.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-5467892.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@hey-api/openapi-ts` to `0.99.0`.

--- a/workspaces/nexus-repository-manager/.changeset/renovate-bf67c9b.md
+++ b/workspaces/nexus-repository-manager/.changeset/renovate-bf67c9b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-nexus-repository-manager': patch
----
-
-Updated dependency `@types/node` to `22.20.1`.

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @backstage-community/plugin-nexus-repository-manager
 
+## 1.25.1
+
+### Patch Changes
+
+- 60b0cea: Fixed nested interactive controls accessibility violation in artifact table by disabling column dragging
+- 6622075: Updated dependency `@playwright/test` to `1.61.1`.
+- 53f1fff: Updated dependency `@hey-api/openapi-ts` to `0.99.0`.
+- 72557ed: Updated dependency `@types/node` to `22.20.1`.
+
 ## 1.25.0
 
 ### Minor Changes

--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-nexus-repository-manager",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-nexus-repository-manager@1.25.1

### Patch Changes

-   60b0cea: Fixed nested interactive controls accessibility violation in artifact table by disabling column dragging
-   6622075: Updated dependency `@playwright/test` to `1.61.1`.
-   53f1fff: Updated dependency `@hey-api/openapi-ts` to `0.99.0`.
-   72557ed: Updated dependency `@types/node` to `22.20.1`.
