### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/gentle-birds-march.md
+++ b/workspaces/quay/.changeset/gentle-birds-march.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Fixed nested interactive controls accessibility violation in tag and security scan tables by disabling column dragging

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay
 
+## 1.37.1
+
+### Patch Changes
+
+- f3536fd: Fixed nested interactive controls accessibility violation in tag and security scan tables by disabling column dragging
+
 ## 1.37.0
 
 ### Minor Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.37.1

### Patch Changes

-   f3536fd: Fixed nested interactive controls accessibility violation in tag and security scan tables by disabling column dragging
