### PR TITLE
chore(mcp-chat): version all plugins together via a fixed changeset group

### DIFF
--- a/workspaces/mcp-chat/.changeset/config.json
+++ b/workspaces/mcp-chat/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [["@backstage-community/*"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION
## Description

The `mcp-chat` workspace ships a frontend and a backend plugin that are released and used as a pair. Without a `fixed` group, changesets bumps them independently, so their published versions drift apart and it becomes unclear which frontend version matches which backend version.

This adds `"fixed": [["@backstage-community/*"]]` to the workspace's changeset config so all plugins in the workspace are released with the same version, mirroring what the `npm` workspace already does.

#### Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) — not applicable, no published source changed
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))