### PR TITLE
chore(ocm): keep all plugin versions in sync via changeset fixed group

### DIFF
--- a/workspaces/ocm/.changeset/config.json
+++ b/workspaces/ocm/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@backstage-community/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a changeset `fixed` group to the `ocm` workspace so that all `@backstage-community/*` packages in this workspace are released with the same version number, instead of drifting apart over time.

This matches the setup already used in the `npm` workspace.

No changeset is included since this only affects release tooling configuration and does not change any published package code.

The current versions of the OCM frontend and backend packages are "really close to each other", but at the same time not aligned:

```
grep version workspaces/ocm/plugins/*/package.json

workspaces/ocm/plugins/ocm-backend/package.json:  "version": "5.21.0",
workspaces/ocm/plugins/ocm-common/package.json:   "version": "3.24.0",
workspaces/ocm/plugins/ocm/package.json:          "version": "5.20.0",
```

This confusion gets resolved by this configuration, the next time a minor version for the frontend or backend package will release a 5.22 of all packages. The ocm frontend version 5.21 get skipped, and ocm-common will also jump to an aligned version.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))