### PR TITLE
fix(topology): expand pod tooltip hover area to cover entire pod

### DIFF
--- a/workspaces/topology/.changeset/brave-foxes-glow.md
+++ b/workspaces/topology/.changeset/brave-foxes-glow.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-topology': patch
 ---
 
-Fixed pod tooltip to appear when hovering anywhere on the pod, not just on the text label.
+Fixed pod tooltip so it appears when hovering anywhere on the pod and stays visible together with the node hover shadow.

--- a/workspaces/topology/.changeset/brave-foxes-glow.md
+++ b/workspaces/topology/.changeset/brave-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Fixed pod tooltip to appear when hovering anywhere on the pod, not just on the text label.

--- a/workspaces/topology/plugins/topology/src/components/Graph/BaseNode.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Graph/BaseNode.tsx
@@ -24,7 +24,6 @@ import {
   NodeStatus,
   observer,
   ScaleDetailsLevel,
-  TOP_LAYER,
   useCombineRefs,
   useHover,
   WithDragNodeProps,
@@ -93,8 +92,11 @@ const BaseNode = ({
       )
     : '';
 
+  // Keep the node on a stable layer. Switching DEFAULT_LAYER → TOP_LAYER on
+  // hover portals the DOM under the cursor, which synthesizes mouseleave and
+  // cancels child tooltips (e.g. PodStatus) while the hover shadow remains.
   return (
-    <Layer id={hover ? TOP_LAYER : DEFAULT_LAYER}>
+    <Layer id={DEFAULT_LAYER}>
       <g
         ref={nodeHoverRefs as LegacyRef<SVGGElement>}
         data-test-id={element.getLabel()}

--- a/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -228,7 +228,16 @@ const PodStatus = ({
     );
     return (
       <Tooltip content={tipContent} triggerRef={chartTriggerRef}>
-        <g ref={chartTriggerRef}>{chartDonut}</g>
+        <g ref={chartTriggerRef}>
+          <rect
+            x={x || 0}
+            y={y || 0}
+            width={size}
+            height={size}
+            fill="transparent"
+          />
+          {chartDonut}
+        </g>
       </Tooltip>
     );
   }

--- a/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -230,8 +230,8 @@ const PodStatus = ({
       <Tooltip content={tipContent} triggerRef={chartTriggerRef}>
         <g ref={chartTriggerRef}>
           <rect
-            x={x || 0}
-            y={y || 0}
+            x={x && y ? x : 0}
+            y={x && y ? y : 0}
             width={size}
             height={size}
             fill="transparent"

--- a/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ReactElement } from 'react';
+import type { MouseEvent, ReactElement } from 'react';
 
 import { useState, useRef, useMemo, memo } from 'react';
 
@@ -83,6 +83,7 @@ const PodStatus = ({
 }: PodStatusProps) => {
   const { t } = useTranslation();
   const [updateOnEnd, setUpdateOnEnd] = useState<boolean>(false);
+  const [isHovered, setIsHovered] = useState<boolean>(false);
 
   const translatePodStatus = (status: string) => {
     switch (status) {
@@ -226,9 +227,31 @@ const PodStatus = ({
         })}
       </div>
     );
+    // Drive visibility with React hover events. PatternFly's native mouseenter
+    // on triggerRef is unreliable for SVG nodes that may be relocated in the
+    // topology graph. A leave with no relatedTarget is treated as a DOM move,
+    // not a real pointer exit.
+    const handleMouseEnter = () => setIsHovered(true);
+    const handleMouseLeave = (event: MouseEvent) => {
+      if (!event.relatedTarget) {
+        return;
+      }
+      setIsHovered(false);
+    };
+
     return (
-      <Tooltip content={tipContent} triggerRef={chartTriggerRef}>
-        <g ref={chartTriggerRef}>
+      <Tooltip
+        content={tipContent}
+        triggerRef={chartTriggerRef}
+        isVisible={isHovered}
+        trigger="manual"
+        entryDelay={0}
+      >
+        <g
+          ref={chartTriggerRef}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
           <rect
             x={x && y ? x : 0}
             y={x && y ? y : 0}

--- a/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Pods/PodStatus.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { MouseEvent, ReactElement } from 'react';
+import type { KeyboardEvent, ReactElement } from 'react';
 
 import { useState, useRef, useMemo, memo } from 'react';
 
@@ -83,7 +83,6 @@ const PodStatus = ({
 }: PodStatusProps) => {
   const { t } = useTranslation();
   const [updateOnEnd, setUpdateOnEnd] = useState<boolean>(false);
-  const [isHovered, setIsHovered] = useState<boolean>(false);
 
   const translatePodStatus = (status: string) => {
     switch (status) {
@@ -114,6 +113,18 @@ const PodStatus = ({
   const forceUpdate = useForceUpdate();
   const prevVData = useRef<PodData[] | null>(null);
   const chartTriggerRef = useRef<SVGGElement | null>(null);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      chartTriggerRef.current?.dispatchEvent(
+        new MouseEvent('click', {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+        }),
+      );
+    }
+  };
 
   const vData = useMemo(() => {
     const updateVData: PodData[] = podStatus.map((pod: any) => ({
@@ -227,36 +238,13 @@ const PodStatus = ({
         })}
       </div>
     );
-    // Drive visibility with React hover events. PatternFly's native mouseenter
-    // on triggerRef is unreliable for SVG nodes that may be relocated in the
-    // topology graph. A leave with no relatedTarget is treated as a DOM move,
-    // not a real pointer exit.
-    const handleMouseEnter = () => setIsHovered(true);
-    const handleMouseLeave = (event: MouseEvent) => {
-      if (!event.relatedTarget) {
-        return;
-      }
-      setIsHovered(false);
-    };
-
     return (
-      <Tooltip
-        content={tipContent}
-        triggerRef={chartTriggerRef}
-        isVisible={isHovered}
-        trigger="manual"
-        entryDelay={0}
-      >
-        <g
-          ref={chartTriggerRef}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          <rect
-            x={x && y ? x : 0}
-            y={x && y ? y : 0}
-            width={size}
-            height={size}
+      <Tooltip content={tipContent} triggerRef={chartTriggerRef}>
+        <g ref={chartTriggerRef} tabIndex={0} onKeyDown={handleKeyDown}>
+          <circle
+            cx={(x ?? 0) + size / 2}
+            cy={(y ?? 0) + size / 2}
+            r={outerRadius}
             fill="transparent"
           />
           {chartDonut}


### PR DESCRIPTION
## Description

The `PodStatus` component's tooltip only triggered when hovering directly over the pod count text or colored donut arcs, not when hovering over other areas of the pod. This was because the SVG `<g>` group element used as the tooltip trigger ref has no intrinsic rendered area — pointer events only fire on its visible children.

### Root cause
The `PodStatus` component wraps the `ChartDonut` in a `<g>` SVG group element used as the tooltip trigger ref. SVG `<g>` elements have no intrinsic rendered area — pointer events only fire on visible children (the donut arc segments and the pod count text). The empty space inside the donut center and between elements does not capture hover events, so the tooltip only appears when hovering directly over the text or the colored arcs.

The fix adds a transparent `<rect>` covering the full chart area inside the tooltip trigger, ensuring the rect captures pointer events across the entire pod area.

## Fixed
- Fixes https://github.com/backstage/community-plugins/issues/9843

## UI Before / After

## Before
[before-fix.webm](https://github.com/user-attachments/assets/2262ac74-7214-48a9-a98b-b30a053bb2e2)

## After
[after-fix.webm](https://github.com/user-attachments/assets/715ac59e-d7c8-429d-b2bd-fd7fed672386)


## Test Plan
- Open an entity from the catalog with the topology tab
- Navigate to the topology tab
- Change the filter to Show pod count
- Hover over the pod area around the indicator (not directly on the text)
- Verify tooltip is displayed when hovering anywhere over the pod
- Hover directly over the pod count text
- Verify tooltip still appears correctly when hovering over text
- Verify other pod display modes and decorators are unaffected

#### Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Note
> This bug fix was identified and implemented using the agent skills. Please verify the fix thoroughly before merging.