### PR TITLE
refactor(announcements): use StorageApi instead of WebStorage

### DIFF
--- a/workspaces/announcements/.changeset/per-announcement-dismiss.md
+++ b/workspaces/announcements/.changeset/per-announcement-dismiss.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements-react': minor
+'@backstage-community/plugin-announcements': minor
+---
+
+Added per-announcement dismiss tracking to replace the single-timestamp mechanism. Each banner can now be dismissed independently without affecting the visibility of other announcements. The `AnnouncementsApi` interface gains two new methods: `dismissAnnouncement(id)` and `isAnnouncementDismissed(id)`. The existing `lastSeenDate` mechanism is preserved as a backward-compatible fallback.

--- a/workspaces/announcements/.changeset/use-storage-api.md
+++ b/workspaces/announcements/.changeset/use-storage-api.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-announcements-react': minor
+'@backstage-community/plugin-announcements': minor
+---
+
+Replaced direct `WebStorage` usage with the Backstage `StorageApi` interface for dismiss state persistence. This allows Backstage instances with a user-settings backend to automatically persist announcement dismiss state server-side, enabling cross-device and cross-browser consistency. The `@backstage/core-app-api` dependency has been removed from `announcements-react` as it is no longer needed.

--- a/workspaces/announcements/plugins/announcements-react/package.json
+++ b/workspaces/announcements/plugins/announcements-react/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@backstage-community/plugin-announcements-common": "workspace:^",
     "@backstage/catalog-model": "backstage:^",
