### PR TITLE
fix(rbac): resolve nested interactive controls accessibility violations

### DIFF
--- a/workspaces/rbac/.changeset/tidy-wolves-march.md
+++ b/workspaces/rbac/.changeset/tidy-wolves-march.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Fixed nested interactive controls accessibility violations (WCAG 4.1.2) in RBAC tables

--- a/workspaces/rbac/plugins/rbac/report-alpha.api.md
+++ b/workspaces/rbac/plugins/rbac/report-alpha.api.md
@@ -311,6 +311,7 @@ export const rbacTranslationRef: TranslationRef<
     readonly 'common.expandRow': string;
     readonly 'common.configureAccessFor': string;
     readonly 'common.defaultResourceTypeVisible': string;
+    readonly 'common.tableAction': string;
   }
 >;
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/de.ts
@@ -236,6 +236,7 @@ const rbacTranslationDe = createTranslationMessages({
     'common.configureAccessFor': 'Zugriff konfigurieren für',
     'common.defaultResourceTypeVisible':
       'Standardmäßig ist der ausgewählte Ressourcentyp für alle hinzugefügten Benutzer sichtbar. Wenn Sie bestimmte Plugin-Regeln einschränken oder Berechtigungen dafür erteilen möchten, wählen Sie diese aus, und fügen Sie die Parameter hinzu.',
+    'common.tableAction': 'Tabellenaktion',
   },
 });
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/es.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/es.ts
@@ -231,6 +231,7 @@ const rbacTranslationEs = createTranslationMessages({
     'common.configureAccessFor': 'Configurar acceso para',
     'common.defaultResourceTypeVisible':
       'De forma predeterminada, todos los usuarios agregados pueden visualizar el tipo de recurso seleccionado. Si desea restringir u otorgar permiso a reglas de complementos específicas, selecciónelas y agregue los parámetros.',
+    'common.tableAction': 'Acción de tabla',
   },
 });
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/fr.ts
@@ -237,6 +237,7 @@ const rbacTranslationFr = createTranslationMessages({
     'common.configureAccessFor': "Configurer l'accès pour le",
     'common.defaultResourceTypeVisible':
       'Par défaut, le type de ressource sélectionné est visible par tous les utilisateurs ajoutés. Si vous souhaitez restreindre ou accorder une autorisation à des règles de plugin spécifiques, sélectionnez-les et ajoutez les paramètres.',
+    'common.tableAction': 'Action de tableau',
   },
 });
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/it.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/it.ts
@@ -230,6 +230,7 @@ const rbacTranslationIt = createTranslationMessages({
     'common.configureAccessFor': "Configurare l'accesso per il",
     'common.defaultResourceTypeVisible':
       'Per impostazione predefinita, il tipo di risorsa selezionato è visibile a tutti gli utenti aggiunti. Per limitare o concedere autorizzazioni a regole specifiche del plugin, selezionarle e aggiungere i parametri.',
+    'common.tableAction': 'Azione tabella',
   },
 });
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/ja.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/ja.ts
@@ -219,6 +219,7 @@ const rbacTranslationJa = createTranslationMessages({
     'common.configureAccessFor': '以下に対するアクセス権を設定',
     'common.defaultResourceTypeVisible':
       'デフォルトでは、選択したリソースタイプが、追加されたすべてのユーザーに表示されます。特定のプラグインルールに対する権限を制限または付与する場合は、そのルールを選択してパラメーターを追加してください。',
+    'common.tableAction': 'テーブルアクション',
   },
 });
 

