### PR TITLE
fix(codecov): point codecov upload at workspace root where coverage files live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspaceNodeMatrix.workspace }}
-          directory: ./workspaces/${{ matrix.workspaceNodeMatrix.workspace }}/plugins
+          directory: ./workspaces/${{ matrix.workspaceNodeMatrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -132,6 +132,6 @@ jobs:
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: ${{ matrix.workspace }}
-          directory: ./workspaces/${{ matrix.workspace }}/plugins
+          directory: ./workspaces/${{ matrix.workspace }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Just a small change to correct where the CI looks for the coverage files (at the workspace root as opposed to under the `plugins/` directory). This should fix the lack of coverage uploads - see an example failed run [here](https://github.com/backstage/community-plugins/actions/runs/31803091467/job/94775611249#step:7:316).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