-    "@backstage/core-app-api": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -46,6 +46,8 @@ export interface AnnouncementsApi {
   deleteCategory(slug: string): Promise<void>;
   // (undocumented)
   deleteTag(slug: string): Promise<void>;
+  dismissAnnouncement(id: string): void;
+  isAnnouncementDismissed(id: string): boolean;
   // (undocumented)
   lastSeenDate(): DateTime;
   // (undocumented)
@@ -92,6 +94,10 @@ export class AnnouncementsClient implements AnnouncementsApi {
   deleteCategory(slug: string): Promise<void>;
   // (undocumented)
   deleteTag(slug: string): Promise<void>;
+  // (undocumented)
+  dismissAnnouncement(id: string): void;
+  // (undocumented)
+  isAnnouncementDismissed(id: string): boolean;
   // (undocumented)
   lastSeenDate(): DateTime;
   // (undocumented)

--- a/workspaces/announcements/plugins/announcements-react/report.api.md
+++ b/workspaces/announcements/plugins/announcements-react/report.api.md
@@ -14,6 +14,7 @@ import { Entity } from '@backstage/catalog-model';
 import { ErrorApi } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
+import { StorageApi } from '@backstage/core-plugin-api';
 import { Tag } from '@backstage-community/plugin-announcements-common';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
 
@@ -117,6 +118,7 @@ export type AnnouncementsClientOptions = {
   identityApi: IdentityApi;
   errorApi: ErrorApi;
   fetchApi: FetchApi;
+  storageApi: StorageApi;
 };
 
 // @public

--- a/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsApi.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsApi.ts
@@ -69,4 +69,14 @@ export interface AnnouncementsApi {
 
   lastSeenDate(): DateTime;
   markLastSeenDate(date: DateTime): void;
+
+  /**
+   * Dismiss a specific announcement by ID so it no longer appears as unseen.
+   */
+  dismissAnnouncement(id: string): void;
+
+  /**
+   * Check whether a specific announcement has been dismissed.
+   */
+  isAnnouncementDismissed(id: string): boolean;
 }

--- a/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
@@ -36,6 +36,8 @@ import {
 } from './types';
 
 const lastSeenKey = 'user_last_seen_date';
+const dismissedIdsKey = 'dismissed_announcement_ids';
+const MAX_DISMISSED_IDS = 50;
 
 /**
  * Options for the AnnouncementsClient
@@ -235,5 +237,26 @@ export class AnnouncementsClient implements AnnouncementsApi {
 
   markLastSeenDate(date: DateTime): void {
     this.webStorage.set<string>(lastSeenKey, date.toISO()!);
+  }
+
+  dismissAnnouncement(id: string): void {
+    const dismissed = this.getDismissedIds();
+    if (!dismissed.includes(id)) {
+      // Create a new array since WebStorage returns frozen objects
+      const updated = [...dismissed, id];
+      // Cap at MAX_DISMISSED_IDS to prevent localStorage bloat
+      while (updated.length > MAX_DISMISSED_IDS) {
+        updated.shift();
+      }
+      this.webStorage.set<string[]>(dismissedIdsKey, updated);
+    }
+  }
+
+  isAnnouncementDismissed(id: string): boolean {
+    return this.getDismissedIds().includes(id);
+  }
+
+  private getDismissedIds(): string[] {
+    return this.webStorage.get<string[]>(dismissedIdsKey) ?? [];
   }
 }

--- a/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
+++ b/workspaces/announcements/plugins/announcements-react/src/apis/AnnouncementsClient.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 import { DateTime } from 'luxon';
-import { WebStorage } from '@backstage/core-app-api';
 import {
   DiscoveryApi,
   ErrorApi,
   IdentityApi,
   FetchApi,
+  StorageApi,
 } from '@backstage/core-plugin-api';
 import { ResponseError } from '@backstage/errors';
 import {
@@ -49,6 +49,7 @@ export type AnnouncementsClientOptions = {
   identityApi: IdentityApi;
   errorApi: ErrorApi;
   fetchApi: FetchApi;
+  storageApi: StorageApi;
 };
 
 /**
@@ -59,13 +60,13 @@ export type AnnouncementsClientOptions = {
 export class AnnouncementsClient implements AnnouncementsApi {
   private readonly discoveryApi: DiscoveryApi;
   private readonly identityApi: IdentityApi;
-  private readonly webStorage: WebStorage;
+  private readonly storage: StorageApi;
   private readonly fetchApi: FetchApi;
 
   constructor(opts: AnnouncementsClientOptions) {
     this.discoveryApi = opts.discoveryApi;
     this.identityApi = opts.identityApi;
-    this.webStorage = new WebStorage('announcements', opts.errorApi);
+    this.storage = opts.storageApi.forBucket('announcements');
     this.fetchApi = opts.fetchApi;
   }
 
@@ -226,29 +227,28 @@ export class AnnouncementsClient implements AnnouncementsApi {
   }
 
   lastSeenDate(): DateTime {
-    const lastSeen = this.webStorage.get<string>(lastSeenKey);
-    if (!lastSeen) {
+    const snapshot = this.storage.snapshot<string>(lastSeenKey);
+    if (snapshot.presence !== 'present' || !snapshot.value) {
       // magic default date, probably enough in the past to consider every announcement as "not seen"
       return DateTime.fromISO('1990-01-01');
     }
 
-    return DateTime.fromISO(lastSeen);
+    return DateTime.fromISO(snapshot.value);
   }
 
   markLastSeenDate(date: DateTime): void {
-    this.webStorage.set<string>(lastSeenKey, date.toISO()!);
+    this.storage.set<string>(lastSeenKey, date.toISO()!);
   }
 
   dismissAnnouncement(id: string): void {
     const dismissed = this.getDismissedIds();
     if (!dismissed.includes(id)) {
-      // Create a new array since WebStorage returns frozen objects
       const updated = [...dismissed, id];
-      // Cap at MAX_DISMISSED_IDS to prevent localStorage bloat
+      // Cap at MAX_DISMISSED_IDS to prevent storage bloat
       while (updated.length > MAX_DISMISSED_IDS) {
         updated.shift();
       }
-      this.webStorage.set<string[]>(dismissedIdsKey, updated);
+      this.storage.set<string[]>(dismissedIdsKey, updated);
     }
   }
 
@@ -257,6 +257,9 @@ export class AnnouncementsClient implements AnnouncementsApi {
   }
 
   private getDismissedIds(): string[] {
-    return this.webStorage.get<string[]>(dismissedIdsKey) ?? [];
+    const snapshot = this.storage.snapshot<string[]>(dismissedIdsKey);
+    return snapshot.presence === 'present' && snapshot.value
+      ? snapshot.value
+      : [];
   }
 }

--- a/workspaces/announcements/plugins/announcements/src/alpha/apis.ts
+++ b/workspaces/announcements/plugins/announcements/src/alpha/apis.ts
@@ -19,6 +19,7 @@ import {
   errorApiRef,
   fetchApiRef,
   identityApiRef,
+  storageApiRef,
 } from '@backstage/frontend-plugin-api';
 import {
   announcementsApiRef,
@@ -43,13 +44,21 @@ export const announcementsApiExtension = ApiBlueprint.make({
         identityApi: identityApiRef,
         fetchApi: fetchApiRef,
         errorApi: errorApiRef,
+        storageApi: storageApiRef,
       },
-      factory: ({ discoveryApi, identityApi, fetchApi, errorApi }) =>
+      factory: ({
+        discoveryApi,
+        identityApi,
+        fetchApi,
+        errorApi,
+        storageApi,
+      }) =>
         new AnnouncementsClient({
           discoveryApi,
           identityApi,
           fetchApi,
           errorApi,
+          storageApi,
         }),
     }),
 });

--- a/workspaces/announcements/plugins/announcements/src/alpha/entityCards.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/alpha/entityCards.test.tsx
@@ -44,6 +44,8 @@ jest.mock('@backstage/plugin-permission-react', () => {
 describe('Entity card extensions', () => {
   const mockAnnouncementsApi = {
     lastSeenDate: () => DateTime.now(),
+    dismissAnnouncement: jest.fn(),
+    isAnnouncementDismissed: jest.fn().mockReturnValue(false),
     announcements: async () => ({
       count: 1,
       results: [

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.test.tsx
@@ -30,6 +30,8 @@ import { analyticsApiRef } from '@backstage/core-plugin-api';
 const mockAnnouncementsApi = (announcements: AnnouncementsList) => ({
   announcements: jest.fn().mockResolvedValue(announcements),
   lastSeenDate: jest.fn().mockReturnValue(DateTime.now().minus({ days: 1 })),
+  dismissAnnouncement: jest.fn(),
+  isAnnouncementDismissed: jest.fn().mockReturnValue(false),
 });
 
 type AnalyticsMock = ReturnType<typeof mockApis.analytics.mock>;

--- a/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/AnnouncementsCard/AnnouncementsCard.tsx
@@ -129,7 +129,9 @@ export const AnnouncementsCard = ({
               <Box
                 style={{
                   visibility:
-                    lastSeen < DateTime.fromISO(announcement.created_at)
+                    !announcementsApi.isAnnouncementDismissed(
+                      announcement.id,
+                    ) && lastSeen < DateTime.fromISO(announcement.created_at)
                       ? 'visible'
                       : 'hidden',
                 }}

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.test.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.test.tsx
@@ -30,6 +30,8 @@ const mockAnnouncementsApi = (announcements: AnnouncementsList) => ({
   announcements: jest.fn().mockResolvedValue(announcements),
   lastSeenDate: jest.fn().mockReturnValue(DateTime.now().minus({ days: 1 })),
   markLastSeenDate: jest.fn(),
+  dismissAnnouncement: jest.fn(),
+  isAnnouncementDismissed: jest.fn().mockReturnValue(false),
 });
 
 type AnalyticsMock = ReturnType<typeof mockApis.analytics.mock>;
@@ -121,7 +123,7 @@ describe('NewAnnouncementBanner', () => {
       expect(screen.queryAllByText('New Announcement').length).toBe(0);
     });
 
-    expect(mockApi.markLastSeenDate).toHaveBeenCalled();
+    expect(mockApi.dismissAnnouncement).toHaveBeenCalledWith('1');
   });
 
   it('does not render when there are no unseen announcements', async () => {

--- a/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
+++ b/workspaces/announcements/plugins/announcements/src/components/NewAnnouncementBanner/NewAnnouncementBanner.tsx
@@ -75,9 +75,7 @@ const AnnouncementBanner = (props: AnnouncementBannerProps) => {
   const excerptLength = props.cardOptions?.excerptLength;
 
   const markSeen = () => {
-    announcementsApi.markLastSeenDate(
-      DateTime.fromISO(announcement.created_at),
-    );
+    announcementsApi.dismissAnnouncement(announcement.id);
     setBannerOpen(false);
   };
 
@@ -225,11 +223,22 @@ export const NewAnnouncementBanner = (props: NewAnnouncementBannerProps) => {
   }
 
   const unseenAnnouncements = announcements.results.filter(announcement => {
-    return lastSeen < DateTime.fromISO(announcement.created_at);
+    // Per-announcement dismiss tracking (primary mechanism)
+    if (announcementsApi.isAnnouncementDismissed(announcement.id)) {
+      return false;
+    }
+    // lastSeenDate as backward-compatible fallback for announcements dismissed
+    // before per-ID tracking was introduced, or when the ID set overflows (>50)
+    if (lastSeen >= DateTime.fromISO(announcement.created_at)) {
+      return false;
+    }
+    return true;
   });
 
   if (signaledAnnouncement) {
-    unseenAnnouncements.push(signaledAnnouncement);
+    if (!announcementsApi.isAnnouncementDismissed(signaledAnnouncement.id)) {
+      unseenAnnouncements.push(signaledAnnouncement);
+    }
   }
 
   if (unseenAnnouncements?.length === 0) {

--- a/workspaces/announcements/plugins/announcements/src/plugin.ts
+++ b/workspaces/announcements/plugins/announcements/src/plugin.ts
@@ -23,6 +23,7 @@ import {
   errorApiRef,
   identityApiRef,
   fetchApiRef,
+  storageApiRef,
 } from '@backstage/core-plugin-api';
 import {
   createSearchResultListItemExtension,
@@ -51,13 +52,21 @@ export const announcementsPlugin = createPlugin({
         identityApi: identityApiRef,
         errorApi: errorApiRef,
         fetchApi: fetchApiRef,
+        storageApi: storageApiRef,
       },
-      factory: ({ discoveryApi, identityApi, errorApi, fetchApi }) => {
+      factory: ({
+        discoveryApi,
+        identityApi,
+        errorApi,
+        fetchApi,
+        storageApi,
+      }) => {
         return new AnnouncementsClient({
           discoveryApi: discoveryApi,
           identityApi: identityApi,
           errorApi: errorApi,
           fetchApi: fetchApi,
+          storageApi: storageApi,
         });
       },
     }),

--- a/workspaces/announcements/yarn.lock
+++ b/workspaces/announcements/yarn.lock
@@ -1829,7 +1829,6 @@ __metadata:
     "@backstage-community/plugin-announcements-common": "workspace:^"
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
-    "@backstage/core-app-api": "backstage:^"
     "@backstage/core-plugin-api": "backstage:^"
     "@backstage/errors": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR replaces direct `WebStorage` instantiation with the Backstage `StorageApi` interface for announcement dismiss state persistence.

### Problem

The `AnnouncementsClient` directly instantiates `WebStorage` (from `@backstage/core-app-api`), bypassing the Backstage `StorageApi` abstraction. This means even if a Backstage instance has the User Settings Backend deployed (which persists state server-side per user), the announcements plugin always uses raw browser localStorage.

This causes dismissed announcements to reappear on new devices, incognito mode, or after clearing browser data.

### Solution

- Replace `WebStorage` import with `StorageApi` from `@backstage/core-plugin-api`
- Add `storageApi: StorageApi` to `AnnouncementsClientOptions`
- Use `StorageApi.snapshot()` instead of the non-standard `WebStorage.get()`
- Use `storageApi.forBucket("announcements")` instead of `new WebStorage("announcements", errorApi)`
- Update both legacy `plugin.ts` and alpha `apis.ts` factories to inject `storageApiRef`
- Remove `@backstage/core-app-api` dependency from `announcements-react` (no longer needed)

### Benefits

- **Respects instance configuration**: If the Backstage admin deploys user-settings-backend, dismiss state is automatically persisted server-side per user
- **Cross-device consistency**: Users won't see already-dismissed announcements on new devices
- **Proper abstraction**: Uses the Backstage contract instead of the concrete implementation
- **Smaller dependency footprint**: Removes `@backstage/core-app-api` from the react package

### Testing

- All 112 unit tests pass (announcements plugin)
- All 12 unit tests pass (announcements-react plugin)
- TypeScript compilation passes cleanly
- Full workspace build succeeds
- Manually tested: dismiss announcements, reload page, verify persistence
- Manually tested: new browser session shows all announcements (localStorage starts fresh)

### Note

This PR is based on #10316 (per-announcement dismiss tracking) which must be merged first.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation (API reports regenerated)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

Related: #9118