### PR TITLE
fix(tech-insights): move @backstage/backend-test-utils to devDependencies

### DIFF
--- a/workspaces/tech-insights/.changeset/tech-insights-backend-test-utils-devdep.md
+++ b/workspaces/tech-insights/.changeset/tech-insights-backend-test-utils-devdep.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights-backend': patch
+---
+
+Moved `@backstage/backend-test-utils` from `dependencies` to `devDependencies`, as it is only used in tests. This stops it, and its `better-sqlite3` dependency, from being installed into consumers' production dependency trees.

--- a/workspaces/tech-insights/plugins/tech-insights-backend/knip-report.md
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/knip-report.md
@@ -4,7 +4,7 @@
 
 | Name | Location          | Severity |
 | :- | :---------------- | :------- |
-| yn | package.json:71:6 | error    |
+| yn | package.json:70:6 | error    |
 
 ## Unused devDependencies (1)
 

--- a/workspaces/tech-insights/plugins/tech-insights-backend/package.json
+++ b/workspaces/tech-insights/plugins/tech-insights-backend/package.json
@@ -52,7 +52,6 @@
     "@backstage-community/plugin-tech-insights-node": "workspace:^",
     "@backstage/backend-defaults": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
-    "@backstage/backend-test-utils": "backstage:^",
     "@backstage/catalog-client": "backstage:^",
     "@backstage/catalog-model": "backstage:^",
     "@backstage/config": "backstage:^",
@@ -71,6 +70,7 @@
     "yn": "^4.0.0"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "backstage:^",
     "@backstage/cli": "backstage:^",
     "@types/lodash": "^4.14.151",
     "@types/semver": "^7.3.8",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`@backstage-community/plugin-tech-insights-backend` declares `@backstage/backend-test-utils` under `dependencies`, so every adopter installs it — and its `better-sqlite3` dependency — into their **production** dependency tree.

`backend-test-utils` is a test-only package. This PR moves it to `devDependencies`, keeping the `backstage:^` version specifier.

### Why this is safe

Every import of `@backstage/backend-test-utils` in this package is in a `*.test.ts` file. The runtime import that originally required it — `mockServices` in `src/service/persistence/persistenceContext.ts`, reported in #788 — was removed in #787, but the `dependencies` entry was left behind.

`yarn install` and `yarn test` were run in `workspaces/tech-insights` after the change; the tests still resolve `backend-test-utils` from `devDependencies`.

### Impact for consumers

`backend-test-utils` depends on `better-sqlite3@^12`, a native module. Because of this entry, a production-only install (`yarn workspaces focus --all --production`) pulls in `better-sqlite3` and requires a native build toolchain (`python` + a C++ compiler) in the container image, purely to compile a test-only database driver. Backends running on Postgres never load it.

### Related

This is the leftover half of #1715, where @Rugvip confirmed the dependency shouldn't be there and @awanlin marked it as welcoming contributions; the issue went stale before a fix landed. `announcements-backend` has the same problem — the fix for it is #10539, kept separate since the repo releases per workspace.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
