### PR TITLE
docs: enhance kafka workspace README

### DIFF
--- a/workspaces/azure-devops/README.md
+++ b/workspaces/azure-devops/README.md
@@ -1,17 +1,35 @@
 # Azure DevOps
 
-This workspace contains plugins that integrate Azure DevOps features within Backstage.
+This workspace contains plugins for integrating [Azure DevOps](https://dev.azure.com/) with Backstage, including build/PR dashboards, catalog entity annotation, scaffolder actions, and search indexing.
 
 ## Plugins
 
-[azure-devops](plugins/azure-devops)
-[azure-devops-backend](plugins/azure-devops-backend)
-[azure-devops-common](plugins/azure-devops-common)
-[catalog-backend-module-azure-devops-annotator-processor](plugins/catalog-backend-module-azure-devops-annotator-processor)
-[scaffolder-backend-module-azure-devops](plugins/scaffolder-backend-module-azure-devops)
-[scaffolder-backend-module-dotnet](plugins/scaffolder-backend-module-dotnet)
-[search-backend-module-azure-devops](plugins/search-backend-module-azure-devops)
+This workspace is composed of several packages:
+
+- [azure-devops](./plugins/azure-devops/README.md) - The frontend plugin that displays Azure Pipelines builds, Azure Repos pull requests, git tags, and a pull request dashboard.
+- [azure-devops-backend](./plugins/azure-devops-backend/README.md) - The backend plugin that proxies requests to the Azure DevOps REST API.
+- [azure-devops-common](./plugins/azure-devops-common) - A common library containing types shared between the frontend and backend plugins.
+- [catalog-backend-module-azure-devops-annotator-processor](./plugins/catalog-backend-module-azure-devops-annotator-processor/README.md) - A catalog backend module that automatically annotates entities with the Azure DevOps host and repo location, so they don't need to be added manually.
+- [scaffolder-backend-module-azure-devops](./plugins/scaffolder-backend-module-azure-devops/README.md) - A scaffolder backend module providing custom actions to run/create/permit Azure Pipelines and to clone/push/create pull requests against Azure Repos.
+- [scaffolder-backend-module-dotnet](./plugins/scaffolder-backend-module-dotnet/README.md) - A scaffolder backend module providing a `dotnet:new` custom action that wraps the [`dotnet` CLI](https://learn.microsoft.com/en-us/dotnet/core/tools/).
+- [search-backend-module-azure-devops](./plugins/search-backend-module-azure-devops/README.md) - A search backend module that indexes articles from an Azure DevOps project wiki so they're available in Backstage Search.
+
+## Quick start
+
+You will find detailed installation and configuration instructions in each plugin's README file.
+
+```sh
+# From your Backstage root directory
+# install backend
+yarn --cwd packages/backend add @backstage-community/plugin-azure-devops-backend
+
+# install frontend
+yarn --cwd packages/app add @backstage-community/plugin-azure-devops
+
+# see the READMEs in the frontend and backend plugin for configuration details,
+# including how to set up the integrations.azure section of app-config.yaml
+```
 
 ## About this workspace
 
-Use these plugins to connect Backstage with Azure DevOps workflows.
+Use these plugins to connect Backstage with Azure DevOps workflows: surfacing pipeline and pull request activity on entity pages, keeping catalog entities annotated with their Azure DevOps location, running Azure Pipelines and .NET project actions from Software Templates, and indexing Azure DevOps wikis for search.

--- a/workspaces/kafka/README.md
+++ b/workspaces/kafka/README.md
@@ -1,10 +1,30 @@
-# [Backstage](https://backstage.io)
+# Kafka
 
-This is your newly scaffolded Backstage App, Good Luck!
+This workspace contains plugins for integrating [Apache Kafka](https://kafka.apache.org/) with Backstage, allowing you to view cluster, topic, and consumer group information for a service directly on its entity page.
 
-To start the app, run:
+## Plugins
+
+This workspace is composed of two packages:
+
+- [kafka](./plugins/kafka/README.md) - The frontend plugin that adds a Kafka tab to entity pages, showing topic offsets and consumer group status per cluster.
+- [kafka-backend](./plugins/kafka-backend/README.md) - The backend plugin that connects to your Kafka brokers and serves the data the frontend displays.
+
+## Quick start
+
+You will find detailed installation and configuration instructions in each plugin's README file.
 
 ```sh
-yarn install
-yarn start
+# From your Backstage root directory
+# install frontend
+yarn --cwd packages/app add @backstage-community/plugin-kafka
+
+# install backend
+yarn --cwd packages/backend add @backstage-community/plugin-kafka-backend
+
+# see the READMEs in the frontend and backend plugin for more details,
+# including how to add the EntityKafkaContent tab and configure clusters/brokers
 ```
+
+## About this workspace
+
+Use these plugins to give service owners visibility into the Kafka topics and consumer groups their service depends on, without leaving Backstage. Clusters and brokers are configured per-entity through the `kafka` section of `app-config.yaml`, with optional TLS and SASL authentication.

--- a/workspaces/kafka/README.md
+++ b/workspaces/kafka/README.md
@@ -1,30 +1,8 @@
-# Kafka
+# Kafka Workspace
 
-This workspace contains plugins for integrating [Apache Kafka](https://kafka.apache.org/) with Backstage, allowing you to view cluster, topic, and consumer group information for a service directly on its entity page.
+This workspace contains plugins for viewing [Apache Kafka](https://kafka.apache.org/) cluster, topic, and consumer group information for a service within Backstage.
 
 ## Plugins
 
-This workspace is composed of two packages:
-
-- [kafka](./plugins/kafka/README.md) - The frontend plugin that adds a Kafka tab to entity pages, showing topic offsets and consumer group status per cluster.
-- [kafka-backend](./plugins/kafka-backend/README.md) - The backend plugin that connects to your Kafka brokers and serves the data the frontend displays.
-
-## Quick start
-
-You will find detailed installation and configuration instructions in each plugin's README file.
-
-```sh
-# From your Backstage root directory
-# install frontend
-yarn --cwd packages/app add @backstage-community/plugin-kafka
-
-# install backend
-yarn --cwd packages/backend add @backstage-community/plugin-kafka-backend
-
-# see the READMEs in the frontend and backend plugin for more details,
-# including how to add the EntityKafkaContent tab and configure clusters/brokers
-```
-
-## About this workspace
-
-Use these plugins to give service owners visibility into the Kafka topics and consumer groups their service depends on, without leaving Backstage. Clusters and brokers are configured per-entity through the `kafka` section of `app-config.yaml`, with optional TLS and SASL authentication.
+- [kafka](./plugins/kafka): Frontend plugin that adds a Kafka tab to entity pages.
+- [kafka-backend](./plugins/kafka-backend): Backend plugin that connects to Kafka brokers and serves the data the frontend displays.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enhances the workspace-level README for the `kafka` workspace to match the structure used by other workspace READMEs (such as `announcements`).

`workspaces/kafka/README.md` currently has the default scaffolded boilerplate ("This is your newly scaffolded Backstage App, Good Luck!"). This PR adds:

- A one-line workspace summary
- A `## Plugins` section listing the two packages with short descriptions
- A `## Quick start` section with install commands
- An `## About this workspace` section explaining its purpose

#### :heavy_check_mark: Checklist

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message.
