### PR TITLE
fix(scaffolder-backend-module-annotate): update descriptions and show examples for annotate action

### DIFF
--- a/workspaces/scaffolder-backend-module-annotator/.changeset/early-snakes-reflect.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/early-snakes-reflect.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-annotator': patch
+---
+
+Installed Actions now better describes what each annotator action does and includes template examples for `catalog:annotate`.

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/README.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/README.md
@@ -48,7 +48,7 @@ backend.start();
 | Parameter Name                     |   Type   | Required | Description                                                                                                                                                                                                                                     |
 | ---------------------------------- | :------: | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `actionId`                         | `string` |   Yes    | A unique id for the action. Default: `catalog:annotate`, please provide one or else it may conflict with the generic `catalog:annotate` custom action that is provided by this module.                                                          |
-| `actionDescription`                | `string` |    No    | A description of what the action accomplishes. Default: "Creates a new scaffolder action to annotate the entity object with specified label(s), annotation(s) and spec property(ies)."                                                          |
+| `actionDescription`                | `string` |    No    | A description of what the action accomplishes. Default: "Annotates the entity object with specified label(s), annotation(s) and spec property(ies)."                                                                                            |
 | `loggerInfoMsg`                    | `string` |    No    | A message that will be logged upon the execution of the action. Default: "Annotating your object"                                                                                                                                               |
 | `annotateEntityObject.labels`      | `object` |    No    | Key-value pairs to be added to the `metadata.labels` of the entity                                                                                                                                                                              |
 | `annotateEntityObject.annotations` | `object` |    No    | Key-value pairs to be added to the `metadata.annotations` of the entity                                                                                                                                                                         |
@@ -67,7 +67,7 @@ import { createAnnotatorAction } from '@backstage-community/plugin-scaffolder-ba
 export const createAddCompanyTitleAction = () => {
   return createAnnotatorAction(
     'catalog:company-title',
-    'Creates a new `catalog:company-title` Scaffolder action to annotate scaffolded entities with the company title.',
+    'Annotates scaffolded entities with the company title.',
     'Annotating catalog-info.yaml with the company title',
   );
 };

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/annotator/annotator.test.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/annotator/annotator.test.ts
@@ -319,4 +319,12 @@ describe('catalog annotator', () => {
     expect(ctx.logger.info).toHaveBeenCalledWith('some logger info msg');
     expect(entity?.spec?.scaffoldedFrom).toBe('test-entityRef');
   });
+
+  it('attaches default examples only for catalog:annotate', () => {
+    expect(createAnnotatorAction().examples?.length).toBeGreaterThan(0);
+    expect(
+      createAnnotatorAction('catalog:company-title', 'Adds a company title')
+        .examples,
+    ).toBeUndefined();
+  });
 });

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/annotator/annotator.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/annotator/annotator.ts
@@ -26,6 +26,7 @@ import { getObjectToAnnotate } from '../../utils/getObjectToAnnotate';
 import { resolveSpec } from '../../utils/resolveSpec';
 import { resolveAnnotation } from '../../utils/resolveAnnotation';
 import { Value } from '../../types';
