### PR TITLE
feat(nomad): migrate plugin UI from MUI to BUI

### DIFF
--- a/workspaces/nomad/.changeset/tender-apples-beam.md
+++ b/workspaces/nomad/.changeset/tender-apples-beam.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-nomad': patch
+---
+
+Migrated the nomad plugin from Material-UI (MUI) to Backstage UI (BUI). Replaced `@material-ui/core` components (`Box`, `Card`, `Table`, `Typography`) with their BUI equivalents and replaced `makeStyles` with CSS Modules using BUI CSS custom properties. Closes #7869

--- a/workspaces/nomad/plugins/nomad/package.json
+++ b/workspaces/nomad/plugins/nomad/package.json
@@ -41,8 +41,8 @@
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
+    "@backstage/ui": "backstage:^",
+    "@remixicon/react": "^4.2.0",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "luxon": "^3.3.0",
     "react-use": "^17.2.4"

--- a/workspaces/nomad/plugins/nomad/src/components/EntityNomadJobVersionListCard/EntityNomadJobVersionListCard.tsx
+++ b/workspaces/nomad/plugins/nomad/src/components/EntityNomadJobVersionListCard/EntityNomadJobVersionListCard.tsx
@@ -33,8 +33,8 @@ import {
   NOMAD_NAMESPACE_ANNOTATION,
   isNomadJobIDAvailable,
 } from '../../annotations';
-import OpenInNewIcon from '@material-ui/icons/OpenInNew';
-import Chip from '@material-ui/core/Chip';
+import { RiExternalLinkLine } from '@remixicon/react';
+import { Tag, TagGroup } from '@backstage/ui';
 
 type rowType = Version & { nomadAddr: string };
 
@@ -47,7 +47,11 @@ const columns: TableColumn<rowType>[] = [
   {
     title: 'Stable',
     field: 'Stable',
-    render: row => <Chip label={`${row.Stable}`} />,
+    render: row => (
+      <TagGroup aria-label="stable">
+        <Tag id="stable">{`${row.Stable}`}</Tag>
+      </TagGroup>
+    ),
   },
   {
     title: 'Submitted',
@@ -132,7 +136,7 @@ export const EntityNomadJobVersionListCard = () => {
       title="Job versions"
       actions={[
         {
-          icon: () => <OpenInNewIcon />,
+          icon: () => <RiExternalLinkLine />,
           tooltip: 'Open in Nomad UI',
           isFreeAction: true,
           onClick: () => window.open(`${nomadAddr}/ui/jobs/${jobID}/versions`),

--- a/workspaces/nomad/yarn.lock
+++ b/workspaces/nomad/yarn.lock
@@ -1729,8 +1729,7 @@ __metadata:
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/dev-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
-    "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
+    "@backstage/ui": "backstage:^"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -3099,7 +3098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.0":
+"@backstage/ui@backstage:^::backstage=1.53.0&npm=0.17.0, @backstage/ui@npm:^0.17.0":
   version: 0.17.0
   resolution: "@backstage/ui@npm:0.17.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the `nomad` workspace from Material-UI (MUI) to Backstage UI (BUI) as part of #7869
### What changed

- Replaced `@material-ui/core` components (`Box`, `Card`, `Table`, `Typography`, `makeStyles`) with BUI equivalents (`Tag`, `TagGroup` from `@backstage/ui`)
- Replaced `@material-ui/icons` (`OpenInNewIcon`) with `@remixicon/react` (`RiExternalLinkLine`)
- Removed `@material-ui/core` and `@material-ui/icons` from dependencies
- Added `@backstage/ui` as a dependency

<img width="822" height="445" alt="image" src="https://github.com/user-attachments/assets/165d91da-6cd1-4cd9-b7dc-3e2bd1276037" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
