### PR TITLE
fix(ci): widen auto version bump scheduler window from 7 to 10 days

### DIFF
--- a/scripts/ci/trigger-auto-version-bump.js
+++ b/scripts/ci/trigger-auto-version-bump.js
@@ -82,17 +82,19 @@ async function main() {
       return;
     }
 
-    const isRecent =
+    const daysSinceRelease =
       (Date.now() - new Date(minorRelease.published_at)) /
-        (1000 * 60 * 60 * 24) <=
-      7;
+      (1000 * 60 * 60 * 24);
+    const isRecent = daysSinceRelease <= 10;
     console.log(
       `Minor release ${minorReleaseTag} published: ${minorRelease.published_at}`,
     );
-    console.log(`Within the past week: ${isRecent}`);
+    console.log(
+      `Days since release: ${daysSinceRelease.toFixed(2)}, within window: ${isRecent}`,
+    );
 
     if (!isRecent) {
-      console.log('Minor release is older than 7 days');
+      console.log('Minor release is older than 10 days');
       await setOutput('false');
       return;
     }

--- a/scripts/ci/trigger-auto-version-bump.js
+++ b/scripts/ci/trigger-auto-version-bump.js
@@ -21,6 +21,9 @@ import { EOL } from 'os';
 const BACKSTAGE_MANIFEST_URL =
   'https://versions.backstage.io/v1/tags/main/manifest.json';
 
+const WINDOW_DAYS = 10;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
 async function fetchBackstageManifest() {
   const response = await fetch(BACKSTAGE_MANIFEST_URL);
 
@@ -83,18 +86,19 @@ async function main() {
     }
 
     const daysSinceRelease =
-      (Date.now() - new Date(minorRelease.published_at)) /
-      (1000 * 60 * 60 * 24);
-    const isRecent = daysSinceRelease <= 10;
+      (Date.now() - new Date(minorRelease.published_at)) / MS_PER_DAY;
+    const isRecent = daysSinceRelease <= WINDOW_DAYS;
     console.log(
       `Minor release ${minorReleaseTag} published: ${minorRelease.published_at}`,
     );
     console.log(
-      `Days since release: ${daysSinceRelease.toFixed(2)}, within window: ${isRecent}`,
+      `Days since release: ${daysSinceRelease.toFixed(
+        2,
+      )}, within window: ${isRecent}`,
     );
 
     if (!isRecent) {
-      console.log('Minor release is older than 10 days');
+      console.log(`Minor release is older than ${WINDOW_DAYS} days`);
       await setOutput('false');
       return;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The auto version bump scheduler [failed to trigger on 2026-07-21](https://github.com/backstage/community-plugins/actions/runs/29834647547) because the v1.53.0 release was published on Tuesday July 14 at 12:35 UTC — just before the scheduler's 13:00 UTC cron time. By the following Tuesday at 13:30 UTC, the release was 7 days and 55 minutes old, exceeding the 7-day window.

This happened because v1.53.0 was released earlier in the day than usual (CST timezone vs the typical CET/Swedish timezone). Previous releases (v1.52.0 at 18:16 UTC, v1.51.0 at 21:12 UTC) were published after 13:00 UTC, so they were still within 7 days when checked the following Tuesday.

Widening the window to 10 days ensures any Tuesday release is caught by the next Tuesday's scheduler run, regardless of the release time. It won't cause false triggers since releases are ~4 weeks apart — a 10-day window is well under that cadence. The `next` release line is unaffected because the script only checks the `main` manifest.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))