### PR TITLE
docs: fix typo alternativly -> alternatively

### DIFF
--- a/workspaces/npm/README.md
+++ b/workspaces/npm/README.md
@@ -282,7 +282,7 @@ npm:
 
 The `npm/registry: npmjs` annotation is required to use the npm backend.
 
-Alternativly you can setup a default registry (also for npmjs):
+Alternatively you can setup a default registry (also for npmjs):
 
 ```yaml
 # app-config.yaml


### PR DESCRIPTION
Corrects the misspelling `alternativly` -> `alternatively` in `workspaces/npm/README.md`.

Documentation only, no behaviour change.