### PR TITLE
fix(rbac): improve edit/create role page performance

### DIFF
--- a/workspaces/rbac/.changeset/soft-stingrays-ring.md
+++ b/workspaces/rbac/.changeset/soft-stingrays-ring.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-rbac': patch
+---
+
+Improve role page performance by replacing bulk member loading with server-side search and fetching only the members assigned to a role.

--- a/workspaces/rbac/plugins/rbac/dev/mocks.ts
+++ b/workspaces/rbac/plugins/rbac/dev/mocks.ts
@@ -89,6 +89,24 @@ class MockRBACApi implements RBACAPI {
     return mockMembers;
   }
 
+  async getMembersByRefs(
+    entityRefs: string[],
+  ): Promise<(MemberEntity | undefined)[]> {
+    return entityRefs.map(ref => {
+      const name = ref.split('/').pop();
+      return mockMembers.find(m => m.metadata.name === name);
+    });
+  }
+
+  async searchMembers(searchTerm: string): Promise<MemberEntity[]> {
+    if (!searchTerm.trim()) {
+      return mockMembers;
+    }
+    return mockMembers.filter(m =>
+      m.metadata.name.toLowerCase().includes(searchTerm.toLowerCase()),
+    );
+  }
+
   async listPermissions(): Promise<PluginPermissionMetaData[]> {
     return mockPermissionPolicies;
   }

--- a/workspaces/rbac/plugins/rbac/report-legacy.api.md
+++ b/workspaces/rbac/plugins/rbac/report-legacy.api.md
@@ -58,6 +58,10 @@ export type RBACAPI = {
     page?: number,
     pageSize?: number,
   ) => Promise<MemberEntity[] | Response>;
+  getMembersByRefs: (
+    entityRefs: string[],
+  ) => Promise<(MemberEntity | undefined)[] | Response>;
+  searchMembers: (searchTerm: string) => Promise<MemberEntity[] | Response>;
   listPermissions: () => Promise<PluginPermissionMetaData[] | Response>;
   createRole: (role: Role) => Promise<RoleError | Response>;
   updateRole: (oldRole: Role, newRole: Role) => Promise<RoleError | Response>;

--- a/workspaces/rbac/plugins/rbac/report.api.md
+++ b/workspaces/rbac/plugins/rbac/report.api.md
@@ -19,8 +19,87 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
 import { TranslationResource } from '@backstage/frontend-plugin-api';
 
-// @public
-const _default: OverridableFrontendPlugin<
+// @public (undocumented)
+export const Administration: () => JSX_2.Element | null;
+
+export { AdminPanelSettingsOutlinedIcon };
+
+// @public (undocumented)
+export type ConditionRule = {
+  name: string;
+  description?: string;
+  resourceType: string;
+  paramsSchema: RJSFSchema;
+};
+
+// @public (undocumented)
+export type MemberEntity = UserEntity | GroupEntity;
+
+// @public (undocumented)
+export type PluginConditionRules = {
+  pluginId: string;
+  rules: ConditionRule[];
+};
+
+// @public (undocumented)
+export type RBACAPI = {
+  getUserAuthorization: () => Promise<{
+    status: string;
+  }>;
+  getRoles: () => Promise<Role[] | Response>;
+  getPolicies: () => Promise<RoleBasedPolicy[] | Response>;
+  getAssociatedPolicies: (
+    entityReference: string,
+  ) => Promise<RoleBasedPolicy[] | Response>;
+  deleteRole: (role: string) => Promise<Response>;
+  getRole: (role: string) => Promise<Role[] | Response>;
+  getMembers: (
+    page?: number,
+    pageSize?: number,
+  ) => Promise<MemberEntity[] | Response>;
+  getMembersByRefs: (
+    entityRefs: string[],
+  ) => Promise<(MemberEntity | undefined)[] | Response>;
+  searchMembers: (searchTerm: string) => Promise<MemberEntity[] | Response>;
+  listPermissions: () => Promise<PluginPermissionMetaData[] | Response>;
+  createRole: (role: Role) => Promise<RoleError | Response>;
+  updateRole: (oldRole: Role, newRole: Role) => Promise<RoleError | Response>;
+  updatePolicies: (
+    entityReference: string,
+    oldPolicy: RoleBasedPolicy[],
+    newPolicy: RoleBasedPolicy[],
+  ) => Promise<RoleError | Response>;
+  createPolicies: (polices: RoleBasedPolicy[]) => Promise<RoleError | Response>;
+  deletePolicies: (
+    entityReference: string,
+    polices: RoleBasedPolicy[],
+  ) => Promise<RoleError | Response>;
+  getPluginsConditionRules: () => Promise<PluginConditionRules[] | Response>;
+  createConditionalPermission: (
+    conditionalPermission: RoleBasedConditions,
+  ) => Promise<RoleError | Response>;
+  getRoleConditions: (
+    roleRef: string,
+  ) => Promise<RoleConditionalPolicyDecision<PermissionAction>[] | Response>;
+  updateConditionalPolicies: (
+    conditionId: number,
+    data: RoleBasedConditions,
+  ) => Promise<RoleError | Response>;
+  deleteConditionalPolicies: (
+    conditionId: number,
+  ) => Promise<RoleError | Response>;
+};
+
+// @public (undocumented)
+export const rbacApiRef: ApiRef<RBACAPI>;
+
+export { RbacIcon };
+
+// @public (undocumented)
+export const RbacPage: (input: { useHeader?: boolean }) => JSX_2.Element;
+
+// @public (undocumented)
+export const rbacPlugin: BackstagePlugin<
   {
     root: RouteRef<undefined>;
   },

--- a/workspaces/rbac/plugins/rbac/report.api.md
+++ b/workspaces/rbac/plugins/rbac/report.api.md
@@ -19,87 +19,8 @@ import { RouteRef } from '@backstage/frontend-plugin-api';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
 import { TranslationResource } from '@backstage/frontend-plugin-api';
 
