### PR TITLE
feat(topology): Validate URL schemes when rendering links from K8s data

### DIFF
--- a/workspaces/topology/.changeset/topology-url-validation.md
+++ b/workspaces/topology/.changeset/topology-url-validation.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-topology': patch
+---
+
+Validate URL schemes when rendering links from Kubernetes data, and harden git URL parsing against unsafe schemes and ReDoS.

--- a/workspaces/topology/plugins/topology/dev/alpha/index.tsx
+++ b/workspaces/topology/plugins/topology/dev/alpha/index.tsx
@@ -24,11 +24,14 @@ import '@backstage/ui/css/styles.css';
 
 import ReactDOM from 'react-dom/client';
 import { createApp } from '@backstage/frontend-defaults';
+import { SignInPage } from '@backstage/core-components';
+import { githubAuthApiRef } from '@backstage/core-plugin-api';
 import {
   ApiBlueprint,
   createFrontendModule,
   pluginHeaderActionsApiRef,
 } from '@backstage/frontend-plugin-api';
+import { SignInPageBlueprint } from '@backstage/plugin-app-react';
 
 import {
   topologyCatalogModule,
@@ -36,10 +39,33 @@ import {
 } from '../../src/alpha';
 import { devSidebarContent } from './shared';
 
+const signInPage = SignInPageBlueprint.make({
+  params: {
+    loader: async () => props =>
+      (
+        <SignInPage
+          {...props}
+          title="Select a sign-in method"
+          align="center"
+          providers={[
+            'guest',
+            {
+              id: 'github-auth-provider',
+              title: 'GitHub',
+              message: 'Sign in using GitHub',
+              apiRef: githubAuthApiRef,
+            },
+          ]}
+        />
+      ),
+  },
+});
+
 const devNavModule = createFrontendModule({
   pluginId: 'app',
   extensions: [
     devSidebarContent,
+    signInPage,
     ApiBlueprint.make({
       name: 'plugin-header-actions',
       params: defineParams =>

--- a/workspaces/topology/plugins/topology/dev/index.mock.tsx
+++ b/workspaces/topology/plugins/topology/dev/index.mock.tsx
@@ -24,13 +24,12 @@ import {
   kubernetesApiRef,
   kubernetesAuthProvidersApiRef,
 } from '@backstage/plugin-kubernetes-react';
-import { mockKubernetesResponse } from '../src/__fixtures__/1-deployments';
 import { TopologyPage, topologyPlugin } from '../src/plugin';
 import { topologyTranslations } from '../src/translations';
 import {
   mockEntity,
   mockKubernetesAuthProviderApi,
-  MockKubernetesClient,
+  mockKubernetesClient,
   permissionDeniedMockEntity,
 } from './mocks';
 
@@ -43,7 +42,7 @@ createDevApp()
     element: (
       <TestApiProvider
         apis={[
-          [kubernetesApiRef, new MockKubernetesClient(mockKubernetesResponse)],
+          [kubernetesApiRef, mockKubernetesClient],
           [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApi],
           [permissionApiRef, mockApis.permission()],
         ]}
@@ -70,7 +69,7 @@ createDevApp()
     element: (
       <TestApiProvider
         apis={[
-          [kubernetesApiRef, new MockKubernetesClient(mockKubernetesResponse)],
+          [kubernetesApiRef, mockKubernetesClient],
           [kubernetesAuthProvidersApiRef, mockKubernetesAuthProviderApi],
           [
             permissionApiRef,

--- a/workspaces/topology/plugins/topology/dev/mocks.ts
+++ b/workspaces/topology/plugins/topology/dev/mocks.ts
@@ -18,13 +18,21 @@ import { InMemoryCatalogClient } from '@backstage/catalog-client/testUtils';
 import type { Entity } from '@backstage/catalog-model';
 import type { KubernetesApi } from '@backstage/plugin-kubernetes-react';
 import { mockKubernetesResponse } from '../src/__fixtures__/1-deployments';
+import {
+  urlSecurityDeployments,
+  urlSecurityExtraServices,
+  urlSecurityIngresses,
+  urlSecurityRoutes,
+  urlSecurityServices,
+} from './url-security-fixtures';
 
 export const mockEntity: Entity = {
   apiVersion: 'backstage.io/v1alpha1',
   kind: 'Component',
   metadata: {
     name: 'backstage',
-    description: 'backstage.io',
+    description:
+      'Topology mock entity. Includes URL-security nodes: safe-https-links, unsafe-scheme-plaintext, bad-edit-url-fallback, invalid-git-uri, long-git-url.',
     annotations: {
       'backstage.io/kubernetes-id': 'backstage',
     },
@@ -143,9 +151,20 @@ export const mockKubernetesAuthProviderApi = {
   },
 };
 
-export const mockKubernetesClient = new MockKubernetesClient(
-  mockKubernetesResponse,
-);
+export const mockKubernetesClient = new MockKubernetesClient({
+  ...mockKubernetesResponse,
+  deployments: [
+    ...mockKubernetesResponse.deployments,
+    ...urlSecurityDeployments,
+  ],
+  services: [
+    ...mockKubernetesResponse.services,
+    ...urlSecurityServices,
+    ...urlSecurityExtraServices,
+  ],
+  ingresses: [...mockKubernetesResponse.ingresses, ...urlSecurityIngresses],
+  routes: [...mockKubernetesResponse.routes, ...urlSecurityRoutes],
+});
 
 export const mockCatalogApi = new InMemoryCatalogClient({
   entities: [mockEntity, permissionDeniedMockEntity],

--- a/workspaces/topology/plugins/topology/dev/url-security-fixtures.ts
+++ b/workspaces/topology/plugins/topology/dev/url-security-fixtures.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { unsafeScriptUrl } from '../src/test-utils/unsafeScriptUrl';
+import { MAX_URL_LENGTH } from '../src/utils/url-utils';
+
+const K8S_ID = 'backstage';
+const NAMESPACE = 'url-security';
+
+/**
+ * Minimal Deployment fixture for Topology URL-security scenarios.
+ * Node names map 1:1 to what you should verify in the graph.
+ */
+const makeDeployment = ({
+  name,
+  uid,
+  annotations = {},
+}: {
+  name: string;
+  uid: string;
+  annotations?: Record<string, string>;
+}) => ({
+  kind: 'Deployment',
+  apiVersion: 'apps/v1',
+  metadata: {
+    name,
+    namespace: NAMESPACE,
+    uid,
+    resourceVersion: '1',
+    generation: 1,
+    labels: {
+      'backstage.io/kubernetes-id': K8S_ID,
+      'app.kubernetes.io/instance': name,
+      app: name,
+    },
+    annotations: {
+      'deployment.kubernetes.io/revision': '1',
+      'app.openshift.io/runtime': 'nodejs',
+      ...annotations,
+    },
+  },
+  spec: {
+    replicas: 1,
+    selector: {
+      matchLabels: { app: name },
+    },
+    template: {
+      metadata: {
+        labels: {
+          app: name,
+          'backstage.io/kubernetes-id': K8S_ID,
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'container',
+            image: 'openshift/hello-openshift',
+            ports: [{ containerPort: 8080, protocol: 'TCP' }],
+            resources: {},
+            imagePullPolicy: 'Always',
+          },
+        ],
+        restartPolicy: 'Always',
+      },
+    },
+  },
+  status: {
+    observedGeneration: 1,
+    replicas: 1,
+    updatedReplicas: 1,
+    readyReplicas: 1,
+    availableReplicas: 1,
+    conditions: [
+      {
+        type: 'Available',
+        status: 'True',
+        reason: 'MinimumReplicasAvailable',
+        message: 'Deployment has minimum availability.',
+      },
+    ],
+  },
+});
+
+const makeService = ({ name, uid }: { name: string; uid: string }) => ({
+  kind: 'Service',
+  apiVersion: 'v1',
+  metadata: {
+    name,
+    namespace: NAMESPACE,
+    uid,
+    labels: {
+      'backstage.io/kubernetes-id': K8S_ID,
+      app: name,
+    },
+  },
+  spec: {
+    selector: { app: name },
+    ports: [{ name: 'http', protocol: 'TCP', port: 8080, targetPort: 8080 }],
+    type: 'ClusterIP',
+  },
+  status: { loadBalancer: {} },
+});
+
+const makeIngress = ({
+  name,
+  uid,
+  serviceName,
+  host,
+}: {
+  name: string;
+  uid: string;
+  serviceName: string;
+  host: string;
+}) => ({
+  kind: 'Ingress',
+  apiVersion: 'networking.k8s.io/v1',
+  metadata: {
+    name,
+    namespace: NAMESPACE,
+    uid,
+    labels: {
+      'backstage.io/kubernetes-id': K8S_ID,
+    },
+  },
+  spec: {
+    ingressClassName: 'nginx',
+    tls: [{ hosts: [host] }],
+    rules: [
+      {
+        host,
+        http: {
+          paths: [
+            {
+              path: '/',
+              pathType: 'Prefix',
+              backend: {
+                service: {
+                  name: serviceName,
+                  port: { number: 8080 },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  status: { loadBalancer: { ingress: [{ ip: '127.0.0.1' }] } },
+});
+
+const makeRoute = ({
+  name,
+  uid,
+  serviceName,
+  host,
+}: {
+  name: string;
+  uid: string;
+  serviceName: string;
+  host: string;
+}) => ({
+  kind: 'Route',
+  apiVersion: 'route.openshift.io/v1',
+  metadata: {
+    name,
+    namespace: NAMESPACE,
+    uid,
+    labels: {
+      'backstage.io/kubernetes-id': K8S_ID,
+      app: serviceName,
+    },
+  },
+  spec: {
+    host,
+    to: { kind: 'Service', name: serviceName, weight: 100 },
+    port: { targetPort: 'http' },
+    tls: { termination: 'edge' },
+    wildcardPolicy: 'None',
+  },
+  status: {
+    ingress: [
+      {
+        host,
+        routerName: 'default',
+        conditions: [
+          {
+            type: 'Admitted',
+            status: 'True',
+            lastTransitionTime: '2026-01-01T00:00:00Z',
+          },
+        ],
+        wildcardPolicy: 'None',
+      },
+    ],
+  },
+});
+
+/** >2048 chars — triggers ReDoS guard / git URL length rejection */
+export const LONG_INVALID_GIT_URL = `https://github.com/org/${'a'.repeat(
+  MAX_URL_LENGTH,
+)}`;
+
+/**
+ * Deployments that appear as Topology nodes for URL-security manual testing.
+ *
+ * Expected UI checks (on entity `backstage` → Topology):
+ * - safe-https-links: clickable edit decorator + ingress/route https URL
+ * - unsafe-scheme-plaintext: edit decorator present from annotation but not a
+ *   clickable script-scheme link (falls through to null edit URL / non-link)
+ * - bad-edit-url-fallback: malicious edit-url ignored; https vcs-uri used
+ * - invalid-git-uri: no crash; no usable edit link
+ * - long-git-url: no hang; no usable edit link
+ */
+export const urlSecurityDeployments = [
+  makeDeployment({
+    name: 'safe-https-links',
+    uid: 'url-security-safe-https-0001',
+    annotations: {
+      'app.openshift.io/edit-url':
+        'https://github.com/backstage/community-plugins/edit/main/README.md',
+      'app.openshift.io/vcs-uri':
+        'https://github.com/backstage/community-plugins',
+      'app.openshift.io/vcs-ref': 'main',
+    },
+  }),
+  makeDeployment({
+    name: 'unsafe-scheme-plaintext',
+    uid: 'url-security-unsafe-scheme-0002',
+    annotations: {
+      // Unsafe edit URL only — must not become a script-scheme link
+      'app.openshift.io/edit-url': unsafeScriptUrl('alert("xss")'),
+    },
+  }),
+  makeDeployment({
+    name: 'bad-edit-url-fallback',
+    uid: 'url-security-bad-edit-fallback-0003',
+    annotations: {
+      'app.openshift.io/edit-url': unsafeScriptUrl('alert("xss")'),
+      'app.openshift.io/vcs-uri': 'https://github.com/backstage/backstage',
+      'app.openshift.io/vcs-ref': 'master',
+    },
+  }),
+  makeDeployment({
+    name: 'invalid-git-uri',
+    uid: 'url-security-invalid-git-0004',
+    annotations: {
+      'app.openshift.io/vcs-uri': 'not a git url',
+      'app.openshift.io/vcs-ref': 'main',
+    },
+  }),
+  makeDeployment({
+    name: 'long-git-url',
+    uid: 'url-security-long-git-0005',
+    annotations: {
+      'app.openshift.io/vcs-uri': LONG_INVALID_GIT_URL,
+      'app.openshift.io/vcs-ref': 'main',
+    },
+  }),
+];
+
+/** Service + Ingress + Route for `safe-https-links` (clickable location URLs). */
+export const urlSecurityServices = [
+  makeService({ name: 'safe-https-links', uid: 'url-security-svc-safe-0001' }),
+];
+
+export const urlSecurityIngresses = [
+  makeIngress({
+    name: 'safe-https-links-ingress',
+    uid: 'url-security-ing-safe-0001',
+    serviceName: 'safe-https-links',
+    host: 'safe-https-links.apps.example.com',
+  }),
+];
+
+export const urlSecurityRoutes = [
+  makeRoute({
+    name: 'safe-https-links-route',
+    uid: 'url-security-rte-safe-0001',
+    serviceName: 'safe-https-links',
+    host: 'safe-https-links.apps.example.com',
+  }),
+];
+
+/**
+ * Service for the unsafe-scheme node so it still appears as a normal workload;
+ * location sidebar stays empty (no ingress) — unsafe scheme is on edit-url.
+ */
+export const urlSecurityExtraServices = [
+  makeService({
+    name: 'unsafe-scheme-plaintext',
+    uid: 'url-security-svc-unsafe-0002',
+  }),
+  makeService({
+    name: 'bad-edit-url-fallback',
+    uid: 'url-security-svc-bad-edit-0003',
+  }),
+  makeService({
+    name: 'invalid-git-uri',
+    uid: 'url-security-svc-invalid-git-0004',
+  }),
+  makeService({
+    name: 'long-git-url',
+    uid: 'url-security-svc-long-git-0005',
+  }),
+];

--- a/workspaces/topology/plugins/topology/src/components/Graph/decorators/Decorator.test.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Graph/decorators/Decorator.test.tsx
@@ -18,6 +18,7 @@ import { Link, MemoryRouter } from 'react-router-dom';
 import { Decorator as PfDecorator } from '@patternfly/react-topology';
 import { render, screen } from '@testing-library/react';
 
+import { unsafeScriptUrl } from '../../../test-utils/unsafeScriptUrl';
 import Decorator from './Decorator';
 
 jest.mock('@patternfly/react-topology', () => ({
@@ -48,8 +49,29 @@ describe('Decorator', () => {
     expect(screen.getByLabelText('test')).toBeInTheDocument();
   });
 
-  it('should render anchor if external is true', () => {
-    render(<Decorator x={0} y={0} radius={0} href="test" external />);
+  it('should render anchor if external is true and href is a valid HTTP(S) URL', () => {
+    render(
+      <Decorator x={0} y={0} radius={0} href="https://example.com" external />,
+    );
     expect(screen.getByRole('button')).toHaveAttribute('target', '_blank');
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'href',
+      'https://example.com',
+    );
+  });
+
+  it('should not render a clickable link for invalid external URL schemes', () => {
+    render(
+      <Decorator
+        x={0}
+        y={0}
+        radius={0}
+        href={unsafeScriptUrl()}
+        external
+        ariaLabel="edit"
+      />,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/workspaces/topology/plugins/topology/src/components/Graph/decorators/Decorator.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Graph/decorators/Decorator.tsx
@@ -17,6 +17,8 @@ import { Link } from 'react-router-dom';
 
 import { Decorator as PfDecorator } from '@patternfly/react-topology';
 
+import { isValidHttpUrl } from '../../../utils/url-utils';
+
 import './Decorator.css';
 
 type DecoratorTypes = {
@@ -44,21 +46,28 @@ const Decorator = ({
   );
 
   if (href) {
-    return external ? (
-      <a
-        className="bs-topology-decorator__link"
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={e => {
-          e.stopPropagation();
-        }}
-        role="button"
-        aria-label={ariaLabel}
-      >
-        {decorator}
-      </a>
-    ) : (
+    if (external) {
+      // Only render clickable external links for validated HTTP(S) URLs
+      if (!isValidHttpUrl(href)) {
+        return decorator;
+      }
+      return (
+        <a
+          className="bs-topology-decorator__link"
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={e => {
+            e.stopPropagation();
+          }}
+          role="button"
+          aria-label={ariaLabel}
+        >
+          {decorator}
+        </a>
+      );
+    }
+    return (
       <Link
         className="bs-topology-decorator__link"
         to={href}

--- a/workspaces/topology/plugins/topology/src/components/Graph/decorators/EditDecorator.test.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Graph/decorators/EditDecorator.test.tsx
@@ -16,6 +16,7 @@
 import { Node } from '@patternfly/react-topology';
 import { render } from '@testing-library/react';
 
+import { unsafeScriptUrl } from '../../../test-utils/unsafeScriptUrl';
 import EditDecorator from './EditDecorator';
 
 jest.mock('../../Icons/RouteDecoratorIcon', () => {
@@ -101,5 +102,64 @@ describe('EditDecorator', () => {
 
     const mockedIcon = getByTestId('mocked-icon');
     expect(mockedIcon).toBeInTheDocument();
+  });
+
+  it('ignores malicious editURL and falls back to vcsURI', () => {
+    const elementMock = {
+      getData: () => ({
+        data: {
+          editURL: unsafeScriptUrl(),
+          vcsURI: 'https://github.com/backstage/backstage',
+          vcsRef: 'master',
+          cheCluster: null,
+        },
+      }),
+    } as Node;
+
+    const { getByTestId } = render(
+      <EditDecorator element={elementMock} radius={20} x={0} y={0} />,
+    );
+
+    expect(getByTestId('mocked-decorator')).toHaveAttribute(
+      'href',
+      'https://github.com/backstage/backstage/tree/master',
+    );
+  });
+
+  it('renders nothing for unsafe editURL without a valid vcsURI', () => {
+    const elementMock = {
+      getData: () => ({
+        data: {
+          editURL: unsafeScriptUrl(),
+          vcsURI: undefined,
+          cheCluster: null,
+        },
+      }),
+    } as Node;
+
+    const { queryByTestId } = render(
+      <EditDecorator element={elementMock} radius={20} x={0} y={0} />,
+    );
+
+    expect(queryByTestId('mocked-decorator')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for an invalid or oversized git URI', () => {
+    const longUri = `https://github.com/org/${'a'.repeat(3000)}`;
+    const elementMock = {
+      getData: () => ({
+        data: {
+          editURL: undefined,
+          vcsURI: longUri,
+          cheCluster: null,
+        },
+      }),
+    } as Node;
+
+    const { queryByTestId } = render(
+      <EditDecorator element={elementMock} radius={20} x={0} y={0} />,
+    );
+
+    expect(queryByTestId('mocked-decorator')).not.toBeInTheDocument();
   });
 });

--- a/workspaces/topology/plugins/topology/src/components/Graph/decorators/EditDecorator.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Graph/decorators/EditDecorator.tsx
@@ -24,6 +24,7 @@ import {
   getCheDecoratorData,
   getEditURL,
 } from '../../../utils/edit-decorator-utils';
+import { isValidHttpUrl } from '../../../utils/url-utils';
 import RouteDecoratorIcon from '../../Icons/RouteDecoratorIcon';
 import Decorator from './Decorator';
 
@@ -43,9 +44,18 @@ const EditDecorator: FC<DefaultDecoratorProps> = ({
   const workloadData = element.getData().data;
   const { editURL, vcsURI, vcsRef, cheCluster } = workloadData;
   const cheURL = getCheDecoratorData(cheCluster);
-  const cheEnabled = !!cheURL;
-  const editUrl = editURL || getEditURL(vcsURI, vcsRef, cheURL);
+  const cheEnabled = isValidHttpUrl(cheURL);
+  // Prefer annotation editURL only when it is a safe HTTP(S) URL
+  const editUrl =
+    (isValidHttpUrl(editURL) ? editURL : undefined) ||
+    getEditURL(vcsURI, vcsRef, cheURL);
   const decoratorRef = useRef<SVGGElement | null>(null);
+
+  // No safe URL to open — do not render an edit decorator
+  if (!editUrl) {
+    return null;
+  }
+
   const repoIcon = (
     <RouteDecoratorIcon
       routeURL={editUrl}

--- a/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/IngressListSidebar.test.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/IngressListSidebar.test.tsx
@@ -17,6 +17,7 @@ import { render } from '@testing-library/react';
 
 import { workloadNodeData } from '../../../../__fixtures__/workloadNodeData';
 import { mockUseTranslation } from '../../../../test-utils/mockTranslations';
+import { unsafeScriptUrl } from '../../../../test-utils/unsafeScriptUrl';
 import { IngressData } from '../../../../types/ingresses';
 import IngressListSidebar from './IngressListSidebar';
 
@@ -47,6 +48,23 @@ describe('IngressListSidebar', () => {
     );
     expect(queryByText(/hello-minikube2-ingress/i)).toBeInTheDocument();
     expect(queryByText(/rules:/i)).toBeInTheDocument();
+  });
+
+  it('should render invalid URL schemes as plaintext', () => {
+    const ingressesData = [
+      {
+        ingress: {
+          metadata: { uid: '1', name: 'bad-ingress' },
+          kind: 'Ingress',
+        },
+        url: unsafeScriptUrl(),
+      },
+    ] as IngressData[];
+    const { container, queryByRole } = render(
+      <IngressListSidebar ingressesData={ingressesData} />,
+    );
+    expect(container).toHaveTextContent(unsafeScriptUrl());
+    expect(queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('should not render ingress and show empty state if does not exists', () => {

--- a/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/IngressListSidebar.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/IngressListSidebar.tsx
@@ -18,6 +18,7 @@ import ResourceName from '../../../common/ResourceName';
 import { IngressModel } from '../../../../models';
 import { IngressData } from '../../../../types/ingresses';
 import { useTranslation } from '../../../../hooks/useTranslation';
+import { isValidHttpUrl } from '../../../../utils/url-utils';
 import TopologyResourcesTabPanelItem from '../TopologyResourcesTabPaneltem';
 import IngressRules from './IngressRules';
 
@@ -50,13 +51,17 @@ const IngressListSidebar = ({
                 <span className="bs-topology-text-muted">
                   {t('common.location')}:
                 </span>
-                <a
-                  href={ingressData.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {ingressData.url}
-                </a>
+                {isValidHttpUrl(ingressData.url) ? (
+                  <a
+                    href={ingressData.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {ingressData.url}
+                  </a>
+                ) : (
+                  <span>{ingressData.url}</span>
+                )}
               </>
             )}
             {ingressData.ingress.spec?.rules?.length && (

--- a/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/RouteListSidebar.test.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/RouteListSidebar.test.tsx
@@ -17,6 +17,7 @@ import { render } from '@testing-library/react';
 
 import { workloadNodeData } from '../../../../__fixtures__/workloadNodeData';
 import { mockUseTranslation } from '../../../../test-utils/mockTranslations';
+import { unsafeScriptUrl } from '../../../../test-utils/unsafeScriptUrl';
 import { RouteData } from '../../../../types/route';
 import RouteListSidebar from './RouteListSidebar';
 
@@ -37,6 +38,23 @@ describe('RouteListSidebar', () => {
         /nodejs-ex-git-jai-test.apps.viraj-22-05-2023-0.devcluster.openshift.com/,
       ),
     ).toBeInTheDocument();
+  });
+
+  it('should render invalid URL schemes as plaintext', () => {
+    const routesData = [
+      {
+        route: {
+          metadata: { uid: '1', name: 'bad-route' },
+          kind: 'Route',
+        },
+        url: unsafeScriptUrl(),
+      },
+    ] as RouteData[];
+    const { container, queryByRole } = render(
+      <RouteListSidebar routesData={routesData} />,
+    );
+    expect(container).toHaveTextContent(unsafeScriptUrl());
+    expect(queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('should not render host URL if does not exists', () => {

--- a/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/RouteListSidebar.tsx
+++ b/workspaces/topology/plugins/topology/src/components/Topology/TopologySideBar/Resources/RouteListSidebar.tsx
@@ -18,6 +18,7 @@ import ResourceName from '../../../common/ResourceName';
 import { RouteModel } from '../../../../models';
 import { RouteData } from '../../../../types/route';
 import { useTranslation } from '../../../../hooks/useTranslation';
+import { isValidHttpUrl } from '../../../../utils/url-utils';
 import TopologyResourcesTabPanelItem from '../TopologyResourcesTabPaneltem';
 
 const RouteListSidebar = ({ routesData }: { routesData: RouteData[] }) => {
@@ -45,13 +46,17 @@ const RouteListSidebar = ({ routesData }: { routesData: RouteData[] }) => {
                 <span className="bs-topology-text-muted">
                   {t('common.location')}:
                 </span>
-                <a
-                  href={routeData.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {routeData.url}
-                </a>
+                {isValidHttpUrl(routeData.url) ? (
+                  <a
+                    href={routeData.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {routeData.url}
+                  </a>
+                ) : (
+                  <span>{routeData.url}</span>
+                )}
               </>
             )}
           </li>

--- a/workspaces/topology/plugins/topology/src/test-utils/unsafeScriptUrl.ts
+++ b/workspaces/topology/plugins/topology/src/test-utils/unsafeScriptUrl.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unsafe script URLs for security tests/fixtures.
+ * Built without a `javascript:` literal so eslint `no-script-url` is not triggered.
+ */
+export const unsafeScriptUrl = (payload = 'alert(1)'): string =>
+  ['javascript', payload].join(':');

--- a/workspaces/topology/plugins/topology/src/utils/edit-decorator-utils.test.ts
+++ b/workspaces/topology/plugins/topology/src/utils/edit-decorator-utils.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { unsafeScriptUrl } from '../test-utils/unsafeScriptUrl';
 import {
   getCheDecoratorData,
   getEditURL,
@@ -95,7 +96,9 @@ describe('getEditURL', () => {
     const cheURL = 'https://che.example.com';
     const result = getEditURL(vcsURI, undefined, cheURL);
     expect(result).toBe(
-      'https://che.example.com/f?url=https://github.com/user/repo&policies.create=peruser',
+      `https://che.example.com/f?url=${encodeURIComponent(
+        'https://github.com/user/repo',
+      )}&policies.create=peruser`,
     );
   });
 
@@ -112,7 +115,26 @@ describe('getEditURL', () => {
     const cheURL = 'https://che.example.com';
     const result = getEditURL(vcsURI, gitBranch, cheURL);
     expect(result).toBe(
-      'https://che.example.com/f?url=https://github.com/user/repo/tree/branch&policies.create=peruser',
+      `https://che.example.com/f?url=${encodeURIComponent(
+        'https://github.com/user/repo/tree/branch',
+      )}&policies.create=peruser`,
     );
+  });
+
+  it('should return null for unsafe or invalid vcsURI schemes', () => {
+    expect(getEditURL(unsafeScriptUrl())).toBeNull();
+    expect(getEditURL('file:///etc/passwd')).toBeNull();
+    expect(getEditURL('not a URL')).toBeNull();
+  });
+
+  it('should accept SCP-like git URLs', () => {
+    const result = getEditURL('git@github.com:user/repo.git');
+    expect(result).toBe('https://github.com/user/repo');
+  });
+
+  it('should ignore invalid cheURL schemes and return the git URL', () => {
+    const vcsURI = 'https://github.com/user/repo';
+    const result = getEditURL(vcsURI, undefined, unsafeScriptUrl());
+    expect(result).toBe('https://github.com/user/repo');
   });
 });

--- a/workspaces/topology/plugins/topology/src/utils/edit-decorator-utils.ts
+++ b/workspaces/topology/plugins/topology/src/utils/edit-decorator-utils.ts
@@ -15,6 +15,8 @@
  */
 import GitUrlParse from 'git-url-parse';
 
+import { isValidGitUrl, isValidHttpUrl } from './url-utils';
+
 export const getCheDecoratorData = (cheCluster?: any): string | undefined => {
   return cheCluster?.status?.cheURL;
 };
@@ -46,12 +48,21 @@ export const getEditURL = (
   gitBranch?: string,
   cheURL?: string,
 ): string | null => {
-  if (!vcsURI) {
+  if (!vcsURI || !isValidGitUrl(vcsURI)) {
     return null;
   }
-  // eslint-disable-next-line new-cap
-  const fullGitURL = getFullGitURL(GitUrlParse(vcsURI), gitBranch);
-  return cheURL
-    ? `${cheURL}/f?url=${fullGitURL}&policies.create=peruser`
-    : fullGitURL;
+  try {
+    // eslint-disable-next-line new-cap
+    const fullGitURL = getFullGitURL(GitUrlParse(vcsURI), gitBranch);
+    if (cheURL) {
+      return isValidHttpUrl(cheURL)
+        ? `${cheURL}/f?url=${encodeURIComponent(
+            fullGitURL,
+          )}&policies.create=peruser`
+        : fullGitURL;
+    }
+    return fullGitURL;
+  } catch {
+    return null;
+  }
 };

--- a/workspaces/topology/plugins/topology/src/utils/git-utils.test.ts
+++ b/workspaces/topology/plugins/topology/src/utils/git-utils.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { detectGitType, GitProvider, hasDomain } from './git-utils';
+import { MAX_URL_LENGTH } from './url-utils';
 
 describe('hasDomain', () => {
   it('should return true if URL starts with https://domain/', () => {
@@ -82,5 +83,10 @@ describe('detectGitType', () => {
 
   it('should return GitProvider.INVALID for invalid URLs', () => {
     expect(detectGitType('not a URL')).toBe(GitProvider.INVALID);
+  });
+
+  it('should return GitProvider.INVALID for URLs exceeding the length limit', () => {
+    const longUrl = `https://github.com/user/${'a'.repeat(MAX_URL_LENGTH)}`;
+    expect(detectGitType(longUrl)).toBe(GitProvider.INVALID);
   });
 });

--- a/workspaces/topology/plugins/topology/src/utils/git-utils.ts
+++ b/workspaces/topology/plugins/topology/src/utils/git-utils.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { MAX_URL_LENGTH } from './url-utils';
+
 export const gitUrlRegex =
   /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;
 
@@ -33,7 +35,8 @@ export enum GitProvider {
 }
 
 export const detectGitType = (url: string): GitProvider => {
-  if (!gitUrlRegex.test(url)) {
+  // Guard against ReDoS from nested quantifiers in gitUrlRegex
+  if (url.length > MAX_URL_LENGTH || !gitUrlRegex.test(url)) {
     // Not a URL
     return GitProvider.INVALID;
   }

--- a/workspaces/topology/plugins/topology/src/utils/resource-utils.ts
+++ b/workspaces/topology/plugins/topology/src/utils/resource-utils.ts
@@ -41,6 +41,7 @@ import {
   getPodsDataForResource,
 } from './pod-resource-utils';
 import { WORKLOAD_TYPES } from './topology-utils';
+import { isValidHttpUrl } from './url-utils';
 
 export const byCreationTime = (left: any, right: any): number => {
   const leftCreationTime = new Date(
@@ -155,9 +156,6 @@ export const getIngressesURL = (
   return ingressData?.url;
 };
 
-const validUrl = (url?: string | null) =>
-  url?.startsWith('http://') || url?.startsWith('https://');
-
 export const getIngressesDataForResourceServices = (
   resources: K8sResponseData,
   resource: K8sWorkloadResource,
@@ -186,7 +184,7 @@ export const getIngressesDataForResourceServices = (
       });
       acc.push({
         ingress,
-        url: validUrl(ingressURL) ? ingressURL : undefined,
+        url: isValidHttpUrl(ingressURL) ? ingressURL : undefined,
       });
     }
     return acc;

--- a/workspaces/topology/plugins/topology/src/utils/url-utils.test.ts
+++ b/workspaces/topology/plugins/topology/src/utils/url-utils.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { unsafeScriptUrl } from '../test-utils/unsafeScriptUrl';
+import { isValidGitUrl, isValidHttpUrl, MAX_URL_LENGTH } from './url-utils';
+
+describe('isValidHttpUrl', () => {
+  it('should accept http and https URLs', () => {
+    expect(isValidHttpUrl('http://example.com')).toBe(true);
+    expect(isValidHttpUrl('https://example.com/path')).toBe(true);
+  });
+
+  it('should reject non-http schemes and empty values', () => {
+    expect(isValidHttpUrl(unsafeScriptUrl())).toBe(false);
+    expect(isValidHttpUrl('data:text/html,hi')).toBe(false);
+    expect(isValidHttpUrl('ftp://example.com')).toBe(false);
+    expect(isValidHttpUrl('')).toBe(false);
+    expect(isValidHttpUrl(null)).toBe(false);
+    expect(isValidHttpUrl(undefined)).toBe(false);
+  });
+
+  it('should reject URLs longer than MAX_URL_LENGTH', () => {
+    expect(
+      isValidHttpUrl(`https://example.com/${'a'.repeat(MAX_URL_LENGTH)}`),
+    ).toBe(false);
+  });
+});
+
+describe('isValidGitUrl', () => {
+  it('should accept http, https, ssh, and git schemes', () => {
+    expect(isValidGitUrl('https://github.com/user/repo')).toBe(true);
+    expect(isValidGitUrl('http://github.com/user/repo')).toBe(true);
+    expect(isValidGitUrl('ssh://git@github.com/user/repo.git')).toBe(true);
+    expect(isValidGitUrl('git://github.com/user/repo.git')).toBe(true);
+  });
+
+  it('should accept SCP-like git URLs', () => {
+    expect(isValidGitUrl('git@github.com:user/repo.git')).toBe(true);
+    expect(isValidGitUrl('user@gitlab.com:group/repo.git')).toBe(true);
+  });
+
+  it('should reject unsafe or invalid values', () => {
+    expect(isValidGitUrl(unsafeScriptUrl())).toBe(false);
+    expect(isValidGitUrl('file:///etc/passwd')).toBe(false);
+    expect(isValidGitUrl('not a URL')).toBe(false);
+    expect(isValidGitUrl('')).toBe(false);
+    expect(isValidGitUrl(null)).toBe(false);
+  });
+
+  it('should reject URLs longer than MAX_URL_LENGTH', () => {
+    expect(
+      isValidGitUrl(`https://github.com/user/${'a'.repeat(MAX_URL_LENGTH)}`),
+    ).toBe(false);
+  });
+});

--- a/workspaces/topology/plugins/topology/src/utils/url-utils.ts
+++ b/workspaces/topology/plugins/topology/src/utils/url-utils.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Maximum length for untrusted URL inputs before regex/parse operations. */
+export const MAX_URL_LENGTH = 2048;
+
+/**
+ * Returns true if the URL uses an HTTP or HTTPS scheme.
+ * Used when rendering clickable links from untrusted Kubernetes data.
+ */
+export const isValidHttpUrl = (url?: string | null): boolean => {
+  if (!url || url.length > MAX_URL_LENGTH) {
+    return false;
+  }
+  return url.startsWith('http://') || url.startsWith('https://');
+};
+
+/**
+ * Returns true if the URL uses an allowed git scheme (http, https, ssh, git)
+ * or SCP-like syntax (user@host:path).
+ */
+export const isValidGitUrl = (url?: string | null): boolean => {
+  if (!url || url.length > MAX_URL_LENGTH) {
+    return false;
+  }
+  if (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('ssh://') ||
+    url.startsWith('git://')
+  ) {
+    return true;
+  }
+  // SCP-like: git@host:path or user@host:path
+  return /^[^@\s/]+@[^:\s/]+:/.test(url);
+};

--- a/workspaces/topology/yarn.lock
+++ b/workspaces/topology/yarn.lock
@@ -1999,12 +1999,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:^0.6.9":
-  version: 0.6.10
-  resolution: "@backstage/backend-openapi-utils@npm:0.6.10"
+"@backstage/backend-openapi-utils@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/backend-openapi-utils@npm:0.7.0"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/types": "npm:^1.2.2"
     "@types/express": "npm:^4.17.6"
@@ -2019,20 +2019,20 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/56ba10cee438924b221f2219794d917377705acc16d6547083cec5836e50a11d5b288ccbfd20383be4b22815a9b767523c6212dfc99a2302bb24a92127629570
+  checksum: 10/4adc8b3b0d068d7d624d7dd5b1e2a38a850d410dfdeb105a3fdc62811ade22cf4d8a6759c13ae552e05ab8315d9767d98e7b806910c9ae62194db4d94e744ebf
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.8.0, @backstage/backend-plugin-api@npm:^1.9.0, @backstage/backend-plugin-api@npm:^1.9.1, @backstage/backend-plugin-api@npm:^1.9.2":
-  version: 1.9.2
-  resolution: "@backstage/backend-plugin-api@npm:1.9.2"
+"@backstage/backend-plugin-api@npm:^1.8.0, @backstage/backend-plugin-api@npm:^1.9.0, @backstage/backend-plugin-api@npm:^1.9.1, @backstage/backend-plugin-api@npm:^1.9.2, @backstage/backend-plugin-api@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@backstage/backend-plugin-api@npm:1.9.3"
   dependencies:
-    "@backstage/cli-common": "npm:^0.2.2"
+    "@backstage/cli-common": "npm:^0.3.0"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-auth-node": "npm:^0.7.2"
+    "@backstage/plugin-auth-node": "npm:^0.7.3"
     "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.1"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
     "@backstage/types": "npm:^1.2.2"
     "@types/express": "npm:^4.17.6"
     "@types/json-schema": "npm:^7.0.6"
@@ -2040,22 +2040,22 @@ __metadata:
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/6592ae8fd1c4f23708b64506a90995a561347751fae4240bd6f1d2607ee8175163d3b03182297a647563875b7e3165466c043e930c9818805f7aa291a4b8c1b8
+  checksum: 10/578530991f9ec6c35bc34ba5cb8037fe986d991717c2f62e18de2e17afc24e8355dbf370be18c8756e8067ca57b8a88849d6348e302bbccc749d594f451e777b
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.14.0, @backstage/catalog-client@npm:^1.15.1, @backstage/catalog-client@npm:^1.16.0":
-  version: 1.16.0
-  resolution: "@backstage/catalog-client@npm:1.16.0"
+"@backstage/catalog-client@npm:^1.14.0, @backstage/catalog-client@npm:^1.15.1, @backstage/catalog-client@npm:^1.16.0, @backstage/catalog-client@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@backstage/catalog-client@npm:1.16.1"
   dependencies:
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/errors": "npm:^1.3.1"
-    "@backstage/filter-predicates": "npm:^0.1.3"
+    "@backstage/filter-predicates": "npm:^0.1.4"
     "@backstage/plugin-catalog-common": "npm:^1.1.10"
     cross-fetch: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     uri-template: "npm:^2.0.0"
-  checksum: 10/2348646d6cdad5ff4c3df9dd909aa0e0f886fb652d35b4f78987c551a0c95a882b2641c3b823c5635c66a03d53690ba16675495eba67f7ec3cdbb0a9cc64133c
+  checksum: 10/7ecd7b38e71db7afbcde34ce7397a7e58681f28df78a1012a0200b73a381d99881f9a9a561f971b3fe4dc1a2e1075918ae3f292314e3ce94f3b3fe4afcf67d6a
   languageName: node
   linkType: hard
 
@@ -2082,6 +2082,16 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.24.5"
   checksum: 10/1fc0067fbdb113e317e68e631d4e5bad92efc41d2a6671a15c143c05d87567281e43991f2bb25902e4752c59762577258e97097299f57b3f2d471c863cc1d244
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/cli-common@npm:0.3.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+  checksum: 10/323c455d4e842f045bd2e29149897c2fe004156d28f933dc7019d8789eb6fea82eeb82863d5b0471bb0b14b09e5863c3ab281e8e33f91651f08d0eb1c131bddb
   languageName: node
   linkType: hard
 
@@ -2723,16 +2733,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/filter-predicates@npm:^0.1.1, @backstage/filter-predicates@npm:^0.1.2, @backstage/filter-predicates@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "@backstage/filter-predicates@npm:0.1.3"
+"@backstage/filter-predicates@npm:^0.1.1, @backstage/filter-predicates@npm:^0.1.2, @backstage/filter-predicates@npm:^0.1.3, @backstage/filter-predicates@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/filter-predicates@npm:0.1.4"
   dependencies:
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/types": "npm:^1.2.2"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10/b84c43e86efef80baececb0391efdb000284de66c0454109e30f5f70af01d5c3421783e9fb75ab237eae47644860fa23d663420462cb806c732ec8ca319144a8
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10/42445bd8cfdf8e329c34019d159058d6d0c38b5a58ba010287499f87aac3fd84c4fd43e7afd29b0fcfd6822cf8a7dbf6fc307a42e99057bb350a1d2b9b3db1d3
   languageName: node
   linkType: hard
 
@@ -2884,7 +2894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:^2.0.0, @backstage/integration@npm:^2.0.2, @backstage/integration@npm:^2.0.3":
+"@backstage/integration@npm:^2.0.0, @backstage/integration@npm:^2.0.3":
   version: 2.0.3
   resolution: "@backstage/integration@npm:2.0.3"
   dependencies:
@@ -3053,12 +3063,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:^0.7.0, @backstage/plugin-auth-node@npm:^0.7.1, @backstage/plugin-auth-node@npm:^0.7.2":
-  version: 0.7.2
-  resolution: "@backstage/plugin-auth-node@npm:0.7.2"
+"@backstage/plugin-auth-node@npm:^0.7.0, @backstage/plugin-auth-node@npm:^0.7.1, @backstage/plugin-auth-node@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@backstage/plugin-auth-node@npm:0.7.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
-    "@backstage/catalog-client": "npm:^1.16.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
@@ -3071,28 +3081,28 @@ __metadata:
     passport: "npm:^0.7.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10/063c1b934a4f91c17b30f148a77d3b11f19d83273843b083cc8a8c272533fd33f6c6964a61d254ea3cba29e0200b505398d9595f3fb6ff5eb1e54dcdb4b0fdc0
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10/729d71af478d2da5e8254ee2cb2116df19f58be316776505b37707b7a490faff83f3fd4792779c1422ed59ccf159cb0ebb32f307d1064d0bd09d8d1d8e033474
   languageName: node
   linkType: hard
 
 "@backstage/plugin-catalog-backend@npm:^3.5.0":
-  version: 3.7.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.7.0"
+  version: 3.8.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.8.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:^0.6.9"
-    "@backstage/backend-plugin-api": "npm:^1.9.1"
-    "@backstage/catalog-client": "npm:^1.15.1"
+    "@backstage/backend-openapi-utils": "npm:^0.7.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
-    "@backstage/filter-predicates": "npm:^0.1.3"
-    "@backstage/integration": "npm:^2.0.2"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/integration": "npm:^2.0.3"
     "@backstage/plugin-catalog-common": "npm:^1.1.10"
-    "@backstage/plugin-catalog-node": "npm:^2.2.1"
-    "@backstage/plugin-events-node": "npm:^0.4.22"
+    "@backstage/plugin-catalog-node": "npm:^2.2.3"
+    "@backstage/plugin-events-node": "npm:^0.4.24"
     "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.0"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
     "@backstage/types": "npm:^1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     ajv: "npm:^8.10.0"
@@ -3113,8 +3123,8 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
-  checksum: 10/5dd9efcd56516047aba5963e20ae1a80ceaafd12203213f05aea2798d81514104eaad233398844963511cbd920f3fedc4d3fb9974b95e096243f1e3caca71c8d
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10/9bdf457d15a3f12706cc483bdd388863b36cc15a456f1e529e0722c5c23677581fc599526835f49e6e654dd82d7f29fb52232247dd603fc0c1aa2e555b9625c3
   languageName: node
   linkType: hard
 
@@ -3129,27 +3139,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^2.1.0, @backstage/plugin-catalog-node@npm:^2.2.1":
-  version: 2.2.2
-  resolution: "@backstage/plugin-catalog-node@npm:2.2.2"
+"@backstage/plugin-catalog-node@npm:^2.1.0, @backstage/plugin-catalog-node@npm:^2.2.1, @backstage/plugin-catalog-node@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "@backstage/plugin-catalog-node@npm:2.2.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
-    "@backstage/catalog-client": "npm:^1.16.0"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
     "@backstage/catalog-model": "npm:^1.9.0"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/plugin-catalog-common": "npm:^1.1.10"
     "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.1"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
     "@backstage/types": "npm:^1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
   peerDependencies:
-    "@backstage/backend-test-utils": ^1.11.4
+    "@backstage/backend-test-utils": ^1.11.5
   peerDependenciesMeta:
     "@backstage/backend-test-utils":
       optional: true
-  checksum: 10/80db02b656a9e099e75ea6d437a4bf72e7e0f109b8fc44c33fd05448b9aa0b788e96a7d8b6dc4979b2c38e08dec266ea86f4ea84e9674dbf4e15db33133d697d
+  checksum: 10/e213a3a9c190cdd0f10b4abec7cebe3bc9dbf45c3e2ad3fd7c0379b07c92039dc56a377defc37a3a39720df23eed7c22f6e10d7e6b82e17d17c22df11ea47c76
   languageName: node
   linkType: hard
 
@@ -3246,11 +3256,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:^0.4.20, @backstage/plugin-events-node@npm:^0.4.22":
-  version: 0.4.23
-  resolution: "@backstage/plugin-events-node@npm:0.4.23"
+"@backstage/plugin-events-node@npm:^0.4.20, @backstage/plugin-events-node@npm:^0.4.24":
+  version: 0.4.24
+  resolution: "@backstage/plugin-events-node@npm:0.4.24"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/types": "npm:^1.2.2"
     "@types/content-type": "npm:^1.1.8"
@@ -3259,7 +3269,7 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     express: "npm:^4.22.0"
     uri-template: "npm:^2.0.0"
-  checksum: 10/3eef8215b0c51df85c3773bc39eb87bccb28b7e2b1dd4245e64eb7499a7648b2d9a93a76518e7cd416d017e01ab5147948e888993a050aaa13097e80b2280397
+  checksum: 10/e36fb85c8d3cdb0781d9ed92050432f139925e3828912ac6ce1202be65540552db2b569b693015d54c26c635318a32a5ed550954aef2b4d3c5450e240e0208fe
   languageName: node
   linkType: hard
 
@@ -3453,11 +3463,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.11.0, @backstage/plugin-permission-node@npm:^0.11.1":
-  version: 0.11.1
-  resolution: "@backstage/plugin-permission-node@npm:0.11.1"
+"@backstage/plugin-permission-node@npm:^0.11.0, @backstage/plugin-permission-node@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@backstage/plugin-permission-node@npm:0.11.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
     "@backstage/config": "npm:^1.3.8"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/plugin-permission-common": "npm:^0.9.9"
@@ -3466,7 +3476,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10/2b8c3e280aef147e0df147c7cd5508983462501f8fd9472a7ca82afe6b7dc6e2432e7e48e64e2446f190368a07e13d05000414836cf5aeb68e3aa813ecb1c715
+  checksum: 10/976668176dd9df5e423c4f9f24450b7e7e36ccea548aac7199788869e773adf06eb9974263df231410da9f91d9f276888bd8c54c1bfb50edb8912fa1ccec6769
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Solution description:**
- getEditURL() validates git schemes and wraps GitUrlParse in try/catch
- Mock Topology nodes for manual URL-security checks (yarn start:alpha:mock)

**Screenshots:**
_TODO_

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
