### PR TITLE
fix(rbac): fix cancel button position on role form page

### DIFF
--- a/workspaces/rbac/.changeset/gentle-doors-sing.md
+++ b/workspaces/rbac/.changeset/gentle-doors-sing.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Fixed cancel button position on the role form page by removing absolute positioning and placing it in the document flow after the error alert

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.tsx
@@ -362,13 +362,17 @@ export const RoleForm = ({
             <Alert severity="error">{`${formik.status.submitError}`}</Alert>
           </Box>
         )}
-        <Button
-          style={{ position: 'absolute', right: '2.75rem', bottom: '2.75rem' }}
-          onClick={() => setOpenCancelDialog(true)}
-          color="primary"
+        <Box
+          style={{
+            display: 'flex',
+            flexDirection: 'row-reverse',
+            marginTop: '1rem',
+          }}
         >
-          {t('roleForm.steps.cancel')}
-        </Button>
+          <Button onClick={() => setOpenCancelDialog(true)} color="primary">
+            {t('roleForm.steps.cancel')}
+          </Button>
+        </Box>
       </CardContent>
       <CancelDialog
         open={openCancelDialog}


### PR DESCRIPTION
## Description

The cancel button on the role create/edit form used `position: absolute` with `bottom: 2.75rem`, placing it outside the normal document flow. When a submit error alert appeared between the stepper and the cancel button, the form height grew and pushed the cancel button further down, visually disconnecting it from the form controls.

This fix removes the absolute positioning and places the cancel button in the normal document flow, right-aligned below the error alert.

Before:

<img width="1677" height="724" alt="image" src="https://github.com/user-attachments/assets/bed5df33-e547-4e30-a35a-e0bfc236edd9" />

With this PR:

<img width="1677" height="724" alt="image" src="https://github.com/user-attachments/assets/80750624-5796-4258-891a-755e3c8a0906" />

## Fixed
- Fixes https://github.com/backstage/community-plugins/issues/10086

#### Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))