### PR TITLE
fix(linguist): improve error handling when generating entity languages

### DIFF
--- a/workspaces/linguist/.changeset/ms81m63o65132c.md
+++ b/workspaces/linguist/.changeset/ms81m63o65132c.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-linguist': patch
+'@backstage-community/plugin-linguist-backend': patch
+---
+
+Improved error handling in LinguistBackendClient and LinguistBackendDatabase for better reliability and debugging.

--- a/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-linguist-backend
 
+## 0.29.1
+
+### Patch Changes
+
+- Improved error handling in LinguistBackendClient and LinguistBackendDatabase for better reliability and debugging.
+
 ## 0.29.0
 
 ### Minor Changes

--- a/workspaces/linguist/plugins/linguist-backend/src/api/LinguistBackendClient.test.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/api/LinguistBackendClient.test.ts
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-import {
-  UrlReaderService,
-  UrlReaderServiceReadTreeResponse,
-} from '@backstage/backend-plugin-api';
-import { CatalogApi } from '@backstage/catalog-client';
-import { Results } from 'linguist-js/dist/types';
 import { DateTime } from 'luxon';
-import { LinguistBackendStore } from '../db';
 import { kindOrDefault, LinguistBackendClient } from './LinguistBackendClient';
 import fs from 'fs-extra';
 import { LINGUIST_ANNOTATION } from '@backstage-community/plugin-linguist-common';
