### PR TITLE
Fix file filtering in router service

### DIFF
--- a/workspaces/adr/plugins/adr-backend/src/service/router.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.ts
@@ -20,7 +20,8 @@ import Router from 'express-promise-router';
 import {
   AdrInfo,
   AdrInfoParser,
-  madrParser,
+  madrFilePathFilter,
+  madrParser
 } from '@backstage-community/plugin-adr-common';
 import {
   CacheService,
@@ -67,7 +68,8 @@ export async function createRouter(
       const treeGetResponse = await reader.readTree(urlToProcess, {
         etag: cachedTree?.etag,
       });
-      const files = await treeGetResponse.files();
+      const files = const files = (await treeGetResponse.files())
+        .filter(f => madrFilePathFilter(f.path));
       const results = await Promise.all(
         files
           .map(async file => {

--- a/workspaces/adr/plugins/adr-backend/src/service/router.ts
+++ b/workspaces/adr/plugins/adr-backend/src/service/router.ts
@@ -68,8 +68,7 @@ export async function createRouter(
       const treeGetResponse = await reader.readTree(urlToProcess, {
         etag: cachedTree?.etag,
       });
-      const files = const files = (await treeGetResponse.files())
-        .filter(f => madrFilePathFilter(f.path));
+      const files = (await treeGetResponse.files()).filter(f => madrFilePathFilter(f.path));
       const results = await Promise.all(
         files
           .map(async file => {


### PR DESCRIPTION
/api/adr/list endpoint walks
 every file in the discovered ADR directory and runs madrParser() on each one.
 Any file that isn't a real ADR ( templates/madr-template.md, adr-template.md,
 .gitignore, README.md, etc.) throws an error

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
