### PR TITLE
Version Packages (firehydrant)

### DIFF
--- a/workspaces/firehydrant/.changeset/sharp-turkeys-joke.md
+++ b/workspaces/firehydrant/.changeset/sharp-turkeys-joke.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-firehydrant': patch
----
-
-Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.

--- a/workspaces/firehydrant/plugins/firehydrant/CHANGELOG.md
+++ b/workspaces/firehydrant/plugins/firehydrant/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-firehydrant
 
+## 0.22.1
+
+### Patch Changes
+
+- 970c5fc: Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/firehydrant/plugins/firehydrant/package.json
+++ b/workspaces/firehydrant/plugins/firehydrant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-firehydrant",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A Backstage plugin that integrates towards FireHydrant",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-firehydrant@0.22.1

### Patch Changes

-   970c5fc: Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.
