### PR TITLE
fix(quay): disable column dragging to fix nested-interactive a11y violation

### DIFF
--- a/workspaces/quay/.changeset/gentle-birds-march.md
+++ b/workspaces/quay/.changeset/gentle-birds-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-quay': patch
+---
+
+Fixed nested interactive controls accessibility violation in tag and security scan tables by disabling column dragging

--- a/workspaces/quay/package.json
+++ b/workspaces/quay/package.json
@@ -18,6 +18,7 @@
     "clean": "backstage-cli repo clean",
     "test": "backstage-cli repo test",
     "test:all": "backstage-cli repo test --coverage",
+    "test:e2e": "playwright test",
     "fix": "backstage-cli repo fix",
     "lint": "backstage-cli repo lint --since origin/main",
     "lint:all": "backstage-cli repo lint",

--- a/workspaces/quay/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
+++ b/workspaces/quay/plugins/quay/src/components/QuayRepository/QuayRepository.tsx
@@ -64,7 +64,12 @@ export function QuayRepository(_props: QuayRepositoryProps) {
     <div data-testid="quay-repo-table">
       <Table
         title={title}
-        options={{ sorting: true, paging: true, padding: 'dense' }}
+        options={{
+          sorting: true,
+          paging: true,
+          padding: 'dense',
+          draggable: false,
+        }}
         data={data}
         columns={columns}
         emptyContent={

--- a/workspaces/quay/plugins/quay/src/components/QuayTagDetails/component.tsx
+++ b/workspaces/quay/plugins/quay/src/components/QuayTagDetails/component.tsx
@@ -150,6 +150,7 @@ export const QuayTagDetails = ({
       </Flex>
       <Table
         title={`Vulnerabilities for ${digest.substring(0, 17)}`}
+        options={{ draggable: false }}
         data={vulnerabilities}
         columns={columns}
       />

--- a/workspaces/quay/plugins/quay/tests/quayHelper.ts
+++ b/workspaces/quay/plugins/quay/tests/quayHelper.ts
@@ -103,5 +103,10 @@ export class Common {
       body: JSON.stringify(accessibilityScanResults.violations, null, 2),
       contentType: 'application/json',
     });
+
+    expect(
+      accessibilityScanResults.violations,
+      `Accessibility check (${accessibilityScanResults.violations.length} violations)`,
+    ).toEqual([]);
   }
 }


### PR DESCRIPTION
## Description

Fixes accessibility violations (`nested-interactive`, serious impact, WCAG 2.0 Level A) in both the tag table and security scan details table of the quay plugin. The Backstage `Table` component (which wraps `material-table`) enables column reordering via `react-beautiful-dnd` by default. This creates nested interactive controls: a MUI `TableSortLabel` (`role="button"`, `tabindex="0"`) wrapping a `react-beautiful-dnd` draggable div (also `role="button"`, `tabindex="0"`). Setting `draggable: false` in the table options disables column reordering, removing the nested interactive elements.

### Root cause
The `material-table` library used by `@backstage/core-components` `Table` enables column drag-and-drop reordering by default. Each column header's sort label (`<span role="button" tabindex="0">`) wraps a `react-beautiful-dnd` drag handle (`<div role="button" tabindex="0">`), creating nested interactive controls that violate WCAG 4.1.2 (Name, Role, Value). This causes focus and announcement issues for screen readers and other assistive technologies.

## Fixed
- Fixes https://github.com/backstage/community-plugins/issues/9826

## Test Plan
- [ ] Run axe accessibility scan on the tag table — verify no `nested-interactive` violations
- [ ] Run axe accessibility scan on the security scan details table — verify no `nested-interactive` violations
- [ ] Verify column sorting still works on both tables
- [ ] Verify no visual regression in table headers

#### Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Note
> This bug fix was identified and implemented using the agent skills. Please verify the fix thoroughly before merging.