### PR TITLE
fix(announcements): exclude inactive announcements from search results

### DIFF
--- a/workspaces/announcements/.changeset/grumpy-lions-drive.md
+++ b/workspaces/announcements/.changeset/grumpy-lions-drive.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-announcements': minor
+---
+
+Inactive announcements are no longer indexed for search. This fixes an issue where inactive announcements were still being returned in search results.

--- a/workspaces/announcements/plugins/search-backend-module-announcements/README.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/README.md
@@ -1,6 +1,6 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
-The announcements backend module for the search plugin.
+The announcements backend module for the search plugin. Only active announcements are indexed.
 
 ## Installation
 

--- a/workspaces/announcements/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.test.ts
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.test.ts
@@ -22,7 +22,7 @@ import { rest } from 'msw';
 import { mockServices } from '@backstage/backend-test-utils';
 
 const mockAnnouncements = {
-  count: 3,
+  count: 4,
   results: [
     {
       id: '1',
@@ -31,6 +31,7 @@ const mockAnnouncements = {
       body: 'body',
       excerpt: 'excerpt',
       created_at: 'created_at',
+      active: true,
     },
     {
       id: '2',
@@ -39,6 +40,7 @@ const mockAnnouncements = {
       body: 'body',
       excerpt: 'excerpt',
       created_at: 'created_at',
+      active: true,
     },
     {
       id: '3',
@@ -47,6 +49,16 @@ const mockAnnouncements = {
       body: 'body',
       excerpt: 'excerpt',
       created_at: 'created_at',
+      active: true,
+    },
+    {
+      id: '4',
+      title: 'inactive title',
+      publisher: 'publisher4',
+      body: 'body',
+      excerpt: 'excerpt',
+      created_at: 'created_at',
+      active: false,
     },
   ],
 };
@@ -85,12 +97,17 @@ describe('AnnouncementCollatorFactory', () => {
       expect(collator).toBeInstanceOf(Readable);
     });
 
-    it('runs against announcements', async () => {
+    it('runs against announcements, skipping inactive ones', async () => {
       collator = await factory.getCollator();
       const pipeline = TestPipeline.fromCollator(collator);
       const { documents } = await pipeline.execute();
       expect(mockDiscovery.getBaseUrl).toHaveBeenCalledWith('announcements');
-      expect(documents).toHaveLength(mockAnnouncements.results.length);
+      expect(documents).toHaveLength(3);
+      expect(documents).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({ location: '/announcements/view/4' }),
+        ]),
+      );
     });
   });
 });

--- a/workspaces/announcements/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.ts
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/src/collators/AnnouncementCollatorFactory.ts
@@ -88,6 +88,10 @@ export class AnnouncementCollatorFactory implements DocumentCollatorFactory {
     this.logger.debug(`got ${results.length} announcements`);
 
     for (const result of results) {
+      if (!result.active) {
+        continue;
+      }
+
       yield this.getDocumentInfo(result);
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

It fixes #10197.  I've added a `continue` when we have an inactive announcement in the indexation loop,

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
