### PR TITLE
fix: get renovate to stop upgrading to react router 7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,10 @@
     {
       "matchPackageNames": ["yn"],
       "allowedVersions": "<5.0.0"
+    },
+    {
+      "matchPackageNames": ["react-router", "react-router-dom"],
+      "allowedVersions": "<7.0.0"
     }
   ],
   "ignorePaths": ["**/dist-dynamic/**"],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

React Router 7 is not supported in backstage per https://github.com/backstage/backstage/issues/27927, however renovate doesn't know that and will suggest upgrading to it. 

This results in noise for community plugins maintainers that have to close the PRs:

<img width="812" height="318" alt="image" src="https://github.com/user-attachments/assets/f96fc621-4756-498c-a9ff-5541661a4e7a" />

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
