### PR TITLE
chore(fairwinds-insights): migrate deprecated config.schema to configSchema

### DIFF
--- a/workspaces/fairwinds-insights/.changeset/migrate-config-schema.md
+++ b/workspaces/fairwinds-insights/.changeset/migrate-config-schema.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-fairwinds-insights': patch
+---
+
+Migrated extension config from deprecated `config.schema` to `configSchema` with zod v4 Standard Schema

--- a/workspaces/fairwinds-insights/plugins/fairwinds-insights/knip-report.md
+++ b/workspaces/fairwinds-insights/plugins/fairwinds-insights/knip-report.md
@@ -11,8 +11,8 @@
 
 | Name                        | Location          | Severity |
 | :-------------------------- | :---------------- | :------- |
-| @testing-library/user-event | package.json:82:6 | error    |
-| @backstage/app-defaults     | package.json:71:6 | error    |
-| @backstage/core-app-api     | package.json:74:6 | error    |
-| msw                         | package.json:85:6 | error    |
+| @testing-library/user-event | package.json:83:6 | error    |
+| @backstage/app-defaults     | package.json:72:6 | error    |
+| @backstage/core-app-api     | package.json:75:6 | error    |
+| msw                         | package.json:86:6 | error    |
 

--- a/workspaces/fairwinds-insights/plugins/fairwinds-insights/package.json
+++ b/workspaces/fairwinds-insights/plugins/fairwinds-insights/package.json
@@ -65,7 +65,8 @@
     "@mui/styles": "5.18.0",
     "@mui/utils": "5.17.1",
     "@mui/x-charts": "7.29.1",
-    "react-use": "^17.6.0"
+    "react-use": "^17.6.0",
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/app-defaults": "backstage:^",

