### PR TITLE
fix(airbrake): upgrade http-proxy-middleware to v3

### DIFF
--- a/workspaces/airbrake/.changeset/shiny-airbrake-proxy-v3.md
+++ b/workspaces/airbrake/.changeset/shiny-airbrake-proxy-v3.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-airbrake-backend': patch
+---
+
+Upgraded `http-proxy-middleware` to v3.

--- a/workspaces/airbrake/plugins/airbrake-backend/package.json
+++ b/workspaces/airbrake/plugins/airbrake-backend/package.json
@@ -39,7 +39,7 @@
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",
-    "http-proxy-middleware": "^2.0.0"
+    "http-proxy-middleware": "^3.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "backstage:^",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Upgrades `http-proxy-middleware` from `^2.0.0` to `^3.0.0` in the `airbrake-backend` plugin, resolving #629.

### Context

A previous Renovate PR (#406) attempting this same upgrade was closed without merging, since it was suspected to break due to the "pathRewrite (potential behavior change)" note in http-proxy-middleware's v3 migration guide (v3 removes automatic req.url patching, so pathRewrite may see the path already stripped of its mount prefix): https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION_V3.md#pathrewrite-potential-behavior-change

Looking at this plugin's `generateAirbrakePathRewrite` function, it strips any leading path only up through the first `/api` segment using a regex, and otherwise leaves the path untouched. This makes it a no-op passthrough when the mount prefix has already been stripped, so it continues to behave correctly whether or not req.url still contains that prefix. This repo's `report-portal-backend` plugin already uses `http-proxy-middleware@^3.0.0` successfully with a similar proxy setup, which supports this.

No source code changes were needed, only the dependency bump and an accompanying changeset.

#### Checklist
- [x] A changeset describing the change and affected packages
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message.


Closes #629