### PR TITLE
chore(servicenow): keep all plugin versions in sync via changesets

### DIFF
--- a/workspaces/servicenow/.changeset/config.json
+++ b/workspaces/servicenow/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@backstage-community/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Configures changesets to keep all `@backstage-community/*` packages in the servicenow workspace on the same version, so the frontend and backend plugins are always released together. Same setup as the `npm` workspace.

The current versions of the different servicenow packages are "really close to each other", but at the same time not aligned:

```
grep version workspaces/servicenow/plugins/*/package.json

workspaces/servicenow/plugins/servicenow-backend/package.json:  "version": "1.14.0",
workspaces/servicenow/plugins/servicenow-common/package.json:   "version": "1.13.0",
workspaces/servicenow/plugins/servicenow/package.json:          "version": "1.15.0",
```

This confusion gets resolved by this configuration, the next time a minor version for the frontend or backend package will release a 1.16 of all packages.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMgd39M5Fn1YHZQXJtkJMs