### PR TITLE
fix(servicenow): resolve WCAG accessibility violations

### DIFF
--- a/workspaces/servicenow/.changeset/gentle-waves-fix.md
+++ b/workspaces/servicenow/.changeset/gentle-waves-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-servicenow': patch
+---
+
+Fixed WCAG accessibility violations: added accessible name to pagination select and filter inputs, and enabled assertion of zero violations in e2e accessibility scan.

--- a/workspaces/servicenow/plugins/servicenow/report-alpha.api.md
+++ b/workspaces/servicenow/plugins/servicenow/report-alpha.api.md
@@ -233,6 +233,7 @@ export const servicenowTranslationRef: TranslationRef<
     readonly 'table.columns.state': string;
     readonly 'table.columns.actions': string;
     readonly 'table.emptyContent': string;
+    readonly 'table.rowsPerPage': string;
     readonly 'filter.priority': string;
     readonly 'filter.state': string;
     readonly 'priority.critical': string;

--- a/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/EntityServicenowContent.tsx
+++ b/workspaces/servicenow/plugins/servicenow/src/components/Servicenow/EntityServicenowContent.tsx
@@ -234,7 +234,23 @@ export const EntityServicenowContent = () => {
         page={pageNumber}
         onPageChange={handlePageChange}
         onRowsPerPageChange={handleRowsPerPageChange}
-        labelRowsPerPage={null}
+        labelRowsPerPage={
+          <span
+            style={{
+              position: 'absolute',
+              width: '1px',
+              height: '1px',
+              padding: 0,
+              margin: '-1px',
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+            }}
+          >
+            {t('table.rowsPerPage')}
+          </span>
+        }
         showFirstButton
         showLastButton
       />

--- a/workspaces/servicenow/plugins/servicenow/src/components/shared-components/IncidentEnumFilter.tsx
+++ b/workspaces/servicenow/plugins/servicenow/src/components/shared-components/IncidentEnumFilter.tsx
@@ -63,7 +63,6 @@ export const IncidentEnumFilter = ({
       <Autocomplete
         multiple
         disableCloseOnSelect
-        aria-label={label}
         options={items}
         isOptionEqualToValue={(option, val) => option.value === val.value}
         getOptionLabel={option => option.label}
@@ -90,7 +89,16 @@ export const IncidentEnumFilter = ({
             data-testid={`select-${label.toLowerCase().replace(/\s/g, '-')}`}
           />
         }
-        renderInput={params => <TextField {...params} variant="outlined" />}
+        renderInput={params => (
+          <TextField
+            {...params}
+            variant="outlined"
+            inputProps={{
+              ...params.inputProps,
+              'aria-label': label,
+            }}
+          />
+        )}
       />
     </Box>
   );

--- a/workspaces/servicenow/plugins/servicenow/src/translations/de.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/de.ts
@@ -49,6 +49,7 @@ const servicenowTranslationDe = createTranslationMessages({
     'table.columns.state': 'Status',
     'table.columns.actions': 'Aktionen',
     'table.emptyContent': 'Keine Datensätze gefunden',
+    'table.rowsPerPage': 'Zeilen pro Seite',
     'actions.openInServicenow': 'In ServiceNow öffnen',
   },
 });

--- a/workspaces/servicenow/plugins/servicenow/src/translations/es.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/es.ts
@@ -49,6 +49,7 @@ const servicenowTranslationEs = createTranslationMessages({
     'table.columns.state': 'Estado',
     'table.columns.actions': 'Acciones',
     'table.emptyContent': 'No se encontraron registros',
+    'table.rowsPerPage': 'Filas por página',
     'actions.openInServicenow': 'Abrir en ServiceNow',
   },
 });

--- a/workspaces/servicenow/plugins/servicenow/src/translations/fr.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/fr.ts
@@ -50,6 +50,7 @@ const servicenowTranslationFr = createTranslationMessages({
     'table.columns.state': 'État',
     'table.columns.actions': 'Actions',
     'table.emptyContent': 'Aucun enregistrement trouvé',
+    'table.rowsPerPage': 'Lignes par page',
     'actions.openInServicenow': 'Ouvrir dans ServiceNow',
   },
 });

--- a/workspaces/servicenow/plugins/servicenow/src/translations/it.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/it.ts
@@ -50,6 +50,7 @@ const servicenowTranslationIt = createTranslationMessages({
     'table.columns.state': 'Stato',
     'table.columns.actions': 'Azioni',
     'table.emptyContent': 'Nessun risultato trovato',
+    'table.rowsPerPage': 'Righe per pagina',
     'actions.openInServicenow': 'Apri in ServiceNow',
   },
 });