+import { ANNOTATION_SOURCE_LOCATION } from '@backstage/catalog-model';
 import { mockServices } from '@backstage/backend-test-utils';
 
 const linguistResultMock = Promise.resolve({
@@ -58,7 +52,7 @@ const linguistResultMock = Promise.resolve({
     },
     extensions: {},
   },
-} as Results);
+});
 
 describe('kindOrDefault', () => {
   it('should return default kind when undefined', () => {
@@ -75,9 +69,10 @@ describe('kindOrDefault', () => {
 describe('Linguist backend API', () => {
   const logger = mockServices.logger.mock();
 
-  const store: jest.Mocked<LinguistBackendStore> = {
+  const store = {
     insertEntityResults: jest.fn(),
     insertNewEntity: jest.fn(),
+    markEntityProcessed: jest.fn(),
     getEntityResults: jest.fn(),
     getProcessedEntities: jest.fn(),
     getUnprocessedEntities: jest.fn(),
@@ -85,22 +80,23 @@ describe('Linguist backend API', () => {
     deleteEntity: jest.fn(),
   };
 
-  const urlReader: jest.Mocked<UrlReaderService> = {
+  const urlReader = {
     readTree: jest.fn(),
     search: jest.fn(),
     readUrl: jest.fn(),
   };
 
-  const catalogApi: jest.Mocked<CatalogApi> = {
+  const catalogApi = {
     getEntities: jest.fn(),
     getEntityByRef: jest.fn(),
-  } as any;
+  };
 
   const api = new LinguistBackendClient(
     logger,
     store,
     urlReader,
     mockServices.auth(),
+    // @ts-ignore test mock only includes methods used by the client
     catalogApi,
   );
 
@@ -188,6 +184,38 @@ describe('Linguist backend API', () => {
     // Should only make 1 catalog API call (not N+1)
     expect(catalogApi.getEntities).toHaveBeenCalledTimes(1);
     expect(catalogApi.getEntityByRef).not.toHaveBeenCalled();
+  });
+
+  it('should synchronize entities using source location annotation and custom kinds', async () => {
+    const apiWithSourceLocation = new LinguistBackendClient(
+      logger,
+      store,
+      urlReader,
+      mockServices.auth(),
+      // @ts-ignore test mock only includes methods used by the client
+      catalogApi,
+      undefined,
+      undefined,
+      true,
+      ['Resource'],
+    );
+
+    catalogApi.getEntities.mockResolvedValue({ items: [] });
+    store.getAllEntities.mockResolvedValue([]);
+
+    await apiWithSourceLocation.synchronizeEntitiesWithCatalog();
+
+    expect(catalogApi.getEntities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: expect.objectContaining({
+          kind: ['Resource'],
+          [`metadata.annotations.${ANNOTATION_SOURCE_LOCATION}`]:
+            expect.anything(),
+        }),
+        fields: ['kind', 'metadata'],
+      }),
+      expect.anything(),
+    );
   });
 
   it('should synchronize entities with catalog - no changes needed', async () => {
@@ -298,6 +326,7 @@ describe('Linguist backend API', () => {
       store,
       urlReader,
       mockServices.auth(),
+      // @ts-ignore test mock only includes methods used by the client
       catalogApi,
       { days: 5 },
     );
@@ -334,6 +363,7 @@ describe('Linguist backend API', () => {
   it('should generate and save languages for an entity', async () => {
     const spy = jest
       .spyOn(api, 'getLinguistResults')
+      // @ts-expect-error fixture shape is sufficient for this test
       .mockImplementation(() => linguistResultMock);
 
     urlReader.readTree.mockResolvedValueOnce({
@@ -344,7 +374,7 @@ describe('Linguist backend API', () => {
         },
       ],
       dir: async () => '/temp/my-code',
-    } as UrlReaderServiceReadTreeResponse);
+    });
 
     const fsSpy = jest.spyOn(fs, 'remove');
 
@@ -356,6 +386,32 @@ describe('Linguist backend API', () => {
     expect(store.insertEntityResults).toHaveBeenCalled();
     expect(fs.remove).toHaveBeenCalled();
     spy.mockClear();
+    fsSpy.mockClear();
+  });
+
+  it('should clean up and mark an entity processed when linguist fails', async () => {
+    jest.spyOn(api, 'getLinguistResults').mockRejectedValue(new Error('boom'));
+
+    urlReader.readTree.mockResolvedValueOnce({
+      files: async () => [],
+      dir: async () => '/temp/my-code',
+    });
+
+    const fsSpy = jest.spyOn(fs, 'remove');
+
+    await expect(
+      api.generateEntityLanguages(
+        'component:default/fake-service',
+        'https://some.fake/service/',
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(store.markEntityProcessed).toHaveBeenCalledWith(
+      'component:default/fake-service',
+      expect.any(Date),
+    );
+    expect(store.insertEntityResults).not.toHaveBeenCalled();
+    expect(fs.remove).toHaveBeenCalled();
     fsSpy.mockClear();
   });
 
@@ -392,6 +448,7 @@ describe('Linguist backend API', () => {
 
     const resultsSpy = jest
       .spyOn(api, 'getLinguistResults')
+      // @ts-expect-error fixture shape is sufficient for this test
       .mockImplementation(() => linguistResultMock);
 
     urlReader.readTree.mockResolvedValue({
@@ -402,7 +459,7 @@ describe('Linguist backend API', () => {
         },
       ],
       dir: async () => '/temp/my-code',
-    } as UrlReaderServiceReadTreeResponse);
+    });
 
     const fsSpy = jest.spyOn(fs, 'remove');
 
@@ -415,12 +472,83 @@ describe('Linguist backend API', () => {
     fsSpy.mockClear();
   });
 
+  it('should strip url prefix before generating entity languages', async () => {
+    store.getProcessedEntities.mockResolvedValue([]);
+    store.getUnprocessedEntities.mockResolvedValue([
+      'component:default/service-one',
+    ]);
+
+    catalogApi.getEntityByRef.mockResolvedValue({
+      apiVersion: 'backstage.io/v1beta1',
+      metadata: {
+        name: 'service-one',
+        annotations: {
+          [LINGUIST_ANNOTATION]: 'url:https://some.fake/service/',
+        },
+      },
+      kind: 'Component',
+    });
+
+    const generateEntityLanguages = jest
+      .spyOn(api, 'generateEntityLanguages')
+      .mockResolvedValue('ok');
+
+    await api.generateEntitiesLanguages();
+
+    expect(generateEntityLanguages).toHaveBeenCalledWith(
+      'component:default/service-one',
+      'https://some.fake/service/',
+    );
+
+    generateEntityLanguages.mockRestore();
+  });
+
+  it('should process entities by synchronizing then generating', async () => {
+    const synchronizeSpy = jest
+      .spyOn(api, 'synchronizeEntitiesWithCatalog')
+      .mockResolvedValue();
+    const generateSpy = jest
+      .spyOn(api, 'generateEntitiesLanguages')
+      .mockResolvedValue();
+
+    await api.processEntities();
+
+    expect(synchronizeSpy).toHaveBeenCalledTimes(1);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(synchronizeSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      generateSpy.mock.invocationCallOrder[0],
+    );
+
+    synchronizeSpy.mockRestore();
+    generateSpy.mockRestore();
+  });
+
+  it('should mark entity processed and rethrow when reading source tree fails', async () => {
+    urlReader.readTree.mockRejectedValue(new Error('read failed'));
+    const fsSpy = jest.spyOn(fs, 'remove');
+
+    await expect(
+      api.generateEntityLanguages(
+        'component:default/fake-service',
+        'https://some.fake/service/',
+      ),
+    ).rejects.toThrow('read failed');
+
+    expect(store.markEntityProcessed).toHaveBeenCalledWith(
+      'component:default/fake-service',
+      expect.any(Date),
+    );
+    expect(fsSpy).not.toHaveBeenCalled();
+    fsSpy.mockClear();
+  });
+
   it('should generate languages for entities using defined batch size', async () => {
     const apiWithBatchSize = new LinguistBackendClient(
       logger,
       store,
       urlReader,
       mockServices.auth(),
+      // @ts-ignore test mock only includes methods used by the client
       catalogApi,
       undefined,
       2,
@@ -458,6 +586,7 @@ describe('Linguist backend API', () => {
 
     const resultsSpy = jest
       .spyOn(apiWithBatchSize, 'getLinguistResults')
+      // @ts-expect-error fixture shape is sufficient for this test
       .mockImplementation(() => linguistResultMock);
 
     urlReader.readTree.mockResolvedValue({
@@ -468,7 +597,7 @@ describe('Linguist backend API', () => {
         },
       ],
       dir: async () => '/temp/my-code',
-    } as UrlReaderServiceReadTreeResponse);
+    });
 
     const fsSpy = jest.spyOn(fs, 'remove');
 

--- a/workspaces/linguist/plugins/linguist-backend/src/api/LinguistBackendClient.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/api/LinguistBackendClient.ts
@@ -138,9 +138,9 @@ export class LinguistBackendClient implements LinguistBackendApi {
 
     if (entitiesToAdd.length > 0) {
       this.logger?.info(`Adding ${entitiesToAdd.length} new entities`);
-      entitiesToAdd.forEach(entityRef => {
-        this.store.insertNewEntity(entityRef);
-      });
+      await Promise.all(
+        entitiesToAdd.map(entityRef => this.store.insertNewEntity(entityRef)),
+      );
     }
 
     if (entitiesToRemove.length > 0) {
@@ -234,12 +234,17 @@ export class LinguistBackendClient implements LinguistBackendApi {
       `Processing languages for entity ${entityRef} from ${url}`,
     );
 
-    const readTreeResponse = await this.urlReader.readTree(url);
-    const dir = await readTreeResponse.dir();
-
-    const results = await this.getLinguistResults(dir);
+    let dir: string;
+    try {
+      const readTreeResponse = await this.urlReader.readTree(url);
+      dir = await readTreeResponse.dir();
+    } catch (error) {
+      await this.store.markEntityProcessed(entityRef, new Date());
+      throw error;
+    }
 
     try {
+      const results = await this.getLinguistResults(dir);
       const totalBytes = results.languages.bytes;
       const langResults = results.languages.results;
 
@@ -272,6 +277,15 @@ export class LinguistBackendClient implements LinguistBackendApi {
       };
 
       return await this.store.insertEntityResults(entityResults);
+    } catch (error) {
+      try {
+        await this.store.markEntityProcessed(entityRef, new Date());
+      } catch (markError) {
+        this.logger?.error(
+          `Unable to mark "${entityRef}" as processed after failure: ${markError}`,
+        );
+      }
+      throw error;
     } finally {
       this.logger?.info(`Cleaning up files from ${dir}`);
       await fs.remove(dir);

--- a/workspaces/linguist/plugins/linguist-backend/src/db/LinguistBackendDatabase.test.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/db/LinguistBackendDatabase.test.ts
@@ -137,6 +137,29 @@ describe('Linguist database', () => {
     expect(unprocessedEntities).toMatchObject(validUnprocessedEntities);
   });
 
+  it('should ignore rows that already have a processed date when unprocessed', async () => {
+    await store.markEntityProcessed(
+      'template:default/create-react-app-template',
+      new Date('2023-02-16 20:10:21.378Z'),
+    );
+
+    const unprocessedEntities = await store.getUnprocessedEntities();
+
+    expect(unprocessedEntities).toMatchObject([
+      'template:default/docs-template',
+    ]);
+  });
+
+  it('should treat newly inserted entities as unprocessed', async () => {
+    const newEntityRef = 'component:default/new-entity';
+
+    await store.insertNewEntity(newEntityRef);
+
+    const unprocessedEntities = await store.getUnprocessedEntities();
+
+    expect(unprocessedEntities).toContain(newEntityRef);
+  });
+
   it('should return string[] when there is no unprocessed entities', async () => {
     await testDbClient('entity_result').delete();
     const unprocessedEntities = await store.getUnprocessedEntities();
@@ -182,6 +205,26 @@ describe('Linguist database', () => {
     const after = testDbClient.from('entity_result').count();
 
     expect(before).toEqual(after);
+  });
+
+  it('should update processed date for an entity', async () => {
+    const processedDate = new Date('2023-02-20 20:10:21.378Z');
+
+    await store.markEntityProcessed(
+      'template:default/create-react-app-template',
+      processedDate,
+    );
+
+    const processedEntities = await store.getProcessedEntities();
+
+    expect(processedEntities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          entityRef: 'template:default/create-react-app-template',
+          processedDate,
+        }),
+      ]),
+    );
   });
 
   it('should get all entities', async () => {

--- a/workspaces/linguist/plugins/linguist-backend/src/db/LinguistBackendDatabase.ts
+++ b/workspaces/linguist/plugins/linguist-backend/src/db/LinguistBackendDatabase.ts
@@ -26,14 +26,15 @@ import {
 export type RawDbEntityResultRow = {
   id: string;
   entity_ref: string;
-  languages?: string;
-  processed_date?: Date;
+  languages?: string | null;
+  processed_date?: Date | null;
 };
 
 /** @public */
 export interface LinguistBackendStore {
   insertEntityResults(entityLanguages: EntityResults): Promise<string>;
   insertNewEntity(entityRef: string): Promise<void>;
+  markEntityProcessed(entityRef: string, processedDate: Date): Promise<void>;
   getEntityResults(entityRef: string): Promise<Languages>;
   getProcessedEntities(): Promise<ProcessedEntity[]>;
   getUnprocessedEntities(): Promise<string[]>;
@@ -82,9 +83,20 @@ export class LinguistBackendDatabase implements LinguistBackendStore {
       .insert({
         id: entityLanguageId,
         entity_ref: entityRef,
+        // Must be explicit because older SQLite schemas can still default this to NOW().
+        processed_date: null,
       })
       .onConflict('entity_ref')
       .ignore(); // If the entity_ref is in the table already then we don't want to add it again
+  }
+
+  async markEntityProcessed(
+    entityRef: string,
+    processedDate: Date,
+  ): Promise<void> {
+    await this.db<RawDbEntityResultRow>('entity_result')
+      .where({ entity_ref: entityRef })
+      .update({ processed_date: processedDate });
   }
 
   async getEntityResults(entityRef: string): Promise<Languages> {
@@ -111,9 +123,9 @@ export class LinguistBackendDatabase implements LinguistBackendStore {
   }
 
   async getProcessedEntities(): Promise<ProcessedEntity[]> {
-    const rawEntities = await this.db<RawDbEntityResultRow>('entity_result')
-      .whereNotNull('processed_date')
-      .whereNotNull('languages');
+    const rawEntities = await this.db<RawDbEntityResultRow>(
+      'entity_result',
+    ).whereNotNull('processed_date');
 
     if (!rawEntities) {
       return [];
@@ -144,10 +156,8 @@ export class LinguistBackendDatabase implements LinguistBackendStore {
 
   async getUnprocessedEntities(): Promise<string[]> {
     const rawEntities = await this.db<RawDbEntityResultRow>('entity_result')
-      // TODO(ahhhndre) processed_date should always be null as well but it had a default to the current date
-      // once the default has been removed and released, we can then come back an enable this check
-      // .whereNull('processed_date')
       .whereNull('languages')
+      .whereNull('processed_date')
       .orderBy('created_at', 'asc');
 
     if (!rawEntities) {

--- a/workspaces/linguist/plugins/linguist/CHANGELOG.md
+++ b/workspaces/linguist/plugins/linguist/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-linguist
 
+## 0.23.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @backstage-community/plugin-linguist-backend@0.29.1
+
 ## 0.23.0
 
 ### Minor Changes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The linguist-backend plugin has two shortcomings in the `generateEntityLanguages` method that are causing operational issues.

The call to `getLinguistResults` is executed outside the try-finally block responsible for cleaning up the temporary directory. If this method fails, the directory created under `/tmp` is never removed, resulting in a gradual accumulation of files that can eventually lead to Kubernetes pod evictions.

When an error occurs while processing an entity, the entity's `processDate` is never updated. As a result, the entity remains indefinitely in the queue of pending entities, preventing newly added entities from being processed.

The desired outcome is to provide up-to-date language tags for entities that can be processed, making them available to governance teams and end users, while reducing instability caused by pod evictions due to disk pressure, which can lead to support requests and service disruptions.

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
