### PR TITLE
fix(entity-feedback): add id tiebreaker so rapid re-voting replaces instead of double-counting

### DIFF
--- a/workspaces/entity-feedback/.changeset/fix-ratings-tiebreaker.md
+++ b/workspaces/entity-feedback/.changeset/fix-ratings-tiebreaker.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-feedback-backend': patch
+---
+
+Fixed a bug where casting a vote and quickly changing it (e.g. clicking Like then immediately clicking Dislike) could double-count both ratings instead of replacing the earlier one with the later one, when both writes landed within the same second.

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+// The "latest rating/response per user" queries in DatabaseHandler used to
+// determine recency by comparing `timestamp`, which on SQLite is populated
+// via CURRENT_TIMESTAMP (1-second resolution). Two writes from the same user
+// within the same second tie on `timestamp` and both get treated as current.
+// An auto-incrementing id gives those queries an unambiguous tie-breaker.
+//
+// SQLite cannot ALTER TABLE ADD an autoincrementing primary key column onto
+// an existing table, so on that dialect each table is rebuilt instead, with
+// existing rows re-inserted in their original (rowid) order so the newly
+// assigned ids preserve prior insertion order.
+
+/**
+ * @param { import("knex").Knex } knex
+ * @param { import("knex").Knex.CreateTableBuilder } table
+ */
+function defineRatingsColumns(knex, table) {
+  table
+    .string('entity_ref')
+    .notNullable()
+    .comment('The ref of the entity being rated');
+  table
+    .string('user_ref')
+    .notNullable()
+    .comment('The user applying the rating');
+  table.string('rating').notNullable().comment('The rating value');
+  table
+    .timestamp('timestamp')
+    .defaultTo(knex.fn.now())
+    .notNullable()
+    .comment('When the rating was recorded');
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @param { import("knex").Knex.CreateTableBuilder } table
+ */
+function defineResponsesColumns(knex, table) {
+  table
+    .string('entity_ref')
+    .notNullable()
+    .comment('The ref of the applicable entity');
+  table.string('user_ref').notNullable().comment('The user responding');
+  table.text('response').comment('The serialized response');
+  table.text('comments').comment('Additional user comments');
+  table
+    .boolean('consent')
+    .defaultTo(true)
+    .notNullable()
+    .comment('Whether user (if recorded) consents to being contacted');
+  table
+    .timestamp('timestamp')
+    .defaultTo(knex.fn.now())
+    .notNullable()
+    .comment('When the response was recorded');
+  table.text('link').comment('The entity URL link');
+}
+
+const TABLES = {
+  ratings: {
+    columns: ['entity_ref', 'user_ref', 'rating', 'timestamp'],
+    define: defineRatingsColumns,
+  },
+  responses: {
+    columns: [
+      'entity_ref',
+      'user_ref',
+      'response',
+      'comments',
+      'consent',
+      'timestamp',
+      'link',
+    ],
+    define: defineResponsesColumns,
+  },
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @param { string } tableName
+ * @param { { columns: string[], define: (knex: import("knex").Knex, table: import("knex").Knex.CreateTableBuilder) => void } } table
+ */
+async function addIdColumn(knex, tableName, { columns, define }) {
+  if (knex.client.config.client.includes('sqlite')) {
+    const tmpTableName = `${tableName}_pre_id_migration`;
+    await knex.schema.renameTable(tableName, tmpTableName);
+    await knex.schema.createTable(tableName, table => {
+      table.increments('id').comment('Auto-incrementing id');
+      define(knex, table);
+    });
+    const columnList = columns.join(', ');
+    await knex.raw(
+      `insert into ?? (${columnList}) select ${columnList} from ?? order by rowid`,
+      [tableName, tmpTableName],
+    );
+    await knex.schema.dropTable(tmpTableName);
+  } else {
+    await knex.schema.alterTable(tableName, table => {
+      table
+        .increments('id', { primaryKey: false })
+        .comment('Auto-incrementing id');
+    });
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @param { string } tableName
+ */
+async function dropIdColumn(knex, tableName) {
+  await knex.schema.alterTable(tableName, table => {
+    table.dropColumn('id');
+  });
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  for (const [tableName, table] of Object.entries(TABLES)) {
+    await addIdColumn(knex, tableName, table);
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async function down(knex) {
+  for (const tableName of Object.keys(TABLES)) {
+    await dropIdColumn(knex, tableName);
+  }
+};

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
@@ -23,9 +23,11 @@
 // An auto-incrementing id gives those queries an unambiguous tie-breaker.
 //
 // SQLite cannot ALTER TABLE ADD an autoincrementing primary key column onto
-// an existing table, so on that dialect each table is rebuilt instead, with
-// existing rows re-inserted in their original (rowid) order so the newly
-// assigned ids preserve prior insertion order.
+// an existing table, and other dialects don't guarantee that backfilling an
+// auto-increment column onto existing rows assigns values in recency order
+// (e.g. MySQL may assign them in clustered-index order). So every dialect
+// rebuilds the table instead, re-inserting existing rows ordered by
+// `timestamp` so the newly assigned ids reflect recency.
 
 /**
  * @param { import("knex").Knex } knex
@@ -98,26 +100,18 @@ const TABLES = {
  * @param { { columns: string[], define: (knex: import("knex").Knex, table: import("knex").Knex.CreateTableBuilder) => void } } table
  */
 async function addIdColumn(knex, tableName, { columns, define }) {
-  if (knex.client.config.client.includes('sqlite')) {
-    const tmpTableName = `${tableName}_pre_id_migration`;
-    await knex.schema.renameTable(tableName, tmpTableName);
-    await knex.schema.createTable(tableName, table => {
-      table.increments('id').comment('Auto-incrementing id');
-      define(knex, table);
-    });
-    const columnList = columns.join(', ');
-    await knex.raw(
-      `insert into ?? (${columnList}) select ${columnList} from ?? order by rowid`,
-      [tableName, tmpTableName],
-    );
-    await knex.schema.dropTable(tmpTableName);
-  } else {
-    await knex.schema.alterTable(tableName, table => {
-      table
-        .increments('id', { primaryKey: false })
-        .comment('Auto-incrementing id');
-    });
-  }
+  const tmpTableName = `${tableName}_pre_id_migration`;
+  await knex.schema.renameTable(tableName, tmpTableName);
+  await knex.schema.createTable(tableName, table => {
+    table.increments('id').comment('Auto-incrementing id');
+    define(knex, table);
+  });
+  const columnList = columns.join(', ');
+  await knex.raw(
+    `insert into ?? (${columnList}) select ${columnList} from ?? order by timestamp`,
+    [tableName, tmpTableName],
+  );
+  await knex.schema.dropTable(tmpTableName);
 }
 
 /**

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/migrations/20260723000000_add_id_tiebreaker.js
@@ -117,11 +117,21 @@ async function addIdColumn(knex, tableName, { columns, define }) {
 /**
  * @param { import("knex").Knex } knex
  * @param { string } tableName
+ * @param { { columns: string[], define: (knex: import("knex").Knex, table: import("knex").Knex.CreateTableBuilder) => void } } table
  */
-async function dropIdColumn(knex, tableName) {
-  await knex.schema.alterTable(tableName, table => {
-    table.dropColumn('id');
-  });
+async function dropIdColumn(knex, tableName, { columns, define }) {
+  // `id` is the primary key, so dropping it via alterTable fails on
+  // Postgres/MySQL (the PK constraint depends on the column). Rebuild the
+  // table without it instead, mirroring the `up` migration.
+  const tmpTableName = `${tableName}_pre_id_migration`;
+  await knex.schema.renameTable(tableName, tmpTableName);
+  await knex.schema.createTable(tableName, table => define(knex, table));
+  const columnList = columns.join(', ');
+  await knex.raw(
+    `insert into ?? (${columnList}) select ${columnList} from ?? order by id`,
+    [tableName, tmpTableName],
+  );
+  await knex.schema.dropTable(tmpTableName);
 }
 
 /**
@@ -137,7 +147,7 @@ exports.up = async function up(knex) {
  * @param { import("knex").Knex } knex
  */
 exports.down = async function down(knex) {
-  for (const tableName of Object.keys(TABLES)) {
-    await dropIdColumn(knex, tableName);
+  for (const [tableName, table] of Object.entries(TABLES)) {
+    await dropIdColumn(knex, tableName, table);
   }
 };

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/DatabaseHandler.test.ts
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/DatabaseHandler.test.ts
@@ -219,6 +219,43 @@ describe('DatabaseHandler', () => {
         );
       });
 
+      it('getRatings replaces rather than stacks when a user re-votes within the same timestamp', async () => {
+        // Same entity, same user, same timestamp (down to the second) -- this
+        // is what happens when a user casts a vote and immediately changes
+        // their mind, since SQLite's CURRENT_TIMESTAMP only has 1-second
+        // resolution.
+        await knex('ratings').insert([
+          {
+            entity_ref: 'component:default/service',
+            user_ref: 'user:default/foo',
+            rating: 'LIKE',
+            timestamp: '2004-11-19 08:23:54',
+          },
+          {
+            entity_ref: 'component:default/service',
+            user_ref: 'user:default/foo',
+            rating: 'DISLIKE',
+            timestamp: '2004-11-19 08:23:54',
+          },
+        ]);
+
+        const ratings = await dbHandler.getRatings('component:default/service');
+        expect(ratings).toEqual([
+          { userRef: 'user:default/foo', rating: 'DISLIKE' },
+        ]);
+
+        const aggregates = await dbHandler.getRatingsAggregates([
+          'component:default/service',
+        ]);
+        expect(aggregates).toEqual([
+          {
+            entityRef: 'component:default/service',
+            rating: 'DISLIKE',
+            count: 1,
+          },
+        ]);
+      });
+
       it('recordResponse', async () => {
         const newResponse = {
           userRef: 'user:default/me',

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/DatabaseHandler.ts
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/src/service/DatabaseHandler.ts
@@ -72,13 +72,13 @@ export class DatabaseHandler {
           this.database('ratings')
             .as('latest_ratings')
             .select('entity_ref', 'user_ref')
-            .max('timestamp', { as: 'timestamp' })
+            .max('id', { as: 'id' })
             .whereIn('entity_ref', entityRefs)
             .groupBy('entity_ref', 'user_ref'),
           function joinClause() {
             this.on('ratings.entity_ref', '=', 'latest_ratings.entity_ref')
               .andOn('ratings.user_ref', '=', 'latest_ratings.user_ref')
-              .andOn('ratings.timestamp', '=', 'latest_ratings.timestamp');
+              .andOn('ratings.id', '=', 'latest_ratings.id');
           },
         )
         .select('ratings.entity_ref', 'rating')
@@ -107,14 +107,14 @@ export class DatabaseHandler {
           this.database('ratings')
             .as('latest_ratings')
             .select('user_ref')
-            .max('timestamp', { as: 'timestamp' })
+            .max('id', { as: 'id' })
             .where('entity_ref', entityRef)
             .groupBy('user_ref'),
           function joinClause() {
             this.on('ratings.user_ref', '=', 'latest_ratings.user_ref').andOn(
-              'ratings.timestamp',
+              'ratings.id',
               '=',
-              'latest_ratings.timestamp',
+              'latest_ratings.id',
             );
           },
         )
@@ -143,7 +143,7 @@ export class DatabaseHandler {
           this.database('responses')
             .as('latest_responses')
             .select('user_ref')
-            .max('timestamp', { as: 'timestamp' })
+            .max('id', { as: 'id' })
             .where('entity_ref', entityRef)
             .groupBy('user_ref'),
           function joinClause() {
@@ -151,7 +151,7 @@ export class DatabaseHandler {
               'responses.user_ref',
               '=',
               'latest_responses.user_ref',
-            ).andOn('responses.timestamp', '=', 'latest_responses.timestamp');
+            ).andOn('responses.id', '=', 'latest_responses.id');
           },
         )
         .select('responses.user_ref', 'response', 'comments', 'consent', 'link')


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #9814.

The "latest rating/response per user" queries in `DatabaseHandler` determined recency by comparing `timestamp`, which on SQLite is populated via `CURRENT_TIMESTAMP` (1-second resolution). Two writes from the same user within the same second tied on `timestamp`, so both got counted instead of the newer one replacing the older one — e.g. casting a vote and immediately changing your mind.

Adds an auto-incrementing `id` column to `ratings` and `responses` (new migration; SQLite can't `ALTER TABLE ADD` an autoincrementing primary key onto an existing table, so that dialect rebuilds the table, preserving existing row order via `rowid`) and switches the tiebreaker from `timestamp` to `id`, which is unambiguous.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
