### PR TITLE
test(argocd): add contributing guides, strengthen tests

### DIFF
--- a/workspaces/argocd/.changeset/crazy-cases-raise.md
+++ b/workspaces/argocd/.changeset/crazy-cases-raise.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-argocd-backend': patch
+'@backstage-community/plugin-argocd-common': patch
+'@backstage-community/plugin-argocd': patch
+---
+
+Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.

--- a/workspaces/argocd/plugins/argocd-backend/CONTRIBUTING.md
+++ b/workspaces/argocd/plugins/argocd-backend/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Developer guide for `@backstage-community/plugin-argocd-backend`. For operator i
 ## Prerequisites
 
 - Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
-- Yarn (workspace uses the community-plugins monorepo lockfile)
+- Yarn (this workspace has its own `yarn.lock` under `workspaces/argocd`)
 
 ## Development harness
 
@@ -20,7 +20,7 @@ yarn workspace @backstage-community/plugin-argocd-backend start \
 
 This runs a minimal backend via `dev/index.ts` with the Argo CD backend plugin. Use it for HTTP router, permissions, and Actions API work.
 
-The harness listens on port **7007**. Only one plugin `dev/` harness should run on that port at a time. To work on the frontend plugin instead, stop this process and start the [frontend harness](../argocd/CONTRIBUTING.md).
+The harness listens on port **7007**. Only one backend `dev/` harness should bind to that port at a time. The [frontend harness](../argocd/CONTRIBUTING.md) uses a different port (typically **3000**), so both can run together.
 
 ### Confirm the plugin loaded
 

