### PR TITLE
test(servicenow): increase test coverage, dev harness, and contributor docs

### DIFF
--- a/workspaces/servicenow/.changeset/silly-badgers-tan.md
+++ b/workspaces/servicenow/.changeset/silly-badgers-tan.md
@@ -1,0 +1,7 @@
+---
+'@backstage-community/plugin-servicenow-backend': patch
+'@backstage-community/plugin-servicenow': patch
+'@backstage-community/plugin-servicenow-common': patch
+---
+
+Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.

--- a/workspaces/servicenow/CONTRIBUTING.md
+++ b/workspaces/servicenow/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing — ServiceNow workspace
+
+Plugin-only workspace for `@backstage-community/plugin-servicenow*`. There is **no** in-repo `packages/app` / `packages/backend`; use the plugin `dev/` harnesses and scoped package tests.
+
+## Start both harnesses
+
+From this directory, `backstage-cli repo start` launches the frontend and backend plugin harnesses together:
+
+```bash
+# From workspaces/servicenow
+yarn start
+```
+
+That is the preferred local smoke path — you do **not** need a full Backstage application in this workspace. For ServiceNow instance credentials when exercising the backend, see [plugins/servicenow-backend/CONTRIBUTING.md](./plugins/servicenow-backend/CONTRIBUTING.md).
+
+You can still start a single package when needed:
+
+```bash
+yarn workspace @backstage-community/plugin-servicenow start
+yarn workspace @backstage-community/plugin-servicenow-backend start --config app-config.yaml
+```
+
+## Package test commands
+
+| Package  | Command                                                              |
+| -------- | -------------------------------------------------------------------- |
+| Backend  | `yarn workspace @backstage-community/plugin-servicenow-backend test` |
+| Frontend | `yarn workspace @backstage-community/plugin-servicenow test`         |
+| Common   | `yarn workspace @backstage-community/plugin-servicenow-common test`  |
+
+Typecheck from this directory: `yarn tsc`.
+
+## Contributor guides
+
+- [Backend CONTRIBUTING.md](./plugins/servicenow-backend/CONTRIBUTING.md)
+- [Frontend CONTRIBUTING.md](./plugins/servicenow/CONTRIBUTING.md)

--- a/workspaces/servicenow/CONTRIBUTING.md
+++ b/workspaces/servicenow/CONTRIBUTING.md
@@ -11,14 +11,25 @@ From this directory, `backstage-cli repo start` launches the frontend and backen
 yarn start
 ```
 
-That is the preferred local smoke path — you do **not** need a full Backstage application in this workspace. For ServiceNow instance credentials when exercising the backend, see [plugins/servicenow-backend/CONTRIBUTING.md](./plugins/servicenow-backend/CONTRIBUTING.md).
+That is the preferred local smoke path — you do **not** need a full Backstage application in this workspace.
+
+The frontend harness (http://localhost:3000) has two sidebar pages:
+
+| Sidebar item             | Path               | Data source                                   |
+| ------------------------ | ------------------ | --------------------------------------------- |
+| **ServiceNow (Mock)**    | `/servicenow`      | In-memory fixtures (no backend)               |
+| **ServiceNow (Backend)** | `/servicenow-live` | This workspace's backend harness on port 7007 |
+
+Use **Mock** for UI work without ServiceNow. Use **Backend** when both harnesses are running and you want the frontend client to call the backend plugin (and a real ServiceNow instance, if configured). For instance credentials, see [plugins/servicenow-backend/CONTRIBUTING.md](./plugins/servicenow-backend/CONTRIBUTING.md).
 
 You can still start a single package when needed:
 
 ```bash
 yarn workspace @backstage-community/plugin-servicenow start
-yarn workspace @backstage-community/plugin-servicenow-backend start --config app-config.yaml
+yarn workspace @backstage-community/plugin-servicenow-backend start
 ```
+
+Do **not** pass `--config app-config.yaml` on the backend package start. Relative `--config` paths are resolved from the **package** directory (`plugins/servicenow-backend/`), not this workspace root, so that flag looks for a file that is not in the package. Omit `--config` (or pass `--config ../../app-config.yaml`) so the backend loads [`app-config.yaml`](./app-config.yaml) here. Details are in the [backend contributing guide](./plugins/servicenow-backend/CONTRIBUTING.md).
 
 ## Package test commands
 
@@ -34,3 +45,4 @@ Typecheck from this directory: `yarn tsc`.
 
 - [Backend CONTRIBUTING.md](./plugins/servicenow-backend/CONTRIBUTING.md)
 - [Frontend CONTRIBUTING.md](./plugins/servicenow/CONTRIBUTING.md)
+- [Local development](./docs/Development.md)

--- a/workspaces/servicenow/README.md
+++ b/workspaces/servicenow/README.md
@@ -56,4 +56,4 @@ The plugin includes a condition module (isMyProfile) that checks whether the cur
 
 ## Running the Dev App
 
-From `workspaces/servicenow`, run `yarn start` to launch the frontend and backend plugin harnesses together. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+From `workspaces/servicenow`, run `yarn start` to launch the frontend and backend plugin harnesses together. The frontend sidebar has **ServiceNow (Mock)** (fixture data) and **ServiceNow (Backend)** (calls the backend harness). See [CONTRIBUTING.md](./CONTRIBUTING.md) and [docs/Development.md](./docs/Development.md).

--- a/workspaces/servicenow/README.md
+++ b/workspaces/servicenow/README.md
@@ -36,7 +36,7 @@ metadata:
 
 ## Dynamic Mount Configuration
 
-This plugin supports dynamic mount points via Backstage’s dynamic plugin system (e.g., in [RHDH instances](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.6)).
+This plugin supports dynamic mount points via Backstage’s dynamic plugin system.
 
 ### Backend plugin configuration
 
@@ -56,4 +56,4 @@ The plugin includes a condition module (isMyProfile) that checks whether the cur
 
 ## Running the Dev App
 
-To start the dev app, refer to [plugins/servicenow/README.md](./plugins/README.md)
+From `workspaces/servicenow`, run `yarn start` to launch the frontend and backend plugin harnesses together. See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/workspaces/servicenow/app-config.yaml
+++ b/workspaces/servicenow/app-config.yaml
@@ -114,3 +114,9 @@ kubernetes:
 permission:
   # setting this to `false` will disable permissions
   enabled: true
+
+servicenow:
+  instanceUrl: ${SERVICENOW_BASE_URL}
+  basicAuth:
+    username: ${SERVICENOW_USERNAME}
+    password: ${SERVICENOW_PASSWORD}

--- a/workspaces/servicenow/docs/Development.md
+++ b/workspaces/servicenow/docs/Development.md
@@ -1,29 +1,40 @@
 # Development
 
+This workspace is **plugin-only** (no `packages/app` / `packages/backend`). Local work uses the frontend and backend `dev/` harnesses. Install and operator setup live in [index.md](./index.md) and [Configuration.md](./Configuration.md).
+
 ## Prerequisites
 
-You need to have a ServiceNow developer instance. You can request a new one from the [ServiceNow Developer Portal](https://developer.servicenow.com/dev.do#!/learn/learning-plans/washingtondc/new_to_servicenow/app_store_learnv2_buildmyfirstapp_washingtondc_personal_developer_instances).
+- Node.js matching `engines` in `workspaces/servicenow/package.json`
+- Yarn (Berry)
+- From `workspaces/servicenow`: `yarn install`
 
-## Local testing
+A ServiceNow developer instance is required only for the **Backend** UI page and `/incidents` curl. You can request one from the [ServiceNow Developer Portal](https://developer.servicenow.com/dev.do#!/learn/learning-plans/washingtondc/new_to_servicenow/app_store_learnv2_buildmyfirstapp_washingtondc_personal_developer_instances).
 
-Compile code:
+## Start the harnesses
 
-```
-yarn install
-```
+From `workspaces/servicenow`:
 
-Configure `app-config.local.yaml`. See more in [`Configuration.md`](./Configuration.md).
-
-Open `examples/org.yaml` and set the email for the `guest` user. This email should match a user in your ServiceNow instance.
-
-Open `examples/entities.yaml` and find the `example-website` component. Note the value of the `servicenow.com/entity-id` annotation (e.g., 'website-for-my-nice-service').
-
-In your ServiceNow instance, create a few incidents. Make sure to set the custom field `servicenow.com/entity-id` on these incidents to the same value from the annotation in `examples/entities.yaml`.
-
-Start the development instance:
-
-```
+```bash
 yarn start
 ```
 
