### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/crazy-cases-raise.md
+++ b/workspaces/argocd/.changeset/crazy-cases-raise.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-argocd-backend': patch
-'@backstage-community/plugin-argocd-common': patch
-'@backstage-community/plugin-argocd': patch
----
-
-Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.

--- a/workspaces/argocd/.changeset/gentle-links-speak.md
+++ b/workspaces/argocd/.changeset/gentle-links-speak.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-argocd': patch
----
-
-Added aria-label to icon-only external link buttons to resolve link-name accessibility violations

--- a/workspaces/argocd/.changeset/version-bump-1-52-0.md
+++ b/workspaces/argocd/.changeset/version-bump-1-52-0.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
-'@backstage-community/plugin-argocd-backend': minor
-'@backstage-community/plugin-argocd-common': minor
-'@backstage-community/plugin-argocd-node': minor
----
-
-Backstage version bump to v1.52.0

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.6.0
+
+### Minor Changes
+
+- 730c396: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.
+- Updated dependencies [d640871]
+- Updated dependencies [730c396]
+  - @backstage-community/plugin-argocd-common@1.17.0
+  - @backstage-community/plugin-argocd-node@1.3.0
+
 ## 1.5.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.17.0
+
+### Minor Changes
+
+- 730c396: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.
+
 ## 1.16.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-argocd-node
 
+## 1.3.0
+
+### Minor Changes
+
+- 730c396: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- Updated dependencies [d640871]
+- Updated dependencies [730c396]
+  - @backstage-community/plugin-argocd-common@1.17.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-node/package.json
+++ b/workspaces/argocd/plugins/argocd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-node",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-argocd
 
+## 2.11.0
+
+### Minor Changes
+
+- 730c396: Backstage version bump to v1.52.0
+
+### Patch Changes
+
+- d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.
+- 4cd7a76: Added aria-label to icon-only external link buttons to resolve link-name accessibility violations
+- Updated dependencies [d640871]
+- Updated dependencies [730c396]
+  - @backstage-community/plugin-argocd-common@1.17.0
+
 ## 2.10.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@2.11.0

### Minor Changes

-   730c396: Backstage version bump to v1.52.0

### Patch Changes

-   d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.
-   4cd7a76: Added aria-label to icon-only external link buttons to resolve link-name accessibility violations
-   Updated dependencies [d640871]
-   Updated dependencies [730c396]
    -   @backstage-community/plugin-argocd-common@1.17.0

## @backstage-community/plugin-argocd-backend@1.6.0

### Minor Changes

-   730c396: Backstage version bump to v1.52.0

### Patch Changes

-   d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.
-   Updated dependencies [d640871]
-   Updated dependencies [730c396]
    -   @backstage-community/plugin-argocd-common@1.17.0
    -   @backstage-community/plugin-argocd-node@1.3.0

## @backstage-community/plugin-argocd-common@1.17.0

### Minor Changes

-   730c396: Backstage version bump to v1.52.0

### Patch Changes

-   d640871: Add CI wiring and permission-contract tests for the Argo CD backend and common packages, plus contributor guides and a minimal backend dev/ harness config so Backstage dependency bumps can be trusted without a full workspace smoke.

## @backstage-community/plugin-argocd-node@1.3.0

### Minor Changes

-   730c396: Backstage version bump to v1.52.0

### Patch Changes

-   Updated dependencies [d640871]
-   Updated dependencies [730c396]
    -   @backstage-community/plugin-argocd-common@1.17.0
