### PR TITLE
fix(catalog): correct repository URL for codeowners plugin

### DIFF
--- a/workspaces/catalog/.changeset/fix-codeowners-repository-url.md
+++ b/workspaces/catalog/.changeset/fix-codeowners-repository-url.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-codeowners': patch
+---
+
+Fixed repository URL in package.json to point to community-plugins, resolving NPM provenance publish failures

--- a/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
+++ b/workspaces/catalog/plugins/catalog-backend-module-codeowners/package.json
@@ -14,8 +14,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/backstage/backstage",
-    "directory": "plugins/catalog-backend-module-codeowners"
+    "url": "https://github.com/backstage/community-plugins",
+    "directory": "workspaces/catalog/plugins/catalog-backend-module-codeowners"
   },
   "license": "Apache-2.0",
   "main": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed repository URL in package.json to point to community-plugins, resolving NPM provenance publish failures.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))