### PR TITLE
Version Packages (servicenow)

### DIFF
--- a/workspaces/servicenow/.changeset/silly-badgers-tan.md
+++ b/workspaces/servicenow/.changeset/silly-badgers-tan.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow-backend': patch
-'@backstage-community/plugin-servicenow': patch
-'@backstage-community/plugin-servicenow-common': patch
----
-
-Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.

--- a/workspaces/servicenow/.changeset/version-bump-1-54-5.md
+++ b/workspaces/servicenow/.changeset/version-bump-1-54-5.md
@@ -1,7 +1,0 @@
----
-'@backstage-community/plugin-servicenow': minor
-'@backstage-community/plugin-servicenow-backend': minor
-'@backstage-community/plugin-servicenow-common': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-backend/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-servicenow-backend
 
+## 1.14.0
+
+### Minor Changes
+
+- ede61dd: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
+- Updated dependencies [7640966]
+- Updated dependencies [ede61dd]
+  - @backstage-community/plugin-servicenow-common@1.13.0
+
 ## 1.13.1
 
 ### Patch Changes

--- a/workspaces/servicenow/plugins/servicenow-backend/package.json
+++ b/workspaces/servicenow/plugins/servicenow-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-backend",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow-common/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @backstage-community/plugin-servicenow-common
 
+## 1.13.0
+
+### Minor Changes
+
+- ede61dd: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
+
 ## 1.12.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow-common/package.json
+++ b/workspaces/servicenow/plugins/servicenow-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow-common",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "Apache-2.0",
   "description": "Common functionalities for the servicenow plugin",
   "main": "src/index.ts",

--- a/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
+++ b/workspaces/servicenow/plugins/servicenow/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @backstage-community/plugin-servicenow
 
+## 1.15.0
+
+### Minor Changes
+
+- ede61dd: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- 7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
+- Updated dependencies [7640966]
+- Updated dependencies [ede61dd]
+  - @backstage-community/plugin-servicenow-common@1.13.0
+
 ## 1.14.0
 
 ### Minor Changes

--- a/workspaces/servicenow/plugins/servicenow/package.json
+++ b/workspaces/servicenow/plugins/servicenow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-servicenow",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-servicenow@1.15.0

### Minor Changes

-   ede61dd: Backstage version bump to v1.54.5

### Patch Changes

-   7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
-   Updated dependencies [7640966]
-   Updated dependencies [ede61dd]
    -   @backstage-community/plugin-servicenow-common@1.13.0

## @backstage-community/plugin-servicenow-backend@1.14.0

### Minor Changes

-   ede61dd: Backstage version bump to v1.54.5

### Patch Changes

-   7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
-   Updated dependencies [7640966]
-   Updated dependencies [ede61dd]
    -   @backstage-community/plugin-servicenow-common@1.13.0

## @backstage-community/plugin-servicenow-common@1.13.0

### Minor Changes

-   ede61dd: Backstage version bump to v1.54.5

### Patch Changes

-   7640966: Improve automated coverage for plugin init, Table API client query contracts, and frontend backend client wiring so Backstage version bumps fail in CI when those surfaces break. The backend client now includes the entity annotation field in ServiceNow incident queries.
