### PR TITLE
Version Packages (scaffolder-backend-module-annotator)

### DIFF
--- a/workspaces/scaffolder-backend-module-annotator/.changeset/metal-oranges-work.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/metal-oranges-work.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-annotator': patch
----
-
-Document starting the dev harness with --config app-config.yaml and add a workspace-level app-config.yaml for parity with other harness workspaces.

--- a/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-53-0.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/version-bump-1-53-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-annotator': minor
----
-
-Backstage version bump to v1.53.0

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-scaffolder-backend-module-annotator
 
+## 2.19.0
+
+### Minor Changes
+
+- 4ab17c7: Backstage version bump to v1.53.0
+
+### Patch Changes
+
+- 26bfeb5: Document starting the dev harness with --config app-config.yaml and add a workspace-level app-config.yaml for parity with other harness workspaces.
+
 ## 2.18.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-annotator",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "2.18.1",
+  "version": "2.19.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-annotator@2.19.0

### Minor Changes

-   4ab17c7: Backstage version bump to v1.53.0

### Patch Changes

-   26bfeb5: Document starting the dev harness with --config app-config.yaml and add a workspace-level app-config.yaml for parity with other harness workspaces.
