### PR TITLE
fix(announcements): move @backstage/backend-test-utils to devDependencies

### DIFF
--- a/workspaces/announcements/.changeset/announcements-backend-test-utils-devdep.md
+++ b/workspaces/announcements/.changeset/announcements-backend-test-utils-devdep.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-announcements-backend': patch
+---
+
+Moved `@backstage/backend-test-utils` from `dependencies` to `devDependencies`, as it is only used in tests and the local dev harness. This stops it, and its `better-sqlite3` dependency, from being installed into consumers' production dependency trees.

--- a/workspaces/announcements/plugins/announcements-backend/package.json
+++ b/workspaces/announcements/plugins/announcements-backend/package.json
@@ -41,7 +41,6 @@
     "@backstage-community/plugin-announcements-common": "workspace:^",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
-    "@backstage/backend-test-utils": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-events-node": "backstage:^",
     "@backstage/plugin-notifications-node": "backstage:^",
@@ -55,6 +54,7 @@
     "uuid": "^13.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "backstage:^",
     "@backstage/cli": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
     "@types/supertest": "^7.0.0",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`@backstage-community/plugin-announcements-backend` declares `@backstage/backend-test-utils` under `dependencies`, so every adopter installs it — and its `better-sqlite3` dependency — into their **production** dependency tree.

`backend-test-utils` is a test-only package. This PR moves it to `devDependencies`, keeping the `backstage:^` version specifier.

### Why this is safe

Every import of `@backstage/backend-test-utils` in this package is in a `*.test.ts` file, except `dev/index.ts` — a standalone dev harness that is not published (the package's `files` field is `["dist", "db/migrations/**/*.{js,d.ts}"]`). Nothing in the published `dist` imports it.

`yarn install` and `yarn test` were run in `workspaces/announcements` after the change; the tests still resolve `backend-test-utils` from `devDependencies`.

### Impact for consumers

`backend-test-utils` depends on `better-sqlite3@^12`, a native module. Because of this entry, a production-only install (`yarn workspaces focus --all --production`) pulls in `better-sqlite3` and requires a native build toolchain (`python` + a C++ compiler) in the container image, purely to compile a test-only database driver. Backends running on Postgres never load it.

### Related

The same problem was reported for `tech-insights-backend` in #1715, where it was confirmed as a bug and marked as welcoming contributions before going stale. The equivalent fix for that plugin is #10540, kept separate since the repo releases per workspace.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
