### PR TITLE
Version Packages (jenkins)

### DIFF
--- a/workspaces/jenkins/.changeset/retrigger-release.md
+++ b/workspaces/jenkins/.changeset/retrigger-release.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-jenkins': patch
----
-
-No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)

--- a/workspaces/jenkins/.changeset/version-bump-1-54-5.md
+++ b/workspaces/jenkins/.changeset/version-bump-1-54-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-jenkins': minor
-'@backstage-community/plugin-jenkins-backend': minor
-'@backstage-community/plugin-jenkins-common': minor
-'@backstage-community/plugin-scaffolder-backend-module-jenkins': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-jenkins-backend
 
+## 0.31.0
+
+### Minor Changes
+
+- 9446879: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- Updated dependencies [9446879]
+  - @backstage-community/plugin-jenkins-common@0.22.0
+
 ## 0.30.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins-backend/package.json
+++ b/workspaces/jenkins/plugins/jenkins-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-backend",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "A Backstage backend plugin that integrates towards Jenkins",
   "backstage": {
     "role": "backend-plugin",

--- a/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-jenkins-common
 
+## 0.22.0
+
+### Minor Changes
+
+- 9446879: Backstage version bump to v1.54.5
+
 ## 0.21.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins-common/package.json
+++ b/workspaces/jenkins/plugins/jenkins-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins-common",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "backstage": {
     "role": "common-library",
     "pluginId": "jenkins",

--- a/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/jenkins/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-jenkins
 
+## 0.34.0
+
+### Minor Changes
+
+- 9446879: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- ccc6c95: No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
+- Updated dependencies [9446879]
+  - @backstage-community/plugin-jenkins-common@0.22.0
+
 ## 0.33.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/jenkins/package.json
+++ b/workspaces/jenkins/plugins/jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-jenkins",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "A Backstage plugin that integrates towards Jenkins",
   "backstage": {
     "role": "frontend-plugin",

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-scaffolder-backend-module-jenkins
 
+## 0.24.0
+
+### Minor Changes
+
+- 9446879: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- Updated dependencies [9446879]
+  - @backstage-community/plugin-jenkins-common@0.22.0
+
 ## 0.23.0
 
 ### Minor Changes

--- a/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
+++ b/workspaces/jenkins/plugins/scaffolder-backend-module-jenkins/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-jenkins",
   "description": "Scaffolder plugin for Jenkins",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-jenkins@0.34.0

### Minor Changes

-   9446879: Backstage version bump to v1.54.5

### Patch Changes

-   ccc6c95: No functional changes; re-publish to recover from a [GitHub Actions incident](https://www.githubstatus.com/incidents/y1t7p9fzrlj2)
-   Updated dependencies [9446879]
    -   @backstage-community/plugin-jenkins-common@0.22.0

## @backstage-community/plugin-jenkins-backend@0.31.0

### Minor Changes

-   9446879: Backstage version bump to v1.54.5

### Patch Changes

-   Updated dependencies [9446879]
    -   @backstage-community/plugin-jenkins-common@0.22.0

## @backstage-community/plugin-jenkins-common@0.22.0

### Minor Changes

-   9446879: Backstage version bump to v1.54.5

## @backstage-community/plugin-scaffolder-backend-module-jenkins@0.24.0

### Minor Changes

-   9446879: Backstage version bump to v1.54.5

### Patch Changes

-   Updated dependencies [9446879]
    -   @backstage-community/plugin-jenkins-common@0.22.0
