### PR TITLE
Version Packages (announcements)

### DIFF
--- a/workspaces/announcements/.changeset/grumpy-lions-drive.md
+++ b/workspaces/announcements/.changeset/grumpy-lions-drive.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-announcements': minor
----
-
-Inactive announcements are no longer indexed for search. This fixes an issue where inactive announcements were still being returned in search results.

--- a/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-announcements
 
+## 0.21.0
+
+### Minor Changes
+
+- 4aa61e2: Inactive announcements are no longer indexed for search. This fixes an issue where inactive announcements were still being returned in search results.
+
 ## 0.20.0
 
 ### Minor Changes

--- a/workspaces/announcements/plugins/search-backend-module-announcements/package.json
+++ b/workspaces/announcements/plugins/search-backend-module-announcements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-search-backend-module-announcements",
   "description": "The announcements backend module for the search plugin.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-search-backend-module-announcements@0.21.0

### Minor Changes

-   4aa61e2: Inactive announcements are no longer indexed for search. This fixes an issue where inactive announcements were still being returned in search results.
