### PR TITLE
catalog: address review feedback for AWS Config module

### DIFF
--- a/workspaces/catalog/.changeset/aws-config-review-fixes.md
+++ b/workspaces/catalog/.changeset/aws-config-review-fixes.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-aws-config': patch
+---
+
+Fixed entity name sanitization, null safety for tags and region, and SQL escaping in AWS Config queries

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/README.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/README.md
@@ -1,13 +1,13 @@
 # AWS Config catalog plugin for Backstage
 
-This is the AWS Config catalog plugin which is designed to ingest AWS resource information in to the Backstage catalog.
+This is the AWS Config catalog plugin which is designed to ingest AWS resource information into the Backstage catalog.
 
 Features:
 
 1. Automatically add AWS resources from AWS Config
-1. Uses incremental ingestion to efficiently sync resources
+1. Uses incremental ingestion to efficiently sync resources from AWS Config to the Backstage catalog
 
-_Note:_ It is possible to easily configure this entity provider in a way that ingests a large amount of entities in to the Backstage catalog. Please review the [Considerations](#considerations) section below.
+_Note:_ It is possible to easily configure this entity provider in a way that ingests a large amount of entities into the Backstage catalog. Please review the [Considerations](#considerations) section below.
 
 _Note:_ If you are not already using AWS Config it is important to note that you will incur costs by enabling it. Please review its pricing information before enabling in your AWS organization.
 
@@ -104,7 +104,7 @@ spec:
 
 ## Considerations
 
-It's recommended to use the configuration available to ingest the minimum entities necessary into the Backstage catalog. AWS Config, especially in larger organizations, can be tracking a large number of AWS resources that can have a negative effect on both the ingestion mechanism as well as the user catalog experience once stored.
+It's recommended to use the configuration available to ingest the minimum entities necessary into the Backstage catalog. AWS Config, especially in larger organizations, can be tracking a large number of AWS resources that can have a negative effect on both the ingestion mechanism as well as the catalog experience once stored.
 
 General recommendations are:
 
@@ -114,7 +114,7 @@ General recommendations are:
 
 ## JSONata expressions
 
-One of the ways the provider can transform entities is to use [JSONata](https://docs.jsonata.org/overview.html) expressions via the `expression` fields. This is a flexible way to transform fields on the emitted entity based on any field in the AWS Config resource payload.
+One of the ways the provider can transform entities is to use [JSONata](https://docs.jsonata.org/overview.html) via the `expression` field. This is a flexible way to transform fields on the emitted entity based on any field in the AWS Config resource payload.
 
 The AWS Config resource payload is available through the `$resource` variable.
 

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.test.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.test.ts
@@ -319,6 +319,224 @@ describe('AwsConfigInfrastructureProvider', () => {
       "SELECT resourceId, resourceName, resourceType, awsRegion, accountId, arn, tags, configuration WHERE resourceType IN ('AWS::ECS::Service')",
     );
   });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('should sanitize entity names with invalid characters', async () => {
+    mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+      return {
+        Results: [
+          JSON.stringify(
+            mockResource(
+              'My:Service/Name_Here',
+              '111',
+              'us-west-2',
+              'AWS::ECS::Service',
+              { PlatformVersion: 'LATEST' },
+              { component: 'app1' },
+            ),
+          ),
+        ],
+      };
+    });
+
+    return expectMutation(
+      'default',
+      {
+        filters: { resourceTypes: ['AWS::ECS::Service'] },
+      },
+      [
+        createResource({
+          arn: 'arn:aws:xxx:us-west-2:111:/My:Service/Name_Here',
+          name: 'my-service-name-here',
+          description:
+            'AWS Config Resource AWS::ECS::Service My:Service/Name_Here',
+          accountId: '111',
+          region: 'us-west-2',
+          resourceType: 'AWS::ECS::Service',
+          providerId: 'default',
+          type: 'ecs-service',
+        }),
+      ],
+    );
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('should fall back to hash when sanitized name is empty', async () => {
+    mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+      return {
+        Results: [
+          JSON.stringify(
+            mockResource(
+              ':::',
+              '111',
+              'us-west-2',
+              'AWS::ECS::Service',
+              { PlatformVersion: 'LATEST' },
+              { component: 'app1' },
+            ),
+          ),
+        ],
+      };
+    });
+
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          awsConfig: {
+            default: {
+              filters: { resourceTypes: ['AWS::ECS::Service'] },
+            },
+          },
+        },
+      },
+    });
+
+    const { provider } = (
+      await AwsConfigInfrastructureProvider.fromConfig(config, { logger })
+    )[0];
+
+    const result = await provider.next({}, undefined);
+
+    expect(result.entities[0].entity.metadata.name).toMatch(/^[a-f0-9]{63}$/);
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('should handle resources with missing tags', async () => {
+    mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+      return {
+        Results: [
+          JSON.stringify({
+            resourceId: 'arn:aws:xxx:us-west-2:111:/notags',
+            resourceName: 'notags',
+            resourceType: 'AWS::S3::Bucket',
+            awsRegion: 'us-west-2',
+            accountId: '111',
+            arn: 'arn:aws:xxx:us-west-2:111:/notags',
+            configuration: {},
+          }),
+        ],
+      };
+    });
+
+    return expectMutation(
+      'default',
+      {
+        filters: { resourceTypes: ['AWS::S3::Bucket'] },
+      },
+      [
+        createResource({
+          name: 'notags',
+          accountId: '111',
+          region: 'us-west-2',
+          resourceType: 'AWS::S3::Bucket',
+          providerId: 'default',
+          type: 's3-bucket',
+        }),
+      ],
+    );
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it('should handle resources with missing awsRegion', async () => {
+    mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+      return {
+        Results: [
+          JSON.stringify({
+            resourceId: 'arn:aws:xxx::111:/global-resource',
+            resourceName: 'global-resource',
+            resourceType: 'AWS::IAM::Role',
+            accountId: '111',
+            arn: 'arn:aws:xxx::111:/global-resource',
+            tags: [],
+            configuration: {},
+          }),
+        ],
+      };
+    });
+
+    return expectMutation(
+      'default',
+      {
+        filters: { resourceTypes: ['AWS::IAM::Role'] },
+        region: 'us-east-1',
+      },
+      [
+        createResource({
+          arn: 'arn:aws:xxx::111:/global-resource',
+          name: 'global-resource',
+          description: 'AWS Config Resource AWS::IAM::Role global-resource',
+          accountId: '111',
+          region: 'us-east-1',
+          resourceType: 'AWS::IAM::Role',
+          providerId: 'default',
+          type: 'iam-role',
+        }),
+      ],
+    );
+  });
+
+  it('should escape single quotes in tag filter values', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          awsConfig: {
+            default: {
+              filters: {
+                resourceTypes: ['AWS::S3::Bucket'],
+                tags: [{ key: "team's", value: "it's" }],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return AwsConfigInfrastructureProvider.fromConfig(config, {
+      logger,
+    }).then(async ([{ provider }]) => {
+      mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+        return { Results: [] };
+      });
+
+      await provider.next({}, undefined);
+
+      expect(mock).toHaveReceivedCommandWith(SelectResourceConfigCommand, {
+        Expression:
+          "SELECT resourceId, resourceName, resourceType, awsRegion, accountId, arn, tags, configuration WHERE resourceType IN ('AWS::S3::Bucket') AND tags.tag = 'team''s=it''s'",
+      });
+    });
+  });
+
+  it('should escape single quotes in resource type values', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          awsConfig: {
+            default: {
+              filters: {
+                resourceTypes: ["AWS::Some'Type"],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return AwsConfigInfrastructureProvider.fromConfig(config, {
+      logger,
+    }).then(async ([{ provider }]) => {
+      mock.on(SelectResourceConfigCommand).callsFake(async _ => {
+        return { Results: [] };
+      });
+
+      await provider.next({}, undefined);
+
+      expect(mock).toHaveReceivedCommandWith(SelectResourceConfigCommand, {
+        Expression:
+          "SELECT resourceId, resourceName, resourceType, awsRegion, accountId, arn, tags, configuration WHERE resourceType IN ('AWS::Some''Type')",
+      });
+    });
+  });
 });
 
 function createResource({

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.test.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.test.ts
@@ -397,7 +397,7 @@ describe('AwsConfigInfrastructureProvider', () => {
 
     const result = await provider.next({}, undefined);
 
-    expect(result.entities[0].entity.metadata.name).toMatch(/^[a-f0-9]{63}$/);
+    expect(result.entities![0].entity.metadata.name).toMatch(/^[a-f0-9]{63}$/);
   });
 
   // eslint-disable-next-line jest/expect-expect

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.ts
@@ -132,7 +132,9 @@ export class AwsConfigInfrastructureProvider
 
     let entities: Entity[] = [];
 
-    let response: SelectResourceConfigCommandOutput;
+    let response:
+      | SelectResourceConfigCommandOutput
+      | SelectAggregateResourceConfigCommandOutput;
 
     // TODO: Aggregator option
     if (this.config.aggregator) {
@@ -190,7 +192,9 @@ export class AwsConfigInfrastructureProvider
   }
 
   parseResponse(
-    response: SelectAggregateResourceConfigCommandOutput,
+    response:
+      | SelectResourceConfigCommandOutput
+      | SelectAggregateResourceConfigCommandOutput,
   ): AwsConfigResource[] {
     return (
       response.Results?.map(result => {

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/AwsConfigInfrastructureProvider.ts
@@ -215,8 +215,12 @@ export class AwsConfigInfrastructureProvider
       resourceTitle = resource.resourceName;
     } else {
       resourceName = resource.resourceName
-        ? resource.resourceName.replace(':', '-')
+        ? this.sanitizeEntityName(resource.resourceName)
         : SHA256(resource.arn).toString().slice(0, 63);
+
+      if (!resourceName) {
+        resourceName = SHA256(resource.arn).toString().slice(0, 63);
+      }
     }
 
     const resourceResult: Entity = {
@@ -228,7 +232,8 @@ export class AwsConfigInfrastructureProvider
           'aws.amazon.com/resource-type': resource.resourceType,
           'aws.amazon.com/resource-id': resource.resourceId,
           'aws.amazon.com/name': resourceName,
-          'aws.amazon.com/region': resource.awsRegion!,
+          'aws.amazon.com/region':
+            resource.awsRegion ?? this.config.region ?? 'unknown',
         },
         name: resourceName,
         title: resourceTitle,
@@ -270,17 +275,28 @@ export class AwsConfigInfrastructureProvider
     return type.split('::').slice(1).join('-').toLowerCase();
   }
 
+  private sanitizeEntityName(name: string): string {
+    return name
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, '-')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 63);
+  }
+
   tagsToFilter(): string {
     if (!this.config.filters.tagFilters) {
       return '';
     }
 
     const clauses = this.config.filters.tagFilters.map(f => {
+      const key = f.key.replaceAll("'", "''");
       if (f.value) {
-        return `tags.tag = '${f.key}=${f.value}'`;
+        const value = f.value.replaceAll("'", "''");
+        return `tags.tag = '${key}=${value}'`;
       }
 
-      return `tags.key = '${f.key}'`;
+      return `tags.key = '${key}'`;
     });
 
     return clauses.join(' AND ');
@@ -289,7 +305,7 @@ export class AwsConfigInfrastructureProvider
   createQuery(): string {
     let whereClause = this.config.filters.resourceTypes
       .map(resourceType => {
-        return `'${resourceType}'`;
+        return `'${resourceType.replaceAll("'", "''")}'`;
       })
       .join(', ');
 
@@ -316,7 +332,7 @@ export class AwsConfigInfrastructureProvider
 
     const tagMap: any = {};
 
-    resource.tags.forEach(e => {
+    (resource.tags ?? []).forEach(e => {
       tagMap[e.key] = e.value;
     });
 

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/config.ts
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/src/providers/config.ts
@@ -223,7 +223,7 @@ function readFieldTransformDefinitionFromConfig(
   name: string,
 ): FieldTransformDefinition | undefined {
   if (!isObject(configValue)) {
-    throw new Error(`Field must be an object`);
+    throw new Error(`Field '${name}' parent must be an object`);
   }
 
   if (!(name in configValue)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16811,14 +16811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
-  version: 1.10.0
-  resolution: "shell-quote@npm:1.10.0"
-  checksum: 10/d4a22aeefe64919290af753ac6098239d7ffee52a5db62c20edef69794bd10b5f86e298f68be26af9606ac435e890dd391994a5405a90bb8aebef1ff1dde839b
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.4":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10/d4a22aeefe64919290af753ac6098239d7ffee52a5db62c20edef69794bd10b5f86e298f68be26af9606ac435e890dd391994a5405a90bb8aebef1ff1dde839b


### PR DESCRIPTION
Follow-up to #10075 addressing Copilot review feedback.

- Fix response type mismatch for aggregator vs non-aggregator code paths
- Sanitize entity names to conform to DNS-label rules, with hash fallback
- Guard against missing `resource.tags` and `resource.awsRegion`
- Escape single quotes in AWS Config SQL queries to prevent injection
- Include field name in config parsing error messages
- Fix typos and incomplete sentence in README

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))