### PR TITLE
Version Packages (pingidentity)

### DIFF
--- a/workspaces/pingidentity/.changeset/version-bump-1-54-5.md
+++ b/workspaces/pingidentity/.changeset/version-bump-1-54-5.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-auth-backend-module-pingfederate-provider': minor
-'@backstage-community/plugin-catalog-backend-module-pingidentity': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/pingidentity/.changeset/weak-masks-grow.md
+++ b/workspaces/pingidentity/.changeset/weak-masks-grow.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-auth-backend-module-pingfederate-provider': patch
-'@backstage-community/plugin-catalog-backend-module-pingidentity': patch
----
-
-Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-auth-backend-module-pingfederate-provider
 
+## 0.4.0
+
+### Minor Changes
+
+- 094ed44: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-auth-backend-module-pingfederate-provider
 
+## 0.3.1
+
+### Patch Changes
+
+- 26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-auth-backend-module-pingfederate-provider",
   "description": "The PingFederate provider backend module for the auth plugin.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
+++ b/workspaces/pingidentity/plugins/auth-backend-module-pingfederate-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-auth-backend-module-pingfederate-provider",
   "description": "The PingFederate provider backend module for the auth plugin.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-catalog-backend-module-pingidentity
 
+## 0.15.0
+
+### Minor Changes
+
+- 094ed44: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-pingidentity
 
+## 0.14.1
+
+### Patch Changes
+
+- 26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-pingidentity",
   "description": "The PingOne backend module for the catalog plugin. Ingests organization data (users and groups) from Ping Identity's cloud offering.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
+++ b/workspaces/pingidentity/plugins/catalog-backend-module-pingidentity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-pingidentity",
   "description": "The PingOne backend module for the catalog plugin. Ingests organization data (users and groups) from Ping Identity's cloud offering.",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-auth-backend-module-pingfederate-provider@0.4.0

### Minor Changes

-   094ed44: Backstage version bump to v1.54.5

### Patch Changes

-   26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.

## @backstage-community/plugin-catalog-backend-module-pingidentity@0.15.0

### Minor Changes

-   094ed44: Backstage version bump to v1.54.5

### Patch Changes

-   26bfeb5: Document starting the dev harness with the package config (--config app-config.yaml or app-config.local.yaml) and explain how that differs from the workspace root default.
