### PR TITLE
Version Packages (apollo-explorer)

### DIFF
--- a/workspaces/apollo-explorer/.changeset/clever-hounds-tickle.md
+++ b/workspaces/apollo-explorer/.changeset/clever-hounds-tickle.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-apollo-explorer': minor
----
-
-**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

--- a/workspaces/apollo-explorer/plugins/apollo-explorer/CHANGELOG.md
+++ b/workspaces/apollo-explorer/plugins/apollo-explorer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-apollo-explorer
 
+## 0.23.0
+
+### Minor Changes
+
+- 8f5956f: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+
 ## 0.22.0
 
 ### Minor Changes

--- a/workspaces/apollo-explorer/plugins/apollo-explorer/package.json
+++ b/workspaces/apollo-explorer/plugins/apollo-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-apollo-explorer",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "apollo-explorer",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-apollo-explorer@0.23.0

### Minor Changes

-   8f5956f: **BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
