### PR TITLE
fix(confluence): stream collator results instead of loading everything into memory

### DIFF
--- a/workspaces/confluence/.changeset/late-cups-try.md
+++ b/workspaces/confluence/.changeset/late-cups-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-confluence-collator': patch
+---
+
+Fix Confluence collator to stream search results page-by-page instead of buffering the entire result set, and fix a concurrency regression across page boundaries

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.test.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.test.ts
@@ -31,6 +31,25 @@ const logger = mockServices.logger.mock();
 const BASE_URL = 'http://confluence.example.com';
 const CONFLUENCE_API_PATH = '/rest/api/content/search';
 
+const documentStub = (id: string) => ({
+  id,
+  title: `Document ${id}`,
+  status: 'current',
+  _links: { base: BASE_URL, webui: `/wiki/${id}` },
+  body: { storage: { value: `<p>Body ${id}</p>` } },
+  version: {
+    by: { publicName: 'Author' },
+    when: '2025-01-01T00:00:00.000Z',
+    friendlyWhen: 'January 1st, 2025',
+  },
+  space: {
+    key: 'SPACE',
+    name: 'Space',
+    _links: { webui: '/wiki/space' },
+  },
+  ancestors: [],
+});
+
 /* eslint jest/expect-expect: ["warn", { "assertFunctionNames": ["expect", "testSearchQuery"] }]  */
 const testSearchQuery = (
   request: RestRequest | undefined,
@@ -257,5 +276,241 @@ describe('ConfluenceCollatorFactory', () => {
       cql: '() and (type = page)',
     };
     testSearchQuery(request, expectedSearch);
+  });
+
+  it('loads each page of search results into the database as it is fetched, rather than waiting for all pages', async () => {
+    // Page 2's search request never resolves. If the collator buffered the
+    // full multi-page document list before yielding anything (the bug being
+    // guarded against here), page 1's document would never be yielded either.
+    worker.use(
+      rest.get(BASE_URL + CONFLUENCE_API_PATH, (req, res, ctx) => {
+        if (req.url.searchParams.get('cursor') === 'page2') {
+          return new Promise(() => {});
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.json({
+            results: [{ id: '1' }],
+            _links: { next: `${CONFLUENCE_API_PATH}?cursor=page2` },
+          }),
+        );
+      }),
+      rest.get(`${BASE_URL}/rest/api/content/:id`, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json(documentStub(req.params.id as string)),
+        );
+      }),
+    );
+
+    const collator = await factory.getCollator();
+
+    const firstDocument = await new Promise((resolve, reject) => {
+      collator.on('data', resolve);
+      collator.on('error', reject);
+    });
+    collator.destroy();
+
+    expect(firstDocument).toMatchObject({ title: 'Document 1' });
+  });
+
+  it('keeps fetching documents up to the parallelism limit across a page boundary, instead of draining to zero between pages', async () => {
+    const configWithLowParallelism = new ConfigReader({
+      confluence: {
+        default: {
+          baseUrl: BASE_URL,
+          auth: {
+            type: 'basic',
+            token: 'AA',
+            email: 'user@example.com',
+          },
+          parallelismLimit: 3,
+        },
+      },
+    });
+    const factoryWithLowParallelism = ConfluenceCollatorFactory.fromConfig(
+      configWithLowParallelism,
+      options,
+    );
+
+    // Page 1 has 2 documents whose detail fetch never resolves during the
+    // assertion window, so they permanently occupy 2 of the 3 parallelism
+    // slots. Page 2 has 1 document that resolves immediately.
+    const slowDocumentIds = ['1', '2'];
+    const fastDocumentId = '3';
+    let fastDocumentFetched = false;
+
+    worker.use(
+      rest.get(BASE_URL + CONFLUENCE_API_PATH, (req, res, ctx) => {
+        if (req.url.searchParams.get('cursor') === 'page2') {
+          return res(
+            ctx.status(200),
+            ctx.json({ results: [{ id: fastDocumentId }], _links: {} }),
+          );
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.json({
+            results: slowDocumentIds.map(id => ({ id })),
+            _links: { next: `${CONFLUENCE_API_PATH}?cursor=page2` },
+          }),
+        );
+      }),
+      rest.get(`${BASE_URL}/rest/api/content/:id`, (req, res, ctx) => {
+        const id = req.params.id as string;
+        if (slowDocumentIds.includes(id)) {
+          // Never resolves within the test: proves whether the fast
+          // document on page 2 can still be fetched concurrently.
+          return new Promise(() => {});
+        }
+
+        fastDocumentFetched = true;
+        return res(ctx.status(200), ctx.json(documentStub(id)));
+      }),
+    );
+
+    const collator = await factoryWithLowParallelism.getCollator();
+    collator.on('data', () => {});
+    collator.resume();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(fastDocumentFetched).toBe(true);
+  });
+
+  it('never fetches more documents concurrently than the configured parallelism limit', async () => {
+    const parallelismLimit = 2;
+    const configWithLowParallelism = new ConfigReader({
+      confluence: {
+        default: {
+          baseUrl: BASE_URL,
+          auth: {
+            type: 'basic',
+            token: 'AA',
+            email: 'user@example.com',
+          },
+          parallelismLimit,
+        },
+      },
+    });
+    const factoryWithLowParallelism = ConfluenceCollatorFactory.fromConfig(
+      configWithLowParallelism,
+      options,
+    );
+
+    const documentIds = ['1', '2', '3', '4', '5'];
+    let inFlightCount = 0;
+    let maxInFlightCount = 0;
+    const releaseFns = new Map<string, () => void>();
+
+    worker.use(
+      rest.get(BASE_URL + CONFLUENCE_API_PATH, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            results: documentIds.map(id => ({ id })),
+            _links: {},
+          }),
+        );
+      }),
+      rest.get(`${BASE_URL}/rest/api/content/:id`, (req, res, ctx) => {
+        const id = req.params.id as string;
+
+        inFlightCount += 1;
+        maxInFlightCount = Math.max(maxInFlightCount, inFlightCount);
+
+        return new Promise(resolve => {
+          releaseFns.set(id, () => {
+            inFlightCount -= 1;
+            resolve(res(ctx.status(200), ctx.json(documentStub(id))));
+          });
+        });
+      }),
+    );
+
+    const collator = await factoryWithLowParallelism.getCollator();
+    collator.on('data', () => {});
+    collator.resume();
+
+    // Wait for the initial batch of requests to be dispatched, then release
+    // them one at a time, giving each release a turn to let a queued
+    // document take the freed slot before observing the high-water mark.
+    for (let i = 0; i < documentIds.length; i++) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      const nextToRelease = [...releaseFns.keys()][0];
+      if (nextToRelease) {
+        releaseFns.get(nextToRelease)!();
+        releaseFns.delete(nextToRelease);
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      collator.on('end', resolve);
+      collator.on('error', reject);
+    });
+
+    expect(maxInFlightCount).toBeLessThanOrEqual(parallelismLimit);
+    expect(maxInFlightCount).toBe(parallelismLimit);
+  });
+
+  it('does not raise an unhandled promise rejection when a prefetched page fails while the current page is still being processed', async () => {
+    let releaseSlowDocument: (() => void) | undefined;
+
+    worker.use(
+      rest.get(BASE_URL + CONFLUENCE_API_PATH, (req, res, ctx) => {
+        if (req.url.searchParams.get('cursor') === 'page2') {
+          return res(ctx.status(500), ctx.text('boom'));
+        }
+
+        return res(
+          ctx.status(200),
+          ctx.json({
+            results: [{ id: '1' }],
+            _links: { next: `${CONFLUENCE_API_PATH}?cursor=page2` },
+          }),
+        );
+      }),
+      rest.get(`${BASE_URL}/rest/api/content/:id`, (req, res, ctx) => {
+        return new Promise(resolve => {
+          releaseSlowDocument = () =>
+            resolve(
+              res(
+                ctx.status(200),
+                ctx.json(documentStub(req.params.id as string)),
+              ),
+            );
+        });
+      }),
+    );
+
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const collator = await factory.getCollator();
+      collator.on('data', () => {});
+      collator.resume();
+
+      // Give the (rejecting) page-2 prefetch time to settle while page 1's
+      // document fetch is still deliberately held open, then release it and
+      // let the stream finish. If the rejection was ever truly unhandled,
+      // Node will have already flagged it during this wait.
+      await new Promise(resolve => setTimeout(resolve, 50));
+      releaseSlowDocument?.();
+
+      await new Promise<void>(resolve => {
+        collator.on('end', resolve);
+        collator.on('error', () => resolve());
+      });
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+
+    expect(unhandledRejections).toEqual([]);
   });
 });

