### PR TITLE
Version Packages (github)

### DIFF
--- a/workspaces/github/.changeset/github-issues-null-nodes.md
+++ b/workspaces/github/.changeset/github-issues-null-nodes.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-github-issues': patch
----
-
-Fixed the GitHub Issues card failing with `Cannot read properties of null (reading 'updatedAt')` / repeated "Resource limits for this query exceeded." errors on entities (typically groups) that own many repositories.

--- a/workspaces/github/plugins/github-issues/CHANGELOG.md
+++ b/workspaces/github/plugins/github-issues/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-github-issues
 
+## 1.3.2
+
+### Patch Changes
+
+- bf583e2: Fixed the GitHub Issues card failing with `Cannot read properties of null (reading 'updatedAt')` / repeated "Resource limits for this query exceeded." errors on entities (typically groups) that own many repositories.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/workspaces/github/plugins/github-issues/package.json
+++ b/workspaces/github/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-github-issues",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "github-issues",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-github-issues@1.3.2

### Patch Changes

-   bf583e2: Fixed the GitHub Issues card failing with `Cannot read properties of null (reading 'updatedAt')` / repeated "Resource limits for this query exceeded." errors on entities (typically groups) that own many repositories.