-// @public (undocumented)
-export const Administration: () => JSX_2.Element | null;
-
-export { AdminPanelSettingsOutlinedIcon };
-
-// @public (undocumented)
-export type ConditionRule = {
-  name: string;
-  description?: string;
-  resourceType: string;
-  paramsSchema: RJSFSchema;
-};
-
-// @public (undocumented)
-export type MemberEntity = UserEntity | GroupEntity;
-
-// @public (undocumented)
-export type PluginConditionRules = {
-  pluginId: string;
-  rules: ConditionRule[];
-};
-
-// @public (undocumented)
-export type RBACAPI = {
-  getUserAuthorization: () => Promise<{
-    status: string;
-  }>;
-  getRoles: () => Promise<Role[] | Response>;
-  getPolicies: () => Promise<RoleBasedPolicy[] | Response>;
-  getAssociatedPolicies: (
-    entityReference: string,
-  ) => Promise<RoleBasedPolicy[] | Response>;
-  deleteRole: (role: string) => Promise<Response>;
-  getRole: (role: string) => Promise<Role[] | Response>;
-  getMembers: (
-    page?: number,
-    pageSize?: number,
-  ) => Promise<MemberEntity[] | Response>;
-  getMembersByRefs: (
-    entityRefs: string[],
-  ) => Promise<(MemberEntity | undefined)[] | Response>;
-  searchMembers: (searchTerm: string) => Promise<MemberEntity[] | Response>;
-  listPermissions: () => Promise<PluginPermissionMetaData[] | Response>;
-  createRole: (role: Role) => Promise<RoleError | Response>;
-  updateRole: (oldRole: Role, newRole: Role) => Promise<RoleError | Response>;
-  updatePolicies: (
-    entityReference: string,
-    oldPolicy: RoleBasedPolicy[],
-    newPolicy: RoleBasedPolicy[],
-  ) => Promise<RoleError | Response>;
-  createPolicies: (polices: RoleBasedPolicy[]) => Promise<RoleError | Response>;
-  deletePolicies: (
-    entityReference: string,
-    polices: RoleBasedPolicy[],
-  ) => Promise<RoleError | Response>;
-  getPluginsConditionRules: () => Promise<PluginConditionRules[] | Response>;
-  createConditionalPermission: (
-    conditionalPermission: RoleBasedConditions,
-  ) => Promise<RoleError | Response>;
-  getRoleConditions: (
-    roleRef: string,
-  ) => Promise<RoleConditionalPolicyDecision<PermissionAction>[] | Response>;
-  updateConditionalPolicies: (
-    conditionId: number,
-    data: RoleBasedConditions,
-  ) => Promise<RoleError | Response>;
-  deleteConditionalPolicies: (
-    conditionId: number,
-  ) => Promise<RoleError | Response>;
-};
-
-// @public (undocumented)
-export const rbacApiRef: ApiRef<RBACAPI>;
-
-export { RbacIcon };
-
-// @public (undocumented)
-export const RbacPage: (input: { useHeader?: boolean }) => JSX_2.Element;
-
-// @public (undocumented)
-export const rbacPlugin: BackstagePlugin<
+// @public
+const _default: OverridableFrontendPlugin<
   {
     root: RouteRef<undefined>;
   },

--- a/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.test.ts
@@ -24,6 +24,7 @@ import { RBACAPI, RBACBackendClient } from './RBACBackendClient';
 
 const LOCAL_ADDR = 'https://localhost:7007';
 let lastRequest: any;
