### PR TITLE
vault plugin mui - bui migration

### DIFF
--- a/workspaces/vault/.changeset/mui-to-bui-vault.md
+++ b/workspaces/vault/.changeset/mui-to-bui-vault.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-vault': minor
 ---
 
-MUI - BUI Migration
+**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

--- a/workspaces/vault/.changeset/mui-to-bui-vault.md
+++ b/workspaces/vault/.changeset/mui-to-bui-vault.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-vault': minor
+---
+
+MUI - BUI Migration

--- a/workspaces/vault/plugins/vault/dev/index.tsx
+++ b/workspaces/vault/plugins/vault/dev/index.tsx
@@ -23,7 +23,7 @@ import {
   EntityHasSubcomponentsCard,
   EntityLayout,
 } from '@backstage/plugin-catalog';
-import Grid from '@material-ui/core/Grid';
+import { Grid } from '@backstage/ui';
 import { PropsWithChildren } from 'react';
 import { EntityVaultCard } from '../src/components/EntityVaultCard';
 import { vaultPlugin } from '../src/plugin';
@@ -31,15 +31,15 @@ import { vaultPlugin } from '../src/plugin';
 const SampleEntityPage = ({ children }: PropsWithChildren<{}>) => (
   <EntityLayout>
     <EntityLayout.Route path="/" title="Overview">
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={12}>
+      <Grid.Root columns={{ sm: '12' }} gap="6">
+        <Grid.Item colSpan={{ sm: '12' }}>
           <EntityAboutCard />
-        </Grid>
+        </Grid.Item>
         {children}
-        <Grid item xs={12}>
+        <Grid.Item colSpan={{ sm: '12' }}>
           <EntityHasSubcomponentsCard />
-        </Grid>
-      </Grid>
+        </Grid.Item>
+      </Grid.Root>
     </EntityLayout.Route>
   </EntityLayout>
 );
@@ -58,9 +58,9 @@ createDevApp()
     element: <CatalogEntityPage />,
     children: (
       <SampleEntityPage>
-        <Grid item md={12}>
+        <Grid.Item colSpan={{ sm: '12' }}>
           <EntityVaultCard />
-        </Grid>
+        </Grid.Item>
       </SampleEntityPage>
     ),
   })

--- a/workspaces/vault/plugins/vault/package.json
+++ b/workspaces/vault/plugins/vault/package.json
@@ -47,9 +47,8 @@
     "@backstage/errors": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/core": "^4.12.2",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.61",
+    "@backstage/ui": "backstage:^",
+    "@remixicon/react": "^4.0.0",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-use": "^17.2.4"
   },

--- a/workspaces/vault/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.tsx
+++ b/workspaces/vault/plugins/vault/src/components/EntityVaultTable/EntityVaultTable.tsx
@@ -16,11 +16,8 @@
 import { Entity } from '@backstage/catalog-model';
 import { Link, Table, TableColumn } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import Edit from '@material-ui/icons/Edit';
-import Visibility from '@material-ui/icons/Visibility';
-import Alert from '@material-ui/lab/Alert';
+import { Alert, Box, Text } from '@backstage/ui';
+import { RiEditLine, RiEyeLine } from '@remixicon/react';
 import useAsync from 'react-use/esm/useAsync';
 import { VaultSecret, vaultApiRef } from '../../api';
 import {
@@ -92,9 +89,9 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
       data.push({
         path,
         secret: (
-          <Typography variant="body2" color="textSecondary">
+          <Text variant="body-small" color="secondary">
             No secrets, <Link to={createUrl || ''}>create one</Link>
-          </Typography>
+          </Text>
         ),
         view: null,
         edit: null,
@@ -113,7 +110,7 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
               title={`View ${secretName}`}
               to={secret.showUrl}
             >
-              <Visibility style={{ fontSize: 16 }} />
+              <RiEyeLine size={16} />
             </Link>
           ),
           edit: (
@@ -122,7 +119,7 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
               title={`Edit ${secretName}`}
               to={secret.editUrl}
             >
-              <Edit style={{ fontSize: 16 }} />
+              <RiEditLine size={16} />
             </Link>
           ),
         });
@@ -132,10 +129,12 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
 
   if (error) {
     return (
-      <Alert severity="error">
-        Unexpected error while fetching secrets from path(s) '
-        {secretPaths.join(', ')}': {error.message}
-      </Alert>
+      <Alert
+        status="danger"
+        title={`Unexpected error while fetching secrets from path(s) '${secretPaths.join(
+          ', ',
+        )}': ${error.message}`}
+      />
     );
   }
 
@@ -158,11 +157,11 @@ export const EntityVaultTable = ({ entity }: { entity: Entity }) => {
         search: false,
       }}
       emptyContent={
-        <Box style={{ textAlign: 'center', padding: '15px' }}>
-          <Typography variant="body1">
+        <Box style={{ textAlign: 'center', padding: 'var(--bui-space-4)' }}>
+          <Text variant="body-medium">
             No secrets found for {entity.metadata.name} in{' '}
             {secretPaths.join(', ')}
-          </Typography>
+          </Text>
         </Box>
       }
     />

--- a/workspaces/vault/yarn.lock
+++ b/workspaces/vault/yarn.lock
@@ -2117,9 +2117,8 @@ __metadata:
     "@backstage/plugin-catalog": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@backstage/ui": "backstage:^"
+    "@remixicon/react": "npm:^4.0.0"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -3717,7 +3716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.0":
+"@backstage/ui@backstage:^::backstage=1.53.0&npm=0.17.0, @backstage/ui@npm:^0.17.0":
   version: 0.17.0
   resolution: "@backstage/ui@npm:0.17.0"
   dependencies:
@@ -7189,7 +7188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remixicon/react@npm:^4.6.0":
+"@remixicon/react@npm:^4.0.0, @remixicon/react@npm:^4.6.0":
   version: 4.9.0
   resolution: "@remixicon/react@npm:4.9.0"
   peerDependencies:


### PR DESCRIPTION
Migrated the `vault` plugin from Material UI (MUI) to Backstage UI (BUI) as part of #7869.

**Changes:**
- Replaced `@material-ui/core` (`Box`, `Typography`) with `@backstage/ui` (`Box`, `Text`)
- Replaced `@material-ui/icons` (`Edit`, `Visibility`) with `@remixicon/react` (`RiEditLine`, `RiEyeLine`)
- Replaced `@material-ui/lab` `Alert` with `@backstage/ui` `Alert`
- Replaced MUI `Grid container/item` in `dev/index.tsx` with BUI `Grid.Root`/`Grid.Item`
- Removed all `@material-ui/*` dependencies from `package.json`

**Before:**

<img width="757" height="200" alt="Vault_before" src="https://github.com/user-attachments/assets/f385209d-63ab-4d79-bea5-e6ece82a3da5" />


**After:**

<img width="758" height="194" alt="vault_after" src="https://github.com/user-attachments/assets/14fc9f9c-2779-44bc-beb7-aa2454c85500" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
