### PR TITLE
feat(copilot): support GitHub Enterprise Cloud with data residency (GHE.com)

### DIFF
--- a/workspaces/copilot/.changeset/copilot-ghe-com-api-base-url.md
+++ b/workspaces/copilot/.changeset/copilot-ghe-com-api-base-url.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-copilot-backend': minor
+---
+
+Added support for GitHub Enterprise Cloud with data residency (GHE.com), including a new optional `copilot.apiBaseUrl` setting and a fix so GitHub App authentication targets the configured API host instead of always using `api.github.com`. Report downloads are now allowed from the configured `copilot.host` and its subdomains rather than a fixed list of `github.com` hosts, so GitHub Enterprise Server setups can download reports from their own instance too. An invalid `copilot.apiBaseUrl` is rejected on startup instead of silently falling back to the public GitHub API.

--- a/workspaces/copilot/plugins/copilot-backend/README.md
+++ b/workspaces/copilot/plugins/copilot-backend/README.md
@@ -70,6 +70,7 @@ To install the plugin using the legacy backend system:
 Configure the following `app-config.yaml` values:
 
 - `copilot.host`: GitHub host for the integration, such as `github.com`.
+- `copilot.apiBaseUrl`: Optional override for the base URL of the GitHub REST API. Falls back to `apiBaseUrl` on the matching `integrations.github` entry, then to `https://api.github.com`.
 - `copilot.enterprise`: Optional GitHub enterprise slug.
 - `copilot.organization`: Optional GitHub organization slug.
 - `copilot.schedule`: Optional Backstage scheduler configuration for recurring ingestion.
@@ -101,6 +102,26 @@ copilot:
 ```
 
 `defaultView` and `showLegacyView` are consumed by the frontend plugin, but they commonly live in the same `copilot` config block.
+
+### GitHub Enterprise Cloud With Data Residency (GHE.com)
+
+If your enterprise is hosted on a dedicated GHE.com subdomain, point the integration at that subdomain and set its `apiBaseUrl` to the tenant's API host:
+
+```yaml
+integrations:
+  github:
+    - host: octocorp.ghe.com
+      apiBaseUrl: https://api.octocorp.ghe.com
+      token: ${GITHUB_TOKEN}
+
+copilot:
+  host: octocorp.ghe.com
+  enterprise: octocorp
+```
+
+`copilot.apiBaseUrl` is only needed if you want the plugin to use a different API host than the rest of Backstage. Note that Backstage only defaults `apiBaseUrl` for `github.com`, so on any other host you must set it in one place or the other — otherwise the plugin falls back to the public `https://api.github.com`.
+
+Report documents are downloaded from signed URLs. GitHub serves those from `copilot-reports.github.com`, or `copilot-reports.SUBDOMAIN.ghe.com` on GHE.com, and documents a fallback to Azure Blob Storage. The plugin only follows such links over HTTPS, and only to the configured `copilot.host` and its subdomains, to `githubusercontent.com` and its subdomains, or to the documented object storage hosts. Redirects are re-checked against the same rules on every hop.
 
 ### Why V2 Exists
 

