### PR TITLE
Version Packages (playlist)

### DIFF
--- a/workspaces/playlist/.changeset/version-bump-1-53-0.md
+++ b/workspaces/playlist/.changeset/version-bump-1-53-0.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-playlist': minor
-'@backstage-community/plugin-playlist-backend': minor
-'@backstage-community/plugin-playlist-common': minor
----
-
-Backstage version bump to v1.53.0

--- a/workspaces/playlist/packages/app/CHANGELOG.md
+++ b/workspaces/playlist/packages/app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # app
 
+## 0.0.26
+
+### Patch Changes
+
+- Updated dependencies [ccf9763]
+  - @backstage-community/plugin-playlist@0.21.0
+
 ## 0.0.25
 
 ### Patch Changes

--- a/workspaces/playlist/packages/app/package.json
+++ b/workspaces/playlist/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": true,
   "bundled": true,
   "repository": {

--- a/workspaces/playlist/packages/backend/CHANGELOG.md
+++ b/workspaces/playlist/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.29
+
+### Patch Changes
+
+- Updated dependencies [ccf9763]
+  - @backstage-community/plugin-playlist-backend@0.23.0
+
 ## 0.0.28
 
 ### Patch Changes

--- a/workspaces/playlist/packages/backend/package.json
+++ b/workspaces/playlist/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-playlist-backend
 
+## 0.23.0
+
+### Minor Changes
+
+- ccf9763: Backstage version bump to v1.53.0
+
+### Patch Changes
+
+- Updated dependencies [ccf9763]
+  - @backstage-community/plugin-playlist-common@0.20.0
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/playlist/plugins/playlist-backend/package.json
+++ b/workspaces/playlist/plugins/playlist-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-backend",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "playlist",

--- a/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-playlist-common
 
+## 0.20.0
+
+### Minor Changes
+
+- ccf9763: Backstage version bump to v1.53.0
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/playlist/plugins/playlist-common/package.json
+++ b/workspaces/playlist/plugins/playlist-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist-common",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Common functionalities for the playlist plugin",
   "backstage": {
     "role": "common-library",

--- a/workspaces/playlist/plugins/playlist/CHANGELOG.md
+++ b/workspaces/playlist/plugins/playlist/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-playlist
 
+## 0.21.0
+
+### Minor Changes
+
+- ccf9763: Backstage version bump to v1.53.0
+
+### Patch Changes
+
+- Updated dependencies [ccf9763]
+  - @backstage-community/plugin-playlist-common@0.20.0
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/playlist/plugins/playlist/package.json
+++ b/workspaces/playlist/plugins/playlist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-playlist",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "playlist",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-playlist@0.21.0

### Minor Changes

-   ccf9763: Backstage version bump to v1.53.0

### Patch Changes

-   Updated dependencies [ccf9763]
    -   @backstage-community/plugin-playlist-common@0.20.0

## @backstage-community/plugin-playlist-backend@0.23.0

### Minor Changes

-   ccf9763: Backstage version bump to v1.53.0

### Patch Changes

-   Updated dependencies [ccf9763]
    -   @backstage-community/plugin-playlist-common@0.20.0

## @backstage-community/plugin-playlist-common@0.20.0

### Minor Changes

-   ccf9763: Backstage version bump to v1.53.0

## app@0.0.26

### Patch Changes

-   Updated dependencies [ccf9763]
    -   @backstage-community/plugin-playlist@0.21.0

## backend@0.0.29

### Patch Changes

-   Updated dependencies [ccf9763]
    -   @backstage-community/plugin-playlist-backend@0.23.0
