### PR TITLE
Version Packages (argo-workflows)

### DIFF
--- a/workspaces/argo-workflows/.changeset/lucky-pandas-wander.md
+++ b/workspaces/argo-workflows/.changeset/lucky-pandas-wander.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-argo-workflows': minor
----
-
-Reworked the workflow DAG view. Nodes now render as light cards with a status-coloured accent and matching status icon, and connections are drawn as smooth curves. A minimap in the corner shows your position within larger graphs.
-
-The DAG panel now opens below the runs table instead of covering it, and sizes itself to the space left in the window, so it stays usable at any page size. Zoom and fit-to-view controls moved into the panel header next to the close button.

--- a/workspaces/argo-workflows/plugins/argo-workflows/CHANGELOG.md
+++ b/workspaces/argo-workflows/plugins/argo-workflows/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @backstage-community/plugin-argo-workflows
+
+## 0.2.0
+
+### Minor Changes
+
+- 3171edd: Reworked the workflow DAG view. Nodes now render as light cards with a status-coloured accent and matching status icon, and connections are drawn as smooth curves. A minimap in the corner shows your position within larger graphs.
+
+  The DAG panel now opens below the runs table instead of covering it, and sizes itself to the space left in the window, so it stays usable at any page size. Zoom and fit-to-view controls moved into the panel header next to the close button.

--- a/workspaces/argo-workflows/plugins/argo-workflows/package.json
+++ b/workspaces/argo-workflows/plugins/argo-workflows/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-argo-workflows",
   "description": "Frontend plugin for Argo Workflows in Backstage",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argo-workflows@0.2.0

### Minor Changes

-   3171edd: Reworked the workflow DAG view. Nodes now render as light cards with a status-coloured accent and matching status icon, and connections are drawn as smooth curves. A minimap in the corner shows your position within larger graphs.

    The DAG panel now opens below the runs table instead of covering it, and sizes itself to the space left in the window, so it stays usable at any page size. Zoom and fit-to-view controls moved into the panel header next to the close button.
