### PR TITLE
docs(scaffolder-backend-module-dotnet): add .NET SDK prerequisite to README

### DIFF
--- a/workspaces/azure-devops/.changeset/dotnet-prerequisites-docs.md
+++ b/workspaces/azure-devops/.changeset/dotnet-prerequisites-docs.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-scaffolder-backend-module-dotnet': patch
+---
+
+Added prerequisites section to README documenting the .NET SDK requirement

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/README.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/README.md
@@ -6,6 +6,11 @@ It contains the following actions:
 
 - `dotnet:new`: create a new dotnet project
 
+## Prerequisites
+
+- A [Backstage](https://backstage.io/docs/getting-started/) project
+- The [.NET SDK](https://dotnet.microsoft.com/en-us/download) installed with the `dotnet` CLI available on `PATH` where the Backstage backend is running
+
 ## Installation
 
 From your Backstage instance root folder:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a prerequisites section to the `scaffolder-backend-module-dotnet` README documenting that the .NET SDK must be installed with `dotnet` on `PATH`.

Fixes #10682

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))