### PR TITLE
Version Packages (entity-feedback)

### DIFF
--- a/workspaces/entity-feedback/.changeset/fix-ratings-tiebreaker.md
+++ b/workspaces/entity-feedback/.changeset/fix-ratings-tiebreaker.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-entity-feedback-backend': patch
----
-
-Fixed a bug where casting a vote and quickly changing it (e.g. clicking Like then immediately clicking Dislike) could double-count both ratings instead of replacing the earlier one with the later one, when both writes landed within the same second.

--- a/workspaces/entity-feedback/packages/backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/packages/backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # backend
 
+## 0.0.31
+
+### Patch Changes
+
+- Updated dependencies [0710885]
+  - @backstage-community/plugin-entity-feedback-backend@0.23.1
+
 ## 0.0.30
 
 ### Patch Changes

--- a/workspaces/entity-feedback/packages/backend/package.json
+++ b/workspaces/entity-feedback/packages/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "dist/index.cjs.js",
   "types": "src/index.ts",
   "private": true,

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-entity-feedback-backend
 
+## 0.23.1
+
+### Patch Changes
+
+- 0710885: Fixed a bug where casting a vote and quickly changing it (e.g. clicking Like then immediately clicking Dislike) could double-count both ratings instead of replacing the earlier one with the later one, when both writes landed within the same second.
+
 ## 0.23.0
 
 ### Minor Changes

--- a/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
+++ b/workspaces/entity-feedback/plugins/entity-feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-entity-feedback-backend",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "entity-feedback",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-entity-feedback-backend@0.23.1

### Patch Changes

-   0710885: Fixed a bug where casting a vote and quickly changing it (e.g. clicking Like then immediately clicking Dislike) could double-count both ratings instead of replacing the earlier one with the later one, when both writes landed within the same second.

## backend@0.0.31

### Patch Changes

-   Updated dependencies [0710885]
    -   @backstage-community/plugin-entity-feedback-backend@0.23.1
