### PR TITLE
fix: use modern object form for entity extension default filters

### DIFF
--- a/workspaces/announcements/.changeset/modernize-entity-filters.md
+++ b/workspaces/announcements/.changeset/modernize-entity-filters.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Updated entity extension default filter to use the modern object form.

--- a/workspaces/announcements/plugins/announcements/src/alpha/entityCards.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/entityCards.tsx
@@ -30,7 +30,7 @@ export const entityAnnouncementsCard = EntityCardBlueprint.make({
   name: 'announcements',
   disabled: true,
   params: {
-    filter: 'kind:component,system',
+    filter: { kind: { $in: ['component', 'system'] } },
     loader: async () =>
       import('../components/AnnouncementsCard').then(m =>
         compatWrapper(<m.AnnouncementsCard />),

--- a/workspaces/cicd-statistics/.changeset/modernize-entity-filters.md
+++ b/workspaces/cicd-statistics/.changeset/modernize-entity-filters.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-cicd-statistics': patch
+---
+
+Updated entity extension default filter to use the modern object form.

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/src/alpha/entityContent.tsx
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/src/alpha/entityContent.tsx
@@ -28,7 +28,7 @@ export const entityCicdChartsContent = EntityContentBlueprint.make({
   params: {
     path: 'cicd-statistics',
     title: 'CI/CD Statistics',
-    filter: 'kind:component',
+    filter: { kind: 'component' },
     routeRef: convertLegacyRouteRef(rootCatalogCicdStatsRouteRef),
     loader: () =>
       import('../entity-page').then(m =>

--- a/workspaces/github/.changeset/modernize-entity-filters.md
+++ b/workspaces/github/.changeset/modernize-entity-filters.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-github-pull-requests-board': patch
+'@backstage-community/plugin-github-issues': patch
+'@backstage-community/plugin-github-deployments': patch
+---
+
+Updated entity extension default filters to use the modern object form.

--- a/workspaces/github/plugins/github-deployments/src/alpha/entityCards.tsx
+++ b/workspaces/github/plugins/github-deployments/src/alpha/entityCards.tsx
@@ -21,7 +21,7 @@ import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
 export const entityGithubDeploymentsCard = EntityCardBlueprint.make({
   name: 'overview',
   params: {
-    filter: 'kind:component',
+    filter: { kind: 'component' },
     loader: () =>
       import('../components/GithubDeploymentsCard').then(m => (
         <m.GithubDeploymentsCard />

--- a/workspaces/github/plugins/github-issues/src/alpha/entityCards.tsx
+++ b/workspaces/github/plugins/github-issues/src/alpha/entityCards.tsx
@@ -21,7 +21,7 @@ import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
 export const entityGithubIssuesCard = EntityCardBlueprint.make({
   name: 'overview',
   params: {
-    filter: 'kind:component',
+    filter: { kind: 'component' },
     loader: () =>
       import('../components/GithubIssues').then(m => <m.GithubIssues />),
   },

--- a/workspaces/github/plugins/github-issues/src/alpha/entityContent.tsx
+++ b/workspaces/github/plugins/github-issues/src/alpha/entityContent.tsx
@@ -25,7 +25,7 @@ export const entityGithubIssuesContent = EntityContentBlueprint.make({
   params: {
     path: 'github-issues',
     title: 'GitHub Issues',
-    filter: 'kind:component',
+    filter: { kind: 'component' },
     routeRef: convertLegacyRouteRef(rootRouteRef),
     loader: () =>
       import('../components/GithubIssues').then(m => <m.GithubIssues />),

--- a/workspaces/github/plugins/github-pull-requests-board/src/alpha/entityCards.tsx
+++ b/workspaces/github/plugins/github-pull-requests-board/src/alpha/entityCards.tsx
@@ -22,7 +22,7 @@ import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
 export const entityGithubPullRequestsCard = EntityCardBlueprint.make({
   name: 'overview',
   params: {
-    filter: 'kind:group',
+    filter: { kind: 'group' },
     loader: () =>
       import('../components/EntityTeamPullRequestsCard').then(m => (
         <m.EntityTeamPullRequestsCard />

--- a/workspaces/github/plugins/github-pull-requests-board/src/alpha/entityContent.tsx
+++ b/workspaces/github/plugins/github-pull-requests-board/src/alpha/entityContent.tsx
@@ -26,7 +26,7 @@ export const entityGithubPullRequestsContent = EntityContentBlueprint.make({
   params: {
     path: 'pull-requests',
     title: 'Pull Requests',
-    filter: 'kind:group',
+    filter: { kind: 'group' },
     routeRef: convertLegacyRouteRef(rootRouteRef),
     loader: () =>
       import('../components/EntityTeamPullRequestsContent').then(m => (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replace legacy string-based `filter` syntax (e.g. `'kind:component'`) with the modern object form (e.g. `{ kind: 'component' }`) across entity card and content extensions in the `github`, `cicd-statistics`, and `announcements` workspaces. Multi-value filters use the `$in` operator.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)