-Open catalog http://localhost:3000/catalog/default/component/example-website/servicenow, it should display list tickets.
+That starts the frontend harness on http://localhost:3000 and the backend harness on http://localhost:7007.
+
+After guest sign-in, the frontend sidebar has two pages:
+
+- **ServiceNow (Mock)** (`/servicenow`) — fixture incidents; no backend or ServiceNow instance needed.
+- **ServiceNow (Backend)** (`/servicenow-live`) — real frontend client → this workspace's backend plugin. Needs the backend harness. Needs ServiceNow credentials for real tickets.
+
+Frontend-only: `yarn workspace @backstage-community/plugin-servicenow start` (use the Mock page).
+
+Backend-only: `yarn workspace @backstage-community/plugin-servicenow-backend start` (do **not** pass `--config app-config.yaml`; that path is resolved from `plugins/servicenow-backend/`, not this workspace. See [backend CONTRIBUTING.md](../plugins/servicenow-backend/CONTRIBUTING.md)).
+
+## ServiceNow instance (Backend page)
+
+Put secrets in an untracked `app-config.local.yaml` next to [`app-config.yaml`](../app-config.yaml), or export env vars. See [Configuration.md](./Configuration.md) and [backend CONTRIBUTING.md](../plugins/servicenow-backend/CONTRIBUTING.md).
+
+The harness entity uses the annotation `servicenow.com/entity-id: website-for-my-nice-service`. In ServiceNow, create incidents whose custom field `u_backstage_entity_id` (`Backstage entity id`) matches that value. Then open **ServiceNow (Backend)** and confirm the table lists those tickets.
+
+## Tests
+
+From `workspaces/servicenow`, run scoped package tests (`yarn workspace @backstage-community/plugin-servicenow test`, and the same for `-backend` / `-common`) and `yarn tsc`. Playwright is Mock-page UI smoke only; it does not prove backend or live ServiceNow connectivity.

--- a/workspaces/servicenow/docs/index.md
+++ b/workspaces/servicenow/docs/index.md
@@ -112,3 +112,7 @@ servicenow:
     username: ${SERVICENOW_USERNAME}
     password: ${SERVICENOW_PASSWORD}
 ```
+
+## Local development
+
+This workspace uses plugin `dev/` harnesses (no in-repo `packages/app`). See [Development.md](./Development.md) and the workspace [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/workspaces/servicenow/plugins/servicenow-backend/CONTRIBUTING.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CONTRIBUTING.md
@@ -10,34 +10,42 @@ Contributor guide for `@backstage-community/plugin-servicenow-backend`. For inst
 
 ## Dev harness
 
+The backend `dev/` harness mounts this plugin with mock Backstage `auth` / `httpAuth` so local calls do not need a static token in `app-config.yaml`. Do not add `backend.auth.externalAccess` (or similar) for the harness — it is unused here, and in a real app that token is a **service** principal, which `/incidents` does not accept (`allow: ['user']`).
+
 ### Preferred: start frontend and backend together
 
-From the workspace root, start both plugin harnesses (no full Backstage app required):
-
 ```bash
-# From workspaces/servicenow — export ServiceNow env vars first if you need a live instance
+# From workspaces/servicenow — set ServiceNow env vars first if you need a live instance
 yarn start
 ```
 
-See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+In the frontend, open **ServiceNow (Backend)** (`/servicenow-live`) to hit this plugin. **ServiceNow (Mock)** does not call the backend. See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ### Backend-only
 
 ```bash
 # From workspaces/servicenow