+let byRefsRequests: any[] = [];
 const handlers = [
   rest.get(`${LOCAL_ADDR}/api/permission`, (req, res, ctx) => {
     lastRequest = {
@@ -126,6 +127,57 @@ const handlers = [
       return res(ctx.status(404));
     },
   ),
+  rest.post(
+    `${LOCAL_ADDR}/api/catalog/entities/by-refs`,
+    async (req, res, ctx) => {
+      const authorizationHeader = req.headers.get('Authorization');
+      const body = await req.json();
+      lastRequest = {
+        url: req.url.toString(),
+        authorizationHeader: authorizationHeader,
+        body,
+      };
+      byRefsRequests.push({ body });
+      if (authorizationHeader === 'Bearer test-token') {
+        const { entityRefs } = body;
+        return res(
+          ctx.status(200),
+          ctx.json({
+            items: entityRefs.map((ref: string) => ({
+              kind: ref.startsWith('user:') ? 'User' : 'Group',
+              metadata: { name: ref.split('/').pop(), namespace: 'default' },
+              spec: { profile: {} },
+            })),
+          }),
+        );
+      }
+      return res(ctx.status(404));
+    },
+  ),
+  rest.get(`${LOCAL_ADDR}/api/catalog/entities/by-query`, (req, res, ctx) => {
+    const authorizationHeader = req.headers.get('Authorization');
+    lastRequest = {
+      url: req.url.toString(),
+      authorizationHeader: authorizationHeader,
+    };
+    if (authorizationHeader === 'Bearer test-token') {
+      return res(
+        ctx.status(200),
+        ctx.json({
+          items: [
+            {
+              kind: 'User',
+              metadata: { name: 'john', namespace: 'default' },
+              spec: { profile: { displayName: 'John' } },
+            },
+          ],
+          totalItems: 1,
+          pageInfo: {},
+        }),
+      );
+    }
+    return res(ctx.status(404));
+  }),
   rest.get(`${LOCAL_ADDR}/api/permission/plugins/policies`, (req, res, ctx) => {
     const authorizationHeader = req.headers.get('Authorization');
     lastRequest = {
@@ -282,6 +334,7 @@ describe('RBACBackendClient', () => {
   } as IdentityApi;
 
   beforeEach(() => {
+    byRefsRequests = [];
     rbacApi = new RBACBackendClient({
       configApi: getConfigApi(() => {
         return '/api';
@@ -455,6 +508,121 @@ describe('RBACBackendClient', () => {
       );
 
       await expect(rbacApi.getMembers()).resolves.toEqual(
+        expect.objectContaining({
+          status: 404,
+        }),
+      );
+    });
+  });
+
+  describe('getMembers with pagination', () => {
+    it('should append limit and offset when page and pageSize are provided', async () => {
+      server.use(
+        rest.get(`${LOCAL_ADDR}/api/catalog/entities`, (req, res, ctx) => {
+          lastRequest = {
+            url: req.url.toString(),
+            authorizationHeader: req.headers.get('Authorization'),
+          };
+          return res(ctx.status(200), ctx.json([{ kind: 'User', spec: {} }]));
+        }),
+      );
+
+      const response = await rbacApi.getMembers(2, 50);
+
+      expect(response).toEqual([{ kind: 'User', spec: {} }]);
+      expect(lastRequest.url).toContain('limit=50');
+      expect(lastRequest.url).toContain('offset=50');
+    });
+  });
+
+  describe('getMembersByRefs', () => {
+    it('should return empty array for empty refs', async () => {
+      const response = await rbacApi.getMembersByRefs([]);
+      expect(response).toEqual([]);
+    });
+
+    it('should send a POST request with entity refs', async () => {
+      const refs = ['user:default/john', 'group:default/team-a'];
+      const response = await rbacApi.getMembersByRefs(refs);
+
+      expect(Array.isArray(response)).toBe(true);
+      expect((response as any[]).length).toBe(2);
+      expect(lastRequest.url).toBe(
+        'https://localhost:7007/api/catalog/entities/by-refs',
+      );
+      expect(lastRequest.authorizationHeader).toBe('Bearer test-token');
+      expect(lastRequest.body.entityRefs).toEqual(refs);
+      expect(lastRequest.body.fields).toBeDefined();
+    });
+
+    it('should batch large requests to avoid request entity too large', async () => {
+      const refs = Array.from(
+        { length: 5000 },
+        (_, i) => `user:default/user_${i}`,
+      );
+      const response = await rbacApi.getMembersByRefs(refs);
+
+      expect(Array.isArray(response)).toBe(true);
+      expect((response as any[]).length).toBe(5000);
+      expect(byRefsRequests.length).toBe(3);
+      expect(byRefsRequests[0].body.entityRefs.length).toBe(2000);
+      expect(byRefsRequests[1].body.entityRefs.length).toBe(2000);
+      expect(byRefsRequests[2].body.entityRefs.length).toBe(1000);
+    });
+
+    it('should handle unauthorized response', async () => {
+      server.use(
+        rest.post(
+          `${LOCAL_ADDR}/api/catalog/entities/by-refs`,
+          (_req, res, ctx) => {
+            return res(ctx.status(404));
+          },
+        ),
+      );
+
+      await expect(
+        rbacApi.getMembersByRefs(['user:default/john']),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: 404,
+        }),
+      );
+    });
+  });
+
+  describe('searchMembers', () => {
+    it('should search with fullTextFilterTerm when search term is provided', async () => {
+      const response = await rbacApi.searchMembers('john');
+
+      expect(Array.isArray(response)).toBe(true);
+      expect((response as any[]).length).toBe(1);
+      expect(lastRequest.url).toContain('/api/catalog/entities/by-query');
+      expect(lastRequest.url).toContain('fullTextFilterTerm=john');
+      expect(lastRequest.url).toContain('filter=kind%3Duser');
+      expect(lastRequest.url).toContain('filter=kind%3Dgroup');
+      expect(lastRequest.url).toContain('limit=100');
+    });
+
+    it('should fetch without fullTextFilterTerm when search term is empty', async () => {
+      const response = await rbacApi.searchMembers('');
+
+      expect(Array.isArray(response)).toBe(true);
+      expect(lastRequest.url).toContain('/api/catalog/entities/by-query');
+      expect(lastRequest.url).not.toContain('fullTextFilterTerm');
+      expect(lastRequest.url).not.toContain('fullTextFilterFields');
+    });
+
+    it('should handle unauthorized response', async () => {
+      server.use(
+        rest.get(
+          `${LOCAL_ADDR}/api/catalog/entities/by-query`,
+          (_req, res, ctx) => {
+            return res(ctx.status(404));
+          },
+        ),
+      );
+
+      await expect(rbacApi.searchMembers('test')).resolves.toEqual(
         expect.objectContaining({
           status: 404,
         }),

--- a/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.ts
+++ b/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.ts
@@ -51,6 +51,10 @@ export type RBACAPI = {
     page?: number,
     pageSize?: number,
   ) => Promise<MemberEntity[] | Response>;
+  getMembersByRefs: (
+    entityRefs: string[],
+  ) => Promise<(MemberEntity | undefined)[] | Response>;
+  searchMembers: (searchTerm: string) => Promise<MemberEntity[] | Response>;
   listPermissions: () => Promise<PluginPermissionMetaData[] | Response>;
   createRole: (role: Role) => Promise<RoleError | Response>;
   updateRole: (oldRole: Role, newRole: Role) => Promise<RoleError | Response>;
@@ -218,6 +222,78 @@ export class RBACBackendClient implements RBACAPI {
       return jsonResponse;
     }
     return jsonResponse.json();
+  }
+
+  async getMembersByRefs(entityRefs: string[]) {
+    if (entityRefs.length === 0) {
+      return [];
+    }
+    const { token: idToken } = await this.identityApi.getCredentials();
+    const backendUrl = this.configApi.getString('backend.baseUrl');
+    const batchSize = 2000;
+    const results: (MemberEntity | undefined)[] = [];
+
+    for (let i = 0; i < entityRefs.length; i += batchSize) {
+      const batch = entityRefs.slice(i, i + batchSize);
+      const jsonResponse = await fetch(
+        `${backendUrl}/api/catalog/entities/by-refs`,
+        {
+          method: 'POST',
+          headers: {
+            ...(idToken && { Authorization: `Bearer ${idToken}` }),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            entityRefs: batch,
+            fields: [
+              'metadata.name',
+              'metadata.namespace',
+              'metadata.etag',
+              'kind',
+              'spec.profile',
+              'spec.members',
+              'relations',
+            ],
+          }),
+        },
+      );
+      if (jsonResponse.status !== 200 && jsonResponse.status !== 204) {
+        return jsonResponse;
+      }
+      const data = await jsonResponse.json();
+      results.push(...(data.items as (MemberEntity | undefined)[]));
+    }
+
+    return results;
+  }
+
+  async searchMembers(searchTerm: string) {
+    const { token: idToken } = await this.identityApi.getCredentials();
+    const backendUrl = this.configApi.getString('backend.baseUrl');
+    const params = new URLSearchParams();
+    params.append('filter', 'kind=user');
+    params.append('filter', 'kind=group');
+    params.append('limit', '100');
+    params.append('orderField', 'metadata.name,asc');
+    if (searchTerm.trim()) {
+      params.append('fullTextFilterTerm', searchTerm.trim());
+      params.append('fullTextFilterFields', 'metadata.name');
+      params.append('fullTextFilterFields', 'spec.profile.displayName');
+    }
+    const jsonResponse = await fetch(
+      `${backendUrl}/api/catalog/entities/by-query?${params.toString()}`,
+      {
+        headers: {
+          ...(idToken && { Authorization: `Bearer ${idToken}` }),
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    if (jsonResponse.status !== 200 && jsonResponse.status !== 204) {
+      return jsonResponse;
+    }
+    const data = await jsonResponse.json();
+    return data.items as MemberEntity[];
   }
 
   async listPermissions() {

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.test.tsx
@@ -166,6 +166,7 @@ describe('AddMembersForm', () => {
           expect.objectContaining({ label: 'test user1' }),
           expect.objectContaining({ label: 'test user2' }),
         ]),
+        false,
       );
     });
   });
@@ -267,6 +268,7 @@ describe('AddMembersForm', () => {
             label: 'test user2',
           }),
         ]),
+        false,
       );
     });
   });

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.test.tsx
@@ -25,6 +25,15 @@ jest.mock('../../hooks/useLanguage', () => ({
   useLanguage: () => 'en',
 }));
 
+const mockSearchMembers = jest.fn();
+
+jest.mock('@backstage/core-plugin-api', () => ({
+  ...jest.requireActual('@backstage/core-plugin-api'),
+  useApi: () => ({
+    searchMembers: mockSearchMembers,
+  }),
+}));
+
 const membersData: {
   members: MemberEntity[];
   loading: boolean;
@@ -72,6 +81,14 @@ const selectedMembers = [
 
 describe('AddMembersForm', () => {
   const mockSetFieldValue = jest.fn();
+
+  beforeEach(() => {
+    mockSearchMembers.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('displays error message when membersData.error is provided', async () => {
     const mockError = new Error('Failed to fetch');
@@ -175,12 +192,29 @@ describe('AddMembersForm', () => {
     await user.click(clearButton);
     expect(autocompleteInput).toHaveValue('');
   });
-  it('filters members as the user types in the search input', async () => {
+
+  it('calls searchMembers API when user types in search input', async () => {
     const user = userEvent.setup();
-    const { getByTestId, getAllByTestId } = render(
+    mockSearchMembers.mockResolvedValue([
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'User',
+        spec: { profile: { displayName: 'test user1' } },
+        metadata: {
+          name: 'test user1',
+          etag: 'test user1',
+          namespace: 'default',
+        },
+      },
+    ]);
+    const { getByTestId } = render(
       <AddMembersForm
         selectedMembers={[]}
-        membersData={membersData}
+        membersData={{
+          members: [],
+          loading: false,
+          error: { name: '', message: '' },
+        }}
         setFieldValue={mockSetFieldValue}
       />,
     );
@@ -190,11 +224,11 @@ describe('AddMembersForm', () => {
     if (!autocompleteInput) {
       throw new Error('Input field not found');
     }
-    await user.type(autocompleteInput, 'er1');
+    await user.type(autocompleteInput, 'test');
 
-    const elements = getAllByTestId('test user1');
-    const combinedText = elements.map(el => el.textContent).join('');
-    expect(combinedText).toBe('test user1');
+    await waitFor(() => {
+      expect(mockSearchMembers).toHaveBeenCalledWith('test');
+    });
   });
 
   it('updates the selected member and calls setFieldValue on selection', async () => {
@@ -259,27 +293,24 @@ describe('AddMembersForm', () => {
   it('keeps the search input after each selection', async () => {
     const user = userEvent.setup();
 
-    const { findByText, getByRole } = render(
+    const { findByText, getByTestId } = render(
       <AddMembersForm
         selectedMembers={[]}
         membersData={membersData}
         setFieldValue={mockSetFieldValue}
       />,
     );
-    const autocompleteInput = screen
-      .getByTestId('users-and-groups-text-field')
-      .querySelector('input');
+    const autocompleteInput = getByTestId(
+      'users-and-groups-text-field',
+    ).querySelector('input');
     if (!autocompleteInput) {
       throw new Error('Input field not found');
     }
-    // Open the dropdown
-    user.click(autocompleteInput);
+    await user.click(autocompleteInput);
 
-    await userEvent.type(autocompleteInput, 'er1');
-    const memberOptions = getByRole('listbox');
-    await user.click(memberOptions);
-    const memberOption1 = await findByText('er1');
+    const memberOption1 = await findByText('test user1');
+    await user.type(autocompleteInput, 'test');
     await user.click(memberOption1);
-    expect(autocompleteInput).toHaveValue('er1');
+    expect(autocompleteInput).toHaveValue('test');
   });
 });

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -112,20 +112,28 @@ export const AddMembersForm = ({
 
   const [searchResults, setSearchResults] = useState<MemberEntity[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
 
   const performSearch = useCallback(
     async (term: string) => {
       setSearchLoading(true);
+      setSearchError(null);
       try {
         const result = await rbacApi.searchMembers(term);
         if (Array.isArray(result)) {
           setSearchResults(result);
+        } else {
+          setSearchError(
+            t('common.errorFetchingUserGroups' as any, { error: '' }),
+          );
         }
+      } catch (err) {
+        setSearchError(err instanceof Error ? err.message : String(err));
       } finally {
         setSearchLoading(false);
       }
     },
-    [rbacApi],
+    [rbacApi, t],
   );
 
   useDebounce(
@@ -160,10 +168,6 @@ export const AddMembersForm = ({
     return unique.map((member, index) => toSelectedMember(member, index, t));
   }, [searchResults, membersData.members, search, t]);
 
-  const filteredMembers = useMemo(() => {
-    return membersOptions.slice(0, 99);
-  }, [membersOptions]);
-
   const handleIsOptionEqualToValue = (
     option: SelectedMember,
     value: SelectedMember,
@@ -181,7 +185,7 @@ export const AddMembersForm = ({
         data-testid="users-and-groups-autocomplete"
         sx={{ width: '30%' }}
         multiple
-        options={filteredMembers || []}
+        options={membersOptions}
         getOptionLabel={(option: SelectedMember) => option.label ?? ''}
         isOptionEqualToValue={handleIsOptionEqualToValue}
         loading={searchLoading}
@@ -241,6 +245,7 @@ export const AddMembersForm = ({
         )}
       />
       <br />
+      {searchError && <FormHelperText error>{searchError}</FormHelperText>}
       {membersData.error?.message && (
         <FormHelperText error={!!membersData.error}>
           {t('common.errorFetchingUserGroups' as any, {

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -19,7 +19,9 @@ import { useDebounce } from 'react-use';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 
-import Autocomplete from '@mui/material/Autocomplete';
+import Autocomplete, {
+  AutocompleteRenderOptionState,
+} from '@mui/material/Autocomplete';
 import FormHelperText from '@mui/material/FormHelperText';
 import LinearProgress from '@mui/material/LinearProgress';
 import TextField from '@mui/material/TextField';
@@ -168,13 +170,42 @@ export const AddMembersForm = ({
     return unique.map((member, index) => toSelectedMember(member, index, t));
   }, [searchResults, membersData.members, search, t]);
 
-  const handleIsOptionEqualToValue = (
-    option: SelectedMember,
-    value: SelectedMember,
-  ) =>
-    value.etag
-      ? option.etag === value.etag
-      : selectedMember?.[0].etag === value.etag;
+  const handleIsOptionEqualToValue = useCallback(
+    (option: SelectedMember, value: SelectedMember) =>
+      option.etag === value.etag,
+    [],
+  );
+
+  const handleGetOptionLabel = useCallback(
+    (option: SelectedMember) => option.label ?? '',
+    [],
+  );
+
+  const handleChange = useCallback(
+    (_e: React.SyntheticEvent, value: SelectedMember[]) => {
+      setSelectedMember(value);
+      setFieldValue('selectedMembers', value, false);
+    },
+    [setFieldValue],
+  );
+
+  const handleInputChange = useCallback(
+    (_e: React.SyntheticEvent, newSearch: string, reason: string) => {
+      if (reason === 'input') setSearch(newSearch);
+    },
+    [],
+  );
+
+  const handleFilterOptions = useCallback((x: SelectedMember[]) => x, []);
+
+  const handleRenderOption = useCallback(
+    (
+      props: React.HTMLAttributes<HTMLLIElement>,
+      option: SelectedMember,
+      state: AutocompleteRenderOptionState,
+    ) => <MembersDropdownOption props={props} option={option} state={state} />,
+    [],
+  );
 
   return (
     <>
@@ -186,25 +217,18 @@ export const AddMembersForm = ({
         sx={{ width: '30%' }}
         multiple
         options={membersOptions}
-        getOptionLabel={(option: SelectedMember) => option.label ?? ''}
+        getOptionLabel={handleGetOptionLabel}
         isOptionEqualToValue={handleIsOptionEqualToValue}
         loading={searchLoading}
         loadingText={<LinearProgress />}
         disableClearable
         value={selectedMember}
-        onChange={(_e, value: SelectedMember[]) => {
-          setSelectedMember(value);
-          setFieldValue('selectedMembers', value);
-        }}
+        onChange={handleChange}
         renderTags={() => ''}
         inputValue={search}
-        onInputChange={(_e, newSearch: string, reason) =>
-          reason === 'input' && setSearch(newSearch)
-        }
-        filterOptions={x => x}
-        renderOption={(props, option: SelectedMember, state) => (
-          <MembersDropdownOption props={props} option={option} state={state} />
-        )}
+        onInputChange={handleInputChange}
+        filterOptions={handleFilterOptions}
+        renderOption={handleRenderOption}
         noOptionsText={t('common.noUsersAndGroupsFound')}
         clearOnEscape
         renderInput={params => (

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/AddMembersForm.tsx
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useDebounce } from 'react-use';
 
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { useApi } from '@backstage/core-plugin-api';
 
 import Autocomplete from '@mui/material/Autocomplete';
 import FormHelperText from '@mui/material/FormHelperText';
@@ -25,8 +27,8 @@ import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import IconButton from '@mui/material/IconButton';
 import { FormikErrors } from 'formik';
 
+import { rbacApiRef } from '../../api/RBACBackendClient';
 import { MemberEntity } from '../../types';
-import { useLanguage } from '../../hooks/useLanguage';
 import {
   getChildGroupsCount,
   getMembersCount,
@@ -74,14 +76,33 @@ const getDescription = (
     : undefined;
 };
 
+const toSelectedMember = (
+  member: MemberEntity,
+  index: number,
+  t: TranslationFunction<typeof rbacTranslationRef.T>,
+): SelectedMember => {
+  const tag =
+    member.metadata.etag ?? `${member.metadata.name}-${member.kind}-${index}`;
+  return {
+    id: tag,
+    label: member.spec?.profile?.displayName ?? member.metadata.name,
+    description: getDescription(member, t),
+    etag: tag,
+    type: member.kind,
+    namespace: member.metadata.namespace,
+    members: getMembersCount(member),
+    ref: stringifyEntityRef(member),
+  };
+};
+
 export const AddMembersForm = ({
   selectedMembers,
   selectedMembersError,
   setFieldValue,
   membersData,
 }: AddMembersFormProps) => {
-  const locale = useLanguage();
   const { t } = useTranslation();
+  const rbacApi = useApi(rbacApiRef);
   const [search, setSearch] = useState<string>('');
   const [selectedMember, setSelectedMember] =
     useState<SelectedMember[]>(selectedMembers);
@@ -89,39 +110,59 @@ export const AddMembersForm = ({
     setSelectedMember(selectedMembers);
   }, [selectedMembers]);
 
+  const [searchResults, setSearchResults] = useState<MemberEntity[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const performSearch = useCallback(
+    async (term: string) => {
+      setSearchLoading(true);
+      try {
+        const result = await rbacApi.searchMembers(term);
+        if (Array.isArray(result)) {
+          setSearchResults(result);
+        }
+      } finally {
+        setSearchLoading(false);
+      }
+    },
+    [rbacApi],
+  );
+
+  useDebounce(
+    () => {
+      performSearch(search);
+    },
+    300,
+    [search],
+  );
+
   const membersOptions: SelectedMember[] = useMemo(() => {
-    return membersData.members
-      ? membersData.members.map((member: MemberEntity, index: number) => {
-          const tag =
-            member.metadata.etag ??
-            `${member.metadata.name}-${member.kind}-${index}`;
-          return {
-            id: tag,
-            label: member.spec?.profile?.displayName ?? member.metadata.name,
-            description: getDescription(member, t),
-            etag: tag,
-            type: member.kind,
-            namespace: member.metadata.namespace,
-            members: getMembersCount(member),
-            ref: stringifyEntityRef(member),
-          };
-        })
-      : ([] as SelectedMember[]);
-  }, [membersData.members, t]);
+    const searchEntities = Array.isArray(searchResults) ? searchResults : [];
+    const initialEntities = membersData.members ?? [];
+    const primary = search ? searchEntities : initialEntities;
+    const secondary = search ? initialEntities : searchEntities;
+    const seen = new Set<string>();
+    const unique: MemberEntity[] = [];
+    for (const entity of primary) {
+      const ref = stringifyEntityRef(entity);
+      if (!seen.has(ref)) {
+        seen.add(ref);
+        unique.push(entity);
+      }
+    }
+    for (const entity of secondary) {
+      const ref = stringifyEntityRef(entity);
+      if (!seen.has(ref)) {
+        seen.add(ref);
+        unique.push(entity);
+      }
+    }
+    return unique.map((member, index) => toSelectedMember(member, index, t));
+  }, [searchResults, membersData.members, search, t]);
 
   const filteredMembers = useMemo(() => {
-    if (search) {
-      return membersOptions
-        .filter(m =>
-          m.label
-            .toLocaleLowerCase(locale)
-            .includes(search.toLocaleLowerCase(locale)),
-        )
-        .slice(0, 99);
-    }
-
     return membersOptions.slice(0, 99);
-  }, [membersOptions, search, locale]);
+  }, [membersOptions]);
 
   const handleIsOptionEqualToValue = (
     option: SelectedMember,
@@ -143,7 +184,7 @@ export const AddMembersForm = ({
         options={filteredMembers || []}
         getOptionLabel={(option: SelectedMember) => option.label ?? ''}
         isOptionEqualToValue={handleIsOptionEqualToValue}
-        loading={membersData.loading}
+        loading={searchLoading}
         loadingText={<LinearProgress />}
         disableClearable
         value={selectedMember}
@@ -156,6 +197,7 @@ export const AddMembersForm = ({
         onInputChange={(_e, newSearch: string, reason) =>
           reason === 'input' && setSearch(newSearch)
         }
+        filterOptions={x => x}
         renderOption={(props, option: SelectedMember, state) => (
           <MembersDropdownOption props={props} option={option} state={state} />
         )}

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/CreateRolePage.tsx
@@ -38,7 +38,7 @@ export const CreateRolePage = () => {
     value: members,
     error: membersError,
   } = useAsync(async () => {
-    return await rbacApi.getMembers();
+    return await rbacApi.getMembers(1, 1);
   });
 
   const canReadUsersAndGroups =
@@ -74,8 +74,8 @@ export const CreateRolePage = () => {
             permissionPoliciesTitle: t('roleForm.titles.permissionPolicies'),
           }}
           membersData={{
-            members: Array.isArray(members) ? members : ([] as MemberEntity[]),
-            loading: membersLoading,
+            members: [] as MemberEntity[],
+            loading: false,
             error: (membersError as unknown as Error) || {
               name: (members as unknown as Response)?.status,
               message: (members as unknown as Response)?.statusText,

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/MembersDropdownOption.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/MembersDropdownOption.tsx
@@ -43,7 +43,7 @@ export const MembersDropdownOption = ({
   return (
     <li
       {...props}
-      key={`${etag}`}
+      key={option.ref}
       style={{
         display: 'flex',
         flexDirection: 'column',
@@ -58,9 +58,9 @@ export const MembersDropdownOption = ({
         <div>
           <div>
             <Typography component="span" sx={{ marginTop: '0.5rem' }}>
-              {parts.map(part => (
+              {parts.map((part, index) => (
                 <Typography
-                  key={`${part.text}-${etag}`}
+                  key={`${index}-${etag}`}
                   component="span"
                   sx={{
                     fontWeight: !state.inputValue || part.highlight ? 400 : 700,

--- a/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.test.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/CreateRole/RoleForm.test.tsx
@@ -44,7 +44,9 @@ jest.mock('react-router-dom', () => ({
 
 jest.mock('@backstage/core-plugin-api', () => ({
   ...jest.requireActual('@backstage/core-plugin-api'),
-  useApi: jest.fn(),
+  useApi: jest.fn().mockReturnValue({
+    searchMembers: jest.fn().mockResolvedValue([]),
+  }),
 }));
 
 jest.mock('formik', () => ({

--- a/workspaces/rbac/plugins/rbac/src/hooks/useMembers.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useMembers.test.ts
@@ -22,22 +22,32 @@ jest.mock('./useLanguage', () => ({
 jest.mock('@backstage/core-plugin-api', () => {
   const { mockMembers } = require('../__fixtures__/mockMembers');
 
+  const memberRefs = [
+    'group:default/admins',
+    'user:default/amelia.park',
+    'user:default/calum.leavy',
+    'group:default/team-b',
+    'group:default/team-c',
+  ];
+
   return {
     ...jest.requireActual('@backstage/core-plugin-api'),
     useApi: jest.fn().mockReturnValue({
       getRole: jest.fn().mockReturnValue([
         {
-          memberReferences: [
-            'group:default/admins',
-            'user:default/amelia.park',
-            'user:default/calum.leavy',
-            'group:default/team-b',
-            'group:default/team-c',
-          ],
+          memberReferences: memberRefs,
           name: 'role:default/rbac_admin',
         },
       ]),
-      getMembers: jest.fn().mockReturnValue(mockMembers),
+      getMembers: jest.fn().mockReturnValue(mockMembers.slice(0, 1)),
+      getMembersByRefs: jest.fn().mockImplementation((refs: string[]) =>
+        refs.map(ref => {
+          const name = ref.split('/').pop();
+          return (
+            mockMembers.find((m: any) => m.metadata.name === name) ?? undefined
+          );
+        }),
+      ),
     }),
   };
 });

--- a/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { useAsyncRetry, useInterval } from 'react-use';
 
 import { parseEntityRef } from '@backstage/catalog-model';
@@ -23,6 +23,7 @@ import { rbacApiRef } from '../api/RBACBackendClient';
 import { MemberEntity, MembersData } from '../types';
 import { getMembersFromGroup } from '../utils/rbac-utils';
 import { useLanguage } from './useLanguage';
+import { useStableArray } from './useStableArray';
 import { useTranslation } from './useTranslation';
 
 export type MembersInfo = {
@@ -98,7 +99,6 @@ export const useMembers = (
   const rbacApi = useApi(rbacApiRef);
   const locale = useLanguage();
   const { t } = useTranslation();
-  let data: MembersData[] = [];
   const {
     value: role,
     retry: roleRetry,
@@ -114,18 +114,8 @@ export const useMembers = (
   const canReadUsersAndGroups =
     !authError && Array.isArray(authCheck) && authCheck.length > 0;
 
-  const prevRefs = useRef<string[]>([]);
-  const memberRefs = useMemo(() => {
-    const newRefs = Array.isArray(role) ? role[0].memberReferences : [];
-    if (
-      newRefs.length === prevRefs.current.length &&
-      newRefs.every((v, i) => v === prevRefs.current[i])
-    ) {
-      return prevRefs.current;
-    }
-    prevRefs.current = newRefs;
-    return newRefs;
-  }, [role]);
+  const rawRefs = Array.isArray(role) ? role[0].memberReferences : [];
+  const memberRefs = useStableArray(rawRefs);
 
   const {
     value: members,
@@ -140,7 +130,7 @@ export const useMembers = (
 
   const loading = !roleError && !membersError && !role && !members;
 
-  data = useMemo(
+  const data = useMemo(
     () =>
       Array.isArray(members)
         ? memberRefs.reduce(

--- a/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
@@ -16,7 +16,7 @@
 import { useMemo } from 'react';
 import { useAsyncRetry, useInterval } from 'react-use';
 
-import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
+import { parseEntityRef } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 
 import { rbacApiRef } from '../api/RBACBackendClient';
@@ -64,7 +64,7 @@ const getMemberData = (
   if (memberResource) {
     return {
       name:
-        memberResource.spec.profile?.displayName ??
+        memberResource.spec?.profile?.displayName ??
         memberResource.metadata.name,
       type: memberResource.kind,
       ref: {
@@ -107,34 +107,46 @@ export const useMembers = (
     return await rbacApi.getRole(roleName);
   });
 
+  const { value: authCheck, error: authError } = useAsyncRetry(async () => {
+    return await rbacApi.getMembers(1, 1);
+  });
+
+  const canReadUsersAndGroups =
+    !authError && Array.isArray(authCheck) && authCheck.length > 0;
+
+  const memberRefs = useMemo(
+    () => (Array.isArray(role) ? role[0].memberReferences : []),
+    [role],
+  );
+
   const {
     value: members,
     retry: membersRetry,
     error: membersError,
   } = useAsyncRetry(async () => {
-    return await rbacApi.getMembers();
-  });
-
-  const canReadUsersAndGroups =
-    !membersError && Array.isArray(members) && members.length > 0;
+    if (memberRefs.length === 0) {
+      return [];
+    }
+    return await rbacApi.getMembersByRefs(memberRefs);
+  }, [memberRefs]);
 
   const loading = !roleError && !membersError && !role && !members;
 
   data = useMemo(
     () =>
-      Array.isArray(role)
-        ? role[0].memberReferences.reduce((acc: MembersData[], ref: string) => {
-            const memberResource: MemberEntity | undefined = Array.isArray(
-              members,
-            )
-              ? members.find(member => stringifyEntityRef(member) === ref)
-              : undefined;
-            const memberData = getMemberData(memberResource, ref, locale);
-            acc.push(memberData);
-            return acc;
-          }, [])
+      Array.isArray(members)
+        ? memberRefs.reduce(
+            (acc: MembersData[], ref: string, index: number) => {
+              const memberResource: MemberEntity | undefined =
+                members[index] ?? undefined;
+              const memberData = getMemberData(memberResource, ref, locale);
+              acc.push(memberData);
+              return acc;
+            },
+            [],
+          )
         : [],
-    [role, members, locale],
+    [memberRefs, members, locale],
   );
 
   useInterval(

--- a/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useMembers.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useAsyncRetry, useInterval } from 'react-use';
 
 import { parseEntityRef } from '@backstage/catalog-model';
@@ -114,10 +114,18 @@ export const useMembers = (
   const canReadUsersAndGroups =
     !authError && Array.isArray(authCheck) && authCheck.length > 0;
 
-  const memberRefs = useMemo(
-    () => (Array.isArray(role) ? role[0].memberReferences : []),
-    [role],
-  );
+  const prevRefs = useRef<string[]>([]);
+  const memberRefs = useMemo(() => {
+    const newRefs = Array.isArray(role) ? role[0].memberReferences : [];
+    if (
+      newRefs.length === prevRefs.current.length &&
+      newRefs.every((v, i) => v === prevRefs.current[i])
+    ) {
+      return prevRefs.current;
+    }
+    prevRefs.current = newRefs;
+    return newRefs;
+  }, [role]);
 
   const {
     value: members,
@@ -152,7 +160,6 @@ export const useMembers = (
   useInterval(
     () => {
       roleRetry();
-      membersRetry();
     },
     loading ? null : pollInterval || 10000,
   );

--- a/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.test.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.test.ts
@@ -21,6 +21,7 @@ import { useSelectedMembers } from './useSelectedMembers';
 const apiMock = {
   getRole: jest.fn().mockImplementation(),
   getMembers: jest.fn().mockImplementation(),
+  getMembersByRefs: jest.fn().mockImplementation(),
 };
 
 jest.mock('@backstage/core-plugin-api', () => {
@@ -53,7 +54,19 @@ describe('useSelectedMembers', () => {
         },
       ];
     });
-    apiMock.getMembers = jest.fn().mockImplementation(async () => mockMembers);
+    apiMock.getMembers = jest
+      .fn()
+      .mockImplementation(async () => mockMembers.slice(0, 1));
+    apiMock.getMembersByRefs = jest
+      .fn()
+      .mockImplementation(async (refs: string[]) =>
+        refs.map(ref => {
+          const name = ref.split('/').pop();
+          return (
+            mockMembers.find((m: any) => m.metadata.name === name) ?? undefined
+          );
+        }),
+      );
   });
 
   it('should throw an error on get role', async () => {

--- a/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useAsync } from 'react-use';
 
 import { useApi } from '@backstage/core-plugin-api';
@@ -40,10 +40,18 @@ export const useSelectedMembers = (
   const rbacApi = useApi(rbacApiRef);
   const { role, loading: roleLoading, roleError } = useRole(roleName);
 
-  const memberRefs = useMemo(
-    () => (role ? (role as Role).memberReferences : []),
-    [role],
-  );
+  const prevRefs = useRef<string[]>([]);
+  const memberRefs = useMemo(() => {
+    const newRefs = role ? (role as Role).memberReferences : [];
+    if (
+      newRefs.length === prevRefs.current.length &&
+      newRefs.every((v, i) => v === prevRefs.current[i])
+    ) {
+      return prevRefs.current;
+    }
+    prevRefs.current = newRefs;
+    return newRefs;
+  }, [role]);
 
   const {
     loading: authLoading,

--- a/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
-import { stringifyEntityRef } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 
 import { Role } from '@backstage-community/plugin-rbac-common';
@@ -40,42 +40,70 @@ export const useSelectedMembers = (
   const rbacApi = useApi(rbacApiRef);
   const { role, loading: roleLoading, roleError } = useRole(roleName);
 
+  const memberRefs = useMemo(
+    () => (role ? (role as Role).memberReferences : []),
+    [role],
+  );
+
   const {
-    loading: membersLoading,
-    value: members,
-    error: membersError,
+    loading: authLoading,
+    value: authCheck,
+    error: authError,
   } = useAsync(async () => {
-    return await rbacApi.getMembers();
+    return await rbacApi.getMembers(1, 1);
   });
 
+  const {
+    loading: selectedLoading,
+    value: selectedEntities,
+    error: selectedError,
+  } = useAsync(async () => {
+    if (memberRefs.length === 0) {
+      return [];
+    }
+    return await rbacApi.getMembersByRefs(memberRefs);
+  }, [memberRefs]);
+
   const canReadUsersAndGroups =
-    !membersLoading &&
-    !membersError &&
-    Array.isArray(members) &&
-    members.length > 0;
+    !authLoading &&
+    !authError &&
+    Array.isArray(authCheck) &&
+    authCheck.length > 0;
 
-  const data: SelectedMember[] = role
-    ? (role as Role).memberReferences.reduce((acc: SelectedMember[], ref) => {
-        const memberResource =
-          (Array.isArray(members) &&
-            members.find(member => stringifyEntityRef(member) === ref)) ||
-          undefined;
-        acc.push(getSelectedMember(memberResource, ref));
+  const members: MemberEntity[] = useMemo(
+    () =>
+      Array.isArray(selectedEntities)
+        ? (selectedEntities.filter(Boolean) as MemberEntity[])
+        : [],
+    [selectedEntities],
+  );
 
-        return acc;
-      }, [])
-    : [];
+  const data: SelectedMember[] = useMemo(
+    () =>
+      Array.isArray(selectedEntities)
+        ? memberRefs.reduce(
+            (acc: SelectedMember[], ref: string, index: number) => {
+              const memberResource =
+                (selectedEntities[index] as MemberEntity) ?? undefined;
+              acc.push(getSelectedMember(memberResource, ref));
+              return acc;
+            },
+            [],
+          )
+        : [],
+    [memberRefs, selectedEntities],
+  );
 
   return {
     selectedMembers: data,
-    members: Array.isArray(members) ? members : ([] as MemberEntity[]),
+    members,
     role,
-    membersError: (membersError as Error) || {
-      name: (members as Response)?.status,
-      message: (members as Response)?.statusText,
+    membersError: ((authError || selectedError) as Error) || {
+      name: (authCheck as unknown as Response)?.status,
+      message: (authCheck as unknown as Response)?.statusText,
     },
     roleError: roleError,
-    loading: roleLoading || membersLoading,
+    loading: roleLoading || authLoading || selectedLoading,
     canReadUsersAndGroups,
   };
 };

--- a/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useSelectedMembers.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { useApi } from '@backstage/core-plugin-api';
@@ -25,6 +25,7 @@ import { SelectedMember } from '../components/CreateRole/types';
 import { MemberEntity } from '../types';
 import { getSelectedMember } from '../utils/rbac-utils';
 import { useRole } from './useRole';
+import { useStableArray } from './useStableArray';
 
 export const useSelectedMembers = (
   roleName: string,
@@ -40,18 +41,8 @@ export const useSelectedMembers = (
   const rbacApi = useApi(rbacApiRef);
   const { role, loading: roleLoading, roleError } = useRole(roleName);
 
-  const prevRefs = useRef<string[]>([]);
-  const memberRefs = useMemo(() => {
-    const newRefs = role ? (role as Role).memberReferences : [];
-    if (
-      newRefs.length === prevRefs.current.length &&
-      newRefs.every((v, i) => v === prevRefs.current[i])
-    ) {
-      return prevRefs.current;
-    }
-    prevRefs.current = newRefs;
-    return newRefs;
-  }, [role]);
+  const rawRefs = role ? (role as Role).memberReferences : [];
+  const memberRefs = useStableArray(rawRefs);
 
   const {
     loading: authLoading,

--- a/workspaces/rbac/plugins/rbac/src/hooks/useStableArray.ts
+++ b/workspaces/rbac/plugins/rbac/src/hooks/useStableArray.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useRef } from 'react';
+
+export function useStableArray(arr: string[]): string[] {
+  const ref = useRef(arr);
+  if (
+    arr.length !== ref.current.length ||
+    arr.some((v, i) => v !== ref.current[i])
+  ) {
+    ref.current = arr;
+  }
+  return ref.current;
+}

--- a/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.ts
+++ b/workspaces/rbac/plugins/rbac/src/utils/rbac-utils.ts
@@ -399,7 +399,7 @@ export const getSelectedMember = (
       id: memberResource.metadata.etag as string,
       ref: stringifyEntityRef(memberResource),
       label:
-        memberResource.spec.profile?.displayName ??
+        memberResource.spec?.profile?.displayName ??
         memberResource.metadata.name,
       etag: memberResource.metadata.etag as string,
       type: memberResource.kind,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Improves RBAC create/edit role page performance. 

## Summary

- Replace upfront loading of all catalog users/groups with server-side search (`searchMembers`) fetching only the members assigned to a role (`getMembersByRefs`)
- Add debounced search (300ms) to the users/groups dropdown with first 100 entities loaded by default
- Fetch only required fields when resolving member references, with batching (2000 per request)
- Change `getMembers()` calls to `getMembers(1, 1)` for authentication checks (eg: to enable edit button in role page) instead of fetching all entities




## Screenshots:

## Before fix


| Issues  | Screenshots |
| ------------- | ------------- |
| Stuck in loading phase|<img width="1915" height="928" alt="edit_page_stuck_in_loading" src="https://github.com/user-attachments/assets/3303d414-fd06-40e8-9ede-3b58334e49d6" /> |
| Unresponsive browser|  <img width="1913" height="1006" alt="Unresponsive" src="https://github.com/user-attachments/assets/0b3007e4-0cef-4c56-9562-5d582a2288ca" /> |
| Edit button in role edit page disabled for a very long time. | <img width="1915" height="923" alt="Edit_button_disabled" src="https://github.com/user-attachments/assets/304c73db-f89d-4a77-b6dd-8d52b5f00bdf" /> |











## After fix


https://github.com/user-attachments/assets/fb2b680a-a7a0-4265-bec5-e96efdc38530


## How to test


1. Add the following to your `app-config.yaml` under `catalog.locations`:

   ```yaml
   - type: url
     target: https://github.com/karthikjeeyar/DevRepo/blob/master/load-testing/5k-org-entities.yaml
     rules:
       - allow: [User, Group]
      ``` 

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
