### PR TITLE
Re-trigger release for jenkins, lighthouse, newrelic

### DIFF
--- a/workspaces/jenkins/.changeset/retrigger-release.md
+++ b/workspaces/jenkins/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-jenkins': patch
 ---
 
-Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/jenkins/.changeset/retrigger-release.md
+++ b/workspaces/jenkins/.changeset/retrigger-release.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-jenkins': patch
+---
+
+Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/jenkins/.changeset/retrigger-release.md
+++ b/workspaces/jenkins/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-jenkins': patch
 ---
 
-Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/lighthouse/.changeset/retrigger-release.md
+++ b/workspaces/lighthouse/.changeset/retrigger-release.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-lighthouse': patch
+---
+
+Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/lighthouse/.changeset/retrigger-release.md
+++ b/workspaces/lighthouse/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-lighthouse': patch
 ---
 
-Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/lighthouse/.changeset/retrigger-release.md
+++ b/workspaces/lighthouse/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-lighthouse': patch
 ---
 
-Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/newrelic/.changeset/retrigger-release.md
+++ b/workspaces/newrelic/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-newrelic': patch
 ---
 
-Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/newrelic/.changeset/retrigger-release.md
+++ b/workspaces/newrelic/.changeset/retrigger-release.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-newrelic': patch
 ---
 
-Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+Re-trigger release pipeline after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/newrelic/.changeset/retrigger-release.md
+++ b/workspaces/newrelic/.changeset/retrigger-release.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-newrelic': patch
+---
+
+Re-trigger release pipeline after GitHub Actions incident (https://www.githubstatus.com/incidents/y1t7p9fzrlj2)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Re-trigger release pipeline for jenkins, lighthouse, and newrelic after [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2) left their release runs in a zombie state.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))