### PR TITLE
fix(confluence): make embedded image preservation configurable

### DIFF
--- a/workspaces/confluence/.changeset/tidy-images-import.md
+++ b/workspaces/confluence/.changeset/tidy-images-import.md
@@ -1,4 +1,4 @@
-﻿---
+---
 '@backstage-community/plugin-techdocs-backend-module-confluence': patch
 ---
 

--- a/workspaces/confluence/.changeset/tidy-images-import.md
+++ b/workspaces/confluence/.changeset/tidy-images-import.md
@@ -1,0 +1,5 @@
+﻿---
+'@backstage-community/plugin-techdocs-backend-module-confluence': patch
+---
+
+Add an option to preserve embedded data images when converting Confluence content to Markdown.

--- a/workspaces/confluence/.changeset/tidy-images-import.md
+++ b/workspaces/confluence/.changeset/tidy-images-import.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-techdocs-backend-module-confluence': patch
+'@backstage-community/plugin-techdocs-backend-module-confluence': minor
 ---
 
 Add an option to preserve embedded data images when converting Confluence content to Markdown.

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/README.md
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/README.md
@@ -49,6 +49,20 @@ confluence:
     maxDepth: 5 # Maximum depth to traverse (default: 0 = unlimited)
 ```
 
+### Embedded Images
+
+By default, embedded data images are excluded when converting Confluence HTML to Markdown. To preserve embedded images such as PlantUML or Gliffy SVGs, enable:
+
+`yaml
+confluence:
+
+# ...
+
+keepDataImages: true
+`
+
+The default is alse to preserve existing behavior.
+
 ### Multiple Confluence Instances
 
 When multiple instances are configured (see the [collator README](https://github.com/backstage/community-plugins/tree/main/workspaces/confluence/plugins/search-backend-module-confluence-collator#multiple-instances)), this module automatically routes TechDocs requests to the correct instance by matching the hostname in the entity's `backstage.io/techdocs-ref` URL against each instance's `baseUrl`.

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/app-config.example.yaml
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/app-config.example.yaml
@@ -39,6 +39,9 @@ confluence:
   #   # Maximum depth to traverse when fetching child pages (default: 0 = unlimited)
   #   # Useful for limiting very deep page hierarchies
   #   maxDepth: 0
+  #
+  #   # Preserve embedded data images such as PlantUML/Gliffy SVGs (default: false)
+  #   keepDataImages: true
 # =============================================================================
 # Option 2: Multiple Confluence Instances
 # =============================================================================

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/config.d.ts
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/config.d.ts
@@ -97,6 +97,10 @@ export interface Config {
            * Maximum depth to traverse when fetching child pages. 0 = unlimited. Default: 0
            */
           maxDepth?: number;
+          /**
+           * Preserve embedded data images when converting Confluence HTML to Markdown. Default: false
+           */
+          keepDataImages?: boolean;
         };
       }
     | {
@@ -152,6 +156,10 @@ export interface Config {
              * Maximum depth to traverse when fetching child pages. 0 = unlimited. Default: 0
              */
             maxDepth?: number;
+            /**
+             * Preserve embedded data images when converting Confluence HTML to Markdown. Default: false
+             */
+            keepDataImages?: boolean;
           };
         };
       };

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/report.api.md
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/report.api.md
@@ -20,6 +20,8 @@ export interface ConfluenceConfig {
   // (undocumented)
   email?: string;
   // (undocumented)
+  keepDataImages: boolean;
+  // (undocumented)
   pageTree: {
     parallel: boolean;
     maxDepth: number;

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/src/ConfluencePreparer.test.ts
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/src/ConfluencePreparer.test.ts
@@ -186,6 +186,41 @@ describe('ConfluencePreparer', () => {
       expect(preparer).toBeInstanceOf(ConfluencePreparer);
     });
 
+    it('should default keepDataImages to false', () => {
+      const config = new ConfigReader({
+        confluence: {
+          baseUrl: 'https://company.atlassian.net/wiki',
+          auth: {
+            type: 'bearer',
+            token: 'test-token',
+          },
+        },
+      });
+      const logger = mockLogger;
+
+      const preparer = ConfluencePreparer.fromConfig({ logger, config });
+
+      expect(preparer.getInstances()[0].keepDataImages).toBe(false);
+    });
+
+    it('should read keepDataImages config', () => {
+      const config = new ConfigReader({
+        confluence: {
+          baseUrl: 'https://company.atlassian.net/wiki',
+          auth: {
+            type: 'bearer',
+            token: 'test-token',
+          },
+          keepDataImages: true,
+        },
+      });
+      const logger = mockLogger;
+
+      const preparer = ConfluencePreparer.fromConfig({ logger, config });
+
+      expect(preparer.getInstances()[0].keepDataImages).toBe(true);
+    });
+
     it('should read custom pageTree config', () => {
       const config = new ConfigReader({
         confluence: {

--- a/workspaces/confluence/plugins/techdocs-backend-module-confluence/src/ConfluencePreparer.ts
+++ b/workspaces/confluence/plugins/techdocs-backend-module-confluence/src/ConfluencePreparer.ts
@@ -46,6 +46,7 @@ export interface ConfluenceConfig {
     parallel: boolean;
     maxDepth: number;
   };
+  keepDataImages: boolean;
 }
 
 /**
@@ -276,6 +277,8 @@ export class ConfluencePreparer implements PreparerBase {
           instanceConfig.getOptionalBoolean('pageTree.parallel') ?? true,
         maxDepth: instanceConfig.getOptionalNumber('pageTree.maxDepth') ?? 0,
       },
+      keepDataImages:
+        instanceConfig.getOptionalBoolean('keepDataImages') ?? false,
     };
   }
 
@@ -384,6 +387,7 @@ export class ConfluencePreparer implements PreparerBase {
     const markdown = this.convertHtmlToMarkdown(
       page.body.export_view.value,
       pathPrefix === '' ? page.title : undefined, // Only remove title for root page
+      instanceConfig.keepDataImages,
     );
 
     // Fetch and process attachments for this page
@@ -699,9 +703,13 @@ export class ConfluencePreparer implements PreparerBase {
     return attachments;
   }
 
-  private convertHtmlToMarkdown(html: string, pageTitle?: string): string {
+  private convertHtmlToMarkdown(
+    html: string,
+    pageTitle?: string,
+    keepDataImages = false,
+  ): string {
     let markdown = NodeHtmlMarkdown.translate(html, {
-      keepDataImages: false,
+      keepDataImages,
       useLinkReferenceDefinitions: false,
       useInlineLinks: true,
     });


### PR DESCRIPTION
## Summary

- make `keepDataImages` configurable through Confluence `app-config.yaml`
- preserve the existing default behavior (`false`)
- update the configuration schema and documentation
- add test coverage for enabled and disabled cases

## Validation

- `yarn workspace @backstage-community/plugin-techdocs-backend-module-confluence lint` ✅
- `yarn workspace @backstage-community/plugin-techdocs-backend-module-confluence test --watchAll=false` ✅
- Prettier check ✅
- `git diff --check` ✅

Fixes #10043