--- a/workspaces/argocd/plugins/argocd-backend/CONTRIBUTING.md
+++ b/workspaces/argocd/plugins/argocd-backend/CONTRIBUTING.md
@@ -1,0 +1,134 @@
+# Contributing — Argo CD backend plugin
+
+Developer guide for `@backstage-community/plugin-argocd-backend`. For operator install and configuration, see [README.md](./README.md).
+
+## Prerequisites
+
+- Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
+- Yarn (workspace uses the community-plugins monorepo lockfile)
+
+## Development harness
+
+Start this plugin in isolation with the package’s minimal harness config:
+
+```bash
+yarn workspace @backstage-community/plugin-argocd-backend start \
+  --config app-config.yaml
+```
+
+(`--config` paths are resolved from the plugins directory.)
+
+This runs a minimal backend via `dev/index.ts` with the Argo CD backend plugin. Use it for HTTP router, permissions, and Actions API work.
+
+The harness listens on port **7007**. Only one plugin `dev/` harness should run on that port at a time. To work on the frontend plugin instead, stop this process and start the [frontend harness](../argocd/CONTRIBUTING.md).
+
+### Confirm the plugin loaded
+
+On a successful start you should see (in order):
+
+```log
+backstage info Plugin initialization complete, newly initialized: 'backstage-community-argocd' type="initialization"
+```
+
+If init fails, you will typically see an error stack instead of `Plugin initialization complete` for that plugin id, and `/api/backstage-community-argocd/check` will not return `200`.
+
+### Environment setup
+
+Export these variables in your shell before starting the harness. Use local-only placeholder values for development — do not commit secrets. The static Backstage token must be at least **8 characters**.
+
+| Variable                     | Purpose                                                               |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `BACKSTAGE_DEV_STATIC_TOKEN` | Static bearer token for authenticated `curl` calls to the dev backend |
+| `ARGOCD_URL`                 | Argo CD API base URL (e.g. `https://argocd.example.com`)              |
+| `ARGOCD_AUTH_TOKEN`          | Instance-specific access token (preferred)                            |
+| `ARGOCD_USERNAME`            | Default Argo CD username (fallback auth)                              |
+| `ARGOCD_PASSWORD`            | Default Argo CD password (fallback auth)                              |
+
+[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config required to run the dev harness (listen port, static auth, Actions `pluginSources`, and Argo CD instance keys). Prefer starting with `--config app-config.yaml` as shown above.
+
+By default (without `--config`), `yarn start` loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. That file is for the optional full workspace app and is not required for this harness. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass (or at the workspace root when relying on the default).
+
+### API authentication for `curl`
+
+The harness [`app-config.yaml`](./app-config.yaml) registers a **static** backend access token (see [service-to-service auth](https://backstage.io/docs/auth/service-to-service-auth)):
+
+```yaml
+backend:
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+```
+
+Authenticated API requests must send that token:
+
+```bash
+curl -H "Authorization: Bearer ${BACKSTAGE_DEV_STATIC_TOKEN}" \
+  "http://localhost:7007/api/backstage-community-argocd/check"
+```
+
+Requests without a valid `Authorization: Bearer …` header are rejected when the default auth policy applies.
+
+## Validation commands
+
+From the workspace root (`workspaces/argocd`):
+
+```bash
+yarn workspace @backstage-community/plugin-argocd-backend test
+yarn workspace @backstage-community/plugin-argocd-backend lint
+yarn tsc
+```
+
+Related packages often touched on the same bump:
+
+```bash
+yarn workspace @backstage-community/plugin-argocd-common test
+yarn workspace @backstage-community/plugin-argocd-node test
+```
+
+## What automated tests cover
+
+CI exercises:
+
+- **Plugin wiring** — `startTestBackend` proves router mount, permission registry, and Actions API registration
+- **Router permission middleware** — 403 when `argocd.view.read` is denied; handlers are not invoked on deny
+- **Actions handlers** — unit tests for find/get/list/revision actions (including permission deny)
+- **Node client** — Argo CD HTTP client error paths (`plugin-argocd-node`)
+
+CI does **not** replace reading [Backstage release notes](https://github.com/backstage/backstage/releases) for the `@backstage/*` packages this plugin depends on. After a dependency bump, review those notes and decide whether additional validation is warranted.
+
+## Optional manual smoke checklist
+
+Use when you change backend integration code or are reviewing a Backstage version bump:
+
+1. Export the [environment variables](#environment-setup) and start this harness with `--config app-config.yaml`.
+2. Confirm [plugin load logs](#confirm-the-plugin-loaded) (`Listening on :7007` + `Plugin initialization complete ... 'backstage-community-argocd'`).
+3. Health check (requires Bearer token) — proves router mount + Backstage permission middleware path:
+
+   ```bash
+   curl -i -H "Authorization: Bearer ${BACKSTAGE_DEV_STATIC_TOKEN}" \
+     "http://localhost:7007/api/backstage-community-argocd/check"
+   ```
+
+   Expect `HTTP/1.1 200` and body `OK`. The harness access log should show something like:
+
+   ```log
+   rootHttpRouter info ... "GET /api/backstage-community-argocd/check HTTP/1.1" 200 ...
+   ```
+
+## Full workspace app evaluation
+
+The workspace already ships `packages/app` and `packages/backend`. They are **optional** for cross-plugin UI/RBAC smoke (catalog entity cards, frontend + backend together).
+
+Default for bump-trust and day-to-day work: plugin `dev/` + scoped automated tests. Do **not** add another full Backstage application to this workspace.
+
+```bash
+# Optional — full workspace only when needed
+yarn start:backstage
+```
+
+## Related packages
+
+- [Argo CD frontend plugin](../argocd/CONTRIBUTING.md) — UI extensions and API clients (separate `dev/` harness)

--- a/workspaces/argocd/plugins/argocd-backend/README.md
+++ b/workspaces/argocd/plugins/argocd-backend/README.md
@@ -2,6 +2,8 @@
 
 This plugin enables integration between Backstage and ArgoCD instances, allowing you to monitor your ArgoCD applications.
 
+For local development, the `dev/` harness, scoped test commands, and smoke checklists, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Installation
 
 This plugin is installed via the `@backstage-community/plugin-argocd-backend` package. To install it to your backend package, run:

--- a/workspaces/argocd/plugins/argocd-backend/app-config.yaml
+++ b/workspaces/argocd/plugins/argocd-backend/app-config.yaml
@@ -1,0 +1,24 @@
+backend:
+  baseUrl: http://localhost:7007
+  listen:
+    port: 7007
+  auth:
+    externalAccess:
+      - type: static
+        options:
+          token: ${BACKSTAGE_DEV_STATIC_TOKEN}
+          subject: user:default/guest
+  actions:
+    pluginSources:
+      - backstage-community-argocd
+
+argocd:
+  localDevelopment: true
+  username: ${ARGOCD_USERNAME}
+  password: ${ARGOCD_PASSWORD}
+  appLocatorMethods:
+    - type: 'config'
+      instances:
+        - name: primary
+          url: ${ARGOCD_URL}
+          token: ${ARGOCD_AUTH_TOKEN}

--- a/workspaces/argocd/plugins/argocd-backend/src/plugin.test.ts
+++ b/workspaces/argocd/plugins/argocd-backend/src/plugin.test.ts
@@ -13,10 +13,99 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import request from 'supertest';
 import { argoCDPlugin } from './plugin';
 
-describe('argocd-backend', () => {
-  it('should export the ArgoCD backend plugin', () => {
-    expect(argoCDPlugin).toBeDefined();
+const config = mockServices.rootConfig.factory({
+  data: {
+    argocd: {
+      appLocatorMethods: [
+        {
+          type: 'config',
+          instances: [
+            {
+              name: 'test-instance',
+              url: 'https://argocd.example.com',
+              token: 'test-token',
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+const EXPECTED_ACTION_IDS = [
+  'backstage-community-argocd:create-resources',
+  'backstage-community-argocd:argocd:find-applications',
+  'backstage-community-argocd:argocd:get-application',
+  'backstage-community-argocd:argocd:get-revision-details',
+  'backstage-community-argocd:argocd:list-applications',
+];
+
+function permissionsFactory(
+  result: AuthorizeResult.ALLOW | AuthorizeResult.DENY,
+) {
+  return mockServices.permissions.mock({
+    authorize: async requests => requests.map(() => ({ result })),
+  }).factory;
+}
+
+describe('argoCDPlugin', () => {
+  it('should mount the router and return 200 on /check when allowed', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        argoCDPlugin,
+        config,
+        permissionsFactory(AuthorizeResult.ALLOW),
+      ],
+    });
+
+    const response = await request(server).get(
+      '/api/backstage-community-argocd/check',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe('OK');
+  });
+
+  it('should return 403 on /check when argocd.view.read is denied', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        argoCDPlugin,
+        config,
+        permissionsFactory(AuthorizeResult.DENY),
+      ],
+    });
+
+    const response = await request(server).get(
+      '/api/backstage-community-argocd/check',
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: 'Unauthorized, please ensure you have the correct permissions',
+    });
+  });
+
+  it('should register the expected Actions API action IDs', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        argoCDPlugin,
+        config,
+        permissionsFactory(AuthorizeResult.ALLOW),
+      ],
+    });
+
+    const response = await request(server).get(
+      '/api/backstage-community-argocd/.backstage/actions/v1/actions',
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      response.body.actions.map((a: { id: string }) => a.id).sort(),
+    ).toEqual([...EXPECTED_ACTION_IDS].sort());
   });
 });

--- a/workspaces/argocd/plugins/argocd-backend/src/router.test.ts
+++ b/workspaces/argocd/plugins/argocd-backend/src/router.test.ts
@@ -69,6 +69,28 @@ describe('router', () => {
     app = express().use(router);
   });
 
+  describe('permission denial', () => {
+    beforeEach(() => {
+      mockPermissions.authorize.mockResolvedValue([
+        { result: AuthorizeResult.DENY },
+      ]);
+    });
+
+    it('should return 403 on /check when permission is denied', async () => {
+      const response = await request(app).get('/check').expect(403);
+
+      expect(response.body).toEqual({
+        error: 'Unauthorized, please ensure you have the correct permissions',
+      });
+    });
+
+    it('should return 403 on /find/name/:appName and not invoke the handler', async () => {
+      await request(app).get('/find/name/staging-app').expect(403);
+
+      expect(mockArgoCDService.findApplications).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GET /find/name/:appName', () => {
     it('should return instances with applications filtered by appName and appNamespace', async () => {
       const expectedApplicationResponse = [

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -28,7 +28,7 @@
     "lint": "backstage-cli package lint",
     "postpack": "backstage-cli package postpack",
     "prepack": "backstage-cli package prepack",
-    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "test": "backstage-cli package test --coverage",
     "tsc": "tsc"
   },
   "dependencies": {

--- a/workspaces/argocd/plugins/argocd-common/src/permissions.test.ts
+++ b/workspaces/argocd/plugins/argocd-common/src/permissions.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/argocd/plugins/argocd-common/src/permissions.test.ts
+++ b/workspaces/argocd/plugins/argocd-common/src/permissions.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { argocdPermissions, argocdViewPermission } from './permissions';
+
+describe('argocd permissions', () => {
+  it('should define argocdViewPermission with the expected name and attributes', () => {
+    expect(argocdViewPermission.name).toBe('argocd.view.read');
+    expect(argocdViewPermission.attributes).toEqual({ action: 'read' });
+  });
+
+  it('should export argocdPermissions containing exactly argocdViewPermission', () => {
+    expect(argocdPermissions).toHaveLength(1);
+    expect(argocdPermissions).toContain(argocdViewPermission);
+  });
+});

--- a/workspaces/argocd/plugins/argocd-common/src/permissions.ts
+++ b/workspaces/argocd/plugins/argocd-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/argocd/plugins/argocd-common/src/permissions.ts
+++ b/workspaces/argocd/plugins/argocd-common/src/permissions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspaces/argocd/plugins/argocd/CONTRIBUTING.md
+++ b/workspaces/argocd/plugins/argocd/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing — Argo CD frontend plugin
+
+Developer guide for `@backstage-community/plugin-argocd`. For operator install and end-user configuration, see [README.md](./README.md).
+
+## Prerequisites
+
+- Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
+- Yarn (workspace uses the community-plugins monorepo lockfile)
+
+## Development harness
+
+Start this plugin in isolation:
+
+```bash
+yarn workspace @backstage-community/plugin-argocd start
+```
+
+This serves the frontend plugin via `dev/index.tsx` with mocked Argo CD data for faster iteration. Use it for UI extensions, hooks, and API client work.
+
+Only one frontend `dev/` harness should run at a time on the default plugin port. Backend HTTP work belongs in the [backend harness](../argocd-backend/CONTRIBUTING.md).
+
+### Configuration notes
+
+The `dev/` harness uses fixtures under `dev/__data__/`. Operator-facing config keys (`argocd.appLocatorMethods`, annotations, Kubernetes rollouts) are documented in [README.md](./README.md). Do not commit real credentials.
+
+## Validation commands
+
+From the workspace root (`workspaces/argocd`):
+
+```bash
+yarn workspace @backstage-community/plugin-argocd test
+yarn workspace @backstage-community/plugin-argocd lint
+yarn tsc
+```
+
+## What automated tests cover
+
+CI exercises:
+
+- Plugin API factory and routable extensions (`ArgocdDeploymentLifecycle`, `ArgocdDeploymentSummary`)
+- API clients (`ArgoCDApiClient`, `ArgoCDInstanceApiClient`)
+- Hooks and utils used by the deployment lifecycle/summary UI
+
+CI does **not** replace reading [Backstage release notes](https://github.com/backstage/backstage/releases) for the `@backstage/*` packages this plugin depends on. After a dependency bump, review those notes and decide whether additional validation is warranted.
+
+Backend mount, permissions, and Actions API registration are covered by the [backend package tests](../argocd-backend/CONTRIBUTING.md).
+
+## Optional manual smoke checklist
+
+Use when you change frontend integration code or are reviewing a Backstage version bump:
+
+1. Start this harness and open the plugin UI in the browser (path served by `dev/index.tsx`).
+2. Confirm deployment lifecycle / summary surfaces render with fixture data.
+3. Full catalog-entity + live Argo CD validation needs the backend running (plugin or full workspace) and a real or overlay Argo CD instance — not a merge gate for every bump PR.
+
+## Full workspace app evaluation
+
+The workspace already ships `packages/app` and `packages/backend`. They are **optional** for cross-plugin smoke (entity page cards with a live backend, RBAC, Playwright).
+
+Default for bump-trust and day-to-day work: plugin `dev/` + scoped automated tests. Do **not** add another full Backstage application to this workspace.
+
+```bash
+# Optional — full workspace only when needed
+yarn start:backstage
+```
+
+## Related packages
+
+- [Argo CD backend plugin](../argocd-backend/CONTRIBUTING.md) — HTTP router, permissions, Actions API (separate `dev/` harness)

--- a/workspaces/argocd/plugins/argocd/CONTRIBUTING.md
+++ b/workspaces/argocd/plugins/argocd/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Developer guide for `@backstage-community/plugin-argocd`. For operator install a
 ## Prerequisites
 
 - Node.js **22 or 24** (see workspace `engines` in the workspace root `package.json`)
-- Yarn (workspace uses the community-plugins monorepo lockfile)
+- Yarn (this workspace has its own `yarn.lock` under `workspaces/argocd`)
 
 ## Development harness
 

--- a/workspaces/argocd/plugins/argocd/README.md
+++ b/workspaces/argocd/plugins/argocd/README.md
@@ -1,12 +1,6 @@
 # Argo CD plugin for Backstage
 
-## Getting started
-
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn start` in the root directory, and then navigating to [/argocd/deployment-lifecycle](http://localhost:3000/argocd/deployment-lifecycle).
-
-You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
-This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.
+For local development, the `dev/` harness, scoped test commands, and smoke checklists, see [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## For Administrators
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aims to increase the test coverage for the argocd plugins, with a focus on Backstage integration.

It also adds contributor guides with steps for running the plugin dev/ harness, running the usual package/workspace validation commands, and a short manual smoke checklist. The dev harnesses can act as minimal checks when verifying a new Backstage update.

`--passWithNoTests` was also removed from the test script for `argocd-common` since new minimum tests were added for the plugin.

This effort is primarily being worked on to increase our trust in green CI when merging Backstage version bumps.

The `CONTRIBUTING.md` and `README.md` structures follow the pattern already used by the other plugins revised during the CI bump trust feature.

Testing:
`yarn workspace @backstage-community/plugin-argocd-backend test`
`yarn workspace @backstage-community/plugin-argocd-common test`
`yarn tsc`

Assisted-By: Cursor Desktop

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
