### PR TITLE
Enabled 'codecov' for all RHDH maintained plugins

### DIFF
--- a/workspaces/3scale/bcp.json
+++ b/workspaces/3scale/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/acr/bcp.json
+++ b/workspaces/acr/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/argocd/bcp.json
+++ b/workspaces/argocd/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/jfrog-artifactory/bcp.json
+++ b/workspaces/jfrog-artifactory/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "playwrightTests": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/keycloak/bcp.json
+++ b/workspaces/keycloak/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/multi-source-security-viewer/bcp.json
+++ b/workspaces/multi-source-security-viewer/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": false,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/nexus-repository-manager/bcp.json
+++ b/workspaces/nexus-repository-manager/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "playwrightTests": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/npm/bcp.json
+++ b/workspaces/npm/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/ocm/bcp.json
+++ b/workspaces/ocm/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/pingidentity/bcp.json
+++ b/workspaces/pingidentity/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/quay/bcp.json
+++ b/workspaces/quay/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "playwrightTests": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-backend-module-annotator/bcp.json
+++ b/workspaces/scaffolder-backend-module-annotator/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-backend-module-kubernetes/bcp.json
+++ b/workspaces/scaffolder-backend-module-kubernetes/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-backend-module-regex/bcp.json
+++ b/workspaces/scaffolder-backend-module-regex/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-backend-module-servicenow/bcp.json
+++ b/workspaces/scaffolder-backend-module-servicenow/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-backend-module-sonarqube/bcp.json
+++ b/workspaces/scaffolder-backend-module-sonarqube/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/scaffolder-relation-processor/bcp.json
+++ b/workspaces/scaffolder-relation-processor/bcp.json
@@ -1,5 +1,6 @@
 {
   "autoVersionBump": true,
   "knipReports": true,
-  "listDeprecations": true
+  "listDeprecations": true,
+  "codecov": true
 }

--- a/workspaces/servicenow/bcp.json
+++ b/workspaces/servicenow/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": false,
   "listDeprecations": false,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/tekton/bcp.json
+++ b/workspaces/tekton/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }

--- a/workspaces/topology/bcp.json
+++ b/workspaces/topology/bcp.json
@@ -2,5 +2,6 @@
   "autoVersionBump": true,
   "knipReports": true,
   "listDeprecations": true,
-  "playwrightTests": true
+  "playwrightTests": true,
+  "codecov": true
 }


### PR DESCRIPTION
Enabled the check for workspaces owned by RHDH. Rbac was already enabled.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
