### PR TITLE
Version Packages (argocd)

### DIFF
--- a/workspaces/argocd/.changeset/version-bump-1-54-5.md
+++ b/workspaces/argocd/.changeset/version-bump-1-54-5.md
@@ -1,8 +1,0 @@
----
-'@backstage-community/plugin-argocd': minor
-'@backstage-community/plugin-argocd-backend': minor
-'@backstage-community/plugin-argocd-common': minor
-'@backstage-community/plugin-argocd-node': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-backend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @backstage-community/plugin-argocd-backend
 
+## 1.7.0
+
+### Minor Changes
+
+- 548d597: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- Updated dependencies [548d597]
+  - @backstage-community/plugin-argocd-common@1.18.0
+  - @backstage-community/plugin-argocd-node@1.4.0
+
 ## 1.6.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-backend/package.json
+++ b/workspaces/argocd/plugins/argocd-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-backend",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-argocd-common
 
+## 1.18.0
+
+### Minor Changes
+
+- 548d597: Backstage version bump to v1.54.5
+
 ## 1.17.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-common/package.json
+++ b/workspaces/argocd/plugins/argocd-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-common",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd-node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd-node
 
+## 1.4.0
+
+### Minor Changes
+
+- 548d597: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- Updated dependencies [548d597]
+  - @backstage-community/plugin-argocd-common@1.18.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/workspaces/argocd/plugins/argocd-node/package.json
+++ b/workspaces/argocd/plugins/argocd-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd-node",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/workspaces/argocd/plugins/argocd/CHANGELOG.md
+++ b/workspaces/argocd/plugins/argocd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @backstage-community/plugin-argocd
 
+## 3.1.0
+
+### Minor Changes
+
+- 548d597: Backstage version bump to v1.54.5
+
+### Patch Changes
+
+- Updated dependencies [548d597]
+  - @backstage-community/plugin-argocd-common@1.18.0
+
 ## 3.0.0
 
 ### Major Changes

--- a/workspaces/argocd/plugins/argocd/package.json
+++ b/workspaces/argocd/plugins/argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-argocd",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-argocd@3.1.0

### Minor Changes

-   548d597: Backstage version bump to v1.54.5

### Patch Changes

-   Updated dependencies [548d597]
    -   @backstage-community/plugin-argocd-common@1.18.0

## @backstage-community/plugin-argocd-backend@1.7.0

### Minor Changes

-   548d597: Backstage version bump to v1.54.5

### Patch Changes

-   Updated dependencies [548d597]
    -   @backstage-community/plugin-argocd-common@1.18.0
    -   @backstage-community/plugin-argocd-node@1.4.0

## @backstage-community/plugin-argocd-common@1.18.0

### Minor Changes

-   548d597: Backstage version bump to v1.54.5

## @backstage-community/plugin-argocd-node@1.4.0

### Minor Changes

-   548d597: Backstage version bump to v1.54.5

### Patch Changes

-   Updated dependencies [548d597]
    -   @backstage-community/plugin-argocd-common@1.18.0