-yarn workspace @backstage-community/plugin-servicenow-backend start \
-  --config app-config.yaml
+yarn workspace @backstage-community/plugin-servicenow-backend start
 ```
 
-(`--config` paths are resolved from the plugins directory.)
+Config is loaded from the workspace [`app-config.yaml`](../../app-config.yaml) (and an untracked `app-config.local.yaml` next to it, if present).
 
-[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config for the harness (listen port and ServiceNow keys). Prefer starting with `--config app-config.yaml` when running the backend package alone.
+`--config` paths are resolved from **this package directory** (`plugins/servicenow-backend/`), not the workspace root. This flag is easy to get wrong:
 
-By default (without `--config`), `yarn start` on the package loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass.
+```bash
+# Looks for plugins/servicenow-backend/app-config.yaml — that file is not in this package
+yarn workspace @backstage-community/plugin-servicenow-backend start --config app-config.yaml
+
+# Explicit path to the workspace config, if you must pass --config
+yarn workspace @backstage-community/plugin-servicenow-backend start \
+  --config ../../app-config.yaml
+```
+
+Prefer omitting `--config` so the CLI picks up the workspace file.
 
 ### Environment setup
 
-Export these variables when you want the backend harness to talk to a ServiceNow instance. Use local-only placeholder values — do not commit secrets.
+Export these variables when you want the backend harness to talk to a ServiceNow instance. Use local-only placeholder values — do not commit secrets. You can also put the same keys in `app-config.local.yaml` next to the workspace `app-config.yaml`; see [Configuration.md](../../docs/Configuration.md).
 
 | Variable              | Purpose                                                          |
 | --------------------- | ---------------------------------------------------------------- |
@@ -55,15 +63,14 @@ export SERVICENOW_PASSWORD=test-password
 
 ### Curl smoke (manual)
 
-`/incidents` requires **user** credentials (`httpAuth` with `allow: ['user']`). A static `backend.auth.externalAccess` token is a **service** principal and will not satisfy that check — do not widen the allow list without maintainer agreement.
-
-For backend-only curl, the unauthenticated health route is practical:
+In this harness, `/health` and `/incidents` can be called without a Backstage `Authorization` header (mock `httpAuth` treats missing credentials as a user). You still need a configured ServiceNow instance for `/incidents` to return tickets.
 
 ```bash
 curl -sS http://localhost:7007/api/servicenow/health
+curl -sS 'http://localhost:7007/api/servicenow/incidents?limit=5'
 ```
 
-For UI / incident smoke, prefer `yarn start` so both harnesses run together (see workspace guide). You do not need to scaffold `packages/app` / `packages/backend` in this workspace.
+For UI smoke, prefer `yarn start` and the frontend **ServiceNow (Backend)** page. You do not need to scaffold `packages/app` / `packages/backend` in this workspace.
 
 ## Scoped validation
 
@@ -83,7 +90,7 @@ yarn workspace @backstage-community/plugin-servicenow-common test
 ## Smoke checklist (bump / PR review)
 
 1. Backend package tests pass (includes `plugin.integration.test.ts` mount + health).
-2. Optional: `yarn start` from the workspace (both harnesses) and exercise the UI / hit `/api/servicenow/health`.
+2. Optional: `yarn start` from the workspace (both harnesses). Hit `/api/servicenow/health` and/or the frontend **ServiceNow (Backend)** page.
 3. Do **not** rely on workspace Playwright for backend trust — that suite is frontend UI mock smoke only.
 
 ## When you need something beyond the harnesses

--- a/workspaces/servicenow/plugins/servicenow-backend/CONTRIBUTING.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing — ServiceNow backend
+
+Contributor guide for `@backstage-community/plugin-servicenow-backend`. For install and operator configuration, see the [package README](./README.md) and [Configuration.md](../../docs/Configuration.md).
+
+## Prerequisites
+
+- Node.js matching the workspace `engines` field in `workspaces/servicenow/package.json`
+- Yarn (Berry) as used by this repository
+- From `workspaces/servicenow`: `yarn install`
+
+## Dev harness
+
+### Preferred: start frontend and backend together
+
+From the workspace root, start both plugin harnesses (no full Backstage app required):
+
+```bash
+# From workspaces/servicenow — export ServiceNow env vars first if you need a live instance
+yarn start
+```
+
+See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+
+### Backend-only
+
+```bash
+# From workspaces/servicenow
+yarn workspace @backstage-community/plugin-servicenow-backend start \
+  --config app-config.yaml
+```
+
+(`--config` paths are resolved from the plugins directory.)
+
+[`app-config.yaml`](./app-config.yaml) in this package is the **minimal** config for the harness (listen port and ServiceNow keys). Prefer starting with `--config app-config.yaml` when running the backend package alone.
+
+By default (without `--config`), `yarn start` on the package loads the fuller [`../../app-config.yaml`](../../app-config.yaml) from the workspace root instead. Optional overrides can go in an untracked `app-config.local.yaml` next to whichever config file you pass.
+
+### Environment setup
+
+Export these variables when you want the backend harness to talk to a ServiceNow instance. Use local-only placeholder values — do not commit secrets.
+
+| Variable              | Purpose                                                          |
+| --------------------- | ---------------------------------------------------------------- |
+| `SERVICENOW_BASE_URL` | ServiceNow instance URL (e.g. `https://example.service-now.com`) |
+| `SERVICENOW_USERNAME` | Basic-auth username for the ServiceNow instance                  |
+| `SERVICENOW_PASSWORD` | Basic-auth password for the ServiceNow instance                  |
+
+Example:
+
+```bash
+export SERVICENOW_BASE_URL=https://example.service-now.com
+export SERVICENOW_USERNAME=test-user
+export SERVICENOW_PASSWORD=test-password
+```
+
+### Curl smoke (manual)
+
+`/incidents` requires **user** credentials (`httpAuth` with `allow: ['user']`). A static `backend.auth.externalAccess` token is a **service** principal and will not satisfy that check — do not widen the allow list without maintainer agreement.
+
+For backend-only curl, the unauthenticated health route is practical:
+
+```bash
+curl -sS http://localhost:7007/api/servicenow/health
+```
+
+For UI / incident smoke, prefer `yarn start` so both harnesses run together (see workspace guide). You do not need to scaffold `packages/app` / `packages/backend` in this workspace.
+
+## Scoped validation
+
+```bash
+# From workspaces/servicenow
+yarn workspace @backstage-community/plugin-servicenow-backend test
+yarn workspace @backstage-community/plugin-servicenow-backend lint
+yarn tsc
+```
+
+Shared library contracts live in `@backstage-community/plugin-servicenow-common`:
+
+```bash
+yarn workspace @backstage-community/plugin-servicenow-common test
+```
+
+## Smoke checklist (bump / PR review)
+
+1. Backend package tests pass (includes `plugin.integration.test.ts` mount + health).
+2. Optional: `yarn start` from the workspace (both harnesses) and exercise the UI / hit `/api/servicenow/health`.
+3. Do **not** rely on workspace Playwright for backend trust — that suite is frontend UI mock smoke only.
+
+## When you need something beyond the harnesses
+
+This workspace is **plugin-only**. Do not add `packages/app` or `packages/backend` here.
+
+| Need                                              | Where                                                                |
+| ------------------------------------------------- | -------------------------------------------------------------------- |
+| Day-to-day backend / combined smoke               | `yarn start` (both harnesses) or this package `dev/` + scoped tests  |
+| Production-like catalog entity page in a full app | A separate consumer Backstage deployment                             |
+| Live ServiceNow credential-backed e2e suites      | Outside this workspace (consumer deployment or separate e2e harness) |

