### PR TITLE
fix(tekton): hide CI/CD tab when tekton annotation is not present

### DIFF
--- a/workspaces/tekton/.changeset/fix-tekton-tab-visibility.md
+++ b/workspaces/tekton/.changeset/fix-tekton-tab-visibility.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Hide the CI/CD tab on entity pages when the tekton annotation is not present

--- a/workspaces/tekton/packages/app/src/components/catalog/EntityPage.tsx
+++ b/workspaces/tekton/packages/app/src/components/catalog/EntityPage.tsx
@@ -173,7 +173,7 @@ const serviceEntityPage = (
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="/ci-cd" title="CI/CD" if={isTektonCIAvailable}>
       {cicdContent}
     </EntityLayout.Route>
 
@@ -219,7 +219,7 @@ const websiteEntityPage = (
       {overviewContent}
     </EntityLayout.Route>
 
-    <EntityLayout.Route path="/ci-cd" title="CI/CD">
+    <EntityLayout.Route path="/ci-cd" title="CI/CD" if={isTektonCIAvailable}>
       {cicdContent}
     </EntityLayout.Route>
 

--- a/workspaces/tekton/plugins/tekton/src/alpha.tsx
+++ b/workspaces/tekton/plugins/tekton/src/alpha.tsx
@@ -15,12 +15,14 @@
  */
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { isTektonCIAvailable } from './utils/isTektonCIAvailable';
 
 const tektonEntityContent = EntityContentBlueprint.make({
   name: 'tektonEntityContent',
   params: {
     path: '/tekton',
     title: 'Tekton',
+    filter: isTektonCIAvailable,
     loader: () => import('./components/Router').then(m => <m.Router />),
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#### Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3623

The Tekton CI/CD tab was appearing on component pages even when no `tekton.dev/cicd` or `janus-idp.io/tekton` annotation was defined for that component.

### Changes
- Added `if={isTektonCIAvailable}` guard to the CI/CD `EntityLayout.Route` for both service and website entity pages
- Added `filter: isTektonCIAvailable` to the `EntityContentBlueprint` in the new frontend system (alpha.tsx)

This follows the same pattern already used by the Kubernetes tab (`if={isKubernetesAvailable}`).

---------------------

### Videos

-------BEFORE--------


https://github.com/user-attachments/assets/6208505d-75cd-4f3b-ba1a-29acee9b1c77

------AFTER-----


https://github.com/user-attachments/assets/f612530b-3afc-41ab-9605-a83c0b986481

---------------------


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))