### PR TITLE
chore: update mui-to-bui skill

### DIFF
--- a/.claude/skills/mui-to-bui-migration/SKILL.md
+++ b/.claude/skills/mui-to-bui-migration/SKILL.md
@@ -5,7 +5,7 @@ description: Migrate Backstage plugins from Material-UI (MUI) to Backstage UI (B
 
 # MUI to BUI Migration Skill
 
-This skill helps migrate Backstage plugins from Material-UI (@material-ui/core, @material-ui/icons) to Backstage UI (@backstage/ui).
+This skill helps migrate Backstage plugins from Material-UI (@material-ui/core, @material-ui/icons, @material-ui/lab) to Backstage UI (@backstage/ui).
 
 ## Prerequisites
 
@@ -17,55 +17,82 @@ Before starting migration:
    yarn add @backstage/ui
    ```
 
-2. Add the CSS import to your root file (typically `src/index.ts` or app entry point):
+2. If using icons, add `@remixicon/react` pinned below 4.9.0 (the 4.9.0 release changed its license):
+
+   ```json
+   "@remixicon/react": ">=4.6.0 <4.9.0"
+   ```
+
+3. If the workspace has a full dev app under `packages/app`, add the CSS import to `packages/app/src/index.tsx`:
+
    ```typescript
    import '@backstage/ui/css/styles.css';
    ```
+
+   Skip this for workspaces whose plugins use `createDevApp` from `@backstage/dev-utils` instead; it loads the stylesheet automatically. The plugin package itself should never import the stylesheet.
 
 ## Available BUI Components
 
 ### Layout Components
 
-- `Box` - Basic layout container with CSS properties
+- `Box` - Basic layout container with spacing and sizing props
 - `Container` - Centered content container with max-width
 - `Grid` - CSS Grid-based layout (`Grid.Root`, `Grid.Item`)
-- `Flex` - Flexbox layout component
+- `Flex` - Flexbox layout component (`direction`, `align`, `justify`, `gap`)
+- `FullPage` - Fills the viewport below the page `Header`; content scrolls independently
 
 ### UI Components
 
-- `Accordion` - Collapsible content panels
-- `Avatar` - User/entity avatars
-- `Button` - Primary action buttons (`variant="primary"`, `variant="secondary"`, `isDisabled`)
-- `ButtonIcon` - Icon-only buttons (`icon`, `onPress`, `variant`)
-- `ButtonLink` - Link styled as button
+- `Accordion` - Collapsible content panels (`Accordion`, `AccordionTrigger`, `AccordionPanel`, `AccordionGroup`)
+- `Alert` - Status banners (`status="info" | "success" | "warning" | "danger"`, replaces MUI lab Alert)
+- `Avatar` - User/entity avatars (`src` and `name` are required)
+- `Badge` - Small status/count indicator (`icon`, `size`)
+- `Button` - Primary action buttons (`variant="primary" | "secondary" | "tertiary"`, `isDisabled`, `isPending`, `destructive`, `iconStart`, `iconEnd`)
+- `ButtonIcon` - Icon-only buttons (`icon`, `onPress`, `variant`, requires `aria-label`)
+- `ButtonLink` - Link styled as button (`href`)
 - `Card` - Content cards (`Card`, `CardHeader`, `CardBody`, `CardFooter`)
-- `Checkbox` - Checkbox input
+- `Checkbox` - Checkbox input (`isSelected`, `isIndeterminate`, `onChange` receives a boolean)
+- `CheckboxGroup` - Grouped checkboxes with a shared label (`value: string[]`, `onChange`)
+- `Combobox` - Typeahead input with a filtered option list (replaces MUI lab Autocomplete)
+- `DatePicker` / `DateRangePicker` - Date inputs (values from `@internationalized/date`)
 - `Dialog` - Modal dialogs (`DialogTrigger`, `Dialog`, `DialogHeader`, `DialogBody`, `DialogFooter`)
-- `Header` - Page headers
-- `HeaderPage` - Full page header component
-- `Link` - Navigation links
-- `Menu` - Dropdown menus (`MenuTrigger`, `Menu`, `MenuItem`)
-- `PasswordField` - Password input field
-- `Popover` - Popover overlays
-- `RadioGroup` - Radio button groups
-- `SearchField` - Search input
-- `Select` - Dropdown select
-- `Skeleton` - Loading skeleton
-- `Switch` - Toggle switch
-- `Table` - Data tables
+- `FieldLabel` - Standalone label/description block for custom form fields
+- `Link` - Navigation links (router-aware)
+- `List` / `ListRow` - Interactive lists with keyboard navigation, selection, and row actions (replaces MUI List)
+- `Menu` - Dropdown menus (`MenuTrigger`, `Menu`, `MenuItem`, `MenuSection`, `MenuSeparator`, `SubmenuTrigger`; `MenuAutocomplete`/`MenuAutocompleteListbox` and `MenuListBox`/`MenuListBoxItem` for filterable and listbox-flavored variants)
+- `NumberField` - Numeric input (`value`/`onChange` use numbers, `minValue`, `maxValue`, `step`)
+- `PasswordField` - Password input with visibility toggle
+- `Popover` - Popover overlays (pair with `DialogTrigger`)
+- `RadioGroup` / `Radio` - Radio button groups
+- `SearchAutocomplete` - Search input with suggestion items (`SearchAutocompleteItem`)
+- `SearchField` - Search input with built-in clear button
+- `Select` - Dropdown select (options-driven: `options={[{ id, label }]}`, `value`, `onChange`; `SelectItem`/`SelectItemText`/`SelectItemProfile` for custom option content, same family exists for `Combobox`)
+- `Skeleton` - Loading skeleton (`width`, `height`)
+- `Slider` - Slider input; pass a `number[]` value for a range slider
+- `Switch` - Toggle switch (`isSelected`, `onChange` receives a boolean)
+- `Table` - Data tables (see the Table pattern below; includes `TablePagination`, `TableBodySkeleton`, the low-level `TableRoot`/`TableHeader`/`TableBody`/`Column`/`Row`/`Cell` parts, and the `useTable` hook)
 - `Tabs` - Tab navigation (`Tabs`, `TabList`, `Tab`, `TabPanel`)
 - `Tag` - Tag/chip component (replaces MUI Chip)
-- `TagGroup` - Tag/chip groups
-- `Text` - Typography component (`variant`, `color`)
+- `TagGroup` - Tag groups with selection and removal (`onRemove`)
+- `Text` - Typography component (`variant`, `color`, `weight`, `as`)
 - `TextField` - Text input (`isRequired`, `onChange` receives string directly)
-- `ToggleButton` - Toggle buttons
-- `ToggleButtonGroup` - Grouped toggle buttons
-- `Tooltip` - Tooltip overlays (used with TooltipTrigger from react-aria-components)
+- `TextAreaField` - Multiline text input (`rows`)
+- `ToggleButton` / `ToggleButtonGroup` - Toggle buttons
+- `Tooltip` / `TooltipTrigger` - Tooltip overlays (both imported from `@backstage/ui`)
 - `VisuallyHidden` - Accessibility helper
+- `BUIProvider` / `BgProvider` - Optional providers for wiring analytics and nested surface backgrounds
+
+### Headers
+
+- `Header` - The page header: title, description, tags, metadata (`HeaderMetadataUsers`, `HeaderMetadataStatus` render metadata values), and nav tabs. Successor of `HeaderPage`, which still exists but is deprecated.
+- `PluginHeader` - Toolbar-style header with icon, breadcrumbs, and route tabs. This component was called `Header` in early BUI versions, so older migrated code using `Header` as a toolbar should now use `PluginHeader`.
 
 ### Hooks
 
-- `useBreakpoint` - Responsive breakpoint hook
+- `useBreakpoint` - Responsive breakpoint hook (`{ breakpoint, up, down }`)
+- `useTable` - Data/pagination/sort state management for `Table`
+- `useAsyncList` - Async option loading for `Select`/`Combobox` (re-exported from react-stately)
+- `useAnalytics`, `useBgConsumer`/`useBgProvider`, `getNodeText` - Analytics and surface-tracking utilities; rarely needed in migrations
 
 ## Migration Patterns
 
@@ -84,7 +111,7 @@ import SomeIcon from '@material-ui/icons/SomeIcon';
 
 ```typescript
 // ADD these imports
-import { Box, Flex, Text, Tooltip, Card } from '@backstage/ui';
+import { Box, Flex, Text, Tooltip, TooltipTrigger, Card } from '@backstage/ui';
 import { RiSomeIcon } from '@remixicon/react';
 import styles from './MyComponent.module.css';
 ```
@@ -125,7 +152,9 @@ function MyComponent() {
     <div className={classes.container}>
       <Typography className={classes.title}>Title</Typography>
       <div className={classes.listItem}>
-        <div className={classes.icon}><SomeIcon /></div>
+        <div className={classes.icon}>
+          <SomeIcon />
+        </div>
         <span>Content</span>
       </div>
     </div>
@@ -140,7 +169,7 @@ function MyComponent() {
 @layer components {
   .container {
     padding: var(--bui-space-4);
-    background-color: var(--bui-bg-surface-1);
+    background-color: var(--bui-bg-neutral-1);
     border-radius: var(--bui-radius-2);
   }
 
@@ -176,7 +205,9 @@ function MyComponent() {
     <Box className={styles.container}>
       <Text className={styles.title}>Title</Text>
       <div className={styles.listItem}>
-        <div className={styles.icon}><RiSomeIcon size={24} /></div>
+        <div className={styles.icon}>
+          <RiSomeIcon size={24} />
+        </div>
         <span>Content</span>
       </div>
     </Box>
@@ -205,13 +236,13 @@ function MyComponent() {
 
 ```typescript
 <Flex direction="column" align="center" justify="between">
-  <Flex direction="row" style={{ gap: 'var(--bui-space-4)' }}>
+  <Flex direction="row" gap="4">
     {children}
   </Flex>
 </Flex>
 ```
 
-Note: BUI Flex uses `justify="between"` not `justify="space-between"`.
+Note: BUI Flex uses `justify="between"` not `justify="space-between"`. `gap` takes BUI space steps as strings (`gap="4"` is 16px, the same as MUI `gap={2}`).
 
 ### 4. Grid Layout
 
@@ -229,11 +260,11 @@ Note: BUI Flex uses `justify="between"` not `justify="space-between"`.
 
 ```typescript
 <Grid.Root columns={{ sm: '12' }} gap="6">
-  <Grid.Item colSpan={{ sm: '12', md: '6' }}>
-    {content}
-  </Grid.Item>
+  <Grid.Item colSpan={{ sm: '12', md: '6' }}>{content}</Grid.Item>
 </Grid.Root>
 ```
+
+Note: `columns` and `colSpan` take string literals (`'12'`), not numbers.
 
 ### 5. Typography to Text
 
@@ -249,13 +280,15 @@ Note: BUI Flex uses `justify="between"` not `justify="space-between"`.
 **After (BUI Text):**
 
 ```typescript
-<Text variant="title-large">Heading</Text>
-<Text variant="title-small">Subheading</Text>
+<Text as="h1" variant="title-large">Heading</Text>
+<Text as="h2" variant="title-small">Subheading</Text>
 <Text variant="body-medium">Body text</Text>
 <Text variant="body-small" color="secondary">Secondary text</Text>
 ```
 
 Valid Text variants: `title-large`, `title-medium`, `title-small`, `title-x-small`, `body-large`, `body-medium`, `body-small`, `body-x-small`
+
+Note: `Text` does not infer the HTML element from the variant. Pass `as` explicitly for headings so the document outline survives the migration.
 
 ### 6. Tooltip Pattern
 
@@ -272,16 +305,28 @@ import { Tooltip, Typography } from '@material-ui/core';
 **After (BUI TooltipTrigger pattern):**
 
 ```typescript
-import { Tooltip, Text } from '@backstage/ui';
-import { TooltipTrigger } from 'react-aria-components';
+import { Button, Tooltip, TooltipTrigger } from '@backstage/ui';
 
 <TooltipTrigger>
-  <Text>Hover me</Text>
+  <Button>Hover me</Button>
   <Tooltip>Tooltip content</Tooltip>
 </TooltipTrigger>;
 ```
 
-Note: Add `react-aria-components` to your dependencies.
+Both `Tooltip` and `TooltipTrigger` come from `@backstage/ui`. The trigger child must be focusable (BUI `Button`, `ButtonIcon`, and `ButtonLink` all work). To use a plain element as the trigger, wrap it in `Focusable` (also exported from `@backstage/ui`):
+
+```typescript
+import { Focusable, Tooltip, TooltipTrigger } from '@backstage/ui';
+
+<TooltipTrigger delay={600}>
+  <Focusable>
+    <span>Hover me</span>
+  </Focusable>
+  <Tooltip>Tooltip content</Tooltip>
+</TooltipTrigger>;
+```
+
+Note: the tooltip open delay defaults to 1500ms; pass `delay` on `TooltipTrigger` to shorten it.
 
 ### 7. Dialog Pattern
 
@@ -294,23 +339,52 @@ import { Dialog, DialogTitle, DialogActions, Button } from '@material-ui/core';
   <DialogTitle>Title</DialogTitle>
   <DialogActions>
     <Button onClick={onClose}>Cancel</Button>
-    <Button onClick={onConfirm} color="primary">Confirm</Button>
+    <Button onClick={onConfirm} color="primary">
+      Confirm
+    </Button>
   </DialogActions>
-</Dialog>
+</Dialog>;
 ```
 
-**After (BUI Dialog):**
+**After (BUI Dialog, controlled):**
 
 ```typescript
-import { Dialog, DialogTrigger, DialogHeader, DialogFooter, Button } from '@backstage/ui';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+} from '@backstage/ui';
 
+<Dialog
+  isOpen={isOpen}
+  onOpenChange={open => {
+    if (!open) onClose();
+  }}
+  isDismissable
+>
+  <DialogHeader>Title</DialogHeader>
+  <DialogBody>Content</DialogBody>
+  <DialogFooter>
+    <Button variant="secondary" onPress={onClose}>
+      Cancel
+    </Button>
+    <Button variant="primary" onPress={onConfirm}>
+      Confirm
+    </Button>
+  </DialogFooter>
+</Dialog>;
+```
+
+If the dialog is opened by a button you also own, prefer the uncontrolled `DialogTrigger` pattern and drop the open state entirely:
+
+```typescript
 <DialogTrigger>
-  <Dialog isOpen={isOpen} isDismissable onOpenChange={(open) => { if (!open) onClose(); }}>
+  <Button>Open</Button>
+  <Dialog isDismissable>
     <DialogHeader>Title</DialogHeader>
-    <DialogFooter>
-      <Button onClick={onConfirm} variant="primary">Confirm</Button>
-      <Button onClick={onClose} variant="secondary" slot="close">Cancel</Button>
-    </DialogFooter>
+    <DialogBody>Content</DialogBody>
   </Dialog>
 </DialogTrigger>
 ```
@@ -331,7 +405,7 @@ import { Dialog, DialogTrigger, DialogHeader, DialogFooter, Button } from '@back
 **After (BUI Button):**
 
 ```typescript
-<Button variant="primary" isDisabled={loading} onClick={handleClick}>
+<Button variant="primary" isDisabled={loading} onPress={handleClick}>
   Submit
 </Button>
 <ButtonIcon
@@ -343,7 +417,33 @@ import { Dialog, DialogTrigger, DialogHeader, DialogFooter, Button } from '@back
 />
 ```
 
-### 9. TextField Changes
+Prop mapping:
+
+| MUI                         | BUI                                                |
+| --------------------------- | -------------------------------------------------- |
+| `variant="contained"`       | `variant="primary"`                                |
+| `variant="outlined"`        | `variant="secondary"`                              |
+| `variant="text"`            | `variant="tertiary"`                               |
+| red/error styling           | `destructive` (boolean, combines with any variant) |
+| `disabled`                  | `isDisabled`                                       |
+| `onClick`                   | `onPress`                                          |
+| `startIcon` / `endIcon`     | `iconStart` / `iconEnd`                            |
+| lab `LoadingButton loading` | `isPending`                                        |
+
+There is no `danger` variant; use `destructive`:
+
+```typescript
+<Button
+  variant="primary"
+  destructive
+  isPending={deleting}
+  onPress={handleDelete}
+>
+  Delete
+</Button>
+```
+
+### 9. Form Field Changes
 
 **Before (MUI TextField):**
 
@@ -353,7 +453,7 @@ import { Dialog, DialogTrigger, DialogHeader, DialogFooter, Button } from '@back
   name="title"
   label="Title"
   value={value}
-  onChange={(e) => setValue(e.target.value)}
+  onChange={e => setValue(e.target.value)}
   fullWidth
 />
 ```
@@ -363,14 +463,29 @@ import { Dialog, DialogTrigger, DialogHeader, DialogFooter, Button } from '@back
 ```typescript
 <TextField
   isRequired
-  id="title"
+  name="title"
   label="Title"
   value={value}
-  onChange={(newValue) => setValue(newValue)}  // receives string directly!
+  onChange={newValue => setValue(newValue)} // receives string directly!
 />
 ```
 
-Note: BUI TextField `onChange` receives the string value directly, not an event object.
+Note: BUI form fields call `onChange` with the value directly, not an event object. `TextField` and `TextAreaField` pass a string, `NumberField` a number, and `Checkbox`/`Switch` a boolean.
+
+**Checkbox and Switch:**
+
+```typescript
+<Checkbox
+  isSelected={checked}
+  isIndeterminate={someSelected}
+  onChange={(isSelected) => setChecked(isSelected)}
+>
+  Label
+</Checkbox>
+<Switch label="Enabled" isSelected={enabled} onChange={setEnabled} />
+```
+
+Prop mapping: `checked` → `isSelected`, `indeterminate` → `isIndeterminate`, `disabled` → `isDisabled`. There are no `error`/`helperText` props on BUI fields; use `isInvalid` and `validate` instead.
 
 ### 10. Tabs Pattern
 
@@ -387,7 +502,7 @@ import { TabContext, TabList, TabPanel } from '@material-ui/lab';
   </TabList>
   <TabPanel value="tab1">Content 1</TabPanel>
   <TabPanel value="tab2">Content 2</TabPanel>
-</TabContext>
+</TabContext>;
 ```
 
 **After (BUI Tabs):**
@@ -402,8 +517,10 @@ import { Tabs, TabList, Tab, TabPanel } from '@backstage/ui';
   </TabList>
   <TabPanel id="tab1">Content 1</TabPanel>
   <TabPanel id="tab2">Content 2</TabPanel>
-</Tabs>
+</Tabs>;
 ```
+
+For controlled tabs use `selectedKey` and `onSelectionChange`.
 
 ### 11. Menu Pattern
 
@@ -432,10 +549,12 @@ import { RiMore2Line } from '@remixicon/react';
   <Menu>
     <MenuItem onAction={handleAction}>Action</MenuItem>
   </Menu>
-</MenuTrigger>
+</MenuTrigger>;
 ```
 
-### 12. List to HTML with CSS Modules
+No anchor state needed; `MenuTrigger` manages open/close.
+
+### 12. List Pattern
 
 **Before (MUI List):**
 
@@ -444,52 +563,45 @@ import { List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
 
 <List>
   <ListItem>
-    <ListItemIcon><SomeIcon /></ListItemIcon>
+    <ListItemIcon>
+      <SomeIcon />
+    </ListItemIcon>
     <ListItemText primary="Title" secondary="Description" />
   </ListItem>
-</List>
+</List>;
 ```
 
-**After (HTML list with BUI and CSS Modules):**
-
-```css
-/* MyList.module.css */
-@layer components {
-  .list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-  }
-
-  .listItem {
-    display: flex;
-    align-items: flex-start;
-    padding: var(--bui-space-2) 0;
-  }
-
-  .listItemIcon {
-    min-width: 36px;
-    display: flex;
-    align-items: center;
-    color: var(--bui-fg-primary);
-  }
-}
-```
+**After (BUI List/ListRow):**
 
 ```typescript
-import { Flex, Text } from '@backstage/ui';
+import { List, ListRow } from '@backstage/ui';
 import { RiSomeIcon } from '@remixicon/react';
-import styles from './MyList.module.css';
 
-<ul className={styles.list}>
-  <li className={styles.listItem}>
-    <div className={styles.listItemIcon}><RiSomeIcon size={20} /></div>
-    <Flex direction="column">
-      <Text>Title</Text>
-      <Text variant="body-small" color="secondary">Description</Text>
-    </Flex>
-  </li>
-</ul>
+<List aria-label="Items">
+  <ListRow icon={<RiSomeIcon />} description="Description">
+    Title
+  </ListRow>
+</List>;
+```
+
+The row's main label goes in `children` (arbitrary content is fine); `description` is the secondary line and `icon` the leading icon. `List` gives you keyboard navigation, selection (`selectionMode`, `onSelectionChange`), and row navigation (`href` on `ListRow`) for free. For a per-row dropdown menu pass `MenuItem` elements to `menuItems`; other right-side actions go in `customActions`:
+
+```typescript
+import { List, ListRow, MenuItem } from '@backstage/ui';
+
+<List aria-label="Documents">
+  {documents.map(doc => (
+    <ListRow
+      key={doc.id}
+      id={doc.id}
+      href={doc.url}
+      description={doc.summary}
+      menuItems={<MenuItem onAction={() => handleDelete(doc)}>Delete</MenuItem>}
+    >
+      {doc.title}
+    </ListRow>
+  ))}
+</List>;
 ```
 
 ### 13. Chip to Tag
@@ -499,7 +611,7 @@ import styles from './MyList.module.css';
 ```typescript
 import { Chip } from '@material-ui/core';
 
-<Chip label="Category" size="small" />
+<Chip label="Category" size="small" />;
 ```
 
 **After (BUI Tag):**
@@ -507,10 +619,169 @@ import { Chip } from '@material-ui/core';
 ```typescript
 import { Tag } from '@backstage/ui';
 
-<Tag size="small">Category</Tag>
+<Tag size="small">Category</Tag>;
 ```
 
-### 14. Icons: MUI Icons to Remix Icons
+For removable chips (`onDelete`), wrap Tags with stable `id`s in a `TagGroup` and use its `onRemove` callback.
+
+### 14. Alert Pattern
+
+**Before (MUI lab Alert):**
+
+```typescript
+import { Alert } from '@material-ui/lab';
+
+<Alert severity="error">Something went wrong</Alert>
+<Alert severity="info">
+  <strong>Heads up</strong> - the sync is still running
+</Alert>
+```
+
+**After (BUI Alert):**
+
+```typescript
+import { Alert } from '@backstage/ui';
+
+<Alert status="danger" title="Something went wrong" />
+<Alert
+  status="info"
+  icon
+  title="Heads up"
+  description="The sync is still running"
+/>
+```
+
+Notes:
+
+- The prop is `status`, not `severity`, and MUI's `error` becomes `danger` (valid values: `info`, `success`, `warning`, `danger`).
+- Content goes in the `title` and `description` props; `Alert` takes no children.
+- `icon` renders the status icon (pass `true` for the default or a custom element).
+- For MUI's `action`/`onClose`, pass buttons to `customActions`.
+
+### 15. Table Pattern
+
+**Before (MUI Table):**
+
+```typescript
+import {
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@material-ui/core';
+
+<TableContainer component={Paper}>
+  <Table>
+    <TableHead>
+      <TableRow>
+        <TableCell>Name</TableCell>
+        <TableCell>Owner</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {items.map(item => (
+        <TableRow key={item.id}>
+          <TableCell>{item.name}</TableCell>
+          <TableCell>{item.owner}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+</TableContainer>;
+```
+
+**After (BUI Table):**
+
+BUI's `Table` is configuration-driven: describe the columns once and pass the data. Rows need an `id` field.
+
+```typescript
+import { CellText, Table } from '@backstage/ui';
+
+const columns = [
+  {
+    id: 'name',
+    label: 'Name',
+    cell: (item: Item) => <CellText title={item.name} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner',
+    cell: (item: Item) => <CellText title={item.owner} color="secondary" />,
+  },
+];
+
+<Table columnConfig={columns} data={items} pagination={{ type: 'none' }} />;
+```
+
+Notes:
+
+- `pagination` is required; `{ type: 'none' }` renders all rows.
+- Each `cell` must return a `Cell`, `CellText`, or `CellProfile` element (bare text breaks the layout). `CellText` takes `title`/`description`/`href`; `CellProfile` renders an avatar with `name`/`src`.
+- Row links and clicks go through `rowConfig` (`getHref`, `onClick`); selection through `selection`.
+
+**Pagination and sorting via `useTable`:**
+
+Paginated tables no longer need MUI lab. Let `useTable` manage pagination, sorting, and loading state, and spread its `tableProps`:
+
+```typescript
+import { CellText, Table, useTable } from '@backstage/ui';
+
+const { tableProps } = useTable({
+  mode: 'complete',
+  data: items,
+  paginationOptions: { pageSize: 10 },
+});
+
+<Table columnConfig={columns} {...tableProps} />;
+```
+
+Mark columns with `isSortable: true` to get sort headers. For server-side data use `mode: 'offset'` or `mode: 'cursor'` with a `getData` callback; `useTable` handles the page state and passes `offset`/`cursor` to you. A standalone `TablePagination` component exists for fully custom tables built from the low-level parts (`TableRoot`, `TableHeader`, `TableBody`, `Column`, `Row`, `Cell`).
+
+### 16. Autocomplete to Combobox
+
+**Before (MUI lab Autocomplete):**
+
+```typescript
+import { Autocomplete } from '@material-ui/lab';
+import { TextField } from '@material-ui/core';
+
+<Autocomplete
+  options={users}
+  getOptionLabel={option => option.name}
+  value={selected}
+  onChange={(_event, newValue) => setSelected(newValue)}
+  renderInput={params => <TextField {...params} label="User" />}
+/>;
+```
+
+**After (BUI Combobox):**
+
+```typescript
+import { useState } from 'react';
+import { Combobox, type Key } from '@backstage/ui';
+
+const [selectedId, setSelectedId] = useState<Key | null>(null);
+
+<Combobox
+  label="User"
+  options={users.map(user => ({ id: user.id, label: user.name }))}
+  value={selectedId}
+  onChange={id => setSelectedId(id)}
+/>;
+```
+
+Notes:
+
+- No `renderInput`; the input is built in and labeled via `label`/`placeholder`.
+- Options are `{ id, label }` objects (plus optional `description`, `leadingIcon`, `disabled`); `value`/`onChange` work with the selected option's `id`, not the option object.
+- Type the selection state as `Key | null` with `Key` imported from `@backstage/ui`; React's own `Key` type includes `bigint` and does not typecheck here.
+- For async options, pass the result of `useAsyncList` (re-exported from `@backstage/ui`) as `options`, or use `search: { mode: 'server', ... }` for server-side filtering.
+- `Select` follows the same options-driven API; use `Select` when the user picks from a fixed list without typing.
+
+### 17. Icons: MUI Icons to Remix Icons
 
 **Before (MUI Icons):**
 
@@ -533,29 +804,29 @@ import { RiCloseLine, RiSearchLine } from '@remixicon/react';
 
 Common icon mappings:
 
-| MUI Icon | Remix Icon |
-|----------|------------|
-| `Close` | `RiCloseLine` |
-| `Search` | `RiSearchLine` |
-| `Settings` | `RiSettingsLine` |
-| `Add` | `RiAddLine` |
-| `Delete` | `RiDeleteBinLine` |
-| `Edit` | `RiEditLine` |
-| `Check` | `RiCheckLine` |
-| `Error` | `RiErrorWarningLine` |
-| `Warning` | `RiAlertLine` |
-| `Info` | `RiInformationLine` |
-| `ExpandMore` | `RiArrowDownSLine` |
-| `ExpandLess` | `RiArrowUpSLine` |
-| `ChevronRight` | `RiArrowRightSLine` |
-| `ChevronLeft` | `RiArrowLeftSLine` |
-| `Menu` | `RiMenuLine` |
-| `MoreVert` | `RiMore2Line` |
-| `Visibility` | `RiEyeLine` |
-| `VisibilityOff` | `RiEyeOffLine` |
-| `NewReleases` | `RiMegaphoneLine` |
-| `RecordVoiceOver` | `RiMegaphoneLine` |
-| `Description` | `RiFileTextLine` |
+| MUI Icon          | Remix Icon           |
+| ----------------- | -------------------- |
+| `Close`           | `RiCloseLine`        |
+| `Search`          | `RiSearchLine`       |
+| `Settings`        | `RiSettingsLine`     |
+| `Add`             | `RiAddLine`          |
+| `Delete`          | `RiDeleteBinLine`    |
+| `Edit`            | `RiEditLine`         |
+| `Check`           | `RiCheckLine`        |
+| `Error`           | `RiErrorWarningLine` |
+| `Warning`         | `RiAlertLine`        |
+| `Info`            | `RiInformationLine`  |
+| `ExpandMore`      | `RiArrowDownSLine`   |
+| `ExpandLess`      | `RiArrowUpSLine`     |
+| `ChevronRight`    | `RiArrowRightSLine`  |
+| `ChevronLeft`     | `RiArrowLeftSLine`   |
+| `Menu`            | `RiMenuLine`         |
+| `MoreVert`        | `RiMore2Line`        |
+| `Visibility`      | `RiEyeLine`          |
+| `VisibilityOff`   | `RiEyeOffLine`       |
+| `NewReleases`     | `RiMegaphoneLine`    |
+| `RecordVoiceOver` | `RiMegaphoneLine`    |
+| `Description`     | `RiFileTextLine`     |
 
 Find more icons at: https://remixicon.com/
 
@@ -563,91 +834,110 @@ Find more icons at: https://remixicon.com/
 
 ### Spacing
 
-| MUI theme.spacing() | BUI CSS Variable |
-|---------------------|------------------|
+| MUI theme.spacing()  | BUI CSS Variable     |
+| -------------------- | -------------------- |
 | `theme.spacing(0.5)` | `var(--bui-space-1)` |
-| `theme.spacing(1)` | `var(--bui-space-2)` |
+| `theme.spacing(1)`   | `var(--bui-space-2)` |
 | `theme.spacing(1.5)` | `var(--bui-space-3)` |
-| `theme.spacing(2)` | `var(--bui-space-4)` |
-| `theme.spacing(3)` | `var(--bui-space-6)` |
-| `theme.spacing(4)` | `var(--bui-space-8)` |
+| `theme.spacing(2)`   | `var(--bui-space-4)` |
+| `theme.spacing(3)`   | `var(--bui-space-6)` |
+| `theme.spacing(4)`   | `var(--bui-space-8)` |
+
+The scale runs `--bui-space-0_5` (2px) through `--bui-space-14` (56px) in 4px steps (half steps use an underscore: `0_5`, `1_5`).
 
 ### Colors
 
-| MUI theme.palette | BUI CSS Variable |
-|-------------------|------------------|
-| `text.primary` | `var(--bui-fg-primary)` |
-| `text.secondary` | `var(--bui-fg-secondary)` |
-| `background.paper` | `var(--bui-bg-surface-1)` |
-| `background.default` | `var(--bui-bg-surface-0)` |
-| `primary.main` | `var(--bui-bg-solid)` or `var(--bui-ring)` |
-| `error.main` | `var(--bui-fg-danger)` |
-| `action.hover` | `var(--bui-bg-hover)` |
-| `divider` | `var(--bui-border)` |
+| MUI theme.palette    | BUI CSS Variable                                                          |
+| -------------------- | ------------------------------------------------------------------------- |
+| `text.primary`       | `var(--bui-fg-primary)`                                                   |
+| `text.secondary`     | `var(--bui-fg-secondary)`                                                 |
+| `text.disabled`      | `var(--bui-fg-disabled)`                                                  |
+| `background.default` | `var(--bui-bg-app)`                                                       |
+| `background.paper`   | `var(--bui-bg-neutral-1)`                                                 |
+| `divider`            | `var(--bui-border-1)`                                                     |
+| `primary.main`       | `var(--bui-accent-bg)`                                                    |
+| `error.main`         | `var(--bui-fg-negative)` (text/icons) or `var(--bui-negative-bg)` (fills) |
+| `warning.main`       | `var(--bui-fg-warning)` or `var(--bui-warning-bg)`                        |
+| `success.main`       | `var(--bui-fg-positive)` or `var(--bui-positive-bg)`                      |
+| `info.main`          | `var(--bui-fg-announcement)` or `var(--bui-announcement-bg)`              |
+
+Status and accent colors come in five semantic families: `accent`, `announcement` (MUI "info"), `warning`, `negative` (MUI "error"), `positive` (MUI "success"). The status families provide `--bui-<family>-bg`, `--bui-<family>-fg`, and `--bui-<family>-border`, plus `-subdued` variants for tinted backgrounds; `-hover` and `-disabled` states exist on the `bg` tokens. The `accent` family only has `bg` and `fg` tokens (no `-border`, no `-subdued`):
+
+| Use case                         | Token pattern               | Example                          |
+| -------------------------------- | --------------------------- | -------------------------------- |
+| Solid fill                       | `--bui-<family>-bg`         | `var(--bui-negative-bg)`         |
+| Text on solid fill               | `--bui-<family>-fg`         | `var(--bui-negative-fg)`         |
+| Tinted background                | `--bui-<family>-bg-subdued` | `var(--bui-negative-bg-subdued)` |
+| Text on tinted background        | `--bui-<family>-fg-subdued` | `var(--bui-negative-fg-subdued)` |
+| Border                           | `--bui-<family>-border`     | `var(--bui-negative-border)`     |
+| Status text on a neutral surface | `--bui-fg-<status>`         | `var(--bui-fg-negative)`         |
+
+Neutral surfaces: `--bui-bg-app` is the page background; `--bui-bg-neutral-1` through `--bui-bg-neutral-4` are nested surface levels (cards, panels). Borders: `--bui-border-1` (subtle, dividers) and `--bui-border-2` (strong, inputs).
+
+Do not use `--bui-bg-surface-*`, bare `--bui-border`, `--bui-fg-link`, `--bui-fg-danger/success/info`, `--bui-bg-solid`, `--bui-bg-danger/warning/success/info`, or any `-tint` token; these are removed or deprecated. MUI's `action.hover` has no non-deprecated equivalent; prefer letting interactive BUI components render their own hover states.
 
 ### Typography
 
-| Property | BUI CSS Variable |
-|----------|------------------|
-| Font family | `var(--bui-font-regular)` |
-| Font size small | `var(--bui-font-size-1)` |
-| Font size medium | `var(--bui-font-size-2)` |
-| Font size large | `var(--bui-font-size-3)` |
-| Font weight regular | `var(--bui-font-weight-regular)` |
-| Font weight bold | `var(--bui-font-weight-bold)` |
+| Property                   | BUI CSS Variable                 |
+| -------------------------- | -------------------------------- |
+| Font family                | `var(--bui-font-regular)`        |
+| Monospace font family      | `var(--bui-font-monospace)`      |
+| `caption` font size (12px) | `var(--bui-font-size-2)`         |
+| `body2` font size (14px)   | `var(--bui-font-size-3)`         |
+| `body1` font size (16px)   | `var(--bui-font-size-4)`         |
+| Font weight regular        | `var(--bui-font-weight-regular)` |
+| Font weight bold           | `var(--bui-font-weight-bold)`    |
+
+The size scale runs `--bui-font-size-1` (10px) through `--bui-font-size-10` (92px); the body default is `--bui-font-size-3` (14px).
 
 ### Other
 
-| Property | BUI CSS Variable |
-|----------|------------------|
-| Border radius small | `var(--bui-radius-2)` |
-| Border radius medium | `var(--bui-radius-3)` |
-| Border radius full | `var(--bui-radius-full)` |
-| Link color | `var(--bui-fg-link)` |
+| Property             | BUI CSS Variable         |
+| -------------------- | ------------------------ |
+| Border radius small  | `var(--bui-radius-2)`    |
+| Border radius medium | `var(--bui-radius-3)`    |
+| Border radius full   | `var(--bui-radius-full)` |
 
 ## Known Limitations
 
-Some Backstage APIs still require MUI-compatible icon types:
-
-- **NavItemBlueprint** (`@backstage/frontend-plugin-api`): The `icon` prop expects MUI `IconComponent` type. Remix icons are not type-compatible.
-- **Timeline** (`@material-ui/lab`): No BUI equivalent exists.
-- **Pagination** (`@material-ui/lab`): No BUI equivalent exists.
-- **Alert** (`@material-ui/lab`): No BUI equivalent exists.
-
-For these cases, keep using MUI components.
+- **Timeline** (`@material-ui/lab`): No BUI equivalent exists. Keep using MUI for it.
 
 ## Migration Checklist
 
 When migrating a plugin:
 
 1. [ ] Add `@backstage/ui` dependency
-2. [ ] Add `@remixicon/react` dependency (if using icons)
-3. [ ] Add `react-aria-components` dependency (if using Tooltip)
-4. [ ] Add CSS import to root file
-5. [ ] Remove `@material-ui/core` imports (except components with no BUI equivalent)
-6. [ ] Remove `@material-ui/icons` imports
+2. [ ] Add `@remixicon/react` dependency pinned `>=4.6.0 <4.9.0` (if using icons)
+3. [ ] Add CSS import to `packages/app/src/index.tsx` (only if the workspace has a full dev app; `createDevApp` workspaces need nothing)
+4. [ ] Remove `@material-ui/core` imports (except components with no BUI equivalent)
+5. [ ] Remove `@material-ui/icons` imports
+6. [ ] Remove `@material-ui/lab` imports (Alert, Autocomplete, and Pagination all have BUI equivalents now; Timeline does not)
 7. [ ] Remove `makeStyles` and related imports
 8. [ ] Create `.module.css` files for component styles
 9. [ ] Replace `Typography` with `Text`
 10. [ ] Replace `Box display="flex"` with `Flex`
 11. [ ] Replace `Grid container/item` with `Grid.Root/Grid.Item`
 12. [ ] Replace `Paper` with `Card`
-13. [ ] Replace MUI `Dialog` with BUI `DialogTrigger` pattern
-14. [ ] Replace MUI `Tooltip` with BUI `TooltipTrigger` pattern
+13. [ ] Replace MUI `Dialog` with BUI `Dialog`
+14. [ ] Replace MUI `Tooltip` with BUI `TooltipTrigger` + `Tooltip`
 15. [ ] Replace MUI `Tabs` with BUI `Tabs`
 16. [ ] Replace MUI `Menu` with BUI `MenuTrigger` pattern
-17. [ ] Replace `Chip` with `Tag`
-18. [ ] Replace `IconButton` with `ButtonIcon`
-19. [ ] Update `Button` props (`disabled` → `isDisabled`, `variant="contained"` → `variant="primary"`)
-20. [ ] Update `TextField` props (`required` → `isRequired`, `onChange` signature)
-21. [ ] Replace MUI icons with Remix icons
-22. [ ] Run `yarn tsc` to check for type errors
-23. [ ] Run `yarn build` to verify build
-24. [ ] Run `yarn lint` to check for missing dependencies
-25. [ ] Test component rendering and functionality
+17. [ ] Replace MUI `List` with BUI `List`/`ListRow`
+18. [ ] Replace MUI lab `Alert` with BUI `Alert` (`severity` → `status`, `error` → `danger`)
+19. [ ] Replace MUI `Table` with BUI `Table` (`columnConfig`/`data`/`pagination`, `useTable` for paginated/sorted tables)
+20. [ ] Replace MUI lab `Autocomplete` with BUI `Combobox`
+21. [ ] Replace `Chip` with `Tag`
+22. [ ] Replace `IconButton` with `ButtonIcon`
+23. [ ] Update `Button` props (`variant="contained"` → `variant="primary"`, `disabled` → `isDisabled`, `onClick` → `onPress`, loading state → `isPending`)
+24. [ ] Update `TextField` props (`required` → `isRequired`, `onChange` signature)
+25. [ ] Update `Checkbox`/`Switch` props (`checked` → `isSelected`, `indeterminate` → `isIndeterminate`)
+26. [ ] Replace MUI icons with Remix icons
+27. [ ] Run `yarn tsc:full` to check for type errors
+28. [ ] Run `yarn lint` to check for missing dependencies
+29. [ ] Test component rendering and functionality
 
 ## Reference
 
 - BUI Documentation: https://ui.backstage.io
 - Remix Icons: https://remixicon.com/
-- Example Migration PR: https://github.com/backstage/backstage/pull/31631
+- Example Migration PR: https://github.com/backstage/community-plugins/pull/10062


### PR DESCRIPTION
We have been eagerly using the mui-to-bui skill for migrating our plugins from MUI to BUI, but we noticed the skill hasn't been updated in a while, which often resulted in insufficient and outdated output.

This PR brings the mui-to-bui skill up to date with the latest version of Backstage UI (0.17.1).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
