### PR TITLE
docs: add BearerAuth security scheme to OpenAPI specification

### DIFF
--- a/workspaces/linguist/.changeset/eight-horses-tell.md
+++ b/workspaces/linguist/.changeset/eight-horses-tell.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-linguist-backend': patch
 ---
 
-Updated documentation for the linguist backend plugin.
+Add `BearerAuth` security scheme to OpenAPI specification to reflect existing runtime auth behavior

--- a/workspaces/linguist/.changeset/eight-horses-tell.md
+++ b/workspaces/linguist/.changeset/eight-horses-tell.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-linguist-backend': patch
+---
+
+Updated documentation for the linguist backend plugin.

--- a/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.generated.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.generated.ts
@@ -37,9 +37,11 @@ export const spec = {
       url: '/',
     },
   ],
+  security: [{ BearerAuth: [] }],
   paths: {
     '/health': {
       get: {
+        security: [],
         description: 'Checks if the linguist backend is hooked up properly',
         responses: {
           '200': {
@@ -100,6 +102,13 @@ export const spec = {
     headers: {},
     parameters: {},
     requestBodies: {},
+    securitySchemes: {
+      BearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'Backstage user or service token',
+      },
+    },
     responses: {
       ServerError: {
         description: 'Error',

--- a/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.generated.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.generated.ts
@@ -106,6 +106,7 @@ export const spec = {
       BearerAuth: {
         type: 'http',
         scheme: 'bearer',
+        bearerFormat: 'JWT',
         description: 'Backstage user or service token',
       },
     },

--- a/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.yaml
+++ b/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.yaml
@@ -55,6 +55,7 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
+      bearerFormat: JWT
       description: Backstage user or service token
   responses:
     ServerError:

--- a/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.yaml
+++ b/workspaces/linguist/plugins/linguist-backend/src/schema/openapi.yaml
@@ -9,9 +9,12 @@ info:
   contact: {}
 servers:
   - url: /
+security:
+  - BearerAuth: []
 paths:
   /health:
     get:
+      security: []
       description: Checks if the linguist backend is hooked up properly
       responses:
         '200':
@@ -48,6 +51,11 @@ components:
   headers: {}
   parameters: {}
   requestBodies: {}
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Backstage user or service token
   responses:
     ServerError:
       description: Error


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added BearerAuth (type: http, scheme: bearer) to components.securitySchemes in the linguist-backend OpenAPI spec, set it as the global security default, and added security: [] on GET /health to explicitly mark it as auth-free.
The Backstage backend already enforces token-based auth on all plugin routes via its own middleware — the spec simply didn't reflect that, causing OpenAPI security scanners and linters to flag the API as unauthenticated. This change makes the spec accurately document the existing runtime behavior.
This is a documentation-only change. No runtime behavior, middleware, or route handlers are modified.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
