### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/rich-comics-complain.md
+++ b/workspaces/azure-devops/.changeset/rich-comics-complain.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-azure-devops-common': patch
-'@backstage-community/plugin-azure-devops': patch
----
-
-Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent

--- a/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-azure-devops-backend
 
+## 0.30.1
+
+### Patch Changes
+
+- Updated dependencies [c998902]
+  - @backstage-community/plugin-azure-devops-common@0.24.1
+
 ## 0.30.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-backend/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-backend",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-azure-devops-common
 
+## 0.24.1
+
+### Patch Changes
+
+- c998902: Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent
+
 ## 0.24.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops-common/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops-common",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "backstage": {
     "role": "common-library",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/azure-devops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-azure-devops
 
+## 0.32.1
+
+### Patch Changes
+
+- c998902: Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent
+- Updated dependencies [c998902]
+  - @backstage-community/plugin-azure-devops-common@0.24.1
+
 ## 0.32.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-azure-devops",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "azure-devops",

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor
 
+## 0.20.1
+
+### Patch Changes
+
+- Updated dependencies [c998902]
+  - @backstage-community/plugin-azure-devops-common@0.24.1
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
+++ b/workspaces/azure-devops/plugins/catalog-backend-module-azure-devops-annotator-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor",
   "description": "The azure-devops-annotator-processor backend module for the catalog plugin.",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-azure-devops@0.32.1

### Patch Changes

-   c998902: Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent
-   Updated dependencies [c998902]
    -   @backstage-community/plugin-azure-devops-common@0.24.1

## @backstage-community/plugin-azure-devops-backend@0.30.1

### Patch Changes

-   Updated dependencies [c998902]
    -   @backstage-community/plugin-azure-devops-common@0.24.1

## @backstage-community/plugin-azure-devops-common@0.24.1

### Patch Changes

-   c998902: Added auto-detection of `README.md` from `backstage.io/source-location` when `dev.azure.com/readme-path` annotation is absent

## @backstage-community/plugin-catalog-backend-module-azure-devops-annotator-processor@0.20.1

### Patch Changes

-   Updated dependencies [c998902]
    -   @backstage-community/plugin-azure-devops-common@0.24.1
