### PR TITLE
Version Packages (rbac)

### DIFF
--- a/workspaces/rbac/.changeset/use-ownership-entity-refs.md
+++ b/workspaces/rbac/.changeset/use-ownership-entity-refs.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-rbac-backend': minor
----
-
-Added `permission.rbac.useOwnershipEntityRefs` config option to evaluate group-to-role bindings using ownership entity refs from the sign-in token, in addition to catalog memberOf relations.

--- a/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
+++ b/workspaces/rbac/plugins/rbac-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-rbac-backend
 
+## 7.17.0
+
+### Minor Changes
+
+- 68f5f2e: Added `permission.rbac.useOwnershipEntityRefs` config option to evaluate group-to-role bindings using ownership entity refs from the sign-in token, in addition to catalog memberOf relations.
+
 ## 7.16.2
 
 ### Patch Changes

--- a/workspaces/rbac/plugins/rbac-backend/package.json
+++ b/workspaces/rbac/plugins/rbac-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-rbac-backend",
-  "version": "7.16.2",
+  "version": "7.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-rbac-backend@7.17.0

### Minor Changes

-   68f5f2e: Added `permission.rbac.useOwnershipEntityRefs` config option to evaluate group-to-role bindings using ownership entity refs from the sign-in token, in addition to catalog memberOf relations.