--- a/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
+++ b/workspaces/confluence/plugins/search-backend-module-confluence-collator/src/collators/ConfluenceCollatorFactory.ts
@@ -245,37 +245,34 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
 
   async *execute(): AsyncGenerator<IndexableConfluenceDocument> {
     const query = await this.getConfluenceQuery();
-    const documentsList = await this.getDocuments(query);
-
-    this.logger.debug(`Document list: ${JSON.stringify(documentsList)}`);
-
     const limit = pLimit(this.parallelismLimit || 15);
-    const documentsInfo = documentsList.map(document =>
-      limit(async () => {
-        try {
-          return this.getDocumentInfo(document);
-        } catch (err) {
+
+    // Dispatching a page's document-detail fetches into the shared `limit`
+    // queue as soon as that page arrives (rather than awaiting them before
+    // moving on to the next page) keeps the parallelism window full across
+    // page boundaries instead of draining to zero between pages.
+    const dispatchDocumentFetches = (documentsPage: string[]) =>
+      documentsPage.map(document =>
+        limit(() => this.getDocumentInfo(document)).catch(err => {
           this.logger.warn(
             `error while indexing document "${document}": ${err}`,
           );
-        }
 
-        return [];
-      }),
-    );
+          return [];
+        }),
+      );
 
-    const safePromises = documentsInfo.map(promise =>
-      promise.catch(error => {
-        this.logger.warn(error);
+    for await (const documentsPage of this.getDocumentPages(
+      query,
+      dispatchDocumentFetches,
+    )) {
+      this.logger.debug(`Document page: ${JSON.stringify(documentsPage)}`);
 
-        return [];
-      }),
-    );
+      const documents = (await Promise.all(documentsPage)).flat();
 
-    const documents = (await Promise.all(safePromises)).flat();
-
-    for (const document of documents) {
-      yield document;
+      for (const document of documents) {
+        yield document;
+      }
     }
   }
 
@@ -314,33 +311,73 @@ export class ConfluenceCollatorFactory implements DocumentCollatorFactory {
     return query;
   }
 
-  private async getDocuments(query: string): Promise<string[]> {
-    const documentsList = [];
-
+  private async *getDocumentPages<T>(
+    query: string,
+    dispatch: (documentUrls: string[]) => T,
+  ): AsyncGenerator<T> {
     this.logger.info(`Exploring documents using query: ${query}`);
 
-    let next = true;
-    let requestUrl = `${this.baseUrl}/rest/api/content/search?limit=1000&status=current&cql=${query}`;
-    while (next) {
-      const data = await this.get<ConfluenceDocumentList>(requestUrl);
-      if (!data.results) {
+    let requestUrl:
+      | string
+      | undefined = `${this.baseUrl}/rest/api/content/search?limit=1000&status=current&cql=${query}`;
+
+    // Fetch the next search page and dispatch its document fetches into the
+    // shared limiter *before* yielding the current page's dispatched work.
+    // This keeps pagination and document fetching running ahead of the
+    // consumer, instead of pausing pagination while the consumer processes
+    // (and the caller awaits) the previous page's document fetches.
+    //
+    // `pending` isn't awaited until the *next* loop iteration, which can be
+    // long after it settles (the consumer may still be processing the
+    // current page). If it rejects in the meantime, Node sees an unhandled
+    // rejection before `await pending` ever attaches a handler. Marking it
+    // observed immediately (without consuming the original promise, so
+    // `await pending` below still sees the real error) avoids that.
+    const startFetchingPage = (url: string) => {
+      const fetchPromise = this.fetchAndDispatchPage(url, dispatch);
+      fetchPromise.catch(() => {});
+      return fetchPromise;
+    };
+
+    let pending: Promise<{
+      dispatched: T;
+      nextRequestUrl: string | undefined;
+    } | null> = startFetchingPage(requestUrl);
+
+    while (true) {
+      const result = await pending;
+      if (!result) {
         break;
       }
 
-      documentsList.push(
-        ...data.results.map(
-          result => `${this.baseUrl}/rest/api/content/${result.id}`,
-        ),
-      );
+      requestUrl = result.nextRequestUrl;
+      pending = requestUrl
+        ? startFetchingPage(requestUrl)
+        : Promise.resolve(null);
 
-      if (data._links.next) {
-        requestUrl = `${this.baseUrl}${data._links.next}`;
-      } else {
-        next = false;
-      }
+      yield result.dispatched;
+    }
+  }
+
+  private async fetchAndDispatchPage<T>(
+    requestUrl: string,
+    dispatch: (documentUrls: string[]) => T,
+  ): Promise<{ dispatched: T; nextRequestUrl: string | undefined } | null> {
+    const data = await this.get<ConfluenceDocumentList>(requestUrl);
+    if (!data.results) {
+      return null;
     }
 
-    return documentsList;
+    const documentUrls = data.results.map(
+      result => `${this.baseUrl}/rest/api/content/${result.id}`,
+    );
+
+    return {
+      dispatched: dispatch(documentUrls),
+      nextRequestUrl: data._links.next
+        ? `${this.baseUrl}${data._links.next}`
+        : undefined,
+    };
   }
 
   private async getDocumentInfo(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We were pulling every page of Confluence search results into memory before indexing a single document, which meant large instances could balloon memory usage (or even risk OOM) well before anything got written to the search index. Rework the collator to fetch and dispatch each page's documents as it arrives, so results start flowing into the pipeline immediately instead of after the whole instance has been walked.

Along the way, fix a regression where the concurrency limiter drained to zero between pages (undoing the point of streaming), and a case where a failed page's fetch could sit long enough to trigger Node's unhandled-rejection warning.

<img width="1138" height="346" alt="Screenshot 2026-09-01 at 08 52 31@2x" src="https://github.com/user-attachments/assets/3cba8fb8-468b-4e16-9113-0f1bfc520e15" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