--- a/workspaces/servicenow/plugins/servicenow/src/translations/ja.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/ja.ts
@@ -50,6 +50,7 @@ const servicenowTranslationJa = createTranslationMessages({
     'table.columns.state': '状態',
     'table.columns.actions': 'アクション',
     'table.emptyContent': 'レコードが見つかりません',
+    'table.rowsPerPage': 'ページあたりの行数',
     'actions.openInServicenow': 'ServiceNow で開く',
   },
 });

--- a/workspaces/servicenow/plugins/servicenow/src/translations/ref.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/translations/ref.ts
@@ -32,6 +32,7 @@ export const servicenowMessages = {
       actions: 'Actions',
     },
     emptyContent: 'No records found',
+    rowsPerPage: 'Rows per page',
   },
   filter: {
     state: 'State',

--- a/workspaces/servicenow/plugins/servicenow/tests/servicenow.test.ts
+++ b/workspaces/servicenow/plugins/servicenow/tests/servicenow.test.ts
@@ -115,11 +115,11 @@ test.describe('ServiceNow plugin', () => {
     await expect(rows).toHaveCount(1);
 
     await state.hover();
-    await state.getByRole('button', { name: 'Clear' }).click();
+    await state.locator('..').getByRole('button', { name: 'Clear' }).click();
     await expect(rows).toHaveCount(2);
 
     await priority.hover();
-    await priority.getByRole('button', { name: 'Clear' }).click();
+    await priority.locator('..').getByRole('button', { name: 'Clear' }).click();
     await expect(rows).toHaveCount(5);
   });
 });

--- a/workspaces/servicenow/plugins/servicenow/tests/util/helpers.ts
+++ b/workspaces/servicenow/plugins/servicenow/tests/util/helpers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { AxeBuilder } from '@axe-core/playwright';
-import { type TestInfo, type Page } from '@playwright/test';
+import { expect, type TestInfo, type Page } from '@playwright/test';
 
 export class Common {
   page: Page;
@@ -57,5 +57,7 @@ export class Common {
       body: JSON.stringify(accessibilityScanResults.violations, null, 2),
       contentType: 'application/json',
     });
+
+    expect(accessibilityScanResults.violations).toEqual([]);
   }
 }


### PR DESCRIPTION
## Description

Fix WCAG 2.0/2.1 Level A and AA accessibility violations in the ServiceNow plugin identified by axe-core. The plugin's e2e accessibility scan was only attaching results as artifacts without asserting zero violations — this PR fixes the underlying violations and enables the assertion.

### Root cause
Two WCAG accessibility violations identified by axe-core:

1. **`aria-input-field-name` (serious)** — The `TablePagination` component's rows-per-page select had `labelRowsPerPage={null}`, which removed the label `<p>` element but left a dangling `aria-labelledby` reference on the select. Fixed by providing a visually hidden label using a new `table.rowsPerPage` translation key.

2. **`label` (critical)** — The `IncidentEnumFilter` Autocomplete's `aria-label` was applied to the wrapper `<div>`, not the actual `<input>` element. The `InputLabel` above the Autocomplete was not programmatically connected to the input. Fixed by moving `aria-label` from the wrapper to the input via `renderInput` `inputProps`.

Additionally, the `a11yCheck` helper in the e2e test utilities only attached scan results as a JSON artifact without asserting zero violations. Updated to assert `violations.length === 0`.

## Fixed
- Fixes https://github.com/backstage/community-plugins/issues/9832

## UI before changes
![Before fix](https://raw.githubusercontent.com/its-mitesh-kumar/community-plugins/fix/servicenow-9832-a11y-violations/workspaces/servicenow/.github/screenshots/before-fix.gif)

## UI after changes
![After fix](https://raw.githubusercontent.com/its-mitesh-kumar/community-plugins/fix/servicenow-9832-a11y-violations/workspaces/servicenow/.github/screenshots/after-fix.gif)

## Test Plan
- [ ] Run the e2e tests with axe-core scan (`yarn playwright test --project=en`)
- [ ] Verify the "All columns are shown" test passes with zero accessibility violations
- [ ] Verify filter dropdowns (State, Priority) still work correctly
- [ ] Verify table pagination still works (rows per page selector)
- [ ] Verify the rows-per-page select has no visible label change (visually hidden)
- [ ] Verify search and sorting functionality is unaffected

#### Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Note
> This bug fix was identified and implemented using the agent skills. Please verify the fix thoroughly before merging.