### PR TITLE
Unify newly added CONTRIBUTING guides, add app config for annotator plugin

### DIFF
--- a/workspaces/3scale/.changeset/spicy-rules-kick.md
+++ b/workspaces/3scale/.changeset/spicy-rules-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-3scale-backend': patch
+---
+
+Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.

--- a/workspaces/3scale/plugins/3scale-backend/CONTRIBUTING.md
+++ b/workspaces/3scale/plugins/3scale-backend/CONTRIBUTING.md
@@ -15,16 +15,20 @@ Day-to-day changes do **not** require the full workspace Backstage app (`package
 ```console
 cd workspaces/3scale
 yarn install
-yarn workspace @backstage-community/plugin-3scale-backend start
+cp plugins/3scale-backend/app-config.example.yaml plugins/3scale-backend/app-config.local.yaml
+yarn workspace @backstage-community/plugin-3scale-backend start \
+  --config app-config.local.yaml
 ```
+
+(`--config` paths are resolved from the plugin package directory.)
 
 The harness starts a minimal backend with `@backstage/plugin-catalog-backend` and this module (`dev/index.ts`).
 
-### Configuration
+Copy [app-config.example.yaml](./app-config.example.yaml) to `app-config.local.yaml` in this package before starting. That file is gitignored (`*.local.yaml`) so local tokens and overrides are not committed.
 
-Copy [app-config.example.yaml](./app-config.example.yaml) to `app-config.local.yaml` in this package before starting the plugin harness. That file is gitignored (`*.local.yaml`) so local tokens and overrides are not committed.
+[`app-config.example.yaml`](./app-config.example.yaml) is the **minimal** config required to run the dev harness (listen port, static auth, and 3scale provider settings). Prefer starting with `--config app-config.local.yaml` as shown above.
 
-For `yarn workspace @backstage-community/plugin-3scale-backend start`, config in this package is enough. If you use the full workspace app (`yarn start` from `workspaces/3scale`), put overlapping overrides in the workspace root `app-config.local.yaml` instead.
+By default (without `--config`), `yarn start` loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. That file is for the optional full Backstage app (`packages/app`, `packages/backend`) and is not required for this harness. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass (or at the workspace root when relying on the default).
 
 Set environment variables before starting:
 
@@ -52,7 +56,7 @@ When reviewing dependency updates, read the relevant upstream release notes and 
 
 ## Manual smoke checklist
 
-After `yarn workspace @backstage-community/plugin-3scale-backend start` with valid `THREESCALE_*` env vars, expect log lines similar to:
+After starting the harness with `--config app-config.local.yaml` and valid `THREESCALE_*` env vars, expect log lines similar to:
 
 ```log
 catalog info Discovering ApiEntities from 3scale <baseUrl> type=plugin target=ThreeScaleApiEntityProvider:dev

--- a/workspaces/pingidentity/.changeset/weak-masks-grow.md
+++ b/workspaces/pingidentity/.changeset/weak-masks-grow.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-auth-backend-module-pingfederate-provider': patch
+'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
+---
+
+Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CONTRIBUTING.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CONTRIBUTING.md
@@ -9,11 +9,14 @@ Developer guide for `@backstage-community/plugin-auth-backend-module-pingfederat
 
 ## Development harness
 
-Start this module in isolation:
+Start this module in isolation with the package's minimal harness config:
 
 ```bash
-yarn workspace @backstage-community/plugin-auth-backend-module-pingfederate-provider start
+yarn workspace @backstage-community/plugin-auth-backend-module-pingfederate-provider start \
+  --config app-config.yaml
 ```
+
+(`--config` paths are resolved from the plugin package directory.)
 
 This runs a minimal backend with `@backstage/plugin-auth-backend` and the PingFederate provider module. Use it for OAuth flow, authenticator, and resolver work.
 
@@ -31,7 +34,9 @@ Export these variables in your shell before starting the harness. Use local-only
 | `AUTH_SESSION_SECRET`        | Backstage auth session signing secret (any long random string locally) |
 | `BACKSTAGE_DEV_STATIC_TOKEN` | Static bearer token for authenticated `curl` calls to the dev backend  |
 
-Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
+[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config required to run the dev harness (listen port, static auth, and PingFederate provider settings). Prefer starting with `--config app-config.yaml` as shown above.
+
+By default (without `--config`), `yarn start` loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. That file is for a broader local Backstage app setup, sets `auth.dangerouslyDisableDefaultAuthPolicy: true`, and does not define the static backend token used by the smoke `curl` examples below. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass (or at the workspace root when relying on the default).
 
 ### API authentication for `curl`
 

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CONTRIBUTING.md
@@ -9,11 +9,14 @@ Developer guide for `@backstage-community/plugin-catalog-backend-module-pingiden
 
 ## Development harness
 
-Start this module in isolation:
+Start this module in isolation with the package's minimal harness config:
 
 ```bash
-yarn workspace @backstage-community/plugin-catalog-backend-module-pingidentity start
+yarn workspace @backstage-community/plugin-catalog-backend-module-pingidentity start \
+  --config app-config.yaml
 ```
+
+(`--config` paths are resolved from the plugin package directory.)
 
 This runs a minimal backend with `@backstage/plugin-catalog-backend` and the Ping Identity entity provider module. Use it for ingestion, transformers, and PingOne API client work.
 
@@ -32,7 +35,9 @@ Export these variables in your shell before starting the harness. Use local-only
 | `PING_IDENTITY_CLIENT_SECRET` | OAuth client secret                                                   |
 | `BACKSTAGE_DEV_STATIC_TOKEN`  | Static bearer token for authenticated `curl` calls to the dev backend |
 
-Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
+[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config required to run the dev harness (listen port, static auth, and PingOne provider settings). Prefer starting with `--config app-config.yaml` as shown above.
+
+By default (without `--config`), `yarn start` loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. That file is for a broader local Backstage app setup, sets `auth.dangerouslyDisableDefaultAuthPolicy: true`, and does not define the static backend token used by the smoke `curl` examples below. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass (or at the workspace root when relying on the default).
 
 ### API authentication for `curl`
 

--- a/workspaces/scaffolder-backend-module-annotator/.changeset/metal-oranges-work.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/metal-oranges-work.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-annotator': patch
+---
+
+Document starting the dev harness with --config app-config.yaml and add a workspace-level app-config.yaml for parity with other harness workspaces.

--- a/workspaces/scaffolder-backend-module-annotator/app-config.yaml
+++ b/workspaces/scaffolder-backend-module-annotator/app-config.yaml
@@ -1,0 +1,97 @@
+app:
+  title: Example Annotator Actions Backstage App
+  baseUrl: http://localhost:3000
+
+organization:
+  name: My Company
+
+backend:
+  # Used for enabling authentication, secret is shared by all backend plugins
+  # See https://backstage.io/docs/auth/service-to-service-auth for
+  # information on the format
+  # auth:
+  #   keys:
+  #     - secret: ${BACKEND_SECRET}
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+    # Uncomment the following host directive to bind to specific interfaces
+    # host: 127.0.0.1
+  csp:
+    connect-src: ["'self'", 'http:', 'https:']
+    # Content-Security-Policy directives follow the Helmet format: https://helmetjs.github.io/#reference
+    # Default Helmet Content-Security-Policy values can be removed by setting the key to false
+  cors:
+    origin: http://localhost:3000
+    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
+    credentials: true
+  # This is for local development only, it is not recommended to use this in production
+  # The production database configuration is stored in app-config.production.yaml
+  database:
+    client: better-sqlite3
+    connection: ':memory:'
+  # workingDirectory: /tmp # Use this to configure a working directory for the scaffolder, defaults to the OS temp-dir
+
+integrations:
+  github:
+    - host: github.com
+      # This is a Personal Access Token or PAT from GitHub. You can find out how to generate this token, and more information
+      # about setting up the GitHub integration here: https://backstage.io/docs/integrations/github/locations#configuration
+      token: ${GITHUB_TOKEN}
+    ### Example for how to add your GitHub Enterprise instance using the API:
+    # - host: ghe.example.net
+    #   apiBaseUrl: https://ghe.example.net/api/v3
+    #   token: ${GHE_TOKEN}
+
+proxy:
+  ### Example for how to add a proxy endpoint for the frontend.
+  ### A typical reason to do this is to handle HTTPS and CORS for internal services.
+  # endpoints:
+  #   '/test':
+  #     target: 'https://example.com'
+  #     changeOrigin: true
+
+# Reference documentation http://backstage.io/docs/features/techdocs/configuration
+# Note: After experimenting with basic setup, use CI/CD to generate docs
+# and an external cloud storage when deploying TechDocs for production use-case.
+# https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+
+auth:
+  # see https://backstage.io/docs/auth/ to learn about auth providers
+  providers:
+    # See https://backstage.io/docs/auth/guest/provider
+    guest: {}
+
+scaffolder:
+  # see https://backstage.io/docs/features/software-templates/configuration for software template options
+
+catalog:
+  import:
+    entityFilename: catalog-info.yaml
+    pullRequestBranchName: backstage-integration
+  rules:
+    - allow: [Component, System, API, Resource, Location]
+  locations:
+    ## Uncomment these lines to add more example data
+    # - type: url
+    #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all.yaml
+
+    ## Uncomment these lines to add an example org
+    # - type: url
+    #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
+    #   rules:
+    #     - allow: [User, Group]
+
+kubernetes:
+  # see https://backstage.io/docs/features/kubernetes/configuration for kubernetes configuration options
+
+# see https://backstage.io/docs/permissions/getting-started for more on the permission framework
+permission:
+  # setting this to `false` will disable permissions
+  enabled: true

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CONTRIBUTING.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CONTRIBUTING.md
@@ -9,11 +9,14 @@ Developer guide for `@backstage-community/plugin-scaffolder-backend-module-annot
 
 ## Development harness
 
-Start this module in isolation:
+Start this module in isolation with the package's minimal harness config:
 
 ```bash
-yarn workspace @backstage-community/plugin-scaffolder-backend-module-annotator start
+yarn workspace @backstage-community/plugin-scaffolder-backend-module-annotator start \
+  --config app-config.yaml
 ```
+
+(`--config` paths are resolved from the plugin package directory.)
 
 This runs a minimal backend with `@backstage/plugin-scaffolder-backend` and the annotator module. Use it to verify action registration and local scaffolder integration work.
 
@@ -21,13 +24,15 @@ The harness listens on port **7007**. Only one plugin `dev/` harness should run 
 
 ### Environment setup
 
-Export this variable in your shell before starting the harness. Use a local-only placeholder value for development — do not commit secrets.
+Export this variable in your shell before starting the harness. Use a local-only placeholder value for development — do not commit secrets. The token must be at least **8 characters**.
 
 | Variable                     | Purpose                                                               |
 | ---------------------------- | --------------------------------------------------------------------- |
 | `BACKSTAGE_DEV_STATIC_TOKEN` | Static bearer token for authenticated `curl` calls to the dev backend |
 
-Config keys are defined in [`app-config.yaml`](./app-config.yaml). You may override them in an untracked `app-config.local.yaml` beside the package if your local Backstage CLI setup supports it.
+[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config required to run the dev harness (listen port and static auth). Prefer starting with `--config app-config.yaml` as shown above.
+
+By default (without `--config`), `yarn start` loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. That file is for a broader local Backstage app setup and is not required for this harness. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass (or at the workspace root when relying on the default).
 
 ### API authentication for `curl`
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes [RHIDP-15693](https://redhat.atlassian.net/browse/RHIDP-15693)

During the work for Backstage version bump integrity epics, we realized that contributors must start the package harness with the package-level config, e.g.:
`yarn workspace @backstage-community/plugin-… start --config app-config.yaml`

(-`-config` paths resolve from the plugin package directory.) Without that flag, Backstage CLI defaults to the workspace root app-config.yaml, which is for a fuller local app and is not the minimal harness config (listen port + static auth / provider settings).

This PR adds this information to the newly added CONTRIBUTING guides for plugins under the Backstage version bump integrity feature: 3scale-backend, pingidentity, pingfederate auth provider and scaffolder-backend-module-annotator.

To keep the structure of the workspaces similar, it also adds an example workspace level app config.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
