### PR TITLE
Version Packages (quay)

### DIFF
--- a/workspaces/quay/.changeset/renovate-4933d44.md
+++ b/workspaces/quay/.changeset/renovate-4933d44.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `start-server-and-test` to `3.0.12`.

--- a/workspaces/quay/.changeset/renovate-5a12e48.md
+++ b/workspaces/quay/.changeset/renovate-5a12e48.md
@@ -1,6 +1,0 @@
----
-'@backstage-community/plugin-quay': patch
----
-
-Updated dependency `@remixicon/react` to `<4.10.0`.
-Updated dependency `@playwright/test` to `1.62.1`.

--- a/workspaces/quay/.changeset/version-bump-1-54-6.md
+++ b/workspaces/quay/.changeset/version-bump-1-54-6.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-quay': minor
-'@backstage-community/plugin-scaffolder-backend-module-quay': minor
-'@backstage-community/plugin-quay-backend': minor
-'@backstage-community/plugin-quay-common': minor
----
-
-Backstage version bump to v1.54.6

--- a/workspaces/quay/plugins/quay-actions/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-quay
 
+## 2.22.0
+
+### Minor Changes
+
+- 2f52648: Backstage version bump to v1.54.6
+
 ## 2.21.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-actions/package.json
+++ b/workspaces/quay/plugins/quay-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-quay",
   "description": "The quay-actions module for @backstage-community/plugin-scaffolder-backend-module-quay",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-backend/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-backend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-quay-backend
 
+## 1.18.0
+
+### Minor Changes
+
+- 2f52648: Backstage version bump to v1.54.6
+
+### Patch Changes
+
+- Updated dependencies [2f52648]
+  - @backstage-community/plugin-quay-common@1.23.0
+
 ## 1.17.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-backend/package.json
+++ b/workspaces/quay/plugins/quay-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-backend",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay-common/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-quay-common
 
+## 1.23.0
+
+### Minor Changes
+
+- 2f52648: Backstage version bump to v1.54.6
+
 ## 1.22.1
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay-common/package.json
+++ b/workspaces/quay/plugins/quay-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay-common",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/quay/plugins/quay/CHANGELOG.md
+++ b/workspaces/quay/plugins/quay/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @backstage-community/plugin-quay
 
+## 1.38.0
+
+### Minor Changes
+
+- 2f52648: Backstage version bump to v1.54.6
+
+### Patch Changes
+
+- d68f5f9: Updated dependency `start-server-and-test` to `3.0.12`.
+- 7eee6b2: Updated dependency `@remixicon/react` to `<4.10.0`.
+  Updated dependency `@playwright/test` to `1.62.1`.
+- Updated dependencies [2f52648]
+  - @backstage-community/plugin-quay-common@1.23.0
+
 ## 1.37.2
 
 ### Patch Changes

--- a/workspaces/quay/plugins/quay/package.json
+++ b/workspaces/quay/plugins/quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-quay",
-  "version": "1.37.2",
+  "version": "1.38.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-quay@1.38.0

### Minor Changes

-   2f52648: Backstage version bump to v1.54.6

### Patch Changes

-   d68f5f9: Updated dependency `start-server-and-test` to `3.0.12`.
-   7eee6b2: Updated dependency `@remixicon/react` to `<4.10.0`.
    Updated dependency `@playwright/test` to `1.62.1`.
-   Updated dependencies [2f52648]
    -   @backstage-community/plugin-quay-common@1.23.0

## @backstage-community/plugin-scaffolder-backend-module-quay@2.22.0

### Minor Changes

-   2f52648: Backstage version bump to v1.54.6

## @backstage-community/plugin-quay-backend@1.18.0

### Minor Changes

-   2f52648: Backstage version bump to v1.54.6

### Patch Changes

-   Updated dependencies [2f52648]
    -   @backstage-community/plugin-quay-common@1.23.0

## @backstage-community/plugin-quay-common@1.23.0

### Minor Changes

-   2f52648: Backstage version bump to v1.54.6
