### PR TITLE
fix(argocd): resolve link-name accessibility violations on icon-only links

### DIFF
--- a/workspaces/argocd/.changeset/gentle-links-speak.md
+++ b/workspaces/argocd/.changeset/gentle-links-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-argocd': patch
+---
+
+Added aria-label to icon-only external link buttons to resolve link-name accessibility violations

--- a/workspaces/argocd/plugins/argocd/report-alpha.api.md
+++ b/workspaces/argocd/plugins/argocd/report-alpha.api.md
@@ -82,6 +82,7 @@ export const argocdTranslationRef: TranslationRef<
     readonly 'deploymentLifecycle.sidebar.rollouts.revisions.canaryRevision.revisionType.canary': string;
     readonly 'deploymentLifecycle.sidebar.rollouts.revisions.revisionImage.textPrimary': string;
     readonly 'deploymentLifecycle.sidebar.rollouts.rollOut.title': string;
+    readonly 'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD': string;
     readonly 'deploymentLifecycle.deploymentLifecycleCard.instance': string;
     readonly 'deploymentLifecycle.deploymentLifecycleCard.namespace': string;
     readonly 'deploymentLifecycle.deploymentLifecycleCard.resources': string;

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleHeader.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/DeploymentLifecycleHeader.tsx
@@ -19,10 +19,12 @@ import IconButton from '@mui/material/IconButton';
 import ExternalLinkIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
 import { useArgocdConfig } from '../../hooks/useArgocdConfig';
