### PR TITLE
chore(renovate): block react-router v7 PRs including security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,7 +51,10 @@
     },
     {
       "matchPackageNames": ["react-router", "react-router-dom"],
-      "allowedVersions": "<7.0.0"
+      "allowedVersions": "<7.0.0",
+      "vulnerabilityAlerts": {
+        "enabled": false
+      }
     },
     {
       "matchFileNames": ["workspaces/**"],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up on https://github.com/backstage/community-plugins/pull/10134 as clearly react router 7 PRs are still being opened:

<img width="790" height="927" alt="image" src="https://github.com/user-attachments/assets/6d061cb1-f3dd-4e70-82dc-30938c92183b" />


Disable `vulnerabilityAlerts` for `react-router` and `react-router-dom` in the Renovate config so security remediation cannot bypass `allowedVersions` and open a v7 PR.

`allowedVersions: "<7.0.0"` alone does not stop security-driven updates: Renovate's vulnerability handling uses an internal `force` that overrides `packageRules`, and security fixes can open major-version (v7) PRs regardless of version restrictions. Disabling `vulnerabilityAlerts` for these packages closes that path, mirroring the pattern already used for `@backstage/*`.

Trade-off: this also suppresses react-router security PRs within v6. Renovate cannot express "security fixes, but only below v7", so this is the necessary cost of never opening a v7 PR. However, disabling `vulnerabilityAlerts` only turns off the security remediation path (the expedited channel with the [SECURITY] suffix, immediate PR creation, bypassed rate limits/schedule). The regular update path is still active.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)