### PR TITLE
Version Packages (scaffolder-backend-module-annotator)

### DIFF
--- a/workspaces/scaffolder-backend-module-annotator/.changeset/early-snakes-reflect.md
+++ b/workspaces/scaffolder-backend-module-annotator/.changeset/early-snakes-reflect.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-annotator': patch
----
-
-Installed Actions now better describes what each annotator action does and includes template examples for `catalog:annotate`.

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-annotator
 
+## 2.19.1
+
+### Patch Changes
+
+- bc49474: Installed Actions now better describes what each annotator action does and includes template examples for `catalog:annotate`.
+
 ## 2.19.0
 
 ### Minor Changes

--- a/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
+++ b/workspaces/scaffolder-backend-module-annotator/plugins/scaffolder-backend-module-annotator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-annotator",
   "description": "The annotator module for @backstage/plugin-scaffolder-backend",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-annotator@2.19.1

### Patch Changes

-   bc49474: Installed Actions now better describes what each annotator action does and includes template examples for `catalog:annotate`.
