### PR TITLE
fix(rollbar): support v2 project tokens

### DIFF
--- a/workspaces/rollbar/.changeset/fresh-rollbars-read.md
+++ b/workspaces/rollbar/.changeset/fresh-rollbars-read.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rollbar-backend': patch
+---
+
+Support projects that use Rollbar v2 project access tokens.

--- a/workspaces/rollbar/plugins/rollbar-backend/README.md
+++ b/workspaces/rollbar/plugins/rollbar-backend/README.md
@@ -36,7 +36,8 @@ rollbar:
 
 > [!NOTE]
 > The `ROLLBAR_ACCOUNT_TOKEN` environment variable must be set to a read
-> access account token.
+> access account token. The plugin uses this account token for project API
+> requests, so project access tokens are not required.
 
 ## Links
 

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.test.ts
@@ -21,7 +21,6 @@ import {
 } from '@backstage/backend-test-utils';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { RollbarProjectAccessToken } from './types';
 
 describe('RollbarApi', () => {
   const server = setupServer();
@@ -91,28 +90,6 @@ describe('RollbarApi', () => {
         rest.get(`${mockBaseUrl}/project/123`, (_, res, ctx) => {
           return res(ctx.json({ result: mockProject }));
         }),
-        rest.get(`${mockBaseUrl}/project/123/access_tokens`, (_, res, ctx) => {
-          return res(
-            ctx.json({
-              result: [
-                {
-                  projectId: 123,
-                  name: 'project-token-expired',
-                  scopes: ['read'],
-                  accessToken: 'xyzzy',
-                  status: 'expired',
-                },
-                {
-                  projectId: 123,
-                  name: 'project-token',
-                  scopes: ['read'],
-                  accessToken: 'plugh',
-                  status: 'enabled',
-                },
-              ] satisfies RollbarProjectAccessToken[],
-            }),
-          );
-        }),
       );
     };
 
@@ -120,7 +97,7 @@ describe('RollbarApi', () => {
       setupHandlers();
       const cache = mockServices.cache.mock();
       cache.get.mockResolvedValue({
-        [mockProject.name]: { ...mockProject, accessToken: 'bar' },
+        [mockProject.name]: { ...mockProject },
       });
       const api = new RollbarApi(
         'my-access-token',
@@ -145,11 +122,66 @@ describe('RollbarApi', () => {
       expect(cache.set).toHaveBeenCalledWith(
         'projectmap',
         {
-          abc: { id: 123, name: 'abc', accessToken: 'plugh' },
+          abc: { id: 123, name: 'abc' },
           xyz: { id: 456, name: 'xyz' },
         },
         { ttl: 300 },
       );
+    });
+  });
+
+  describe('getProjectItems', () => {
+    it('uses the account token with the project id', async () => {
+      server.use(
+        rest.get(`${mockBaseUrl}/projects`, (_, res, ctx) =>
+          res(ctx.json({ result: mockProjects })),
+        ),
+        rest.get(`${mockBaseUrl}/items`, (req, res, ctx) => {
+          expect(req.url.searchParams.get('project_id')).toBe('123');
+          expect(req.headers.get('X-Rollbar-Access-Token')).toBe(
+            'my-access-token',
+          );
+          return res(ctx.json({ result: { items: [], page: 1 } }));
+        }),
+      );
+      const api = new RollbarApi(
+        'my-access-token',
+        mockServices.rootLogger(),
+        mockServices.cache.mock(),
+      );
+
+      await expect(api.getProjectItems('abc')).resolves.toEqual({
+        items: [],
+        page: 1,
+      });
+    });
+
+    it('preserves report parameters when adding the project id', async () => {
+      server.use(
+        rest.get(`${mockBaseUrl}/projects`, (_, res, ctx) =>
+          res(ctx.json({ result: mockProjects })),
+        ),
+        rest.get(`${mockBaseUrl}/reports/top_active_items`, (req, res, ctx) => {
+          expect(Object.fromEntries(req.url.searchParams)).toEqual({
+            hours: '12',
+            environment: 'production',
+            project_id: '123',
+          });
+          return res(ctx.json({ result: [] }));
+        }),
+      );
+      const api = new RollbarApi(
+        'my-access-token',
+        mockServices.rootLogger(),
+        mockServices.cache.mock(),
+      );
+
+      await expect(
+        api.getTopActiveItems('abc', {
+          hours: 12,
+          environment: 'production',
+        }),
+      ).resolves.toEqual([]);
     });
   });
 });

--- a/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
+++ b/workspaces/rollbar/plugins/rollbar-backend/src/api/RollbarApi.ts
@@ -20,7 +20,6 @@ import {
   RollbarItemCount,
   RollbarItemsResponse,
   RollbarProject,
-  RollbarProjectAccessToken,
   RollbarTopActiveItem,
 } from './types';
 import fetch from 'node-fetch';
@@ -112,12 +111,6 @@ export class RollbarApi {
     );
   }
 
-  private async getProjectAccessTokens(projectId: number) {
-    return this.get<RollbarProjectAccessToken[]>(
-      `/project/${projectId}/access_tokens`,
-    );
-  }
-
   private async get<T extends {}>(
     url: string,
     accessToken?: string,
@@ -139,11 +132,15 @@ export class RollbarApi {
   private async getForProject<T extends {}>(
     url: string,
     projectName: string,
-    useProjectToken = true,
+    includeProjectId = true,
   ) {
     const project = await this.getProjectMetadata(projectName);
-    const resolvedUrl = url.replace(':projectId', project.id.toString());
-    return this.get<T>(resolvedUrl, useProjectToken ? project.accessToken : '');
+    let resolvedUrl = url.replace(':projectId', project.id.toString());
+    if (includeProjectId) {
+      const separator = resolvedUrl.includes('?') ? '&' : '?';
+      resolvedUrl = `${resolvedUrl}${separator}project_id=${project.id}`;
+    }
+    return this.get<T>(resolvedUrl);
   }
 
   private async getProjectMetadata(name: string) {
@@ -152,25 +149,6 @@ export class RollbarApi {
 
     if (!project) {
       throw Error(`Invalid project: '${name}'`);
-    }
-
-    if (!project.accessToken) {
-      const tokens = await this.getProjectAccessTokens(project.id);
-      const token = tokens.find(
-        t => t.scopes.includes('read') && t.status !== 'expired',
-      );
-      project.accessToken = token ? token.accessToken : undefined;
-
-      // recache to persist mutated item in project map
-      if (this.cache) {
-        this.cache.set(CACHE_KEY, projectMap, { ttl: 300 });
-      }
-    }
-
-    if (!project.accessToken) {
-      throw Error(
-        `Could not find an active project read access token for '${name}'`,
-      );
     }
 
     return project;
@@ -204,7 +182,6 @@ export function getRequestHeaders(token: string) {
 type ProjectMetadata = {
   name: string;
   id: number;
-  accessToken?: string | undefined;
 };
 
 interface ProjectMetadataMap {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Rollbar v2 no longer returns project access-token values from the listing endpoint. The backend now uses its configured read account token for project requests and scopes each request with `project_id`, while preserving existing report query parameters.

Fixes #10111

This change was developed with substantial AI assistance and was independently reviewed. I reviewed the resulting code and verification evidence before submission.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; backend-only change)
- [x] All commits have a `Signed-off-by` line in the message.

Verification:
- Rollbar backend tests: 10/10
- `yarn tsc:full`
- workspace lint
- API report generation
- Prettier
- `git diff --check`