### PR TITLE
feat(rbac): add useOwnershipEntityRefs for sign-in role bindings

### DIFF
--- a/workspaces/rbac/.changeset/use-ownership-entity-refs.md
+++ b/workspaces/rbac/.changeset/use-ownership-entity-refs.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac-backend': minor
+---
+
+Added `permission.rbac.useOwnershipEntityRefs` config option to evaluate group-to-role bindings using ownership entity refs from the sign-in token, in addition to catalog memberOf relations.

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -84,9 +84,34 @@ permission:
         - name: group:default/admins
 ```
 
-> **Note:** **Transient memberships are not supported for `superUsers`.** Meaning, when a group is specified as a super user, only direct group memberships are taken into account. Users who belong to a sub-group of a configured super user group will not be granted super user access.
+> **Note:** Only direct group memberships are supported for `superUsers`. When a group is specified as a super user, users who belong to a sub-group of that group will not be granted super user access.
 
 For more information on the available API endpoints accessible to the policy administrators, refer to the [API documentation](./docs/apis.md).
+
+### Use ownership entity refs for role membership
+
+When users sign in without catalog `memberOf` relations (for example, via a custom sign-in resolver that issues ownership entity refs in the token), you can enable `useOwnershipEntityRefs` so group-to-role bindings are evaluated from those token claims in addition to catalog membership.
+
+```YAML
+permission:
+  rbac:
+    useOwnershipEntityRefs: true
+```
+
+With this enabled, a user whose sign-in resolver issues:
+
+```ts
+ctx.issueToken({
+  claims: {
+    sub: 'user:default/leonardo.vieira',
+    ent: ['user:default/leonardo.vieira', 'group:default/oncall'],
+  },
+});
+```
+
+will receive roles bound to `group:default/oncall` via CSV policies such as `g, group:default/oncall, role:default/oncall`, even when the user has no catalog `memberOf` relation to that group.
+
+> **Note:** Only direct bindings are supported — subgroup hierarchy is not traversed, similar to `superUsers`.
 
 ### Configure default role
 

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -92,6 +92,8 @@ For more information on the available API endpoints accessible to the policy adm
 
 When users sign in without catalog `memberOf` relations (for example, via a custom sign-in resolver that issues ownership entity refs in the token), you can enable `useOwnershipEntityRefs` so group-to-role bindings are evaluated from those token claims in addition to catalog membership.
 
+> **Warning:** When this option is enabled, RBAC trusts the ownership entity refs issued by the sign-in resolver when resolving direct role bindings. Ensure that the resolver only includes user and group refs that the authenticated user is authorized to claim, because an incorrect group ref could grant that group's permissions.
+
 ```YAML
 permission:
   rbac:
