### PR TITLE
feat(nexus-repository-manager): add scalprum config for RHDH dynamic plugin support

### DIFF
--- a/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
+++ b/workspaces/nexus-repository-manager/plugins/nexus-repository-manager/package.json
@@ -30,6 +30,13 @@
       "@backstage-community/plugin-nexus-repository-manager"
     ]
   },
+  "scalprum": {
+    "name": "backstage-community.plugin-nexus-repository-manager",
+    "exposedModules": {
+      "PluginRoot": "./src/index.ts",
+      "Alpha": "./src/alpha/index.ts"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "build": "backstage-cli package build",


### PR DESCRIPTION
## Summary

The Nexus Repository Manager plugin ships with an empty `scalprum` config in its `package.json`, which prevents RHDH (Red Hat Developer Hub) from auto-registering the plugin's entity page route and conditional tab when loaded as a dynamic plugin.

The plugin already has a well-structured `src/alpha/entityContents.tsx` that defines an `EntityContentBlueprint` with:
- Path: `/build-artifacts`
- Title: `Build Artifacts`
- Filter: `isNexusRepositoryManagerExperimentalAvailable`

But without the scalprum `exposedModules` config, RHDH's dynamic plugin loader can't discover these exports.

## Changes

Added `scalprum` config to `package.json` matching the pattern used by the Quay plugin (`@backstage-community/plugin-quay`), exposing both the main `PluginRoot` and the `Alpha` module.

## Impact

This enables RHDH to:
- Auto-register the "Build Artifacts" tab on entity pages
- Conditionally show the tab only when Nexus annotations are present (using the existing `isNexusRepositoryManagerExperimentalAvailable` filter)
- Use the plugin without explicit `pluginConfig` in `dynamic-plugins.yaml`

Currently, RHDH users must manually configure `mountPoints` and `entityTabs` in the dynamic plugins ConfigMap, and the `entityTabs` entry renders unconditionally on all entities — causing errors on entities without Nexus annotations.

## Test plan
- [ ] Verify the plugin builds with `yarn build` in the nexus-repository-manager workspace
- [ ] Deploy as a dynamic plugin in RHDH and verify the Build Artifacts tab appears only on entities with Nexus annotations
- [ ] Verify the tab does not appear on entities without Nexus annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)