+import { useTranslation } from '../../hooks/useTranslation';
 import { Application } from '@backstage-community/plugin-argocd-common';
 
 const DeploymentLifecycleHeader: FC<{ app: Application }> = ({ app }) => {
   const { instances, baseUrl } = useArgocdConfig();
+  const { t } = useTranslation();
 
   const supportsMultipleArgoInstances = !!instances.length;
   const getBaseUrl = (row: Application): string | undefined => {
@@ -50,6 +52,10 @@ const DeploymentLifecycleHeader: FC<{ app: Application }> = ({ app }) => {
         target="_blank"
         href={appUrl}
         onClick={e => e.stopPropagation()}
+        aria-label={t(
+          'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD',
+          { appName: app.metadata.name },
+        )}
       >
         <ExternalLinkIcon />
       </IconButton>

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleHeader.test.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentLifeCycle/__tests__/DeploymentLifecycleHeader.test.tsx
@@ -22,6 +22,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { mockApplication } from '../../../../dev/__data__';
 import DeploymentLifecycleHeader from '../DeploymentLifecycleHeader';
+import { mockUseTranslation } from '../../../test-utils/mockTranslations';
+
+jest.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => mockUseTranslation(),
+}));
 
 describe('DeploymentLifecycleCardHeader', () => {
   const wrapper = ({ children }: { children: ReactNode }) => {

--- a/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
+++ b/workspaces/argocd/plugins/argocd/src/components/DeploymentSummary/DeploymentSummary.tsx
@@ -110,7 +110,14 @@ const DeploymentSummary = ({
           getBaseUrl(row) ? (
             <Link href={`${buildAppUrl(row)}`} target="_blank" rel="noopener">
               {row.metadata.name}{' '}
-              <IconButton color="primary" size="small">
+              <IconButton
+                color="primary"
+                size="small"
+                aria-label={t(
+                  'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD',
+                  { appName: row.metadata.name },
+                )}
+              >
                 <ExternalLinkIcon />
               </IconButton>
             </Link>
@@ -256,7 +263,7 @@ const DeploymentSummary = ({
         render: (row: Application): ReactNode => <AppHealthStatus app={row} />,
       },
     ];
-  }, [baseUrl, columnTitles, entity]);
+  }, [baseUrl, columnTitles, entity, t]);
 
   const visibleColumns = useMemo(
     () =>

--- a/workspaces/argocd/plugins/argocd/src/translations/de.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/de.ts
@@ -154,6 +154,8 @@ const argocdTranslationDe = createTranslationMessages({
     'deploymentLifecycle.deploymentLifecycle.title': 'Deployment-Lifecycle',
     'deploymentLifecycle.deploymentLifecycle.subtitle':
       'Überprüfen Sie die bereitgestellten Komponenten/Systeme im Namespace mithilfe des Argo CD-Plugins.',
+    'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD':
+      '{{appName}} in ArgoCD öffnen',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'Instanz',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'Server',
     'deploymentLifecycle.deploymentLifecycleCard.namespace': 'Namespace',

--- a/workspaces/argocd/plugins/argocd/src/translations/es.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/es.ts
@@ -156,6 +156,8 @@ const argocdTranslationEs = createTranslationMessages({
       'Ciclo de vida de la implementación',
     'deploymentLifecycle.deploymentLifecycle.subtitle':
       'Revisar los componentes/sistemas implementados en el espacio de nombres mediante el complemento Argo CD',
+    'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD':
+      'Abrir {{appName}} en ArgoCD',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'Instancia',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'Servidor',
     'deploymentLifecycle.deploymentLifecycleCard.namespace':

--- a/workspaces/argocd/plugins/argocd/src/translations/fr.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/fr.ts
@@ -155,6 +155,8 @@ const argocdTranslationFr = createTranslationMessages({
       'Cycle de vie du déploiement',
     'deploymentLifecycle.deploymentLifecycle.subtitle':
       "Examiner les composants/systèmes déployés dans l'espace de noms à l'aide du plugin ArgoCD",
+    'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD':
+      'Ouvrir {{appName}} dans ArgoCD',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'Exemple',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'Serveur',
     'deploymentLifecycle.deploymentLifecycleCard.namespace': 'Espace de noms',

--- a/workspaces/argocd/plugins/argocd/src/translations/it.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/it.ts
@@ -155,6 +155,8 @@ const argocdTranslationIt = createTranslationMessages({
       'Ciclo di vita della distribuzione',
     'deploymentLifecycle.deploymentLifecycle.subtitle':
       'Esaminare i componenti/sistemi distribuiti nello spazio dei nomi utilizzando il plug-in ArgoCD',
+    'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD':
+      'Apri {{appName}} in ArgoCD',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'Istanza',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'Server',
     'deploymentLifecycle.deploymentLifecycleCard.namespace': 'Spazio dei nomi',

--- a/workspaces/argocd/plugins/argocd/src/translations/ja.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/ja.ts
@@ -155,6 +155,8 @@ const argocdTranslationJa = createTranslationMessages({
       'デプロイメントライフサイクル',
     'deploymentLifecycle.deploymentLifecycle.subtitle':
       'ArgoCD プラグインを使用して、namespace にデプロイされたコンポーネント/システムをレビューします',
+    'deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD':
+      'ArgoCD で {{appName}} を開く',
     'deploymentLifecycle.deploymentLifecycleCard.instance': 'インスタンス',
     'deploymentLifecycle.deploymentLifecycleCard.server': 'サーバー',
     'deploymentLifecycle.deploymentLifecycleCard.namespace': '名前空間',

--- a/workspaces/argocd/plugins/argocd/src/translations/ref.ts
+++ b/workspaces/argocd/plugins/argocd/src/translations/ref.ts
@@ -168,6 +168,9 @@ export const argocdMessages = {
       subtitle:
         'Review deployed components/systems in the namespace using ArgoCD plugin',
     },
+    deploymentLifecycleHeader: {
+      openInArgoCD: 'Open {{appName}} in ArgoCD',
+    },
     deploymentLifecycleCard: {
       instance: 'Instance',
       server: 'Server',

--- a/workspaces/argocd/plugins/argocd/tests/utils/accessibility.ts
+++ b/workspaces/argocd/plugins/argocd/tests/utils/accessibility.ts
@@ -37,7 +37,7 @@ export async function runAccessibilityTests(
     });
   }
 
-  if (options?.skipViolationsAssert) {
+  if (!options?.skipViolationsAssert) {
     expect(
       accessibilityScanResults.violations,
       'Accessibility violations found',


### PR DESCRIPTION
## Description

Resolve WCAG `link-name` accessibility violations on icon-only external link buttons in the ArgoCD plugin. The `DeploymentLifecycleHeader` component renders MUI `IconButton` elements with `href` (making them `<a>` elements) containing only an icon and no accessible name. The same pattern exists in `DeploymentSummary`.

### Root cause
The `DeploymentLifecycleHeader` component renders an MUI `IconButton` with `href` (which makes it an `<a>` element) containing only an `<ExternalLinkIcon />` icon — no `aria-label`, no visible text. This violates WCAG 2.0 Success Criterion 2.4.4 (Link Purpose) and 4.1.2 (Name, Role, Value), resulting in `link-name` violations detected by axe-core.

The same pattern exists in `DeploymentSummary` where an `IconButton` inside a `Link` wrapper also lacked an `aria-label`.

### Fix
- Added `aria-label` with translated text `"Open {{appName}} in ArgoCD"` to both `DeploymentLifecycleHeader` and `DeploymentSummary` icon buttons
- Added corresponding translation key (`deploymentLifecycle.deploymentLifecycleHeader.openInArgoCD`) across all 6 locales (en, de, es, fr, it, ja)
- Fixed the `runAccessibilityTests` helper to assert violations by default (the `skipViolationsAssert` option had inverted logic — it asserted when `true` instead of skipping)
- Updated `DeploymentLifecycleHeader` unit test to mock the newly-added `useTranslation` hook

## Fixed
- Fixes https://github.com/backstage/community-plugins/issues/9834

## UI before changes
![Before fix](https://raw.githubusercontent.com/its-mitesh-kumar/community-plugins/fix/argocd-9834-a11y-violations/workspaces/argocd/.github/screenshots/before-fix.gif)

## UI after changes
![After fix](https://raw.githubusercontent.com/its-mitesh-kumar/community-plugins/fix/argocd-9834-a11y-violations/workspaces/argocd/.github/screenshots/after-fix.gif)

## Test Plan
- [x] Repro test confirms `link-name` violation on deployment lifecycle page before fix
- [x] Repro test passes (no `link-name` violations) after fix
- [x] Full e2e test suite passes (13/13 tests including accessibility assertions)
- [x] Full unit test suite passes (371/371 tests across 60 suites)
- [x] TypeScript type checking passes (`yarn tsc:full`)
- [ ] CI pipeline passes

#### Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Note
> This bug fix was identified and implemented using the agent skills. Please verify the fix thoroughly before merging.