### PR TITLE
Version Packages (scaffolder-backend-module-kubernetes)

### DIFF
--- a/workspaces/scaffolder-backend-module-kubernetes/.changeset/odd-hats-write.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/.changeset/odd-hats-write.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-kubernetes': patch
----
-
-Add module wiring tests, scaffolder-node input schema coverage, Kubernetes API error-path tests, a local `dev/` harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-kubernetes
 
+## 2.20.1
+
+### Patch Changes
+
+- 9a486a6: Add module wiring tests, scaffolder-node input schema coverage, Kubernetes API error-path tests, a local `dev/` harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.
+
 ## 2.20.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/plugins/kubernetes-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-kubernetes",
   "description": "The kubernetes module for @backstage/plugin-scaffolder-backend",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.20.1

### Patch Changes

-   9a486a6: Add module wiring tests, scaffolder-node input schema coverage, Kubernetes API error-path tests, a local `dev/` harness, and contributor documentation so Backstage dependency bumps are caught by scoped automated tests.
