### PR TITLE
Version Packages (feedback)

### DIFF
--- a/workspaces/feedback/.changeset/neat-ants-trade.md
+++ b/workspaces/feedback/.changeset/neat-ants-trade.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-feedback-backend': patch
----
-
-refactor: Export permissions from the plugin entry point and remove the deprecated or unused feedback actions exports.

--- a/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
+++ b/workspaces/feedback/plugins/feedback-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-feedback-backend
 
+## 2.2.2
+
+### Patch Changes
+
+- 6f6ce47: refactor: Export permissions from the plugin entry point and remove the deprecated or unused feedback actions exports.
+
 ## 2.2.1
 
 ### Patch Changes

--- a/workspaces/feedback/plugins/feedback-backend/package.json
+++ b/workspaces/feedback/plugins/feedback-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-feedback-backend",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-feedback-backend@2.2.2

### Patch Changes

-   6f6ce47: refactor: Export permissions from the plugin entry point and remove the deprecated or unused feedback actions exports.
