### PR TITLE
fix(explore): restore broken layout styling

### DIFF
--- a/workspaces/explore/.changeset/fix-explore-layout.md
+++ b/workspaces/explore/.changeset/fix-explore-layout.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore': patch
+---
+
+Restore broken Explore plugin layout sizing and improve group diagram text contrast.

--- a/workspaces/explore/plugins/explore/src/components/ExploreLayout/ExploreLayout.tsx
+++ b/workspaces/explore/plugins/explore/src/components/ExploreLayout/ExploreLayout.tsx
@@ -127,6 +127,10 @@ export const ExploreLayout = (props: ExploreLayoutProps) => {
         <div
           style={{
             padding: 'var(--bui-space-6)',
+            height: '100%',
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
           }}
         >
           {element ?? routes[0]?.children ?? null}

--- a/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.module.css
+++ b/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.module.css
@@ -67,7 +67,7 @@
 }
 
 .textGroup {
-  color: var(--bui-fg-solid-on-bg, #fff);
+  color: var(--bui-fg-solid);
 }
 
 .textWrapper {

--- a/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.module.css
+++ b/workspaces/explore/plugins/explore/src/components/GroupsExplorerContent/GroupsDiagram.module.css
@@ -67,7 +67,7 @@
 }
 
 .textGroup {
-  color: var(--bui-fg-solid);
+  color: var(--bui-fg-solid, #fff);
 }
 
 .textWrapper {


### PR DESCRIPTION
## Summary

Fixes #10279.

This PR fixes the broken styling in the Explore plugin introduced after the recent UI migration.

### Changes

- Restore full-height flex sizing in `ExploreLayout` so child views can correctly fill the available page height.
- Update the group diagram text color to use the current Backstage UI foreground token, restoring readable text contrast.

### Validation

- `ExploreLayout.test.tsx` — 4/4 tests passed.
- `GroupsExplorerContent.test.tsx` — 3/3 tests passed.
- Explore workspace lint — 0 errors.
- `git diff --check` — passed.

The lint run reports two existing warnings related to the React default import and the TypeScript/@typescript-eslint version compatibility; no lint errors were introduced by this change.