### PR TITLE
Added listDeprecations check to the workspaces/xcmetrics and fixed the deprecations

### DIFF
--- a/workspaces/xcmetrics/.changeset/swift-bags-guess.md
+++ b/workspaces/xcmetrics/.changeset/swift-bags-guess.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-xcmetrics': patch
+---
+
+Added listDeprecations check to the workspaces/xcmetrics and fixed the deprecations in StatusIcon.tsx and XcmetricsLayout.tsx

--- a/workspaces/xcmetrics/bcp.json
+++ b/workspaces/xcmetrics/bcp.json
@@ -1,4 +1,5 @@
 {
   "autoVersionBump": true,
-  "knipReports": false
+  "knipReports": false,
+  "listDeprecations": true
 }

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
@@ -20,7 +20,7 @@ import {
   StatusWarning,
 } from '@backstage/core-components';
 import { BuildStatus } from '../../api';
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 const STATUS_ICONS: { [key in BuildStatus]: ReactElement } = {
   succeeded: <StatusOK />,

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
@@ -20,8 +20,9 @@ import {
   StatusWarning,
 } from '@backstage/core-components';
 import { BuildStatus } from '../../api';
+import { ReactNode } from 'react';
 
-const STATUS_ICONS: { [key in BuildStatus]: JSX.Element } = {
+const STATUS_ICONS: { [key in BuildStatus]: ReactNode } = {
   succeeded: <StatusOK />,
   failed: <StatusError />,
   stopped: <StatusWarning />,

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
@@ -20,9 +20,9 @@ import {
   StatusWarning,
 } from '@backstage/core-components';
 import { BuildStatus } from '../../api';
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 
-const STATUS_ICONS: { [key in BuildStatus]: ReactNode } = {
+const STATUS_ICONS: { [key in BuildStatus]: ReactElement } = {
   succeeded: <StatusOK />,
   failed: <StatusError />,
   stopped: <StatusWarning />,

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/components/StatusIcon/StatusIcon.tsx
@@ -22,7 +22,7 @@ import {
 import { BuildStatus } from '../../api';
 import type { ReactElement } from 'react';
 
-const STATUS_ICONS: { [key in BuildStatus]: ReactElement } = {
+const STATUS_ICONS: Partial<Record<BuildStatus, ReactElement>> = {
   succeeded: <StatusOK />,
   failed: <StatusError />,
   stopped: <StatusWarning />,

--- a/workspaces/xcmetrics/plugins/xcmetrics/src/components/XcmetricsLayout/XcmetricsLayout.tsx
+++ b/workspaces/xcmetrics/plugins/xcmetrics/src/components/XcmetricsLayout/XcmetricsLayout.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ReactChild } from 'react';
+import { ReactNode } from 'react';
 import {
   Content,
   Header,
@@ -28,7 +28,7 @@ import { BuildList } from '../BuildList';
 export interface TabConfig {
   path: string;
   title: string;
-  component: ReactChild;
+  component: ReactNode;
 }
 
 const TABS: TabConfig[] = [


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

 Replaced deprecated 'JSX' global namespace with 'ReactNode' in StatusIcon.tsx. Updated 'ReactChild' types to 'ReactNode' across components in XcmetricsLayout.tsx

Signed-off-by: abrezina@redhat.com

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
