### PR TITLE
Version Packages (kiali)

### DIFF
--- a/workspaces/kiali/.changeset/renovate-bf67c9b.md
+++ b/workspaces/kiali/.changeset/renovate-bf67c9b.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-kiali': patch
----
-
-Updated dependency `@types/node` to `22.20.1`.

--- a/workspaces/kiali/.changeset/rhdh-111-backstage-bump.md
+++ b/workspaces/kiali/.changeset/rhdh-111-backstage-bump.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-kiali-common': patch
-'@backstage-community/plugin-kiali-react': patch
-'@backstage-community/plugin-kiali': patch
-'@backstage-community/plugin-kiali-backend': patch
----
-
-Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.

--- a/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-backend
 
+## 1.29.3
+
+### Patch Changes
+
+- 6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
+
 ## 1.29.2
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-backend/package.json
+++ b/workspaces/kiali/plugins/kiali-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-backend",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-kiali-common
 
+## 0.11.2
+
+### Patch Changes
+
+- 6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
+
 ## 0.11.1
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-common/package.json
+++ b/workspaces/kiali/plugins/kiali-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-kiali-common",
   "description": "Common functionalities for the kiali plugin",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali-react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-kiali-react
 
+## 0.7.4
+
+### Patch Changes
+
+- 6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
+- Updated dependencies [6d02d79]
+  - @backstage-community/plugin-kiali-common@0.11.2
+
 ## 0.7.3
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali-react/package.json
+++ b/workspaces/kiali/plugins/kiali-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali-react",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "license": "Apache-2.0",
   "description": "Web library for the kiali plugin",
   "main": "src/index.ts",

--- a/workspaces/kiali/plugins/kiali/CHANGELOG.md
+++ b/workspaces/kiali/plugins/kiali/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-kiali
 
+## 1.51.2
+
+### Patch Changes
+
+- 72557ed: Updated dependency `@types/node` to `22.20.1`.
+- 6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
+- Updated dependencies [6d02d79]
+  - @backstage-community/plugin-kiali-common@0.11.2
+  - @backstage-community/plugin-kiali-react@0.7.4
+
 ## 1.51.1
 
 ### Patch Changes

--- a/workspaces/kiali/plugins/kiali/package.json
+++ b/workspaces/kiali/plugins/kiali/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-kiali",
-  "version": "1.51.1",
+  "version": "1.51.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-kiali@1.51.2

### Patch Changes

-   72557ed: Updated dependency `@types/node` to `22.20.1`.
-   6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
-   Updated dependencies [6d02d79]
    -   @backstage-community/plugin-kiali-common@0.11.2
    -   @backstage-community/plugin-kiali-react@0.7.4

## @backstage-community/plugin-kiali-backend@1.29.3

### Patch Changes

-   6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.

## @backstage-community/plugin-kiali-common@0.11.2

### Patch Changes

-   6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.

## @backstage-community/plugin-kiali-react@0.7.4

### Patch Changes

-   6d02d79: Bumped Backstage dependencies to 1.52.0 for Red Hat Developer Hub 1.11 compatibility.
-   Updated dependencies [6d02d79]
    -   @backstage-community/plugin-kiali-common@0.11.2
