### PR TITLE
Version Packages (scaffolder-backend-module-servicenow)

### DIFF
--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/ninety-toys-kiss.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/ninety-toys-kiss.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-ServiceNow Table API scaffolder actions now fall back to the HTTP status text (or a clear default) when the API error body omits `error.message`, so template failures surface a useful message instead of an empty error.
-
-Added a contributor guide (`CONTRIBUTING.md`) and a local `dev/` harness so maintainers can smoke-test scaffolder action registration without a full workspace app. Expanded automated tests to cover module wiring, ServiceNow config fail-fast, shared MSW helpers with OpenAPI isolation, and representative API error paths.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-61a90c7.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/renovate-61a90c7.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': patch
----
-
-Updated dependency `axios` to `^1.19.0`.

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-53-0.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-53-0.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': minor
----
-
-Backstage version bump to v1.53.0

--- a/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-54-5.md
+++ b/workspaces/scaffolder-backend-module-servicenow/.changeset/version-bump-1-54-5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-servicenow': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.17.0
+
+### Minor Changes
+
+- 69a21f0: Backstage version bump to v1.53.0
+- 4d7fbde: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 813d384: ServiceNow Table API scaffolder actions now fall back to the HTTP status text (or a clear default) when the API error body omits `error.message`, so template failures surface a useful message instead of an empty error.
+
+  Added a contributor guide (`CONTRIBUTING.md`) and a local `dev/` harness so maintainers can smoke-test scaffolder action registration without a full workspace app. Expanded automated tests to cover module wiring, ServiceNow config fail-fast, shared MSW helpers with OpenAPI isolation, and representative API error paths.
+
+- a36cd39: Updated dependency `axios` to `^1.19.0`.
+
 ## 2.16.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-scaffolder-backend-module-servicenow
 
+## 2.17.0
+
+### Minor Changes
+
+- 69a21f0: Backstage version bump to v1.53.0
+
+### Patch Changes
+
+- 813d384: ServiceNow Table API scaffolder actions now fall back to the HTTP status text (or a clear default) when the API error body omits `error.message`, so template failures surface a useful message instead of an empty error.
+
+  Added a contributor guide (`CONTRIBUTING.md`) and a local `dev/` harness so maintainers can smoke-test scaffolder action registration without a full workspace app. Expanded automated tests to cover module wiring, ServiceNow config fail-fast, shared MSW helpers with OpenAPI isolation, and representative API error paths.
+
 ## 2.16.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
+++ b/workspaces/scaffolder-backend-module-servicenow/plugins/scaffolder-backend-module-servicenow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-servicenow",
   "description": "The servicenow custom actions",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-servicenow@2.17.0

### Minor Changes

-   69a21f0: Backstage version bump to v1.53.0
-   4d7fbde: Backstage version bump to v1.54.5

### Patch Changes

-   813d384: ServiceNow Table API scaffolder actions now fall back to the HTTP status text (or a clear default) when the API error body omits `error.message`, so template failures surface a useful message instead of an empty error.

    Added a contributor guide (`CONTRIBUTING.md`) and a local `dev/` harness so maintainers can smoke-test scaffolder action registration without a full workspace app. Expanded automated tests to cover module wiring, ServiceNow config fail-fast, shared MSW helpers with OpenAPI isolation, and representative API error paths.

-   a36cd39: Updated dependency `axios` to `^1.19.0`.
