### PR TITLE
Version Packages (scaffolder-relation-processor)

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/lazy-brooms-march.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/lazy-brooms-march.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
----
-
-Add module wiring and utility unit tests, a local dev harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests. Also document the pullRequests.templateUpdate config option in the config schema.

--- a/workspaces/scaffolder-relation-processor/.changeset/version-bump-1-53-0.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/version-bump-1-53-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': minor
----
-
-Backstage version bump to v1.53.0

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor
 
+## 2.16.0
+
+### Minor Changes
+
+- 1534c83: Backstage version bump to v1.53.0
+
+### Patch Changes
+
+- 01d115d: Add module wiring and utility unit tests, a local dev harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests. Also document the pullRequests.templateUpdate config option in the config schema.
+
 ## 2.15.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/plugins/catalog-backend-module-scaffolder-relation-processor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor",
   "description": "The scaffolder-relation-processor backend module for the catalog plugin.",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@2.16.0

### Minor Changes

-   1534c83: Backstage version bump to v1.53.0

### Patch Changes

-   01d115d: Add module wiring and utility unit tests, a local dev harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests. Also document the pullRequests.templateUpdate config option in the config schema.