+import { examples as defaultAnnotateExamples } from './annotator.examples';
 
 /**
  * @public
@@ -45,10 +46,12 @@ export const createAnnotatorAction = (
 ) => {
   return createTemplateAction({
     id: actionId,
-    examples,
+    examples:
+      examples ??
+      (actionId === 'catalog:annotate' ? defaultAnnotateExamples : undefined),
     description:
       actionDescription ||
-      'Creates a new scaffolder action to annotate the entity object with specified label(s), annotation(s) and spec property(ies).',
+      'Annotates the entity object with specified label(s), annotation(s) and spec property(ies).',
     schema: {
       input: {
         labels: z =>

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createScaffoldedFromAction.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createScaffoldedFromAction.ts
@@ -22,7 +22,7 @@ import { examples } from './createScaffoldedFromAction.examples';
 export const createScaffoldedFromAction = () => {
   return createAnnotatorAction(
     'catalog:scaffolded-from',
-    'Creates a new `catalog:scaffolded-from` scaffolder action to update a catalog-info.yaml with the entityRef of the template that created it.',
+    'Adds `scaffoldedFrom` spec containing the template entityRef to your entity object',
     'Annotating catalog-info.yaml with template entityRef',
     () => {
       return {

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createTimestampAction.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createTimestampAction.ts
@@ -23,7 +23,7 @@ import { examples } from './createTimestampAction.examples';
 export const createTimestampAction = () => {
   return createAnnotatorAction(
     'catalog:timestamping',
-    'Creates a new `catalog:timestamping` Scaffolder action to annotate scaffolded entities with creation timestamp.',
+    'Adds the `backstage.io/createdAt` annotation containing the current timestamp to your entity object',
     'Annotating catalog-info.yaml with current timestamp',
     () => {
       return {

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createVersionAction.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/actions/customActions/createVersionAction.ts
@@ -22,7 +22,7 @@ import { examples } from './createVersionAction.examples';
 export const createVersionAction = () => {
   return createAnnotatorAction(
     'catalog:template:version',
-    'Creates a new `catalog:template:version` scaffolder action to update a catalog-info.yaml with the versioning information from the scaffolder template',
+    'Adds the `backstage.io/template-version` annotation containing the version of your template to your entity object',
     'Annotating catalog-info.yaml with the version of the scaffolder template',
     () => {
       return {

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/module.test.ts
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/src/module.test.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
-import { scaffolderActionsExtensionPoint } from '@backstage/plugin-scaffolder-node';
+import {
+  scaffolderActionsExtensionPoint,
+  TemplateAction,
+} from '@backstage/plugin-scaffolder-node';
 
 import { scaffolderCustomActionsScaffolderModule } from './module';
 
 describe('scaffolderCustomActionsScaffolderModule', () => {
-  it('registers all four actions via the scaffolder extension point', async () => {
-    const registeredIds: string[] = [];
+  const registerActions = async () => {
+    const registered: TemplateAction[] = [];
     const extensionPoint = {
-      addActions: (...actions: { id: string }[]) => {
-        registeredIds.push(...actions.map(action => action.id));
+      addActions: (...actions: TemplateAction[]) => {
+        registered.push(...actions);
       },
     };
 
@@ -35,6 +38,13 @@ describe('scaffolderCustomActionsScaffolderModule', () => {
       ],
     });
 
+    return registered;
+  };
+
+  it('registers all four actions via the scaffolder extension point', async () => {
+    const registered = await registerActions();
+    const registeredIds = registered.map(action => action.id);
+
     expect(registeredIds).toHaveLength(4);
     expect(registeredIds).toEqual(
       expect.arrayContaining([
@@ -44,5 +54,31 @@ describe('scaffolderCustomActionsScaffolderModule', () => {
         'catalog:template:version',
       ]),
     );
+  });
+
+  it('exposes action-oriented descriptions and examples for Installed Actions', async () => {
+    const registered = await registerActions();
+
+    expect(registered).toHaveLength(4);
+
+    const factoryWording = /Creates a new .*[Ss]caffolder action/;
+    const issues = registered.map(action => ({
+      id: action.id,
+      description: action.description,
+      awkwardDescription: factoryWording.test(action.description ?? ''),
+      exampleCount: action.examples?.length ?? 0,
+    }));
+
+    expect({
+      awkwardDescriptions: issues
+        .filter(issue => issue.awkwardDescription)
+        .map(issue => issue.id),
+      missingExamples: issues
+        .filter(issue => issue.exampleCount === 0)
+        .map(issue => issue.id),
+    }).toEqual({
+      awkwardDescriptions: [],
+      missingExamples: [],
+    });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Cleans up the descriptions of the actions and also ensures that the examples properly show up for the `catalog:annotate` action.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
