### PR TITLE
Version Packages (jaeger)

### DIFF
--- a/workspaces/jaeger/.changeset/smooth-donkeys-share.md
+++ b/workspaces/jaeger/.changeset/smooth-donkeys-share.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jaeger': patch
----
-
-Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.

--- a/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
+++ b/workspaces/jaeger/plugins/jaeger/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jaeger
 
+## 0.18.1
+
+### Patch Changes
+
+- 8a04a5c: Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/workspaces/jaeger/plugins/jaeger/package.json
+++ b/workspaces/jaeger/plugins/jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jaeger",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jaeger@0.18.1

### Patch Changes

-   8a04a5c: Added New Frontend System support. The plugin can now be used with the new frontend system using package discovery or by importing from the `/alpha` entrypoint.
