### PR TITLE
Version Packages (jfrog-artifactory)

### DIFF
--- a/workspaces/jfrog-artifactory/.changeset/four-waves-fetch.md
+++ b/workspaces/jfrog-artifactory/.changeset/four-waves-fetch.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jfrog-artifactory': patch
----
-
-Fetch all JFrog Artifactory tags up to the configured `pageLimit`, including when the result spans multiple API pages.

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jfrog-artifactory
 
+## 1.30.2
+
+### Patch Changes
+
+- 010f9ce: Fetch all JFrog Artifactory tags up to the configured `pageLimit`, including when the result spans multiple API pages.
+
 ## 1.30.1
 
 ### Patch Changes

--- a/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
+++ b/workspaces/jfrog-artifactory/plugins/jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jfrog-artifactory",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jfrog-artifactory@1.30.2

### Patch Changes

-   010f9ce: Fetch all JFrog Artifactory tags up to the configured `pageLimit`, including when the result spans multiple API pages.