--- a/workspaces/servicenow/plugins/servicenow-backend/README.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/README.md
@@ -27,8 +27,6 @@ It provides an API that connects to your ServiceNow instance and returns inciden
 
 Refer to [Configuration.md](../../docs/Configuration.md) for detailed setup instructions, including authentication and ServiceNow instance configuration.
 
-## Development
+## Contributing
 
-This plugin backend can be started in a standalone mode from directly in this
-package with `yarn start`. It is a limited setup that is most convenient when
-developing the plugin backend itself.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness, scoped tests, and curl smoke checklist.

--- a/workspaces/servicenow/plugins/servicenow-backend/README.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/README.md
@@ -29,4 +29,4 @@ Refer to [Configuration.md](../../docs/Configuration.md) for detailed setup inst
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness, scoped tests, and curl smoke checklist.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness, config path notes, scoped tests, and curl smoke checklist.

--- a/workspaces/servicenow/plugins/servicenow-backend/dev/index.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/dev/index.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 import { createBackend } from '@backstage/backend-defaults';
+import { mockServices } from '@backstage/backend-test-utils';
 
 const backend = createBackend();
 
+backend.add(mockServices.auth.factory());
+backend.add(mockServices.httpAuth.factory());
 backend.add(import('../src'));
 
 backend.start();

--- a/workspaces/servicenow/plugins/servicenow-backend/dev/index.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/dev/index.ts
@@ -14,31 +14,8 @@
  * limitations under the License.
  */
 import { createBackend } from '@backstage/backend-defaults';
-import { mockServices } from '@backstage/backend-test-utils';
-import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 
 const backend = createBackend();
-
-backend.add(mockServices.auth.factory());
-backend.add(mockServices.httpAuth.factory());
-
-backend.add(
-  catalogServiceMock.factory({
-    entities: [
-      {
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'Component',
-        metadata: {
-          name: 'sample',
-          title: 'Sample Component',
-        },
-        spec: {
-          type: 'service',
-        },
-      },
-    ],
-  }),
-);
 
 backend.add(import('../src'));
 

