### PR TITLE
chore(announcements): migrate deprecated config.schema to configSchema

### DIFF
--- a/workspaces/announcements/.changeset/migrate-config-schema.md
+++ b/workspaces/announcements/.changeset/migrate-config-schema.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements': patch
+---
+
+Migrated extension config from deprecated `config.schema` to `configSchema` with zod v4 Standard Schema

--- a/workspaces/announcements/plugins/announcements/package.json
+++ b/workspaces/announcements/plugins/announcements/package.json
@@ -73,7 +73,8 @@
     "@uiw/react-md-editor": "^4.0.11",
     "luxon": "^3.2.0",
     "react-use": "^17.2.4",
-    "slugify": "1.6.9"
+    "slugify": "1.6.9",
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",

--- a/workspaces/announcements/plugins/announcements/report-alpha.api.md
+++ b/workspaces/announcements/plugins/announcements/report-alpha.api.md
@@ -59,10 +59,10 @@ const announcementsPlugin: OverridableFrontendPlugin<
       };
       configInput: {
         max?: number | undefined;
+        category?: string | undefined;
         active?: boolean | undefined;
         current?: boolean | undefined;
         tags?: string[] | undefined;
-        category?: string | undefined;
       };
       output: ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>;
       inputs: {};
@@ -124,9 +124,9 @@ const announcementsPlugin: OverridableFrontendPlugin<
       };
       configInput: {
         category?: string | undefined;
-        defaultInactive?: boolean | undefined;
         hideStartAt?: boolean | undefined;
         markdownRenderer?: 'backstage' | 'md-editor' | undefined;
+        defaultInactive?: boolean | undefined;
         path?: string | undefined;
         title?: string | undefined;
       };

--- a/workspaces/announcements/plugins/announcements/src/alpha/banner.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/banner.tsx
@@ -16,6 +16,7 @@
 
 import { compatWrapper } from '@backstage/core-compat-api';
 import { AppRootElementBlueprint } from '@backstage/frontend-plugin-api';
+import { z } from 'zod';
 import { NewAnnouncementBanner } from '../components/NewAnnouncementBanner';
 
 /**
@@ -28,14 +29,12 @@ import { NewAnnouncementBanner } from '../components/NewAnnouncementBanner';
  */
 export const announcementsBanner = AppRootElementBlueprint.makeWithOverrides({
   name: 'banner',
-  config: {
-    schema: {
-      max: z => z.number().optional().default(1),
-      category: z => z.string().optional(),
-      active: z => z.boolean().optional(),
-      current: z => z.boolean().optional(),
-      tags: z => z.array(z.string()).optional(),
-    },
+  configSchema: {
+    max: z.number().optional().default(1),
+    category: z.string().optional(),
+    active: z.boolean().optional(),
+    current: z.boolean().optional(),
+    tags: z.array(z.string()).optional(),
   },
   factory: (originalFactory, { config }) => {
     return originalFactory({

--- a/workspaces/announcements/plugins/announcements/src/alpha/pages.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/pages.tsx
@@ -19,6 +19,7 @@ import {
 } from '@backstage/core-compat-api';
 import { PageBlueprint } from '@backstage/frontend-plugin-api';
 import { RiMegaphoneLine } from '@remixicon/react';
+import { z } from 'zod';
 import { rootRouteRef } from '../routes';
 
 /**
@@ -30,19 +31,17 @@ import { rootRouteRef } from '../routes';
  * @alpha
  */
 export const announcementsPage = PageBlueprint.makeWithOverrides({
-  config: {
-    schema: {
-      /**
-       * @deprecated Filter by category using URL state (e.g. ?category=...). This option will be removed.
-       */
-      category: z => z.string().optional(),
-      hideStartAt: z => z.boolean().optional(),
-      markdownRenderer: z => z.enum(['backstage', 'md-editor']).optional(),
-      /**
-       * @deprecated Inactive announcement are hidden by default. This option will be removed.
-       */
-      defaultInactive: z => z.boolean().optional(),
-    },
+  configSchema: {
+    /**
+     * @deprecated Filter by category using URL state (e.g. ?category=...). This option will be removed.
+     */
+    category: z.string().optional(),
+    hideStartAt: z.boolean().optional(),
+    markdownRenderer: z.enum(['backstage', 'md-editor']).optional(),
+    /**
+     * @deprecated Inactive announcement are hidden by default. This option will be removed.
+     */
+    defaultInactive: z.boolean().optional(),
   },
   factory: (originalFactory, { config }) =>
     originalFactory({

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -1886,6 +1886,7 @@ __metadata:
     react-router-dom: "npm:^6.3.0"
     react-use: "npm:^17.2.4"
     slugify: "npm:1.6.9"
+    zod: "npm:^4.0.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
Migrates the deprecated `config: { schema: { ... } }` extension config pattern to the new `configSchema` option with zod v4 Standard Schema values.

This resolves the following deprecation warning at startup:
> DEPRECATION WARNING: The `config.schema` option for extension config is deprecated. Use the `configSchema` option instead with Standard Schema values.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))