@@ -112,6 +114,8 @@ ctx.issueToken({
 will receive roles bound to `group:default/oncall` via CSV policies such as `g, group:default/oncall, role:default/oncall`, even when the user has no catalog `memberOf` relation to that group.
 
 > **Note:** Only direct bindings are supported — subgroup hierarchy is not traversed, similar to `superUsers`.
+
+Ownership entity refs do not create User or Group entities in the catalog. References that do not exist in the catalog will therefore not appear in the RBAC frontend and cannot be selected there when assigning members to roles. Administrators must define bindings for those references in the CSV policy file; the YAML application configuration only enables this behavior. Groups that already exist in the catalog can still be assigned to roles through the RBAC frontend, while membership supplied by the sign-in token is resolved at runtime.
 
 ### Configure default role
 

--- a/workspaces/rbac/plugins/rbac-backend/README.md
+++ b/workspaces/rbac/plugins/rbac-backend/README.md
@@ -84,7 +84,7 @@ permission:
         - name: group:default/admins
 ```
 
-> **Note:** Only direct group memberships are supported for `superUsers`. When a group is specified as a super user, users who belong to a sub-group of that group will not be granted super user access.
+> **Note:** **Transient memberships are not supported for `superUsers`.** Meaning, when a group is specified as a super user, only direct group memberships are taken into account. Users who belong to a sub-group of a configured super user group will not be granted super user access.
 
 For more information on the available API endpoints accessible to the policy administrators, refer to the [API documentation](./docs/apis.md).
 
@@ -103,8 +103,8 @@ With this enabled, a user whose sign-in resolver issues:
 ```ts
 ctx.issueToken({
   claims: {
-    sub: 'user:default/leonardo.vieira',
-    ent: ['user:default/leonardo.vieira', 'group:default/oncall'],
+    sub: 'user:default/john.doe',
+    ent: ['user:default/john.doe', 'group:default/oncall'],
   },
 });
 ```

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -75,7 +75,6 @@ export interface Config {
        * When enabled, group-to-role bindings are also evaluated using ownership
        * entity refs from the sign-in token, not only catalog memberOf relations.
        * Defaults to false.
-       * @visibility frontend
        */
       useOwnershipEntityRefs?: boolean;
       /**

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -72,6 +72,12 @@ export interface Config {
        */
       policyDecisionPrecedence?: 'basic' | 'conditional';
       /**
+       * When enabled, group-to-role bindings are also evaluated using ownership
+       * entity refs from the sign-in token, not only catalog memberOf relations.
+       * @visibility frontend
+       */
+      useOwnershipEntityRefs?: boolean;
+      /**
        * Configuration for assigning a default role with permissions
        * to all authenticated users.
        */

--- a/workspaces/rbac/plugins/rbac-backend/config.d.ts
+++ b/workspaces/rbac/plugins/rbac-backend/config.d.ts
@@ -74,6 +74,7 @@ export interface Config {
       /**
        * When enabled, group-to-role bindings are also evaluated using ownership
        * entity refs from the sign-in token, not only catalog memberOf relations.
+       * Defaults to false.
        * @visibility frontend
        */
       useOwnershipEntityRefs?: boolean;

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1180,8 +1180,8 @@ describe('useOwnershipEntityRefs', () => {
         'catalog-entity',
         'read',
       ),
-      newPolicyQueryUser('user:default/leonardo.vieira', [
-        'user:default/leonardo.vieira',
+      newPolicyQueryUser('user:default/john.doe', [
+        'user:default/john.doe',
         'group:default/oncall',
       ]),
     );
@@ -1202,8 +1202,8 @@ describe('useOwnershipEntityRefs', () => {
         'catalog-entity',
         'read',
       ),
-      newPolicyQueryUser('user:default/leonardo.vieira', [
-        'user:default/leonardo.vieira',
+      newPolicyQueryUser('user:default/john.doe', [
+        'user:default/john.doe',
         'group:default/oncall',
       ]),
     );
@@ -1247,7 +1247,7 @@ describe('useOwnershipEntityRefs', () => {
   it('should resolve direct user-to-role bindings via ownershipEntityRefs', async () => {
     const policy = await buildPolicy(
       true,
-      [['user:default/leonardo.vieira', oncallRole]],
+      [['user:default/john.doe', oncallRole]],
       oncallPolicies,
     );
 
@@ -1257,9 +1257,7 @@ describe('useOwnershipEntityRefs', () => {
         'catalog-entity',
         'read',
       ),
-      newPolicyQueryUser('user:default/leonardo.vieira', [
-        'user:default/leonardo.vieira',
-      ]),
+      newPolicyQueryUser('user:default/john.doe', ['user:default/john.doe']),
     );
 
     expect(decision.result).toBe(AuthorizeResult.ALLOW);

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1133,6 +1133,139 @@ describe('RBACPermissionPolicy Tests', () => {
   });
 });
 
+describe('useOwnershipEntityRefs', () => {
+  const oncallRole = 'role:default/oncall';
+  const catalogRole = 'role:default/catalog-reader';
+  const oncallPolicies = [
+    [oncallRole, 'catalog.entity.read', 'read', 'allow'],
+    [oncallRole, 'catalog-entity', 'read', 'allow'],
+  ];
+  const catalogPolicies = [
+    [catalogRole, 'catalog.entity.create', 'use', 'allow'],
+    [catalogRole, 'catalog.entity.create', 'create', 'allow'],
+  ];
+
+  async function buildPolicy(
+    useOwnershipEntityRefs: boolean,
+    groupPolicies: string[][],
+    permissionPolicies: string[][],
+  ) {
+    const config = newConfig(
+      undefined,
+      [],
+      undefined,
+      undefined,
+      useOwnershipEntityRefs,
+    );
+    const adapter = await newAdapter(config);
+    const enfDelegate = await newEnforcerDelegate(
+      adapter,
+      config,
+      permissionPolicies,
+      groupPolicies,
+    );
+    return newPermissionPolicy(config, enfDelegate);
+  }
+
+  it('should allow access when enabled and group is in ownershipEntityRefs without catalog memberOf', async () => {
+    const policy = await buildPolicy(
+      true,
+      [['group:default/oncall', oncallRole]],
+      oncallPolicies,
+    );
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/leonardo.vieira', [
+        'user:default/leonardo.vieira',
+        'group:default/oncall',
+      ]),
+    );
+
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  it('should deny access when disabled and group is only in ownershipEntityRefs', async () => {
+    const policy = await buildPolicy(
+      false,
+      [['group:default/oncall', oncallRole]],
+      oncallPolicies,
+    );
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/leonardo.vieira', [
+        'user:default/leonardo.vieira',
+        'group:default/oncall',
+      ]),
+    );
+
+    expect(decision.result).toBe(AuthorizeResult.DENY);
+  });
+
+  it('should merge catalog and token-derived roles', async () => {
+    const policy = await buildPolicy(
+      true,
+      [
+        ['group:default/oncall', oncallRole],
+        ['user:default/catalog-user', catalogRole],
+      ],
+      [...oncallPolicies, ...catalogPolicies],
+    );
+
+    const readDecision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/catalog-user', [
+        'user:default/catalog-user',
+        'group:default/oncall',
+      ]),
+    );
+    expect(readDecision.result).toBe(AuthorizeResult.ALLOW);
+
+    const createDecision = await policy.handle(
+      newPolicyQueryWithBasicPermission('catalog.entity.create', 'create'),
+      newPolicyQueryUser('user:default/catalog-user', [
+        'user:default/catalog-user',
+        'group:default/oncall',
+      ]),
+    );
+    expect(createDecision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  it('should resolve direct user-to-role bindings via ownershipEntityRefs', async () => {
+    const policy = await buildPolicy(
+      true,
+      [['user:default/leonardo.vieira', oncallRole]],
+      oncallPolicies,
+    );
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/leonardo.vieira', [
+        'user:default/leonardo.vieira',
+      ]),
+    );
+
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+});
+
 // Notice: There is corner case, when "resourced" permission policy can be defined not by resource type, but by name.
 describe('Policy checks for resourced permissions defined by name', () => {
   const roleMetadataStorageTest: RoleMetadataStorage = {
@@ -2133,6 +2266,7 @@ function newConfig(
   users?: Array<{ name: string }>,
   superUsers?: Array<{ name: string }>,
   policyDecisionPrecedence?: 'basic' | 'conditional',
+  useOwnershipEntityRefs?: boolean,
 ): Config {
   const testUsers = [
     {
@@ -2154,6 +2288,9 @@ function newConfig(
             superUsers: superUsers,
           },
           policyDecisionPrecedence: policyDecisionPrecedence ?? 'conditional',
+          ...(useOwnershipEntityRefs !== undefined
+            ? { useOwnershipEntityRefs }
+            : {}),
         },
       },
       backend: {

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1164,11 +1164,12 @@ describe('useOwnershipEntityRefs', () => {
       permissionPolicies,
       groupPolicies,
     );
-    return newPermissionPolicy(config, enfDelegate);
+    const policy = await newPermissionPolicy(config, enfDelegate);
+    return { policy, enfDelegate };
   }
 
   it('should allow access when enabled and group is in ownershipEntityRefs without catalog memberOf', async () => {
-    const policy = await buildPolicy(
+    const { policy } = await buildPolicy(
       true,
       [['group:default/oncall', oncallRole]],
       oncallPolicies,
@@ -1190,7 +1191,7 @@ describe('useOwnershipEntityRefs', () => {
   });
 
   it('should deny access when disabled and group is only in ownershipEntityRefs', async () => {
-    const policy = await buildPolicy(
+    const { policy } = await buildPolicy(
       false,
       [['group:default/oncall', oncallRole]],
       oncallPolicies,
@@ -1212,7 +1213,7 @@ describe('useOwnershipEntityRefs', () => {
   });
 
   it('should merge catalog and token-derived roles', async () => {
-    const policy = await buildPolicy(
+    const { policy } = await buildPolicy(
       true,
       [
         ['group:default/oncall', oncallRole],
@@ -1245,11 +1246,12 @@ describe('useOwnershipEntityRefs', () => {
   });
 
   it('should resolve direct user-to-role bindings via ownershipEntityRefs', async () => {
-    const policy = await buildPolicy(
+    const { policy, enfDelegate } = await buildPolicy(
       true,
       [['user:default/john.doe', oncallRole]],
       oncallPolicies,
     );
+    jest.spyOn(enfDelegate, 'getRolesForUser').mockResolvedValueOnce([]);
 
     const decision = await policy.handle(
       newPolicyQueryWithResourcePermission(
@@ -1261,6 +1263,55 @@ describe('useOwnershipEntityRefs', () => {
     );
 
     expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  it('should fall back to user entity ref when ownershipEntityRefs is empty', async () => {
+    const { policy } = await buildPolicy(
+      true,
+      [['user:default/john.doe', oncallRole]],
+      oncallPolicies,
+    );
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/john.doe', []),
+    );
+
+    expect(decision.result).toBe(AuthorizeResult.ALLOW);
+  });
+
+  it('should deduplicate ownership entity refs before resolving roles', async () => {
+    const { policy, enfDelegate } = await buildPolicy(
+      true,
+      [['group:default/oncall', oncallRole]],
+      oncallPolicies,
+    );
+    const getFilteredGroupingPolicySpy = jest.spyOn(
+      enfDelegate,
+      'getFilteredGroupingPolicy',
+    );
+
+    await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/john.doe', [
+        'group:default/oncall',
+        'group:default/oncall',
+      ]),
+    );
+
+    expect(getFilteredGroupingPolicySpy).toHaveBeenCalledTimes(1);
+    expect(getFilteredGroupingPolicySpy).toHaveBeenCalledWith(
+      0,
+      'group:default/oncall',
+    );
   });
 });
 

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -254,16 +254,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       }
 
       const permissionName = request.permission.name;
-      const catalogRoles = await this.enforcer.getRolesForUser(userEntityRef);
-      let roles = catalogRoles;
-      if (this.useOwnershipEntityRefs) {
-        const subjects =
-          userInfo.ownershipEntityRefs.length > 0
-            ? userInfo.ownershipEntityRefs
-            : [userEntityRef];
-        const transientRoles = await this.collectRolesForSubjects(subjects);
-        roles = [...new Set([...catalogRoles, ...transientRoles])];
-      }
+      const roles = await this.resolveRolesForUser(userEntityRef, userInfo);
       // handle permission with 'resource' type
       const hasNamedPermission = await this.hasImplicitPermission(
         permissionName,
@@ -334,6 +325,23 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       });
       return { result: AuthorizeResult.DENY };
     }
+  }
+
+  private async resolveRolesForUser(
+    userEntityRef: string,
+    userInfo: BackstageUserInfo,
+  ): Promise<string[]> {
+    const catalogRoles = await this.enforcer.getRolesForUser(userEntityRef);
+    if (!this.useOwnershipEntityRefs) {
+      return catalogRoles;
+    }
+
+    const subjects =
+      userInfo.ownershipEntityRefs.length > 0
+        ? userInfo.ownershipEntityRefs
+        : [userEntityRef];
+    const ownershipRoles = await this.collectRolesForSubjects(subjects);
+    return [...new Set([...catalogRoles, ...ownershipRoles])];
   }
 
   private async collectRolesForSubjects(subjects: string[]): Promise<string[]> {

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -336,28 +336,29 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       return catalogRoles;
     }
 
-    const subjects =
-      userInfo.ownershipEntityRefs.length > 0
-        ? userInfo.ownershipEntityRefs
-        : [userEntityRef];
+    const subjects = [
+      ...new Set(
+        userInfo.ownershipEntityRefs.length > 0
+          ? userInfo.ownershipEntityRefs
+          : [userEntityRef],
+      ),
+    ];
     const ownershipRoles = await this.collectRolesForSubjects(subjects);
     return [...new Set([...catalogRoles, ...ownershipRoles])];
   }
 
   private async collectRolesForSubjects(subjects: string[]): Promise<string[]> {
-    const roles: string[] = [];
-    for (const subject of subjects) {
-      const groupingPolicies = await this.enforcer.getFilteredGroupingPolicy(
-        0,
-        subject,
-      );
-      for (const policy of groupingPolicies) {
-        if (policy[1]) {
-          roles.push(policy[1]);
-        }
-      }
-    }
-    return roles;
+    const policyGroups = await Promise.all(
+      subjects.map(subject =>
+        this.enforcer.getFilteredGroupingPolicy(0, subject),
+      ),
+    );
+
+    return policyGroups.flatMap(policies =>
+      policies
+        .map(policy => policy[1])
+        .filter((role): role is string => !!role),
+    );
   }
 
   private async hasImplicitPermission(

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -70,6 +70,7 @@ import {
 export class RBACPermissionPolicy implements PermissionPolicy {
   private readonly superUserList?: string[];
   private readonly preferPermissionPolicy: boolean;
+  private readonly useOwnershipEntityRefs: boolean;
 
   public static async build(
     logger: LoggerService,
@@ -117,6 +118,10 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       (configApi.getOptionalString(
         'permission.rbac.policyDecisionPrecedence',
       ) ?? 'conditional') === 'basic';
+
+    const useOwnershipEntityRefs =
+      configApi.getOptionalBoolean('permission.rbac.useOwnershipEntityRefs') ??
+      false;
 
     if (superUsers && superUsers.length > 0) {
       for (const user of superUsers) {
@@ -186,6 +191,7 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       auth,
       conditionalStorage,
       preferPermissionPolicy,
+      useOwnershipEntityRefs,
       superUserList,
     );
   }
@@ -197,10 +203,12 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     private readonly auth: AuthService,
     private readonly conditionStorage: ConditionalStorage,
     preferPermissionPolicy: boolean,
+    useOwnershipEntityRefs: boolean,
     superUserList?: string[],
   ) {
     this.superUserList = superUserList;
     this.preferPermissionPolicy = preferPermissionPolicy;
+    this.useOwnershipEntityRefs = useOwnershipEntityRefs;
   }
 
   async handle(
@@ -246,7 +254,16 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       }
 
       const permissionName = request.permission.name;
-      const roles = await this.enforcer.getRolesForUser(userEntityRef);
+      const catalogRoles = await this.enforcer.getRolesForUser(userEntityRef);
+      let roles = catalogRoles;
+      if (this.useOwnershipEntityRefs) {
+        const subjects =
+          userInfo.ownershipEntityRefs.length > 0
+            ? userInfo.ownershipEntityRefs
+            : [userEntityRef];
+        const transientRoles = await this.collectRolesForSubjects(subjects);
+        roles = [...new Set([...catalogRoles, ...transientRoles])];
+      }
       // handle permission with 'resource' type
       const hasNamedPermission = await this.hasImplicitPermission(
         permissionName,
@@ -317,6 +334,22 @@ export class RBACPermissionPolicy implements PermissionPolicy {
       });
       return { result: AuthorizeResult.DENY };
     }
+  }
+
+  private async collectRolesForSubjects(subjects: string[]): Promise<string[]> {
+    const roles: string[] = [];
+    for (const subject of subjects) {
+      const groupingPolicies = await this.enforcer.getFilteredGroupingPolicy(
+        0,
+        subject,
+      );
+      for (const policy of groupingPolicies) {
+        if (policy[1]) {
+          roles.push(policy[1]);
+        }
+      }
+    }
+    return roles;
   }
 
   private async hasImplicitPermission(


### PR DESCRIPTION
Closes #9755

## Summary

- Add `permission.rbac.useOwnershipEntityRefs` config flag (default `false`) to evaluate group-to-role bindings using ownership entity refs from the sign-in token, in addition to catalog `memberOf` relations
- When enabled, roles are merged from catalog membership and direct Casbin grouping policies for each subject in `ownershipEntityRefs`
- Document the feature in the RBAC backend README with YAML and sign-in resolver examples

## Test plan

- [x] Added unit tests for enabled/disabled flag, catalog + token role merge, and direct user-to-role bindings
- [x] `yarn workspace @backstage-community/plugin-rbac-backend test src/policies/permission-policy.test.ts`
- [x] `yarn tsc:full`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.