### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/tidy-otters-relax.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/tidy-otters-relax.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-regex': patch
----
-
-Add module wiring tests, direct Zod schema validation coverage, a local dev/ harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-regex
 
+## 2.17.1
+
+### Patch Changes
+
+- cce0831: Add module wiring tests, direct Zod schema validation coverage, a local dev/ harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.
+
 ## 2.17.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-regex@2.17.1

### Patch Changes

-   cce0831: Add module wiring tests, direct Zod schema validation coverage, a local dev/ harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.
