### PR TITLE
chore(adr,entity-feedback): migrate deprecated config.schema to configSchema

### DIFF
--- a/workspaces/adr/.changeset/migrate-config-schema.md
+++ b/workspaces/adr/.changeset/migrate-config-schema.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-adr': patch
+---
+
+Migrated extension config from deprecated `config.schema` to `configSchema` with zod v4 Standard Schema

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -66,7 +66,8 @@
     "@material-ui/icons": "^4.9.1",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "lodash": "^4.17.21",
-    "react-use": "^17.2.4"
+    "react-use": "^17.2.4",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.4",

--- a/workspaces/adr/plugins/adr/src/alpha.tsx
+++ b/workspaces/adr/plugins/adr/src/alpha.tsx
@@ -30,6 +30,7 @@ import {
   AdrDocument,
   isAdrAvailable,
 } from '@backstage-community/plugin-adr-common';
+import { z } from 'zod';
 import { rootRouteRef } from './routes';
 import { adrApiRef, AdrClient } from './api';
 
@@ -42,10 +43,8 @@ function isAdrDocument(result: any): result is AdrDocument {
 /** @alpha */
 export const adrSearchResultListItemExtension =
   SearchResultListItemBlueprint.makeWithOverrides({
-    config: {
-      schema: {
-        lineClamp: z => z.number().default(5),
-      },
+    configSchema: {
+      lineClamp: z.number().default(5),
     },
     factory(originalFactory, { config }) {
       return originalFactory({

--- a/workspaces/adr/yarn.lock
+++ b/workspaces/adr/yarn.lock
@@ -1715,6 +1715,7 @@ __metadata:
     react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-router-dom: "npm:6.0.0-beta.0 || ^6.3.0"
     react-use: "npm:^17.2.4"
+    zod: "npm:^4.0.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0

--- a/workspaces/entity-feedback/.changeset/migrate-config-schema.md
+++ b/workspaces/entity-feedback/.changeset/migrate-config-schema.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-entity-feedback': patch
+---
+
+Migrated extension config from deprecated `config.schema` to `configSchema` with zod v4 Standard Schema

--- a/workspaces/entity-feedback/plugins/entity-feedback/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback/package.json
@@ -64,7 +64,8 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-use": "^17.2.4"
+    "react-use": "^17.2.4",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.36.4",

--- a/workspaces/entity-feedback/plugins/entity-feedback/report-alpha.api.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback/report-alpha.api.md
@@ -56,8 +56,8 @@ const entityFeedbackPlugin: OverridableFrontendPlugin<
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        variant?: 'starred' | 'like-dislike' | undefined;
         title?: string | undefined;
+        variant?: 'starred' | 'like-dislike' | undefined;
         requestResponse?: boolean | undefined;
         dialogTitle?: string | undefined;
         dialogResponses?:
@@ -110,9 +110,9 @@ const entityFeedbackPlugin: OverridableFrontendPlugin<
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        variant?: 'starred' | 'like-dislike' | undefined;
         title?: string | undefined;
         allEntities?: boolean | undefined;
+        variant?: 'starred' | 'like-dislike' | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };

--- a/workspaces/entity-feedback/plugins/entity-feedback/src/alpha/entityCards.tsx
+++ b/workspaces/entity-feedback/plugins/entity-feedback/src/alpha/entityCards.tsx
@@ -19,6 +19,7 @@ import { compatWrapper } from '@backstage/core-compat-api';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { useAsyncEntity } from '@backstage/plugin-catalog-react';
 import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { z } from 'zod';
 import {
   entityFeedbackAllPredicate,
   entityFeedbackOwnerPredicate,
@@ -29,22 +30,19 @@ import {
  */
 export const entityRatingsButtonsCard = EntityCardBlueprint.makeWithOverrides({
   name: 'ratings-buttons',
-  config: {
-    schema: {
-      title: z => z.string().default('Rate this entity'),
-      variant: z => z.enum(['like-dislike', 'starred']).default('like-dislike'),
-      requestResponse: z => z.boolean().optional(),
-      dialogTitle: z => z.string().optional(),
-      dialogResponses: z =>
-        z
-          .array(
-            z.object({
-              id: z.string(),
-              label: z.string(),
-            }),
-          )
-          .optional(),
-    },
+  configSchema: {
+    title: z.string().default('Rate this entity'),
+    variant: z.enum(['like-dislike', 'starred']).default('like-dislike'),
+    requestResponse: z.boolean().optional(),
+    dialogTitle: z.string().optional(),
+    dialogResponses: z
+      .array(
+        z.object({
+          id: z.string(),
+          label: z.string(),
+        }),
+      )
+      .optional(),
   },
   factory(originalFactory, { config }) {
     const { variant, title, requestResponse, dialogTitle, dialogResponses } =
@@ -81,12 +79,10 @@ export const entityRatingsButtonsCard = EntityCardBlueprint.makeWithOverrides({
  */
 export const entityRatingsTableCard = EntityCardBlueprint.makeWithOverrides({
   name: 'ratings-table',
-  config: {
-    schema: {
-      title: z => z.string().optional(),
-      allEntities: z => z.boolean().optional(),
-      variant: z => z.enum(['like-dislike', 'starred']).default('like-dislike'),
-    },
+  configSchema: {
+    title: z.string().optional(),
+    allEntities: z.boolean().optional(),
+    variant: z.enum(['like-dislike', 'starred']).default('like-dislike'),
   },
   factory(originalFactory, { config }) {
     const { variant, title, allEntities } = config;

--- a/workspaces/entity-feedback/yarn.lock
+++ b/workspaces/entity-feedback/yarn.lock
@@ -1777,6 +1777,7 @@ __metadata:
     react-dom: "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
     react-router-dom: "npm:6.0.0-beta.0 || ^6.3.0"
     react-use: "npm:^17.2.4"
+    zod: "npm:^4.0.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0


### PR DESCRIPTION
Migrates the deprecated `config: { schema: { ... } }` extension config pattern to the new `configSchema` option with zod v4 Standard Schema values.

This resolves the following deprecation warning at startup:
> DEPRECATION WARNING: The `config.schema` option for extension config is deprecated. Use the `configSchema` option instead with Standard Schema values.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))