--- a/workspaces/rbac/plugins/rbac/src/alpha/translations/ref.ts
+++ b/workspaces/rbac/plugins/rbac/src/alpha/translations/ref.ts
@@ -247,6 +247,7 @@ export const rbacMessages = {
     configureAccessFor: 'Configure access for the',
     defaultResourceTypeVisible:
       'By default, the selected resource type is visible to all added users. If you want to restrict or grant permission to specific plugin rules, select them and add the parameters.',
+    tableAction: 'Table action',
   },
 };
 

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddedMembersTable.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddedMembersTable.tsx
@@ -52,7 +52,7 @@ export const AddedMembersTable = ({
           {t('common.selectedUsersAndGroupsAppearHere')}
         </Box>
       }
-      options={{ emptyRowsWhenPaging: false }}
+      options={{ emptyRowsWhenPaging: false, draggable: false }}
       localization={{
         toolbar: { searchPlaceholder: t('table.searchPlaceholder') },
         pagination: {

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/MembersCard.tsx
@@ -29,6 +29,7 @@ import { useLanguage } from '../../hooks/useLanguage';
 import EditRole from '../EditRole';
 import { getColumns } from './MembersListColumns';
 import { StyledTableWrapper } from './StyledTableWrapper';
+import { TableAction } from './TableAction';
 
 type MembersCardProps = {
   roleName: string;
@@ -78,6 +79,7 @@ export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
       icon: () => getEditIcon(canReadUsersAndGroups, roleName, editTooltip),
       isFreeAction: true,
       onClick: () => {},
+      customComponent: true,
     },
   ];
   const columns = useMemo(() => getColumns(t), [t]);
@@ -109,7 +111,13 @@ export const MembersCard = ({ roleName, membersInfo }: MembersCardProps) => {
               : t('table.headers.usersAndGroups')
           }
           actions={actions}
-          options={{ padding: 'default', search: true, paging: true }}
+          components={{ Action: TableAction }}
+          options={{
+            padding: 'default',
+            search: true,
+            paging: true,
+            draggable: false,
+          }}
           data={data ?? []}
           isLoading={loading}
           columns={getColumns(t)}

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -26,6 +26,7 @@ import { filterTableData } from '../../utils/filter-table-data';
 import EditRole from '../EditRole';
 import { getColumns } from './PermissionsListColumns';
 import { StyledTableWrapper } from './StyledTableWrapper';
+import { TableAction } from './TableAction';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useTranslation } from '../../hooks/useTranslation';
 import { capitalizeFirstLetter } from '../../utils/string-utils';
@@ -117,6 +118,7 @@ export const PermissionsCard = ({
         ),
       isFreeAction: true,
       onClick: () => {},
+      customComponent: true,
     },
   ];
 
@@ -142,7 +144,13 @@ export const PermissionsCard = ({
         <Table
           title={title}
           actions={actions}
-          options={{ padding: 'default', search: true, paging: true }}
+          components={{ Action: TableAction }}
+          options={{
+            padding: 'default',
+            search: true,
+            paging: true,
+            draggable: false,
+          }}
           data={data}
           columns={columns}
           isLoading={loading}

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderInTestApp } from '@backstage/test-utils';
+
+import { TableAction } from './TableAction';
+
+describe('TableAction', () => {
+  it('renders nothing when action is hidden', async () => {
+    const { container } = await renderInTestApp(
+      <TableAction action={{ hidden: true, icon: () => <span>icon</span> }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when action is undefined', async () => {
+    const { container } = await renderInTestApp(
+      <TableAction action={undefined as any} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders an IconButton with tooltip and correct aria-label', async () => {
+    await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => <span data-testid="test-icon">icon</span>,
+          tooltip: 'Refresh',
+          onClick: jest.fn(),
+        }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Refresh' });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+  });
+
+  it('uses translated fallback aria-label when tooltip is missing', async () => {
+    await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => <span>icon</span>,
+          onClick: jest.fn(),
+        }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Table action' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders customComponent directly without wrapping IconButton', async () => {
+    await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => (
+            <button type="button" data-testid="custom-btn">
+              Custom
+            </button>
+          ),
+          customComponent: true,
+          onClick: jest.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('custom-btn')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Table action' })).toBeNull();
+  });
+
+  it('calls onClick when button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = jest.fn();
+
+    await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => <span>icon</span>,
+          tooltip: 'Click me',
+          onClick: handleClick,
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Click me' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a disabled button when action.disabled is true', async () => {
+    await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => <span>icon</span>,
+          tooltip: 'Disabled action',
+          disabled: true,
+          onClick: jest.fn(),
+        }}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Disabled action' });
+    expect(button).toBeDisabled();
+  });
+
+  it('resolves function-style actions', async () => {
+    const actionFn = () => ({
+      icon: () => <span data-testid="fn-icon">icon</span>,
+      tooltip: 'From function',
+      onClick: jest.fn(),
+    });
+
+    await renderInTestApp(<TableAction action={actionFn} />);
+
+    expect(
+      screen.getByRole('button', { name: 'From function' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('fn-icon')).toBeInTheDocument();
+  });
+
+  it('resolves nested action.action functions', async () => {
+    const action = {
+      action: () => ({
+        icon: () => <span data-testid="nested-icon">icon</span>,
+        tooltip: 'Nested action',
+        onClick: jest.fn(),
+      }),
+    };
+
+    await renderInTestApp(<TableAction action={action as any} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Nested action' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('nested-icon')).toBeInTheDocument();
+  });
+
+  it('renders button without tooltip wrapper when no tooltip is provided', async () => {
+    const { container } = await renderInTestApp(
+      <TableAction
+        action={{
+          icon: () => <span>icon</span>,
+          onClick: jest.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+  });
+});

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
@@ -58,6 +58,9 @@ export const TableAction = (props: {
     <IconButton
       size={props.size}
       color="inherit"
+      aria-label={
+        typeof action.tooltip === 'string' ? action.tooltip : 'Table action'
+      }
       disabled={disabled}
       onClick={handleClick}
     >

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
@@ -13,20 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
-export const TableAction = (props: {
-  action: any;
-  data?: any;
+import { useTranslation } from '../../hooks/useTranslation';
+
+interface TableActionDef {
+  tooltip?: string;
+  disabled?: boolean;
+  hidden?: boolean;
+  icon?: (props: Record<string, unknown>) => ReactNode;
+  iconProps?: Record<string, unknown>;
+  onClick?: (event: MouseEvent, data?: unknown) => void;
+  customComponent?: boolean;
+  action?: (data: unknown) => TableActionDef;
+}
+
+interface TableActionProps {
+  action: TableActionDef | ((data?: unknown) => TableActionDef);
+  data?: unknown;
   size?: 'small' | 'medium' | 'large';
   disabled?: boolean;
-}) => {
-  let { action } = props;
-  if (typeof action === 'function') {
-    action = action(props.data);
+}
+
+export const TableAction = (props: TableActionProps) => {
+  const { t } = useTranslation();
+
+  let action: TableActionDef | undefined = undefined;
+  if (typeof props.action === 'function') {
+    action = props.action(props.data);
+  } else {
+    action = props.action;
   }
   if (action?.action) {
     action = action.action(props.data);
@@ -47,7 +66,7 @@ export const TableAction = (props: {
     return <>{icon}</>;
   }
 
-  const handleClick = (event: React.MouseEvent) => {
+  const handleClick = (event: MouseEvent) => {
     if (action.onClick) {
       action.onClick(event, props.data);
       event.stopPropagation();
@@ -59,7 +78,9 @@ export const TableAction = (props: {
       size={props.size}
       color="inherit"
       aria-label={
-        typeof action.tooltip === 'string' ? action.tooltip : 'Table action'
+        typeof action.tooltip === 'string'
+          ? action.tooltip
+          : t('common.tableAction')
       }
       disabled={disabled}
       onClick={handleClick}

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/TableAction.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+
+export const TableAction = (props: {
+  action: any;
+  data?: any;
+  size?: 'small' | 'medium' | 'large';
+  disabled?: boolean;
+}) => {
+  let { action } = props;
+  if (typeof action === 'function') {
+    action = action(props.data);
+  }
+  if (action?.action) {
+    action = action.action(props.data);
+  }
+  if (!action || action.hidden) {
+    return null;
+  }
+
+  const disabled = action.disabled || props.disabled;
+  const icon =
+    typeof action.icon === 'function'
+      ? action.icon({ ...action.iconProps, disabled })
+      : null;
+
+  // Render directly when the icon is already a complete interactive element
+  // to avoid nested interactive controls (WCAG 4.1.2)
+  if (action.customComponent) {
+    return <>{icon}</>;
+  }
+
+  const handleClick = (event: React.MouseEvent) => {
+    if (action.onClick) {
+      action.onClick(event, props.data);
+      event.stopPropagation();
+    }
+  };
+
+  const button = (
+    <IconButton
+      size={props.size}
+      color="inherit"
+      disabled={disabled}
+      onClick={handleClick}
+    >
+      {icon}
+    </IconButton>
+  );
+
+  if (action.tooltip) {
+    return disabled ? (
+      <Tooltip title={action.tooltip}>
+        <span>{button}</span>
+      </Tooltip>
+    ) : (
+      <Tooltip title={action.tooltip}>{button}</Tooltip>
+    );
+  }
+
+  return button;
+};

--- a/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RolesList/RolesList.tsx
@@ -118,6 +118,7 @@ export const RolesList = () => {
           search: true,
           paging: true,
           emptyRowsWhenPaging: false,
+          draggable: false,
         }}
         data={data}
         isLoading={loading}

--- a/workspaces/rbac/plugins/rbac/tests/utils/accessibility.ts
+++ b/workspaces/rbac/plugins/rbac/tests/utils/accessibility.ts
@@ -37,7 +37,7 @@ export async function runAccessibilityTests(
     });
   }
 
-  if (options?.skipViolationsAssert) {
+  if (!options?.skipViolationsAssert) {
     expect(
       accessibilityScanResults.violations,
       'Accessibility violations found',


### PR DESCRIPTION
## Description

Fixed `nested-interactive` accessibility violations (WCAG 4.1.2) in the RBAC plugin tables. material-table's column drag-and-drop creates nested focusable elements (`TableSortLabel` wrapping draggable `div`), and custom action buttons rendered through material-table's action system create nested `IconButton` elements. These violations cause screen reader confusion and focus management issues.

### Root cause

Three sources of nested interactive controls:
1. **Column drag-and-drop** — material-table's `react-beautiful-dnd` creates draggable `div` elements (`role="button"`, `tabindex="0"`) inside `TableSortLabel` (`role="button"`, `tabindex="0"`). Fixed by setting `draggable: false` in table options.
2. **Toolbar action buttons** — The `EditRole` component renders its own `IconButton`, but material-table's `MTableAction` wraps it in another `IconButton`, creating a button-inside-button nesting. Fixed by introducing a custom `TableAction` component that renders pre-built interactive components directly, bypassing the outer `IconButton` wrapper.
3. **Accessibility test assertion** — The `runAccessibilityTests` utility had inverted assertion logic (`if (options?.skipViolationsAssert)` asserted instead of skipping). Fixed by negating the condition.

## Fixed

- Fixes https://github.com/backstage/community-plugins/issues/9831

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Note

> This bug fix was identified and implemented using the agent skills. Please verify the fix thoroughly before merging.