### PR TITLE
Version Packages (github)

### DIFF
--- a/workspaces/github/.changeset/modernize-entity-filters.md
+++ b/workspaces/github/.changeset/modernize-entity-filters.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-github-pull-requests-board': patch
-'@backstage-community/plugin-github-issues': patch
-'@backstage-community/plugin-github-deployments': patch
----
-
-Updated entity extension default filters to use the modern object form.

--- a/workspaces/github/plugins/github-deployments/CHANGELOG.md
+++ b/workspaces/github/plugins/github-deployments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-deployments
 
+## 1.3.1
+
+### Patch Changes
+
+- fcd0f1a: Updated entity extension default filters to use the modern object form.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-deployments/package.json
+++ b/workspaces/github/plugins/github-deployments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-deployments",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Backstage plugin that integrates towards GitHub Deployments",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/github/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-issues
 
+## 1.3.1
+
+### Patch Changes
+
+- fcd0f1a: Updated entity extension default filters to use the modern object form.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-issues/package.json
+++ b/workspaces/github/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "github-issues",

--- a/workspaces/github/plugins/github-pull-requests-board/CHANGELOG.md
+++ b/workspaces/github/plugins/github-pull-requests-board/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-pull-requests-board
 
+## 1.3.1
+
+### Patch Changes
+
+- fcd0f1a: Updated entity extension default filters to use the modern object form.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/github/plugins/github-pull-requests-board/package.json
+++ b/workspaces/github/plugins/github-pull-requests-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-pull-requests-board",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A Backstage plugin that allows you to see all open Pull Requests for all the repositories owned by your team",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-deployments@1.3.1

### Patch Changes

-   fcd0f1a: Updated entity extension default filters to use the modern object form.

## @backstage-community/plugin-github-issues@1.3.1

### Patch Changes

-   fcd0f1a: Updated entity extension default filters to use the modern object form.

## @backstage-community/plugin-github-pull-requests-board@1.3.1

### Patch Changes

-   fcd0f1a: Updated entity extension default filters to use the modern object form.
