### PR TITLE
fix(argocd): allow token or username/password in instance config schema

### DIFF
--- a/workspaces/argocd/.changeset/argocd-optional-instance-auth.md
+++ b/workspaces/argocd/.changeset/argocd-optional-instance-auth.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-argocd': patch
+'@backstage-community/plugin-argocd-backend': patch
+---
+
+Allow Argo CD instance authentication via either an access token or username/password in the config schema. Username and password on each instance are no longer required, matching the documented token-based setup.

--- a/workspaces/argocd/.changeset/argocd-optional-instance-auth.md
+++ b/workspaces/argocd/.changeset/argocd-optional-instance-auth.md
@@ -3,4 +3,4 @@
 '@backstage-community/plugin-argocd-backend': patch
 ---
 
-Allow Argo CD instance authentication via either an access token or username/password in the config schema. Username and password on each instance are no longer required, matching the documented token-based setup.
+Marked `username` and `password` as optional in config schema and fixed visibility metadata for authentication fields.

--- a/workspaces/argocd/plugins/argocd-backend/config.d.ts
+++ b/workspaces/argocd/plugins/argocd-backend/config.d.ts
@@ -17,10 +17,12 @@ export interface Config {
   /** ArgoCD Configurations for the ArgoCD backend plugin */
   argocd?: {
     /**
+     * Default username used when an instance has no token or username.
      * @visibility backend
      */
     username?: string;
     /**
+     * Default password used when an instance has no token or password.
      * @visibility secret
      */
     password?: string;
@@ -34,8 +36,8 @@ export interface Config {
      */
     appLocatorMethods?: Array<{
       /**
-       * The frontend base url of the ArgoCD instance.
-       * @vsibility backend
+       * Locator type. Use `config` to load instances from this file.
+       * @visibility backend
        */
       type: string;
       instances: Array<{
@@ -48,15 +50,18 @@ export interface Config {
          */
         url: string;
         /**
+         * Instance access token. Preferred over username/password when set.
          * @visibility secret
          */
         token?: string;
         /**
+         * Instance username. Used when token is not set.
          * @visibility secret
          */
         username?: string;
         /**
-         * @visiblity secret
+         * Instance password. Used when token is not set.
+         * @visibility secret
          */
         password?: string;
       }>;

--- a/workspaces/argocd/plugins/argocd/config.d.ts
+++ b/workspaces/argocd/plugins/argocd/config.d.ts
@@ -64,13 +64,20 @@ export interface Config {
          */
         url: string;
         /**
+         * Instance access token. Preferred over username/password when set.
          * @visibility secret
          */
-        username: string;
+        token?: string;
         /**
+         * Instance username. Used when token is not set.
          * @visibility secret
          */
-        password: string;
+        username?: string;
+        /**
+         * Instance password. Used when token is not set.
+         * @visibility secret
+         */
+        password?: string;
       }>;
     }>;
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The frontend `config.d.ts` marked instance `username`/`password` as required and did not declare `token`. Plugin settings UIs that generate forms from the merged schema, therefore required username/password even though the backend already prefers an instance access token.

This makes instance `token`, `username`, and `password` optional in both frontend and backend schemas so either documented auth option is valid. Visibility typos on the backend schema (`@vsibility` / `@visiblity`) are also fixed so instance password is treated as a secret.

This PR was written with AI assistance. I reviewed the schemas against the backend auth order (instance token, then instance username/password, then defaults) and the existing token-based examples in the plugin docs and tests.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Assisted-by: Cursor Grok 4.6

Made with [Cursor](https://cursor.com)