--- a/workspaces/fairwinds-insights/plugins/fairwinds-insights/report-alpha.api.md
+++ b/workspaces/fairwinds-insights/plugins/fairwinds-insights/report-alpha.api.md
@@ -17,12 +17,12 @@ import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 // @alpha (undocumented)
 export const entityActionItemsCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -62,12 +62,12 @@ export const entityActionItemsCard: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const entityActionItemsTopCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -107,12 +107,12 @@ export const entityActionItemsTopCard: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const entityMTDCostOverviewCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -152,12 +152,12 @@ export const entityMTDCostOverviewCard: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const entityResourcesHistoryCPUCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -197,12 +197,12 @@ export const entityResourcesHistoryCPUCard: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const entityResourcesHistoryMemoryCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -242,12 +242,12 @@ export const entityResourcesHistoryMemoryCard: OverridableExtensionDefinition<{
 // @alpha (undocumented)
 export const entityResourcesHistoryPodCountCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -287,12 +287,12 @@ export const entityResourcesHistoryPodCountCard: OverridableExtensionDefinition<
 // @alpha (undocumented)
 export const entityVulnerabilitiesCard: OverridableExtensionDefinition<{
   config: {
-    props: {};
+    props: Record<string, never>;
     filter: FilterPredicate | undefined;
     type: 'content' | 'info' | undefined;
   };
   configInput: {
-    props?: {} | undefined;
+    props?: Record<string, never> | undefined;
     filter?: FilterPredicate | undefined;
     type?: 'content' | 'info' | undefined | undefined;
   };
@@ -368,12 +368,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/action-items': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -411,12 +411,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/action-items-top': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -454,12 +454,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/mtd-cost-overview': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -497,12 +497,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/resources-history-cpu': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -540,12 +540,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/resources-history-memory': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -583,12 +583,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/resources-history-pod-count': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };
@@ -626,12 +626,12 @@ const fairwindsInsightsFrontendPlugin: OverridableFrontendPlugin<
     }>;
     'entity-card:fairwinds-insights/vulnerabilities': OverridableExtensionDefinition<{
       config: {
-        props: {};
+        props: Record<string, never>;
         filter: FilterPredicate | undefined;
         type: 'content' | 'info' | undefined;
       };
       configInput: {
-        props?: {} | undefined;
+        props?: Record<string, never> | undefined;
         filter?: FilterPredicate | undefined;
         type?: 'content' | 'info' | undefined | undefined;
       };

--- a/workspaces/fairwinds-insights/plugins/fairwinds-insights/src/alpha/entityCards.tsx
+++ b/workspaces/fairwinds-insights/plugins/fairwinds-insights/src/alpha/entityCards.tsx
@@ -15,6 +15,7 @@
  */
 import { Entity } from '@backstage/catalog-model';
 import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { z } from 'zod';
 
 const FAIRWINDS_APP_GROUPS_ANNOTATION = 'insights.fairwinds.com/app-groups';
 
@@ -38,10 +39,8 @@ function isFairwindsInsightsAvailable(entity: Entity): boolean {
  */
 export const entityActionItemsCard = EntityCardBlueprint.makeWithOverrides({
   name: 'action-items',
-  config: {
-    schema: {
-      props: z => z.object({}).default({}),
-    },
+  configSchema: {
+    props: z.object({}).default({}),
   },
   factory(originalFactory, { config }) {
     return originalFactory({
@@ -59,10 +58,8 @@ export const entityActionItemsCard = EntityCardBlueprint.makeWithOverrides({
  */
 export const entityActionItemsTopCard = EntityCardBlueprint.makeWithOverrides({
   name: 'action-items-top',
-  config: {
-    schema: {
-      props: z => z.object({}).default({}),
-    },
+  configSchema: {
+    props: z.object({}).default({}),
   },
   factory(originalFactory, { config }) {
     return originalFactory({
@@ -80,10 +77,8 @@ export const entityActionItemsTopCard = EntityCardBlueprint.makeWithOverrides({
  */
 export const entityMTDCostOverviewCard = EntityCardBlueprint.makeWithOverrides({
   name: 'mtd-cost-overview',
-  config: {
-    schema: {
-      props: z => z.object({}).default({}),
-    },
+  configSchema: {
+    props: z.object({}).default({}),
   },
   factory(originalFactory, { config }) {
     return originalFactory({
@@ -101,10 +96,8 @@ export const entityMTDCostOverviewCard = EntityCardBlueprint.makeWithOverrides({
  */
 export const entityVulnerabilitiesCard = EntityCardBlueprint.makeWithOverrides({
   name: 'vulnerabilities',
-  config: {
-    schema: {
-      props: z => z.object({}).default({}),
-    },
+  configSchema: {
+    props: z.object({}).default({}),
   },
   factory(originalFactory, { config }) {
     return originalFactory({
@@ -123,10 +116,8 @@ export const entityVulnerabilitiesCard = EntityCardBlueprint.makeWithOverrides({
 export const entityResourcesHistoryPodCountCard =
   EntityCardBlueprint.makeWithOverrides({
     name: 'resources-history-pod-count',
-    config: {
-      schema: {
-        props: z => z.object({}).default({}),
-      },
+    configSchema: {
+      props: z.object({}).default({}),
     },
     factory(originalFactory, { config }) {
       return originalFactory({
@@ -145,10 +136,8 @@ export const entityResourcesHistoryPodCountCard =
 export const entityResourcesHistoryCPUCard =
   EntityCardBlueprint.makeWithOverrides({
     name: 'resources-history-cpu',
-    config: {
-      schema: {
-        props: z => z.object({}).default({}),
-      },
+    configSchema: {
+      props: z.object({}).default({}),
     },
     factory(originalFactory, { config }) {
       return originalFactory({
@@ -167,10 +156,8 @@ export const entityResourcesHistoryCPUCard =
 export const entityResourcesHistoryMemoryCard =
   EntityCardBlueprint.makeWithOverrides({
     name: 'resources-history-memory',
-    config: {
-      schema: {
-        props: z => z.object({}).default({}),
-      },
+    configSchema: {
+      props: z.object({}).default({}),
     },
     factory(originalFactory, { config }) {
       return originalFactory({

--- a/workspaces/fairwinds-insights/yarn.lock
+++ b/workspaces/fairwinds-insights/yarn.lock
@@ -1782,6 +1782,7 @@ __metadata:
     react-dom: "npm:^18.0.0"
     react-router-dom: "npm:^6.30.3"
     react-use: "npm:^17.6.0"
+    zod: "npm:^4.0.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
Migrates the deprecated `config: { schema: { ... } }` extension config pattern to the new `configSchema` option with zod v4 Standard Schema values.

This resolves the following deprecation warning at startup:
> DEPRECATION WARNING: The `config.schema` option for extension config is deprecated. Use the `configSchema` option instead with Standard Schema values.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))