### PR TITLE
fix: use blobless history for workspace detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,6 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Diagnose PR diff refs
-        run: |
-          echo "HEAD=$(git rev-parse HEAD)"
-          echo "BASE=$(git rev-parse origin/${BASE_REF})"
-          echo "MERGE_BASE=$(git merge-base origin/${BASE_REF} HEAD || true)"
-          git rev-parse --is-shallow-repository
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,25 @@ jobs:
           COMMITS: ${{ github.event.pull_request.commits }}
         run: echo "NUMBER_OF_COMMITS=$(($COMMITS + 1))" >> $GITHUB_ENV
 
-      - name: Checkout base branch for diff purposes
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-          fetch-depth: 50 # TODO(awanlin): Temporary fix
-
       - name: Checkout head branch
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
         with:
-          # Needed for diff
+          # Use GitHub's tested merge revision, falling back to the PR head for conflicted PRs.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.NUMBER_OF_COMMITS }}
+
+      - name: Fetch base commit for diff purposes
+        # BASE_REF is the target PR base; HEAD is the tested PR revision.
+        run: git fetch --no-tags origin "${BASE_SHA}:refs/remotes/origin/pr-base" --depth=1
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+      - name: Diagnose PR diff refs
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "BASE=$(git rev-parse origin/pr-base)"
+          echo "MERGE_BASE=$(git merge-base origin/pr-base HEAD || true)"
+          git rev-parse --is-shallow-repository
 
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -43,7 +51,7 @@ jobs:
         id: find-changed-workspaces
         run: node ./scripts/ci/list-workspaces-with-changes.js
         env:
-          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          BASE_REF: origin/pr-base
 
   ci:
     name: Workspace ${{ matrix.workspaceNodeMatrix.workspace }}, CI step for node ${{ matrix.workspaceNodeMatrix.nodeVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,18 @@ jobs:
         with:
           # Use GitHub's tested merge revision, falling back to the PR head for conflicted PRs.
           ref: ${{ github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha }}
-          fetch-depth: ${{ env.NUMBER_OF_COMMITS }}
-
-      - name: Fetch base commit for diff purposes
-        # BASE_REF is the target PR base; HEAD is the tested PR revision.
-        run: git fetch --no-tags origin "${BASE_SHA}:refs/remotes/origin/pr-base" --depth=1
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # Keep the commit graph while avoiding historical file contents.
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Diagnose PR diff refs
         run: |
           echo "HEAD=$(git rev-parse HEAD)"
-          echo "BASE=$(git rev-parse origin/pr-base)"
-          echo "MERGE_BASE=$(git merge-base origin/pr-base HEAD || true)"
+          echo "BASE=$(git rev-parse origin/${BASE_REF})"
+          echo "MERGE_BASE=$(git merge-base origin/${BASE_REF} HEAD || true)"
           git rev-parse --is-shallow-repository
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
@@ -51,7 +49,7 @@ jobs:
         id: find-changed-workspaces
         run: node ./scripts/ci/list-workspaces-with-changes.js
         env:
-          BASE_REF: origin/pr-base
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
 
   ci:
     name: Workspace ${{ matrix.workspaceNodeMatrix.workspace }}, CI step for node ${{ matrix.workspaceNodeMatrix.nodeVersion }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes CI failures on long-lived pull requests where changed-workspace detection reports:

`fatal: origin/main...HEAD: no merge base`

The workflow now checks out the PR revision with the complete commit graph while using `filter: blob:none` to avoid downloading historical file contents.
This ensures Git can always find the merge base, including for stale, rebased, or divergent PRs, without the disk usage of a normal full-history clone. Conflicted PRs fall back from GitHub’s synthetic merge revision to the PR head SHA.
Example affected PR: https://github.com/backstage/community-plugins/actions/runs/32985318155/job/99524505138?pr=10252

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))