--- a/workspaces/servicenow/plugins/servicenow-backend/src/config/config.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/config/config.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { InputError } from '@backstage/errors';
+
+import { readServiceNowConfig } from './config';
+
+describe('readServiceNowConfig', () => {
+  it('returns undefined when servicenow config is absent', () => {
+    expect(readServiceNowConfig(new ConfigReader({}))).toBeUndefined();
+  });
+
+  it('throws when instanceUrl is missing', () => {
+    expect(() =>
+      readServiceNowConfig(
+        new ConfigReader({
+          servicenow: {
+            basicAuth: { username: 'u', password: 'p' },
+          },
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it('throws when both oauth and basicAuth are configured', () => {
+    expect(() =>
+      readServiceNowConfig(
+        new ConfigReader({
+          servicenow: {
+            instanceUrl: 'https://example.service-now.com',
+            oauth: {
+              grantType: 'client_credentials',
+              clientId: 'id',
+              clientSecret: 'secret',
+            },
+            basicAuth: { username: 'u', password: 'p' },
+          },
+        }),
+      ),
+    ).toThrow(InputError);
+  });
+
+  it('throws on unsupported oauth grantType', () => {
+    expect(() =>
+      readServiceNowConfig(
+        new ConfigReader({
+          servicenow: {
+            instanceUrl: 'https://example.service-now.com',
+            oauth: {
+              grantType: 'authorization_code',
+              clientId: 'id',
+              clientSecret: 'secret',
+            },
+          },
+        }),
+      ),
+    ).toThrow(/Unsupported OAuth grantType/);
+  });
+
+  it('throws when password grant is missing username', () => {
+    expect(() =>
+      readServiceNowConfig(
+        new ConfigReader({
+          servicenow: {
+            instanceUrl: 'https://example.service-now.com',
+            oauth: {
+              grantType: 'password',
+              clientId: 'id',
+              clientSecret: 'secret',
+              password: 'p',
+            },
+          },
+        }),
+      ),
+    ).toThrow();
+  });
+
+  it('parses basicAuth configuration', () => {
+    const result = readServiceNowConfig(
+      new ConfigReader({
+        servicenow: {
+          instanceUrl: 'https://example.service-now.com',
+          basicAuth: { username: 'test-user', password: 'test-password' },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      servicenow: {
+        instanceUrl: 'https://example.service-now.com',
+        oauth: undefined,
+        basicAuth: { username: 'test-user', password: 'test-password' },
+      },
+    });
+  });
+
+  it('parses oauth client_credentials configuration', () => {
+    const result = readServiceNowConfig(
+      new ConfigReader({
+        servicenow: {
+          instanceUrl: 'https://example.service-now.com',
+          oauth: {
+            grantType: 'client_credentials',
+            clientId: 'test-client-id',
+            clientSecret: 'test-client-secret',
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      servicenow: {
+        instanceUrl: 'https://example.service-now.com',
+        oauth: {
+          grantType: 'client_credentials',
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          tokenUrl: undefined,
+        },
+        basicAuth: undefined,
+      },
+    });
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow-backend/src/plugin.integration.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/plugin.integration.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import request from 'supertest';
+
+import { servicenowPlugin } from './plugin';
+
+const validServiceNowConfig = {
+  servicenow: {
+    instanceUrl: 'https://example.service-now.com',
+    basicAuth: {
+      username: 'test-user',
+      password: 'test-password',
+    },
+  },
+};
+
+describe('servicenowPlugin integration', () => {
+  it('should mount the router and return 200 on /health with valid config', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        servicenowPlugin,
+        mockServices.rootConfig.factory({ data: validServiceNowConfig }),
+        mockServices.httpAuth.factory(),
+      ],
+    });
+
+    const response = await request(server).get('/api/servicenow/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+
+  it('should not mount the router when servicenow config is missing', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        servicenowPlugin,
+        mockServices.rootConfig.factory({ data: {} }),
+        mockServices.httpAuth.factory(),
+      ],
+    });
+
+    const response = await request(server).get('/api/servicenow/health');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+
+import { DefaultServiceNowClient } from './client';
+import { ServiceNowConnection } from './connection';
+
+describe('DefaultServiceNowClient', () => {
+  const instanceUrl = 'https://example.service-now.com';
+  let mockGet: jest.Mock;
+  let mockConn: jest.Mocked<
+    Pick<
+      ServiceNowConnection,
+      'getAuthHeaders' | 'getAxiosInstance' | 'getInstanceUrl'
+    >
+  >;
+  let client: DefaultServiceNowClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGet = jest.fn();
+    mockConn = {
+      getAuthHeaders: jest
+        .fn()
+        .mockResolvedValue({ Authorization: 'Bearer t' }),
+      getAxiosInstance: jest.fn().mockReturnValue({ get: mockGet }),
+      getInstanceUrl: jest.fn().mockReturnValue(instanceUrl),
+    };
+    client = new DefaultServiceNowClient(
+      mockConn as unknown as ServiceNowConnection,
+      mockServices.logger.mock(),
+    );
+  });
+
+  function lastIncidentRequestUrl(): string {
+    const incidentCalls = mockGet.mock.calls.filter(([url]: [string]) =>
+      String(url).startsWith('api/now/table/incident'),
+    );
+    expect(incidentCalls.length).toBeGreaterThan(0);
+    return String(incidentCalls[incidentCalls.length - 1][0]);
+  }
+
+  function parseIncidentParams(url: string): URLSearchParams {
+    const query = url.includes('?') ? url.slice(url.indexOf('?') + 1) : '';
+    return new URLSearchParams(query);
+  }
+
+  it('builds sysparm_query for entity filter and pagination params', async () => {
+    mockGet.mockResolvedValue({
+      data: { result: [] },
+      headers: { 'x-total-count': '0' },
+    });
+
+    await client.fetchIncidents({
+      u_backstage_entity_id: 'component:default/my-service',
+      limit: 25,
+      offset: 50,
+      search: 'outage',
+      order: 'desc',
+      orderBy: 'number',
+    });
+
+    const params = parseIncidentParams(lastIncidentRequestUrl());
+    const sysparmQuery = params.get('sysparm_query') ?? '';
+
+    expect(sysparmQuery).toContain(
+      'u_backstage_entity_id=component:default/my-service',
+    );
+    expect(sysparmQuery).toContain('numberLIKEoutage');
+    expect(sysparmQuery).toContain('ORDERBYDESCnumber');
+    expect(params.get('sysparm_limit')).toBe('25');
+    expect(params.get('sysparm_offset')).toBe('50');
+    expect(params.get('sysparm_count')).toBe('true');
+    expect(params.get('sysparm_fields')).toContain('u_backstage_entity_id');
+  });
+
+  it('builds userEmail lookup and caller_id/opened_by/assigned_to fragments', async () => {
+    mockGet
+      .mockResolvedValueOnce({
+        data: { result: [{ sys_id: 'user-sys-id-1' }] },
+        headers: {},
+      })
+      .mockResolvedValueOnce({
+        data: { result: [] },
+        headers: { 'x-total-count': '0' },
+      });
+
+    await client.fetchIncidents({
+      userEmail: 'user@example.com',
+    });
+
+    expect(mockGet).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(
+        'api/now/table/sys_user?sysparm_query=email=user%40example.com',
+      ),
+      expect.anything(),
+    );
+
+    const sysparmQuery =
+      parseIncidentParams(lastIncidentRequestUrl()).get('sysparm_query') ?? '';
+    expect(sysparmQuery).toContain(
+      'caller_id=user-sys-id-1^ORopened_by=user-sys-id-1^ORassigned_to=user-sys-id-1',
+    );
+  });
+
+  it('appends state and priority IN segments to sysparm_query', async () => {
+    mockGet.mockResolvedValue({
+      data: { result: [] },
+      headers: { 'x-total-count': '0' },
+    });
+
+    await client.fetchIncidents({
+      state: 'IN1,2',
+      priority: 'IN3',
+    });
+
+    const sysparmQuery =
+      parseIncidentParams(lastIncidentRequestUrl()).get('sysparm_query') ?? '';
+    expect(sysparmQuery).toContain('stateIN1,2');
+    expect(sysparmQuery).toContain('priorityIN3');
+  });
+
+  it('includes custom annotation fields in query and response fields', async () => {
+    mockGet.mockResolvedValue({
+      data: { result: [] },
+      headers: { 'x-total-count': '0' },
+    });
+
+    await client.fetchIncidents({
+      u_custom_field: 'custom-value',
+    });
+
+    const params = parseIncidentParams(lastIncidentRequestUrl());
+    expect(params.get('sysparm_query')).toContain(
+      'u_custom_field=custom-value',
+    );
+    expect(params.get('sysparm_fields')).toContain('u_custom_field');
+  });
+
+  it('returns items with incident URL prefix and totalCount from x-total-count', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        result: [
+          {
+            sys_id: 'abc123',
+            number: 'INC001',
+            short_description: 'Test',
+            description: 'Desc',
+            sys_created_on: '2024-01-01',
+            priority: 2,
+            incident_state: 1,
+          },
+        ],
+      },
+      headers: { 'x-total-count': '42' },
+    });
+
+    const result = await client.fetchIncidents({ limit: 10 });
+
+    expect(result.totalCount).toBe(42);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toEqual(
+      expect.objectContaining({
+        sys_id: 'abc123',
+        number: 'INC001',
+        url: `${instanceUrl}/nav_to.do?uri=incident.do?sys_id=abc123`,
+      }),
+    );
+  });
+
+  it('rejects when user email is not found', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { result: [] },
+      headers: {},
+    });
+
+    await expect(
+      client.fetchIncidents({ userEmail: 'missing@example.com' }),
+    ).rejects.toThrow(
+      'User with email missing@example.com not found in ServiceNow.',
+    );
+  });
+
+  it('wraps axios failures when fetching incidents', async () => {
+    mockGet.mockRejectedValue(new Error('network down'));
+
+    await expect(client.fetchIncidents({ limit: 1 })).rejects.toThrow(
+      'Failed to fetch incidents: network down',
+    );
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service-now-rest/client.ts
@@ -88,6 +88,12 @@ export class DefaultServiceNowClient implements ServiceNowClient {
       }
     }
 
+    // Predefined entity annotation field (mapped from entityId by the validator).
+    if (options.u_backstage_entity_id) {
+      queryParts.push(`u_backstage_entity_id=${options.u_backstage_entity_id}`);
+      responseFields.push('u_backstage_entity_id');
+    }
+
     if (options.userEmail) {
       const id = await this.getUserSysIdByEmail(options.userEmail);
       queryParts.push(`caller_id=${id}^ORopened_by=${id}^ORassigned_to=${id}`);

--- a/workspaces/servicenow/plugins/servicenow-backend/src/service/router.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-backend/src/service/router.test.ts
@@ -78,6 +78,15 @@ describe('createRouter', () => {
     app.use(mockErrorHandler());
   });
 
+  describe('GET /health', () => {
+    it('should return 200 with status ok', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+
   describe('GET /incidents', () => {
     const mockAuthHeader = `Bearer mock-secret-token`;
     const mockCredentials: BackstageCredentials<BackstageUserPrincipal> = {
@@ -96,6 +105,18 @@ describe('createRouter', () => {
         url: 'https://mock-instance.service-now.com/INC001',
       },
     ];
+
+    it('should return 400 for an invalid limit query parameter', async () => {
+      mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);
+
+      const response = await request(app)
+        .get('/incidents?limit=abc')
+        .set('Authorization', mockAuthHeader);
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.name).toBe('InputError');
+      expect(mockFetchIncidents).not.toHaveBeenCalled();
+    });
 
     it('should successfully retrieve incidents', async () => {
       mockHttpAuthService.credentials.mockResolvedValue(mockCredentials);

--- a/workspaces/servicenow/plugins/servicenow-common/README.md
+++ b/workspaces/servicenow/plugins/servicenow-common/README.md
@@ -1,3 +1,7 @@
 # @backstage-community/plugin-servicenow-common
 
-Please visit https://github.com/backstage/community-plugins/tree/main/workspaces/servicenow for more information about the ServiceNow plugin for Backstage
+Please visit https://github.com/backstage/community-plugins/tree/main/workspaces/servicenow for more information about the ServiceNow plugin for Backstage.
+
+## Contributing
+
+Shared helpers are covered from the workspace [CONTRIBUTING.md](../../CONTRIBUTING.md) and backend [CONTRIBUTING.md](../servicenow-backend/CONTRIBUTING.md) (`yarn workspace @backstage-community/plugin-servicenow-common test`).

--- a/workspaces/servicenow/plugins/servicenow-common/src/utils.test.ts
+++ b/workspaces/servicenow/plugins/servicenow-common/src/utils.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+
+import { isServicenowAvailable } from './utils';
+
+function entityWithAnnotations(annotations?: Record<string, string>): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'example',
+      ...(annotations ? { annotations } : {}),
+    },
+  };
+}
+
+describe('isServicenowAvailable', () => {
+  it('returns false when annotations are missing', () => {
+    expect(isServicenowAvailable(entityWithAnnotations())).toBe(false);
+  });
+
+  it('returns true for servicenow.com/entity-id', () => {
+    expect(
+      isServicenowAvailable(
+        entityWithAnnotations({
+          'servicenow.com/entity-id': 'my-entity',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated annotation keys', () => {
+    expect(
+      isServicenowAvailable(
+        entityWithAnnotations({
+          'github.com/project-slug': 'org/repo',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for other servicenow.com/ prefix keys', () => {
+    expect(
+      isServicenowAvailable(
+        entityWithAnnotations({
+          'servicenow.com/custom': 'value',
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow/CONTRIBUTING.md
+++ b/workspaces/servicenow/plugins/servicenow/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing — ServiceNow frontend
+
+Contributor guide for `@backstage-community/plugin-servicenow`. For install and operator-facing setup, see the [package README](./README.md) and workspace [docs](../../docs/index.md).
+
+## Prerequisites
+
+- Node.js matching the workspace `engines` field in `workspaces/servicenow/package.json`
+- Yarn (Berry) as used by this repository
+- From `workspaces/servicenow`: `yarn install`
+
+## Dev harness
+
+### Preferred: start frontend and backend together
+
+From the workspace root, start both plugin harnesses (no full Backstage app required):
+
+```bash
+# From workspaces/servicenow
+yarn start
+```
+
+See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+
+### Frontend-only
+
+```bash
+# From workspaces/servicenow
+yarn workspace @backstage-community/plugin-servicenow start
+```
+
+This uses `dev/` under this package. It is a plugin harness, not a full Backstage application.
+
+## Scoped validation
+
+```bash
+# From workspaces/servicenow
+yarn workspace @backstage-community/plugin-servicenow test
+yarn workspace @backstage-community/plugin-servicenow lint
+yarn tsc
+```
+
+Shared helpers:
+
+```bash
+yarn workspace @backstage-community/plugin-servicenow-common test
+```
+
+## Playwright note
+
+Workspace Playwright under `plugins/servicenow/tests/` is **UI mock smoke** against the frontend harness. It is **not** proof of backend integration or live ServiceNow connectivity, and it is not the merge gate for Backstage version-bump trust.
+
+## Smoke checklist (bump / PR review)
+
+1. Frontend package tests pass (includes `ServiceNowBackendClient` discovery/auth coverage).
+2. Optional: `yarn start` from the workspace (both harnesses) and exercise the UI.
+3. Backend mount and Table API client contracts are covered by `@backstage-community/plugin-servicenow-backend` tests — run those for bump trust.
+
+## When you need something beyond the harnesses
+
+This workspace is **plugin-only**. Do not add `packages/app` or `packages/backend` here.
+
+| Need                                              | Where                                                                |
+| ------------------------------------------------- | -------------------------------------------------------------------- |
+| Day-to-day frontend / combined smoke              | `yarn start` (both harnesses) or this package `dev/` + scoped tests  |
+| Production-like catalog entity page in a full app | A separate consumer Backstage deployment                             |
+| Live ServiceNow credential-backed e2e suites      | Outside this workspace (consumer deployment or separate e2e harness) |

--- a/workspaces/servicenow/plugins/servicenow/CONTRIBUTING.md
+++ b/workspaces/servicenow/plugins/servicenow/CONTRIBUTING.md
@@ -10,16 +10,25 @@ Contributor guide for `@backstage-community/plugin-servicenow`. For install and 
 
 ## Dev harness
 
-### Preferred: start frontend and backend together
+The frontend `dev/` app is a plugin harness, not a full Backstage application. After sign-in, the sidebar has two pages:
 
-From the workspace root, start both plugin harnesses (no full Backstage app required):
+| Sidebar item             | Path               | When to use                                                                     |
+| ------------------------ | ------------------ | ------------------------------------------------------------------------------- |
+| **ServiceNow (Mock)**    | `/servicenow`      | UI, filters, translations, and Playwright. Incidents come from fixtures.        |
+| **ServiceNow (Backend)** | `/servicenow-live` | Combined smoke with the backend harness and (optionally) a ServiceNow instance. |
+
+The mock page never calls the backend. The backend page uses the real frontend API client against `http://localhost:7007`.
+
+### Preferred: start frontend and backend together
 
 ```bash
 # From workspaces/servicenow
 yarn start
 ```
 
-See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+Open http://localhost:3000, sign in as guest, then pick **ServiceNow (Mock)** or **ServiceNow (Backend)**.
+
+For ServiceNow instance credentials on the backend page, see [plugins/servicenow-backend/CONTRIBUTING.md](../servicenow-backend/CONTRIBUTING.md) and [docs/Development.md](../../docs/Development.md).
 
 ### Frontend-only
 
@@ -28,7 +37,7 @@ See the [workspace CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
 yarn workspace @backstage-community/plugin-servicenow start
 ```
 
-This uses `dev/` under this package. It is a plugin harness, not a full Backstage application.
+Use the **Mock** page. The **Backend** page will fail to load incidents unless the backend harness is also running.
 
 ## Scoped validation
 
@@ -47,12 +56,12 @@ yarn workspace @backstage-community/plugin-servicenow-common test
 
 ## Playwright note
 
-Workspace Playwright under `plugins/servicenow/tests/` is **UI mock smoke** against the frontend harness. It is **not** proof of backend integration or live ServiceNow connectivity, and it is not the merge gate for Backstage version-bump trust.
+Workspace Playwright under `plugins/servicenow/tests/` is **UI mock smoke** against the frontend harness (the Mock page). It is **not** proof of backend integration or live ServiceNow connectivity, and it is not the merge gate for Backstage version-bump trust.
 
 ## Smoke checklist (bump / PR review)
 
 1. Frontend package tests pass (includes `ServiceNowBackendClient` discovery/auth coverage).
-2. Optional: `yarn start` from the workspace (both harnesses) and exercise the UI.
+2. Optional: `yarn start` from the workspace (both harnesses). Exercise **Mock** for UI and **Backend** if you have instance credentials.
 3. Backend mount and Table API client contracts are covered by `@backstage-community/plugin-servicenow-backend` tests — run those for bump trust.
 
 ## When you need something beyond the harnesses

--- a/workspaces/servicenow/plugins/servicenow/README.md
+++ b/workspaces/servicenow/plugins/servicenow/README.md
@@ -80,4 +80,4 @@ For more information how to setup the plugin, please refer to the [General](../.
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness, scoped tests, and notes on Playwright vs backend bump trust.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness (Mock vs Backend pages), scoped tests, and notes on Playwright vs backend bump trust.

--- a/workspaces/servicenow/plugins/servicenow/README.md
+++ b/workspaces/servicenow/plugins/servicenow/README.md
@@ -78,9 +78,6 @@ metadata:
 
 For more information how to setup the plugin, please refer to the [General](../../docs/index.md) and [Configuration.md](../../docs/Configuration.md) documentation.
 
-## Development
+## Contributing
 
-1. Install dependencies with `yarn install`
-2. Start the Backstage dev app with `yarn start`
-
-Your plugin has been added to the example app in this `plugins/servicenow` directory, meaning you'll be able to access it by running `yarn start` in the current directory, and then navigating to [/servicenow](http://localhost:3000/servicenow).
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the local `dev/` harness, scoped tests, and notes on Playwright vs backend bump trust.

--- a/workspaces/servicenow/plugins/servicenow/dev/index.tsx
+++ b/workspaces/servicenow/plugins/servicenow/dev/index.tsx
@@ -19,38 +19,62 @@ import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { Header, Page, TabbedLayout } from '@backstage/core-components';
 import {
-  BackstageUserIdentity,
+  discoveryApiRef,
+  fetchApiRef,
   identityApiRef,
+  useApi,
 } from '@backstage/core-plugin-api';
 import { TestApiProvider } from '@backstage/test-utils';
-import { serviceNowApiRef } from '../src/api/ServiceNowBackendClient';
+import {
+  serviceNowApiRef,
+  ServiceNowBackendClient,
+} from '../src/api/ServiceNowBackendClient';
 import { mockComponentEntity } from '../src/__fixtures__/mockEntity';
 import { mockServicenowApi } from '../src/__fixtures__/mockServicenowApi';
 
 import { servicenowPlugin, EntityServicenowContent } from '../src/plugin';
 import { servicenowTranslations } from '../src/translations';
+import { useMemo } from 'react';
 
 const mockIdentityApi = {
-  getUserId: () => 'test-user',
-  getProfile: () => ({
-    email: 'test@example.com',
-    displayName: 'Test User',
-    picture: 'https://example.com/avatar.png',
-  }),
   getProfileInfo: async () => ({
     email: 'test@example.com',
     displayName: 'Test User',
-    picture: 'https://example.com/avatar.png',
   }),
-  getIdToken: async () => 'test-user-token',
   signOut: () => Promise.resolve(),
-  getCredentials: async () => ({ token: 'test-user-token' }),
-  getBackstageIdentity: async (): Promise<BackstageUserIdentity> => ({
-    type: 'user',
+  getCredentials: async () => ({ token: 'mock-user-token' }),
+  getBackstageIdentity: async () => ({
+    type: 'user' as const,
     userEntityRef: 'user:default/test-user',
     ownershipEntityRefs: ['user:default/test-user'],
   }),
 };
+
+function LiveServicenowPage() {
+  const discoveryApi = useApi(discoveryApiRef);
+  const fetchApi = useApi(fetchApiRef);
+  const client = useMemo(
+    () => new ServiceNowBackendClient(discoveryApi, fetchApi, mockIdentityApi),
+    [discoveryApi, fetchApi],
+  );
+  return (
+    <TestApiProvider apis={[[serviceNowApiRef, client]]}>
+      <EntityProvider entity={mockComponentEntity}>
+        <Page themeId="tool">
+          <Header
+            type="component — tool"
+            title={mockComponentEntity.metadata.name}
+          />
+          <TabbedLayout>
+            <TabbedLayout.Route path="/" title="ServiceNow">
+              <EntityServicenowContent />
+            </TabbedLayout.Route>
+          </TabbedLayout>
+        </Page>
+      </EntityProvider>
+    </TestApiProvider>
+  );
+}
 
 // const mockUserEmailToSysId: { [email: string]: string } = {
 //   'test@example.com': 'user-sys-id-1',
@@ -85,6 +109,8 @@ createDevApp()
     }),
   )
   .addPage({
+    title: 'ServiceNow (Mock)',
+    path: '/servicenow',
     element: (
       <TestApiProvider
         apis={[
@@ -107,7 +133,10 @@ createDevApp()
         </EntityProvider>
       </TestApiProvider>
     ),
-    title: 'ServiceNow',
-    path: '/servicenow',
+  })
+  .addPage({
+    title: 'ServiceNow (Backend)',
+    path: '/servicenow-live',
+    element: <LiveServicenowPage />,
   })
   .render();

--- a/workspaces/servicenow/plugins/servicenow/src/api/ServiceNowBackendClient.test.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/api/ServiceNowBackendClient.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DiscoveryApi,
+  FetchApi,
+  IdentityApi,
+} from '@backstage/core-plugin-api';
+
+import {
+  ServiceNowBackendClient,
+  incidentsPickToIncidentsData,
+} from './ServiceNowBackendClient';
+
+describe('ServiceNowBackendClient', () => {
+  const baseUrl = 'http://localhost:7007/api/servicenow';
+  let discoveryApi: jest.Mocked<Pick<DiscoveryApi, 'getBaseUrl'>>;
+  let fetchApi: jest.Mocked<Pick<FetchApi, 'fetch'>>;
+  let identityApi: jest.Mocked<Pick<IdentityApi, 'getCredentials'>>;
+  let client: ServiceNowBackendClient;
+
+  beforeEach(() => {
+    discoveryApi = {
+      getBaseUrl: jest.fn().mockResolvedValue(baseUrl),
+    };
+    fetchApi = {
+      fetch: jest.fn(),
+    };
+    identityApi = {
+      getCredentials: jest.fn().mockResolvedValue({ token: 'test-token' }),
+    };
+    client = new ServiceNowBackendClient(
+      discoveryApi as unknown as DiscoveryApi,
+      fetchApi as unknown as FetchApi,
+      identityApi as unknown as IdentityApi,
+    );
+  });
+
+  it('getIncidents builds discovery URL with auth header and maps snake_case fields', async () => {
+    const rawItems = [
+      {
+        sys_id: 'abc',
+        number: 'INC001',
+        short_description: 'Short',
+        description: 'Long',
+        sys_created_on: '2024-01-01',
+        priority: 2,
+        incident_state: 1,
+        url: 'https://example.service-now.com/INC001',
+      },
+    ];
+    fetchApi.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: rawItems, totalCount: 1 }),
+    } as Response);
+
+    const queryParams = new URLSearchParams({ limit: '10' });
+    const result = await client.getIncidents(queryParams);
+
+    expect(discoveryApi.getBaseUrl).toHaveBeenCalledWith('servicenow');
+    expect(identityApi.getCredentials).toHaveBeenCalled();
+    expect(fetchApi.fetch).toHaveBeenCalledWith(
+      `${baseUrl}/incidents?limit=10`,
+      {
+        headers: { Authorization: 'Bearer test-token' },
+      },
+    );
+    expect(result).toEqual({
+      incidents: incidentsPickToIncidentsData(rawItems),
+      totalCount: 1,
+    });
+    expect(result.incidents[0]).toEqual(
+      expect.objectContaining({
+        sysId: 'abc',
+        shortDescription: 'Short',
+        incidentState: 1,
+      }),
+    );
+  });
+
+  it('getIncidents throws parsed error message on non-OK response', async () => {
+    fetchApi.fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({
+        error: { message: 'backend failed' },
+      }),
+    } as Response);
+
+    await expect(client.getIncidents(new URLSearchParams())).rejects.toThrow(
+      'backend failed',
+    );
+  });
+});

--- a/workspaces/servicenow/plugins/servicenow/src/plugin.test.ts
+++ b/workspaces/servicenow/plugins/servicenow/src/plugin.test.ts
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 import { servicenowPlugin } from './plugin';
+import { serviceNowApiRef } from './api/ServiceNowBackendClient';
 
 describe('servicenow', () => {
   it('should export plugin', () => {
     expect(servicenowPlugin).toBeDefined();
+  });
+
+  it('should register the ServiceNow API factory', () => {
+    const apiFactories = [...servicenowPlugin.getApis()];
+    const apiIds = apiFactories.map(factory => factory.api.id);
+
+    expect(apiIds).toContain(serviceNowApiRef.id);
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR aims to increase the test coverage for the ServiceNow plugin, with a focus on Backstage integration.

It also updates and expands the contributor guides with steps for running the plugin dev/ harness, running the usual package/workspace validation commands.

Finally, the backend client now includes the entity annotation field in ServiceNow incident queries

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
