### PR TITLE
chore(akeyless): cap @types/node to avoid tsc:full breakage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,12 @@
     {
       "matchPackageNames": ["yn"],
       "allowedVersions": "<5.0.0"
+    },
+    {
+      "description": "akeyless: @types/node >=22.10.9 conflicts with @types/webpack-env during tsc:full",
+      "matchPackageNames": ["@types/node"],
+      "matchFileNames": ["workspaces/akeyless/**"],
+      "allowedVersions": "<=22.10.8"
     }
   ],
   "ignorePaths": ["**/dist-dynamic/**"],

--- a/workspaces/akeyless/package.json
+++ b/workspaces/akeyless/package.json
@@ -54,9 +54,9 @@
   "resolutions": {
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "@types/node@npm:*": "22.5.5",
-    "@types/node@npm:>=13.7.0": "22.5.5",
-    "@types/node@npm:>=12.12.47": "22.5.5",
+    "@types/node@npm:*": "22.10.8",
+    "@types/node@npm:>=13.7.0": "22.10.8",
+    "@types/node@npm:>=12.12.47": "22.10.8",
     "csstype@npm:^3.0.2": "3.0.9",
     "csstype@npm:^3.1.2": "3.0.9",
     "csstype@npm:^3.1.3": "3.0.9"

--- a/workspaces/akeyless/yarn.lock
+++ b/workspaces/akeyless/yarn.lock
@@ -9985,12 +9985,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:22.5.5":
-  version: 22.5.5
-  resolution: "@types/node@npm:22.5.5"
+"@types/node@npm:22.10.8":
+  version: 22.10.8
+  resolution: "@types/node@npm:22.10.8"
   dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10/172d02c8e6d921699edcf559c28b3805616bd6481af1b3cb0299f89ad9a6f33b71050434c06ce7b503166054a26275344187c443f99f745d0b12601372452f19
+    undici-types: "npm:~6.20.0"
+  checksum: 10/30dcbd045789b20bbb305c1eafde57b4517486c7e045a54b532a7a6287eca095158204976205d2b452ebbd36c93a444e60d811eb444cee01995e9a644a4f5659
   languageName: node
   linkType: hard
 
@@ -27506,10 +27506,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.2":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: 10/cf0b48ed4fc99baf56584afa91aaffa5010c268b8842f62e02f752df209e3dea138b372a60a963b3b2576ed932f32329ce7ddb9cb5f27a6c83040d8cd74b7a70
+"undici-types@npm:~6.20.0":
+  version: 6.20.0
+  resolution: "undici-types@npm:6.20.0"
+  checksum: 10/583ac7bbf4ff69931d3985f4762cde2690bb607844c16a5e2fbb92ed312fe4fa1b365e953032d469fa28ba8b224e88a595f0b10a449332f83fa77c695e567dbe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Pin akeyless workspace `@types/node` resolutions to `22.10.8` (last version that passes `yarn tsc:full`).
- Add a Renovate `allowedVersions` rule for `workspaces/akeyless/**` so updates stop before `22.10.9`, which conflicts with `@types/webpack-env` (`TS2403` on `require`).

Related: blocks/supersedes the intent of #10114 (`22.20.1`), which fails typecheck for this workspace.

## Test plan
- [x] `yarn tsc:full` passes with `@types/node@22.10.8`
- [x] Confirmed `@types/node@22.10.9` and `22.20.1` fail with the webpack-env `require` clash
- [ ] CI akeyless workspace checks green


Made with [Cursor](https://cursor.com)