### PR TITLE
Version Packages (catalog)

### DIFF
--- a/workspaces/catalog/.changeset/version-bump-1-54-5.md
+++ b/workspaces/catalog/.changeset/version-bump-1-54-5.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-catalog-backend-module-annotate-scm-slug': minor
-'@backstage-community/plugin-catalog-backend-module-aws-config': minor
-'@backstage-community/plugin-catalog-backend-module-codeowners': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/CHANGELOG.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-annotate-scm-slug
 
+## 0.6.0
+
+### Minor Changes
+
+- 93ca09d: Backstage version bump to v1.54.5
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-annotate-scm-slug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-annotate-scm-slug",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "Apache-2.0",
   "description": "The annotate-scm-slug backend module for the catalog plugin.",
   "main": "src/index.ts",

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/CHANGELOG.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-aws-config
 
+## 0.2.0
+
+### Minor Changes
+
+- 93ca09d: Backstage version bump to v1.54.5
+
 ## 0.1.0
 
 ### Minor Changes

--- a/workspaces/catalog/plugins/catalog-backend-module-aws-config/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-aws-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-aws-config",
   "description": "The aws-config backend module for the catalog plugin.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/community-plugins",

--- a/workspaces/catalog/plugins/catalog-backend-module-codeowners/CHANGELOG.md
+++ b/workspaces/catalog/plugins/catalog-backend-module-codeowners/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-catalog-backend-module-codeowners
 
+## 0.6.0
+
+### Minor Changes
+
+- 93ca09d: Backstage version bump to v1.54.5
+
 ## 0.5.0
 
 ### Minor Changes

--- a/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-catalog-backend-module-codeowners",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The codeowners backend module for the catalog plugin.",
   "backstage": {
     "role": "backend-plugin-module",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-catalog-backend-module-annotate-scm-slug@0.6.0

### Minor Changes

-   93ca09d: Backstage version bump to v1.54.5

## @backstage-community/plugin-catalog-backend-module-aws-config@0.2.0

### Minor Changes

-   93ca09d: Backstage version bump to v1.54.5

## @backstage-community/plugin-catalog-backend-module-codeowners@0.6.0

### Minor Changes

-   93ca09d: Backstage version bump to v1.54.5
