### PR TITLE
chore(multi-source-security-viewer): keep all plugin versions in sync via changeset fixed group

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/config.json
+++ b/workspaces/multi-source-security-viewer/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@backstage-community/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a changeset `fixed` group to the `multi-source-security-viewer` workspace so that all `@backstage-community/*` packages in this workspace are released with the same version number, instead of drifting apart over time.

This matches the setup already used in the `npm` workspace, and follows the same change proposed for `ocm` in #10570.

No changeset is included since this only affects release tooling configuration and does not change any published package code.

The current versions of the frontend, backend and common packages have drifted apart:

```
grep version workspaces/multi-source-security-viewer/plugins/*/package.json

.../multi-source-security-viewer-common/package.json:   "version": "0.15.0",
.../multi-source-security-viewer-backend/package.json:  "version": "0.6.0",
.../multi-source-security-viewer/package.json:          "version": "0.17.3",
```

With this configuration the next release will align all three packages on a single version number.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
