### PR TITLE
fix(github-issues): support repositories whose name starts with a number

### DIFF
--- a/workspaces/github/.changeset/github-issues-numeric-repo-name.md
+++ b/workspaces/github/.changeset/github-issues-numeric-repo-name.md
@@ -2,4 +2,4 @@
 '@backstage-community/plugin-github-issues': patch
 ---
 
-Fixed the GitHub Issues card failing to load for entities that own a repository whose name starts with a number (for example `123-service`). The repository name was used directly as a GraphQL alias, which GitHub rejects when it begins with a digit, causing the whole batched request — and every other repository in it — to fail.
+Fixed the GitHub Issues card failing to load for entities that own a repository whose name starts with a number (for example `123-service`).

--- a/workspaces/github/.changeset/github-issues-numeric-repo-name.md
+++ b/workspaces/github/.changeset/github-issues-numeric-repo-name.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-github-issues': patch
+---
+
+Fixed the GitHub Issues card failing to load for entities that own a repository whose name starts with a number (for example `123-service`). The repository name was used directly as a GraphQL alias, which GitHub rejects when it begins with a digit, causing the whole batched request — and every other repository in it — to fail.

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.test.ts
@@ -135,6 +135,56 @@ describe('githubIssuesApi', () => {
       expect(mockGraphQLQuery).toHaveBeenCalledWith(getFragment());
     });
 
+    it('handles repositories whose name starts with a number by using a valid GraphQL alias and still maps the result back to owner/name', async () => {
+      const issueNode = {
+        assignees: { edges: [] },
+        author: { login: 'mrwolny' },
+        repository: { nameWithOwner: 'mrwolny/123-numeric' },
+        title: "It's the ISSUE!",
+        url: 'https://github.com/mrwolny/123-numeric/issues/1',
+        updatedAt: '2022-07-04T18:47:33Z',
+        createdAt: '2022-06-23T18:14:26Z',
+        comments: { totalCount: 0 },
+      };
+      mockGraphQLQuery.mockImplementationOnce(() => ({
+        _123numeric: {
+          issues: { totalCount: 1, edges: [{ node: issueNode }] },
+        },
+      }));
+
+      const data = await api.fetchIssuesByRepoFromGithub(
+        [
+          entityRepository('mrwolny/123-numeric'),
+          entityRepository('mrwolny/456numeric'),
+        ],
+        10,
+        'github.com',
+      );
+
+      expect(mockGraphQLQuery).toHaveBeenCalledTimes(1);
+      // GraphQL aliases must not start with a digit; they are prefixed with an
+      // underscore while the repository() argument keeps the real repo name.
+      expect(mockGraphQLQuery).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '_123numeric: repository(name: "123-numeric", owner: "mrwolny")',
+        ),
+      );
+      expect(mockGraphQLQuery).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '_456numeric: repository(name: "456numeric", owner: "mrwolny")',
+        ),
+      );
+      expect(mockGraphQLQuery).not.toHaveBeenCalledWith(
+        expect.stringMatching(/\s123numeric: repository/),
+      );
+
+      expect(data).toEqual({
+        'mrwolny/123-numeric': {
+          issues: { totalCount: 1, edges: [{ node: issueNode }] },
+        },
+      });
+    });
+
     it('should only fetch data for entities hosted in the same GitHub instance as is entity location', async () => {
       await api.fetchIssuesByRepoFromGithub(
         [

--- a/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
+++ b/workspaces/github/plugins/github-issues/src/api/githubIssuesApi.ts
@@ -199,8 +199,16 @@ export const githubIssuesApi = (
       .map(repo => {
         const [owner, name] = repo.name.split('/');
 
-        const safeNameRegex = /-|\./gi;
-        let safeName = name.replace(safeNameRegex, '');
+        // The safe name is used as a GraphQL alias for the repository field.
+        // GraphQL names must match /[_A-Za-z][_0-9A-Za-z]*/, so strip any
+        // disallowed character and prefix an underscore when the remaining
+        // name would start with a digit (e.g. a repo named "42-tools").
+        // Without this, GitHub rejects the whole batched query with a parse
+        // error and the card fails to render.
+        let safeName = name.replace(/[^_0-9A-Za-z]/g, '');
+        if (/^[0-9]/.test(safeName)) {
+          safeName = `_${safeName}`;
+        }
 
         while (safeNames.includes(safeName)) {
           safeName += 'x';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The GitHub Issues card breaks for any entity that owns a repository whose name starts with a number (e.g. `123-service`).

The plugin builds one batched GraphQL query for several repositories at once and uses the repository name as the field **alias**:

```graphql
query {
  123service: repository(name: "123-service", owner: "acme") { ...issues }
}
```

GraphQL names/aliases must match `/[_A-Za-z][_0-9A-Za-z]*/` and cannot start with a digit, so GitHub rejects the whole query with `Expected NAME, actual: INT ("123")`. Because repositories are batched, one number-prefixed repo takes down every other repo in the same request and the card fails to render.

### Fix

`safeName` (the alias) is now sanitized: any character outside `[_0-9A-Za-z]` is stripped and an underscore is prefixed when the result would start with a digit. The `repository(name: ...)` argument still uses the real repo name, and the same sanitized alias is used both to build the query and to map the response back to `owner/name`. The existing de-duplication of colliding names is unchanged.

Verified against the real GitHub GraphQL API with a test repo whose name starts with a number: the query fails before the change and returns issues after it.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
