### PR TITLE
docs(quay): enhance workspace-level README

### DIFF
--- a/workspaces/quay/README.md
+++ b/workspaces/quay/README.md
@@ -1,16 +1,28 @@
-# [Backstage](https://backstage.io)
+# Quay plugin for Backstage
 
-This is your newly scaffolded Backstage App, Good Luck!
+This workspace contains plugins for viewing and managing [Quay](https://docs.quay.io/) container registry data within Backstage. They let you surface information about your container images and automate common Quay tasks from your Backstage application.
 
-To start the app, run:
+## Plugins
+
+This workspace is composed of several packages:
+
+- [quay](./plugins/quay/README.md) - The frontend plugin that displays information about your container images from the Quay registry on entity pages.
+- [quay-backend](./plugins/quay-backend/README.md) - The backend plugin that queries the Quay API, with support for permissions and OAuth2 access token authentication.
+- [quay-actions](./plugins/quay-actions/README.md) - A scaffolder backend module providing software template actions for Quay, such as creating a Quay repository.
+- [quay-common](./plugins/quay-common/README.md) - A common library containing shared types and utilities used by the other Quay plugins.
+
+## Quick start
+
+You will find detailed installation instructions in each plugin's README file.
 
 ```sh
-yarn install
-yarn start
+# From your Backstage root directory
+
+# install the frontend plugin
+yarn --cwd packages/app add @backstage-community/plugin-quay
+
+# install the backend plugin
+yarn --cwd packages/backend add @backstage-community/plugin-quay-backend
 ```
 
-To generate knip reports for this app, run:
-
-```sh
-yarn backstage-repo-tools knip-reports
-```
+See the [quay](./plugins/quay/README.md) and [quay-backend](./plugins/quay-backend/README.md) READMEs for configuration and entity page setup.


### PR DESCRIPTION
## What does this PR do?

Replaces the default scaffolded README in `workspaces/quay` with a workspace-specific overview. The new README describes the Quay workspace purpose, lists its four packages (`quay`, `quay-backend`, `quay-actions`, `quay-common`) with links and short descriptions, and adds a quick-start install snippet that points to the per-plugin READMEs.

## Why was this PR needed?

Issue [#4056](https://github.com/backstage/community-plugins/issues/4056) asks for stronger workspace-level READMEs so contributors can understand what each workspace contains. Investigation showed that `workspaces/analytics` (my original target) was already improved in #6852, while `workspaces/quay` still used the boilerplate "This is your newly scaffolded Backstage App, Good Luck!" text despite being a multi-plugin workspace. This change follows the format used by gold-standard workspace READMEs (e.g. `announcements`) and the precedent of #6852.

This is a follow-up to closed PR #9538. Per maintainer feedback:
- Removed the workspace README regression test (docs-only PRs do not need that coverage)
- Signed the commit with DCO (`Signed-off-by: Ahnaf Labib <ahnaflabib212@gmail.com>`)

## What are the relevant issue numbers?

Addresses #4056

## Screenshots / Recordings (if applicable)

Documentation-only change (no UI or backend runtime). Before/after of `workspaces/quay/README.md`:

**Before (scaffold):**

```
# Backstage

This is your newly scaffolded Backstage App, Good Luck!

To start the app, run:

yarn install
yarn start
```

**After:** workspace title + purpose, Plugins section linking all four Quay packages, and Quick start install commands.

- Rendered after: https://github.com/AhnfLabib/community-plugins/blob/fix-issue-4056/workspaces/quay/README.md

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior — N/A (docs-only; no runtime behavior; test removed per maintainer request on #9538)
- [x] All tests passing — CI checks should run on this PR (DCO, quay workspace CI/verify)
- [x] Follows project style guide — matches existing enhanced workspace README pattern (#6852 / announcements)
- [x] No breaking changes introduced
- [x] Documentation updated (if applicable)
- [x] All commits have a Signed-off-by line
