### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/real-moles-hide.md
+++ b/workspaces/adr/.changeset/real-moles-hide.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-adr': minor
----
-
-Update new frontend system extension definitions to remove unnecessary compatibility wrappers
-
-**BREAKING** The extension name for `adrEntityContentExtension` and `adrApiExtension` has been removed since it was unnecessary

--- a/workspaces/adr/plugins/adr/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage-community/plugin-adr
 
+## 0.28.0
+
+### Minor Changes
+
+- ce13433: Update new frontend system extension definitions to remove unnecessary compatibility wrappers
+
+  **BREAKING** The extension name for `adrEntityContentExtension` and `adrApiExtension` has been removed since it was unnecessary
+
 ## 0.27.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr/package.json
+++ b/workspaces/adr/plugins/adr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "adr",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr@0.28.0

### Minor Changes

-   ce13433: Update new frontend system extension definitions to remove unnecessary compatibility wrappers

    **BREAKING** The extension name for `adrEntityContentExtension` and `adrApiExtension` has been removed since it was unnecessary
