### PR TITLE
Version Packages (cicd-statistics)

### DIFF
--- a/workspaces/cicd-statistics/.changeset/modernize-entity-filters.md
+++ b/workspaces/cicd-statistics/.changeset/modernize-entity-filters.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-cicd-statistics': patch
----
-
-Updated entity extension default filter to use the modern object form.

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cicd-statistics-module-buildkite
 
+## 0.18.1
+
+### Patch Changes
+
+- Updated dependencies [fcd0f1a]
+  - @backstage-community/plugin-cicd-statistics@0.19.1
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-buildkite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-buildkite",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "CI/CD Statistics plugin module; Buildkite CI/CD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cicd-statistics-module-github
 
+## 0.17.1
+
+### Patch Changes
+
+- Updated dependencies [fcd0f1a]
+  - @backstage-community/plugin-cicd-statistics@0.19.1
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-github",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "CI/CD Statistics plugin module; Github CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @backstage-community/plugin-cicd-statistics-module-gitlab
 
+## 0.19.1
+
+### Patch Changes
+
+- Updated dependencies [fcd0f1a]
+  - @backstage-community/plugin-cicd-statistics@0.19.1
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics-module-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics-module-gitlab",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "CI/CD Statistics plugin module; Gitlab CICD",
   "backstage": {
     "role": "frontend-plugin-module",

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-cicd-statistics
 
+## 0.19.1
+
+### Patch Changes
+
+- fcd0f1a: Updated entity extension default filter to use the modern object form.
+
 ## 0.19.0
 
 ### Minor Changes

--- a/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
+++ b/workspaces/cicd-statistics/plugins/cicd-statistics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-cicd-statistics",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A frontend plugin visualizing CI/CD pipeline statistics (build time)",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-cicd-statistics@0.19.1

### Patch Changes

-   fcd0f1a: Updated entity extension default filter to use the modern object form.

## @backstage-community/plugin-cicd-statistics-module-buildkite@0.18.1

### Patch Changes

-   Updated dependencies [fcd0f1a]
    -   @backstage-community/plugin-cicd-statistics@0.19.1

## @backstage-community/plugin-cicd-statistics-module-github@0.17.1

### Patch Changes

-   Updated dependencies [fcd0f1a]
    -   @backstage-community/plugin-cicd-statistics@0.19.1

## @backstage-community/plugin-cicd-statistics-module-gitlab@0.19.1

### Patch Changes

-   Updated dependencies [fcd0f1a]
    -   @backstage-community/plugin-cicd-statistics@0.19.1