--- a/workspaces/copilot/plugins/copilot-backend/config.d.ts
+++ b/workspaces/copilot/plugins/copilot-backend/config.d.ts
@@ -39,6 +39,17 @@ export interface Config {
      */
     host: string;
     /**
+     * Base URL of the GitHub REST API to call.
+     *
+     * Set this when the host is not `github.com`, for example a GitHub
+     * Enterprise Cloud with data residency tenant on GHE.com, where the API
+     * lives at `https://api.SUBDOMAIN.ghe.com`.
+     *
+     * Falls back to `apiBaseUrl` from the matching `integrations.github` entry.
+     * @default 'https://api.github.com'
+     */
+    apiBaseUrl?: string;
+    /**
      * Earliest date to ingest for v2. Must be >= '2025-10-10' (GitHub API limit).
      * On first run the task backfills every calendar day from this date to yesterday.
      * @default '2025-10-10'

--- a/workspaces/copilot/plugins/copilot-backend/src/client/GithubClientV2.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/client/GithubClientV2.test.ts
@@ -74,7 +74,7 @@ describe('GithubClientV2', () => {
   it('downloadDocument rejects disallowed hosts (SSRF guard)', async () => {
     const client = await GithubClientV2.fromConfig(mockConfig, mockLogger);
     await expect(
-      client.downloadDocument('http://internal.example.com/evil'),
+      client.downloadDocument('https://internal.example.com/evil'),
     ).rejects.toThrow(/Refused to download from disallowed host/i);
   });
 
@@ -133,6 +133,242 @@ describe('GithubClientV2', () => {
     expect(result).toEqual(fakeJson);
   });
 
+  it('scopes the download host allowlist to the configured GitHub host', async () => {
+    const mockFetch = (global as any).fetch as jest.MockedFunction<any>;
+    const fakeJson = { ok: true };
+    const download = (client: GithubClientV2, url: string) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(JSON.stringify(fakeJson)),
+        status: 200,
+        statusText: 'OK',
+      });
+      return client.downloadDocument(url);
+    };
+
+    const gheClient = new GithubClientV2(
+      {
+        host: 'octocorp.ghe.com',
+        enterprise: 'octocorp',
+        apiBaseUrl: 'https://api.octocorp.ghe.com',
+      },
+      mockConfig,
+      mockLogger,
+    );
+
+    await expect(
+      download(gheClient, 'https://objects.octocorp.ghe.com/report.json?sig=a'),
+    ).resolves.toEqual(fakeJson);
+    await expect(
+      download(
+        gheClient,
+        'https://mystorage.blob.core.windows.net/report.json?sig=b',
+      ),
+    ).resolves.toEqual(fakeJson);
+    await expect(
+      download(
+        gheClient,
+        'https://raw.githubusercontent.com/report.json?sig=c',
+      ),
+    ).resolves.toEqual(fakeJson);
+
+    // A GHE.com tenant must not trust github.com or another tenant.
+    await expect(
+      download(gheClient, 'https://downloads.github.com/report.json?sig=d'),
+    ).rejects.toThrow(/Refused to download from disallowed host/i);
+    await expect(
+      download(gheClient, 'https://objects.evilcorp.ghe.com/report.json'),
+    ).rejects.toThrow(/Refused to download from disallowed host/i);
+
+    // And a github.com deployment must not trust a GHE.com tenant.
+    const dotComClient = await GithubClientV2.fromConfig(
+      mockConfig,
+      mockLogger,
+    );
+    await expect(
+      download(dotComClient, 'https://objects.octocorp.ghe.com/report.json'),
+    ).rejects.toThrow(/Refused to download from disallowed host/i);
+
+    // Object storage is a documented fallback for both, so it stays allowed
+    // regardless of which host is configured.
+    await expect(
+      download(dotComClient, 'https://mystorage.blob.core.windows.net/r.json'),
+    ).resolves.toEqual(fakeJson);
+
+    // The guard must reject before issuing the request, so only the four
+    // allowed downloads ever reached fetch.
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('normalises the configured host and rejects non-https download links', async () => {
+    const mockFetch = (global as any).fetch as jest.MockedFunction<any>;
+    const fakeJson = { ok: true };
+    const download = (client: GithubClientV2, url: string) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: jest.fn().mockResolvedValue(JSON.stringify(fakeJson)),
+        status: 200,
+        statusText: 'OK',
+      });
+      return client.downloadDocument(url);
+    };
+
+    // Casing and a port on copilot.host must not break host matching, and the
+    // host itself is allowed, not just its subdomains.
+    const gheClient = new GithubClientV2(
+      {
+        host: 'Octocorp.GHE.com:8443',
+        enterprise: 'octocorp',
+        apiBaseUrl: 'https://api.octocorp.ghe.com',
+      },
+      mockConfig,
+      mockLogger,
+    );
+
+    await expect(
+      download(gheClient, 'https://octocorp.ghe.com/report.json?sig=a'),
+    ).resolves.toEqual(fakeJson);
+
+    // Plain HTTP is never followed, even on an otherwise allowed host.
+    await expect(
+      download(gheClient, 'http://objects.octocorp.ghe.com/report.json'),
+    ).rejects.toThrow(/Refused to download over insecure protocol: http:/i);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-applies the host allowlist to redirect targets', async () => {
+    const client = await GithubClientV2.fromConfig(mockConfig, mockLogger);
+    const mockFetch = (global as any).fetch as jest.MockedFunction<any>;
+
+    // A signed link on an allowed host must not be able to bounce the download
+    // to an internal address.
+    mockFetch.mockResolvedValueOnce({
+      status: 302,
+      statusText: 'Found',
+      ok: false,
+      headers: { get: () => 'https://169.254.169.254/latest/meta-data/' },
+      text: jest.fn().mockResolvedValue(''),
+    });
+
+    await expect(
+      client.downloadDocument('https://downloads.github.com/report.json?sig=a'),
+    ).rejects.toThrow(/Refused to download from disallowed host/i);
+
+    // A redirect that stays within the allowlist is followed.
+    mockFetch.mockResolvedValueOnce({
+      status: 302,
+      statusText: 'Found',
+      ok: false,
+      headers: { get: () => 'https://my-bucket.s3.amazonaws.com/report.json' },
+      text: jest.fn().mockResolvedValue(''),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+    });
+
+    await expect(
+      client.downloadDocument('https://downloads.github.com/report.json?sig=b'),
+    ).resolves.toEqual({ ok: true });
+
+    // `redirect: 'manual'` is what makes the per-hop re-check reachable at all;
+    // without it undici would follow redirects internally and bypass the guard.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      3,
+      'https://my-bucket.s3.amazonaws.com/report.json',
+      { redirect: 'manual' },
+    );
+  });
+
+  it('points the GitHub App installation lookup at the configured API base url', async () => {
+    const { getCopilotConfig, getGithubCredentials } = jest.requireMock(
+      '../utils/GithubUtils',
+    );
+    getCopilotConfig.mockReturnValueOnce({
+      host: 'octocorp.ghe.com',
+      enterprise: 'octocorp',
+      apiBaseUrl: 'https://api.octocorp.ghe.com',
+    });
+    getGithubCredentials.mockResolvedValueOnce({
+      enterprise: { appId: 123, privateKey: 'private-key' },
+    });
+    mockRequest.mockResolvedValueOnce({ data: { download_links: [] } });
+
+    const client = await GithubClientV2.fromConfig(mockConfig, mockLogger);
+    await client.fetchEnterpriseReportLinks('2026-01-01');
+
+    // Both the installation-lookup client and the report client must target the
+    // tenant's API. The lookup one used to always hit api.github.com.
+    const MockedOctokit = Octokit as unknown as jest.Mock;
+    expect(MockedOctokit.mock.calls[0][0].baseUrl).toBe(
+      'https://api.octocorp.ghe.com',
+    );
+    expect(MockedOctokit.mock.calls[1][0].baseUrl).toBe(
+      'https://api.octocorp.ghe.com',
+    );
+  });
+
+  it('resolves relative redirects and rejects malformed redirect chains', async () => {
+    const client = await GithubClientV2.fromConfig(mockConfig, mockLogger);
+    const mockFetch = (global as any).fetch as jest.MockedFunction<any>;
+    const redirectTo = (location: string | null) => ({
+      status: 302,
+      statusText: 'Found',
+      ok: false,
+      headers: { get: () => location },
+      text: jest.fn().mockResolvedValue(''),
+    });
+
+    // A relative Location resolves against the URL it came from.
+    mockFetch.mockResolvedValueOnce(redirectTo('/reports/final.json'));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: jest.fn().mockResolvedValue(JSON.stringify({ ok: true })),
+    });
+
+    await expect(
+      client.downloadDocument(
+        'https://my-bucket.s3.eu-north-1.amazonaws.com/a/b.json?sig=1',
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://my-bucket.s3.eu-north-1.amazonaws.com/reports/final.json',
+      { redirect: 'manual' },
+    );
+
+    // A redirect without a Location header is an error, not a silent retry.
+    mockFetch.mockResolvedValueOnce(redirectTo(null));
+    await expect(
+      client.downloadDocument('https://downloads.github.com/r.json?sig=2'),
+    ).rejects.toThrow(/without a location header/i);
+
+    // A Location that will not parse must not surface the signed URL, which
+    // Node attaches to the error it throws.
+    mockFetch.mockResolvedValueOnce(redirectTo('http://%'));
+    const error: any = await client
+      .downloadDocument('https://downloads.github.com/r.json?sig=secret')
+      .catch(e => e);
+    expect(error.message).toBe('Malformed redirect location');
+    // Node attaches the base URL to the error it throws; ours must not.
+    expect(Object.keys(error)).not.toContain('base');
+    expect(JSON.stringify(error)).not.toContain('sig=secret');
+
+    // And an endless redirect chain is capped rather than spinning forever.
+    mockFetch.mockResolvedValue(
+      redirectTo('https://downloads.github.com/loop.json'),
+    );
+    await expect(
+      client.downloadDocument('https://downloads.github.com/loop.json?sig=3'),
+    ).rejects.toThrow(/exceeded 5 redirects/i);
+  });
+
   it('downloadDocument throws on non-OK HTTP status', async () => {
     const client = await GithubClientV2.fromConfig(mockConfig, mockLogger);
     const mockFetch = (global as any).fetch as jest.MockedFunction<any>;
@@ -172,6 +408,7 @@ describe('GithubClientV2', () => {
     const MockedOctokit = Octokit as unknown as jest.Mock;
     const firstCallArgs = MockedOctokit.mock.calls[0][0] as any;
     expect(firstCallArgs.headers['X-GitHub-Api-Version']).toBe('2026-03-10');
+    expect(firstCallArgs.baseUrl).toBe('https://api.github.com');
 
     expect(res.download_links[0]).toContain('s3.amazonaws.com');
   });

--- a/workspaces/copilot/plugins/copilot-backend/src/client/GithubClientV2.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/client/GithubClientV2.ts
@@ -27,21 +27,56 @@ import {
   getGithubCredentials,
 } from '../utils/GithubUtils';
 
-// Allowed hosts for signed URL download (SSRF guard)
-const ALLOWED_DOWNLOAD_HOSTS = [
-  /^[a-zA-Z0-9-]+\.github\.com$/,
-  /^[a-zA-Z0-9-]+\.githubusercontent\.com$/,
+// GitHub serves user content from this domain on both github.com and GHE.com.
+const GITHUB_USER_CONTENT_DOMAIN = 'githubusercontent.com';
+
+// Object storage the signed report links can fall back to. GitHub documents the
+// Azure Blob Storage fallback for github.com and GHE.com alike, so this list is
+// not scoped to the configured host.
+const STORAGE_DOWNLOAD_HOSTS = [
   /^[a-zA-Z0-9.-]+\.s3\.amazonaws\.com$/,
   /^[a-zA-Z0-9.-]+\.s3\.[a-z0-9-]+\.amazonaws\.com$/,
+  /^[a-zA-Z0-9-]+\.blob\.core\.windows\.net$/,
 ];
 
-function isAllowedDownloadHost(url: string): boolean {
+// Follow at most this many redirects, re-checking the allowlist on every hop.
+const MAX_DOWNLOAD_REDIRECTS = 5;
+
+function isWithinDomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+// `copilot.host` may carry a port, which URL.hostname never does.
+function normalizeConfiguredHost(githubHost: string): string {
   try {
-    const { hostname } = new URL(url);
-    return ALLOWED_DOWNLOAD_HOSTS.some(pattern => pattern.test(hostname));
+    return new URL(`https://${githubHost}`).hostname;
   } catch {
+    return githubHost.toLowerCase();
+  }
+}
+
+/**
+ * SSRF guard for signed report download links. The allowed hosts are derived
+ * from the configured GitHub host so that a github.com deployment never trusts
+ * a GHE.com tenant, and vice versa.
+ */
+function isAllowedDownloadHost(url: URL, githubHost: string): boolean {
+  const hostname = url.hostname.toLowerCase();
+  const host = normalizeConfiguredHost(githubHost);
+
+  // An empty host would make every domain check below match.
+  if (!host) {
     return false;
   }
+
+  if (
+    isWithinDomain(hostname, host) ||
+    isWithinDomain(hostname, GITHUB_USER_CONTENT_DOMAIN)
+  ) {
+    return true;
+  }
+
+  return STORAGE_DOWNLOAD_HOSTS.some(pattern => pattern.test(hostname));
 }
 
 export class GithubClientV2 {
@@ -87,6 +122,7 @@ export class GithubClientV2 {
       octokitConfig.auth = authStrategy;
     } else {
       const appOctokit = new Octokit({
+        baseUrl: this.copilotConfig.apiBaseUrl,
         authStrategy: createAppAuth,
         auth: {
           appId: authStrategy.appId,
@@ -187,7 +223,8 @@ export class GithubClientV2 {
 
   /**
    * Download a signed document URL containing a JSON payload (array or object).
-   * SSRF guard: only allows downloads from known GitHub/AWS S3 hosts.
+   * SSRF guard: only allows downloads from hosts derived from the configured
+   * GitHub host, plus the documented object storage fallbacks.
    * Logs only origin+pathname (never query string which contains credentials).
    * Use for entity-level reports (enterprise-1-day, organization-1-day).
    */
@@ -218,30 +255,81 @@ export class GithubClientV2 {
     return rows;
   }
 
-  private async downloadText(url: string): Promise<string> {
+  /**
+   * Parses a download URL and applies the SSRF guard. Called for the initial
+   * URL and again for every redirect target, so a signed link on an allowed
+   * host cannot bounce the download to an internal address.
+   */
+  private assertAllowedDownloadUrl(url: string): URL {
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(url);
     } catch {
-      throw new Error(`Malformed URL: ${url}`);
+      // The URL carries a signature, so it must never reach the logs.
+      throw new Error('Malformed download URL');
     }
 
-    if (!isAllowedDownloadHost(url)) {
+    if (parsedUrl.protocol !== 'https:') {
+      throw new Error(
+        `Refused to download over insecure protocol: ${parsedUrl.protocol}`,
+      );
+    }
+
+    if (!isAllowedDownloadHost(parsedUrl, this.copilotConfig.host)) {
       throw new Error(
         `Refused to download from disallowed host: ${parsedUrl.hostname}`,
       );
     }
-    const { origin, pathname } = parsedUrl;
-    this.logger.debug(
-      `[GithubClientV2] Downloading document: ${origin}${pathname}`,
-    );
 
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to download document: HTTP ${response.status} ${response.statusText}`,
+    return parsedUrl;
+  }
+
+  private async downloadText(url: string): Promise<string> {
+    let currentUrl = url;
+
+    for (let hop = 0; hop <= MAX_DOWNLOAD_REDIRECTS; hop++) {
+      const { origin, pathname } = this.assertAllowedDownloadUrl(currentUrl);
+      this.logger.debug(
+        `[GithubClientV2] Downloading document: ${origin}${pathname}`,
       );
+
+      const response = await fetch(currentUrl, { redirect: 'manual' });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get('location');
+        if (!location) {
+          throw new Error(
+            `Failed to download document: HTTP ${response.status} ${response.statusText} without a location header`,
+          );
+        }
+        // Drain the redirect body so undici can reuse the connection. A
+        // truncated body must not fail a download whose target we already have.
+        await response.text().catch(() => undefined);
+
+        let nextUrl: URL;
+        try {
+          nextUrl = new URL(location, currentUrl);
+        } catch {
+          // Node attaches the base URL, which carries a signature, to the
+          // thrown error, so none of it may reach the caller.
+          throw new Error('Malformed redirect location');
+        }
+
+        currentUrl = nextUrl.toString();
+        continue;
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download document: HTTP ${response.status} ${response.statusText}`,
+        );
+      }
+
+      return response.text();
     }
-    return response.text();
+
+    throw new Error(
+      `Failed to download document: exceeded ${MAX_DOWNLOAD_REDIRECTS} redirects`,
+    );
   }
 }

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.test.ts
@@ -83,6 +83,83 @@ describe('getCopilotConfig', () => {
       'Organization API for copilot works with both classic and fine grained PAT tokens or GitHub apps. No token or app is configured for "github.com" in the config.',
     );
   });
+
+  it('resolves the api base url from copilot config, the integration, then the default', () => {
+    const buildConfig = (host: string, copilot: object, integration?: object) =>
+      mockServices.rootConfig({
+        data: {
+          integrations: {
+            github: [{ host, token: 'token', ...integration }],
+          },
+          copilot: { host, organization: 'test', ...copilot },
+        },
+      });
+
+    // Nothing configured on a github.com host.
+    expect(getCopilotConfig(buildConfig('github.com', {})).apiBaseUrl).toBe(
+      'https://api.github.com',
+    );
+
+    // Nothing configured anywhere: Backstage leaves the integration's
+    // apiBaseUrl undefined for non-github.com hosts, so the default applies.
+    expect(
+      getCopilotConfig(buildConfig('octocorp.ghe.com', {})).apiBaseUrl,
+    ).toBe('https://api.github.com');
+
+    // The integration wins over the default.
+    expect(
+      getCopilotConfig(
+        buildConfig(
+          'ghes.example.com',
+          {},
+          { apiBaseUrl: 'https://ghes.example.com/api/v3' },
+        ),
+      ).apiBaseUrl,
+    ).toBe('https://ghes.example.com/api/v3');
+
+    // copilot.apiBaseUrl wins over the integration, and is trimmed.
+    expect(
+      getCopilotConfig(
+        buildConfig(
+          'octocorp.ghe.com',
+          { apiBaseUrl: '  https://api.octocorp.ghe.com/  ' },
+          { apiBaseUrl: 'https://ghes.example.com/api/v3' },
+        ),
+      ).apiBaseUrl,
+    ).toBe('https://api.octocorp.ghe.com');
+
+    // An invalid value on the plugin's own key is rejected outright rather than
+    // silently falling back to the public GitHub API.
+    for (const invalid of ['/', ' ', 'api.octocorp.ghe.com', 'ftp://ghe.com']) {
+      expect(() =>
+        getCopilotConfig(
+          buildConfig('octocorp.ghe.com', { apiBaseUrl: invalid }),
+        ),
+      ).toThrow(/Invalid "copilot.apiBaseUrl" value/);
+    }
+  });
+
+  it('supports a GHE.com data residency host', () => {
+    const mockConfig = mockServices.rootConfig({
+      data: {
+        integrations: {
+          github: [{ host: 'octocorp.ghe.com', token: 'token' }],
+        },
+        copilot: {
+          host: 'octocorp.ghe.com',
+          apiBaseUrl: 'https://api.octocorp.ghe.com',
+          enterprise: 'octocorp',
+        },
+      },
+    });
+
+    expect(getCopilotConfig(mockConfig)).toEqual({
+      host: 'octocorp.ghe.com',
+      enterprise: 'octocorp',
+      organization: undefined,
+      apiBaseUrl: 'https://api.octocorp.ghe.com',
+    });
+  });
 });
 
 describe('getGithubCredentials', () => {

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/GithubUtils.ts
@@ -32,10 +32,34 @@ export type CopilotConfig = {
   apiBaseUrl: string;
 };
 
+const DEFAULT_API_BASE_URL = 'https://api.github.com';
+
+const resolveApiBaseUrl = (value: string): string => {
+  const trimmed = value.trim().replace(/\/+$/, '');
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `Invalid "copilot.apiBaseUrl" value "${value}". Expected an absolute URL such as "https://api.octocorp.ghe.com".`,
+    );
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(
+      `Invalid "copilot.apiBaseUrl" value "${value}". Only http and https are supported.`,
+    );
+  }
+
+  return trimmed;
+};
+
 export const getCopilotConfig = (config: Config): CopilotConfig => {
   const host = config.getString('copilot.host');
   const enterprise = config.getOptionalString('copilot.enterprise');
   const organization = config.getOptionalString('copilot.organization');
+  const apiBaseUrl = config.getOptionalString('copilot.apiBaseUrl');
 
   const integrations = ScmIntegrations.fromConfig(config);
 
@@ -63,7 +87,11 @@ export const getCopilotConfig = (config: Config): CopilotConfig => {
     host,
     enterprise,
     organization,
-    apiBaseUrl: githubConfig.apiBaseUrl ?? 'https://api.github.com',
+    // Only the plugin's own key is validated; the integration's value is owned
+    // and already normalised by @backstage/integration.
+    apiBaseUrl: apiBaseUrl
+      ? resolveApiBaseUrl(apiBaseUrl)
+      : githubConfig.apiBaseUrl ?? DEFAULT_API_BASE_URL,
   };
 };
 

--- a/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
+++ b/workspaces/copilot/plugins/copilot-backend/src/utils/reportParser.ts
@@ -147,11 +147,12 @@ export function parseEnterpriseDocument(
   // Normalize: the GitHub report API (2026-03-10) downloads a single flat
   // V2EnterpriseDayTotal object per file — not a V2EnterpriseDocument with a
   // day_totals wrapper. Accept both shapes for robustness.
-  const rawDocs: unknown[] = Array.isArray(doc)
-    ? doc
-    : isRecord(doc)
-    ? [doc]
-    : [];
+  let rawDocs: unknown[] = [];
+  if (Array.isArray(doc)) {
+    rawDocs = doc;
+  } else if (isRecord(doc)) {
+    rawDocs = [doc];
+  }
 
   if (rawDocs.length === 0) {
     logWarn(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Copilot backend fell back to `https://api.github.com` and only accepted report downloads from a fixed list of `github.com` hosts, so it could not be used with GitHub Enterprise Cloud with data residency. On GHE.com the REST API is at `https://api.SUBDOMAIN.ghe.com` and report documents are served from `copilot-reports.SUBDOMAIN.ghe.com`.

Changes:

- New optional `copilot.apiBaseUrl`. It falls back to `apiBaseUrl` on the matching `integrations.github` entry, then to `https://api.github.com`, so existing configuration is unaffected.
- The GitHub App installation lookup now uses the configured API base URL. It previously created its own Octokit client without one and always called `api.github.com`, which also broke App authentication on GitHub Enterprise Server.
- The allowed report download hosts are derived from `copilot.host` and its subdomains, plus `githubusercontent.com` and the object storage hosts GitHub documents as a fallback. Redirects are checked against the same rules on each hop instead of being followed blindly.

One unrelated change: `reportParser.ts` had a nested ternary that fails `no-nested-ternary` when the package is linted, which would fail CI for this PR. It is flattened here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
