### PR TITLE
Version Packages (feedback)

### DIFF
--- a/workspaces/feedback/.changeset/beige-wombats-warn.md
+++ b/workspaces/feedback/.changeset/beige-wombats-warn.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-feedback-common': major
----
-
-Exported and documented default constants for error listings (`DEFAULT_ERROR_LIST`) and experience lists (`DEFAULT_EXPERIENCE_LIST`), along with full permission declarations and helpers (`isFeedbackPermission`) to support secure feedback operations.

--- a/workspaces/feedback/.changeset/empty-chicken-sneeze.md
+++ b/workspaces/feedback/.changeset/empty-chicken-sneeze.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-feedback-backend': minor
----
-
-Registered Model Context Protocol (MCP) actions (`list-feedbacks`, `get-feedback`, `create-feedback`, `update-feedback`, `delete-feedback`) with respective state attributes (`idempotent`, `readOnly`, `destructive`) for granular tooling safety. Secured router endpoints using Backstage permissions.

--- a/workspaces/feedback/.changeset/pretty-poets-accept.md
+++ b/workspaces/feedback/.changeset/pretty-poets-accept.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-feedback': patch
----
-
-Refactored the frontend to consume feedback constants directly from the common `@backstage-community/plugin-feedback-common` package instead of local definitions.

--- a/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-feedback-backend
 
+## 2.2.0
+
+### Minor Changes
+
+- 59725e0: Registered Model Context Protocol (MCP) actions (`list-feedbacks`, `get-feedback`, `create-feedback`, `update-feedback`, `delete-feedback`) with respective state attributes (`idempotent`, `readOnly`, `destructive`) for granular tooling safety. Secured router endpoints using Backstage permissions.
+
+### Patch Changes
+
+- Updated dependencies [59725e0]
+  - @backstage-community/plugin-feedback-common@1.0.0
+
 ## 2.1.8
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-backend",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/feedback/plugins/feedback-common/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-common/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @backstage-community/plugin-feedback-common
+
+## 1.0.0
+
+### Major Changes
+
+- 59725e0: Exported and documented default constants for error listings (`DEFAULT_ERROR_LIST`) and experience lists (`DEFAULT_EXPERIENCE_LIST`), along with full permission declarations and helpers (`isFeedbackPermission`) to support secure feedback operations.

--- a/workspaces/feedback/plugins/feedback-common/package.json
+++ b/workspaces/feedback/plugins/feedback-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-common",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the feedback plugin",
   "main": "src/index.ts",

--- a/workspaces/feedback/plugins/feedback/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-feedback
 
+## 1.8.7
+
+### Patch Changes
+
+- 59725e0: Refactored the frontend to consume feedback constants directly from the common `@backstage-community/plugin-feedback-common` package instead of local definitions.
+- Updated dependencies [59725e0]
+  - @backstage-community/plugin-feedback-common@1.0.0
+
 ## 1.8.6
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback/package.json
+++ b/workspaces/feedback/plugins/feedback/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-feedback-common@1.0.0

### Major Changes

-   59725e0: Exported and documented default constants for error listings (`DEFAULT_ERROR_LIST`) and experience lists (`DEFAULT_EXPERIENCE_LIST`), along with full permission declarations and helpers (`isFeedbackPermission`) to support secure feedback operations.

## @backstage-community/plugin-feedback-backend@2.2.0

### Minor Changes

-   59725e0: Registered Model Context Protocol (MCP) actions (`list-feedbacks`, `get-feedback`, `create-feedback`, `update-feedback`, `delete-feedback`) with respective state attributes (`idempotent`, `readOnly`, `destructive`) for granular tooling safety. Secured router endpoints using Backstage permissions.

### Patch Changes

-   Updated dependencies [59725e0]
    -   @backstage-community/plugin-feedback-common@1.0.0

## @backstage-community/plugin-feedback@1.8.7

### Patch Changes

-   59725e0: Refactored the frontend to consume feedback constants directly from the common `@backstage-community/plugin-feedback-common` package instead of local definitions.
-   Updated dependencies [59725e0]
    -   @backstage-community/plugin-feedback-common@1.0.0
