### PR TITLE
fix(bookmarks): make config schema self-contained

### DIFF
--- a/workspaces/bookmarks/.changeset/tricky-donkeys-shave.md
+++ b/workspaces/bookmarks/.changeset/tricky-donkeys-shave.md
@@ -1,0 +1,11 @@
+---
+'@backstage-community/plugin-bookmarks': patch
+---
+
+Fix config schema loading failing for the published package. `config.d.ts` referenced a type from the `src` folder, which is not shipped in the npm package, so apps depending on the plugin failed with:
+
+```
+Error: The TypeScript configuration schema for package '@backstage-community/plugin-bookmarks' contains an error - node_modules/@backstage-community/plugin-bookmarks/config.d.ts(17,38): error TS2307: Cannot find module './src/hooks/useCustomProtocol' or its corresponding type declarations.
+```
+
+The schema is now self-contained.

--- a/workspaces/bookmarks/plugins/bookmarks/config.d.ts
+++ b/workspaces/bookmarks/plugins/bookmarks/config.d.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { CustomProtocolConfig } from './src/hooks/useCustomProtocol';
-
 export interface Config {
   /**
    * Configuration for the Bookmarks plugin
@@ -29,6 +27,20 @@ export interface Config {
      *
      * @deepVisibility frontend
      */
-    customProtocols?: CustomProtocolConfig;
+    customProtocols?: {
+      /** The custom protocol to match, e.g. "myapp" for "myapp://some/path" */
+      [protocol: string]: {
+        /**
+         * The base URL to use for iframe src with %s replaced by the encoded original URL,
+         * e.g. "https://myapp-iframe-host.com/iframe?url=%s"
+         */
+        iframeBaseUrl: string;
+        /**
+         * The base URL to use for anchor href with %s replaced by the encoded original URL,
+         * e.g. "https://myapp-web-host.com/open?url=%s"
+         */
+        linkBaseUrl: string;
+      };
+    };
   };
 }

--- a/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.ts
+++ b/workspaces/bookmarks/plugins/bookmarks/src/hooks/useCustomProtocol.ts
@@ -16,28 +16,17 @@
 
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 
+import { Config } from '../../config';
+
+type CustomProtocolConfig = NonNullable<
+  NonNullable<Config['bookmarks']>['customProtocols']
+>;
+
 export type UseCustomProtocolResult = {
   /** The URL to be used in an iframe src attribute */
   src: string;
   /** The URL to be used in an anchor href attribute */
   href: string;
-};
-
-/** The schema of `bookmarks.customProtocols` config */
-export type CustomProtocolConfig = {
-  /** The custom protocol to match, e.g. "myapp" for "myapp://some/path" */
-  [protocol: string]: {
-    /**
-     * The base URL to use for iframe src with %s replaced by the encoded original URL,
-     * e.g. "https://myapp-iframe-host.com/iframe?url=%s"
-     */
-    iframeBaseUrl: string;
-    /**
-     * The base URL to use for anchor href with %s replaced by the encoded original URL,
-     * e.g. "https://myapp-web-host.com/open?url=%s"
-     */
-    linkBaseUrl: string;
-  };
 };
 
 /** Validates if the given config matches the CustomProtocolConfig schema */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`plugins/bookmarks/config.d.ts` imported the custom protocol type from `./src/hooks/useCustomProtocol`, but the `src` folder is not part of the published npm package. Apps that install `@backstage-community/plugin-bookmarks` therefore fail to load the config schema:

```
Error: The TypeScript configuration schema for package '@backstage-community/plugin-bookmarks' contains an error - node_modules/@backstage-community/plugin-bookmarks/config.d.ts(17,38): error TS2307: Cannot find module './src/hooks/useCustomProtocol' or its corresponding type declarations.
```

The protocol map is now declared inline in `config.d.ts`, and `useCustomProtocol` derives its type from the config schema instead — so the published schema no longer references anything outside the package.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))