### PR TITLE
The techinsights page did not appear in the sidebar when hosted on NFS.

### DIFF
--- a/workspaces/tech-insights/.changeset/lazy-rivers-brake.md
+++ b/workspaces/tech-insights/.changeset/lazy-rivers-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tech-insights': patch
+---
+
+The techinsights page did not appear in the sidebar when hosted on NFS.

--- a/workspaces/tech-insights/plugins/tech-insights/src/alpha/pages.tsx
+++ b/workspaces/tech-insights/plugins/tech-insights/src/alpha/pages.tsx
@@ -16,6 +16,7 @@
 import { compatWrapper } from '@backstage/core-compat-api';
 import { PageBlueprint } from '@backstage/frontend-plugin-api';
 import EmojiObjectsIcon from '@material-ui/icons/EmojiObjects';
+import { rootRouteRef } from '../routes';
 
 /**
  * Page extension that displays the Tech Insights scorecards overview page.
@@ -27,6 +28,7 @@ export const techInsightsScorecardPage = PageBlueprint.make({
     path: '/tech-insights',
     title: 'Tech Insights',
     icon: <EmojiObjectsIcon />,
+    routeRef: rootRouteRef,
     loader: () =>
       import('../components/ScorecardsPage').then(m =>
         compatWrapper(<m.ScorecardsPage />),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes : #9800 

The techinsights page did not appear in the sidebar when hosted on NFS.

As discussed in the ticket for #9800, it is necessary to add `routeDef` to the `PageBlueprint` specification.


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
