### PR TITLE
feat(jenkins): support jobs across multiple instances

### DIFF
--- a/workspaces/jenkins/.changeset/calm-dragons-build.md
+++ b/workspaces/jenkins/.changeset/calm-dragons-build.md
@@ -1,0 +1,6 @@
+---
+'@backstage-community/plugin-jenkins': minor
+'@backstage-community/plugin-jenkins-backend': minor
+---
+
+Support jobs from multiple named Jenkins instances on the same catalog entity while preserving the source instance for build details, history, logs, and retries.

--- a/workspaces/jenkins/app-config.yaml
+++ b/workspaces/jenkins/app-config.yaml
@@ -66,3 +66,7 @@ jenkins:
       baseUrl: https://jenkins.example.com
       username: backstage-bot
       apiKey: 123456789abcdef0123456789abcedf012
+    - name: production
+      baseUrl: https://jenkins-production.example.com
+      username: backstage-bot
+      apiKey: 123456789abcdef0123456789abcedf012

--- a/workspaces/jenkins/examples/entities.yaml
+++ b/workspaces/jenkins/examples/entities.yaml
@@ -13,7 +13,9 @@ kind: Component
 metadata:
   name: example-website
   annotations:
-    jenkins.io/job-full-name: 'folder-name/project-name'
+    # The first job uses the default instance. The second uses the named instance.
+    # They may have the same full name because the instance is part of their identity.
+    jenkins.io/job-full-name: 'folder-name/project-name,production:folder-name/project-name'
 spec:
   type: website
   lifecycle: experimental

--- a/workspaces/jenkins/plugins/jenkins-backend/README.md
+++ b/workspaces/jenkins/plugins/jenkins-backend/README.md
@@ -4,8 +4,8 @@ Welcome to the Jenkins backend plugin! Website: [https://jenkins.io/](https://je
 
 This is the backend half of the 2 Jenkins plugins and is responsible for:
 
-- finding an appropriate instance of Jenkins for an entity
-- finding the appropriate job(s) on that instance for an entity
+- finding the appropriate Jenkins instance or instances for an entity
+- finding the appropriate job(s) on each instance for an entity
 - connecting to Jenkins and gathering data to present to the frontend
 
 ## Integrating into a backstage instance
@@ -145,11 +145,13 @@ sent in is not null, along with the regex string list, and then compares the url
 
 This use case is for Jenkins systems where there are a lot of Jenkins instances configured from a base instance, which share the same API keys. Therefore a user does not have to define all of the instances here, but in the catalog for ease of use.
 
-#### Example - Defining Multiple Jenkins Jobs for a Single instance
+The override annotation contains one URL. When an entity references jobs from multiple instances, that URL is evaluated against every referenced instance's `allowedBaseUrlOverrideRegex`. Only use the override together with multiple instances when all matching instances are intentionally served from that URL.
 
-You can configure multiple Jenkins jobs for a **single** component by specifying multiple project names in the `jenkins.io/job-full-name` annotation.
+#### Example - Defining Multiple Jenkins Jobs Across Instances
 
-This is useful when you want to track different types of jobs for the same component.
+You can configure multiple Jenkins jobs for a **single** component by specifying comma-separated project names in the `jenkins.io/job-full-name` annotation. Each job may belong to a different configured Jenkins instance.
+
+An unprefixed job belongs to the `default` instance. A prefixed job such as `departmentFoo:teamA/artistLookup-build` belongs only to the named instance. Jobs are identified by the pair `(instance name, job full name)`, so the same job full name may safely exist on more than one instance.
 
 Config
 
@@ -166,6 +168,11 @@ jenkins:
       username: backstage-bot
       projectCountLimit: 100
       apiKey: 123456789abcdef0123456789abcedf012
+    - name: departmentBar
+      baseUrl: https://jenkins-bar.example.com
+      username: backstage-bot
+      projectCountLimit: 100
+      apiKey: 123456789abcdef0123456789abcedf012
 ```
 
 Catalog
@@ -176,15 +183,24 @@ kind: Component
 metadata:
   name: artist-lookup
   annotations:
-    'jenkins.io/job-full-name': departmentFoo:teamA/artistLookup-build,departmentFoo:teamA/artistLookup-test
+    'jenkins.io/job-full-name': teamA/artistLookup-test,departmentFoo:teamA/artistLookup-build,departmentBar:teamA/artistLookup-build
 ```
 
 This configuration will track jobs at:
 
+- `https://jenkins.example.com/job/teamA/job/artistLookup-test`
 - `https://jenkins-foo.example.com/job/teamA/job/artistLookup-build`
-- `https://jenkins-foo.example.com/job/teamA/job/artistLookup-test`
+- `https://jenkins-bar.example.com/job/teamA/job/artistLookup-build`
 
-**Limitation:** Currently you cannot associate jobs from different Jenkins instances with the same component. All jobs must belong to the same Jenkins instance.
+The two `artistLookup-build` jobs above do not collide because their instance names are different. The frontend and backend preserve the instance name when opening build details, viewing run history, reading console output, or retrying a build.
+
+If a request does not specify an instance, the provider uses the `default` instance. For backwards compatibility, an entity that references exactly one named instance also works without an explicit instance selector.
+
+All referenced instances are queried in parallel. The current API does not return partial results: if one instance is unavailable, misconfigured, or lacks credentials for its annotated job, the projects request fails for the entity. The error identifies the failing instance and its job names. `projectCountLimit` continues to apply independently to each instance.
+
+### Actions
+
+The `jenkins:list-builds` action returns `instanceName` for every build. Pass that value to the optional `instanceName` input of `jenkins:get-build`, `jenkins:get-build-logs`, and `jenkins:trigger-build`. This is required to disambiguate jobs whose full names are equal across instances. Omitting it selects the entity's default instance.
 
 ### Custom JenkinsInfoProvider
 
@@ -194,10 +210,7 @@ An example of a bespoke JenkinsInfoProvider which uses an organisation specific 
 class AcmeJenkinsInfoProvider implements JenkinsInfoProvider {
   constructor(private readonly catalog: CatalogClient) {}
 
-  async getInstance(opt: {
-    entityRef: EntityName;
-    jobFullName?: string;
-  }): Promise<JenkinsInfo> {
+  async getInstance(opt: JenkinsInfoProviderOptions): Promise<JenkinsInfo> {
     const PAAS_ANNOTATION = 'acme.example.com/paas-project-name';
 
     // lookup pass-project-name from entity annotation
@@ -228,11 +241,13 @@ class AcmeJenkinsInfoProvider implements JenkinsInfoProvider {
     const creds = btoa(`${username}:${apiKey}`);
 
     return {
+      instanceName: 'default',
       baseUrl,
       headers: {
         Authorization: `Basic ${creds}`,
       },
-      jobFullName,
+      fullJobNames: [jobFullName],
+      projectCountLimit,
     };
   }
 
@@ -250,6 +265,8 @@ class AcmeJenkinsInfoProvider implements JenkinsInfoProvider {
   }
 }
 ```
+
+A custom provider that supports multiple instances should also implement the optional `getInstances` method and return one `JenkinsInfo` per instance. Existing custom providers that only implement `getInstance` remain supported and are treated as single-instance providers.
 
 No config would be needed if using this JenkinsInfoProvider
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildAction.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildAction.test.ts
@@ -78,6 +78,7 @@ describe('createGetBuildAction', () => {
         kind: 'Component',
         namespace: 'default',
         jobFullName: 'my-folder/my-pipeline',
+        instanceName: 'prod',
         buildNumber: 42,
       },
       credentials,
@@ -89,6 +90,16 @@ describe('createGetBuildAction', () => {
       ['my-folder', 'my-pipeline'],
       42,
     );
+    expect(mockJenkinsInfoProvider.getInstance).toHaveBeenCalledWith({
+      entityRef: {
+        kind: 'Component',
+        namespace: 'default',
+        name: 'my-service',
+      },
+      fullJobNames: ['my-folder/my-pipeline'],
+      instanceName: 'prod',
+      credentials,
+    });
     expect(result.output).toMatchObject({
       number: 42,
       result: 'SUCCESS',

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildAction.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildAction.ts
@@ -79,6 +79,13 @@ For console output use \`jenkins:get-build-logs\`.
             .describe(
               'Full name of the Jenkins job, e.g. "my-folder/my-pipeline" or "my-folder/my-pipeline/main".',
             ),
+          instanceName: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              'Configured Jenkins instance that owns the job. Defaults to the entity default when omitted.',
+            ),
           buildNumber: z
             .number()
             .int()
@@ -164,6 +171,7 @@ For console output use \`jenkins:get-build-logs\`.
       const jenkinsInfo = await jenkinsInfoProvider.getInstance({
         entityRef,
         fullJobNames: [input.jobFullName],
+        instanceName: input.instanceName,
         credentials,
       });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildLogsAction.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildLogsAction.test.ts
@@ -65,6 +65,7 @@ describe('createGetBuildLogsAction', () => {
         kind: 'Component',
         namespace: 'default',
         jobFullName: 'my-pipeline/main',
+        instanceName: 'dev',
         buildNumber: 7,
       },
       credentials,
@@ -76,6 +77,16 @@ describe('createGetBuildLogsAction', () => {
       ['my-pipeline', 'main'],
       7,
     );
+    expect(mockJenkinsInfoProvider.getInstance).toHaveBeenCalledWith({
+      entityRef: {
+        kind: 'Component',
+        namespace: 'default',
+        name: 'my-service',
+      },
+      fullJobNames: ['my-pipeline/main'],
+      instanceName: 'dev',
+      credentials,
+    });
     expect(result.output.consoleText).toBe(
       'Started by user admin\nFinished: SUCCESS\n',
     );
@@ -93,6 +104,8 @@ describe('createGetBuildLogsAction', () => {
 
     expect(mockJenkinsInfoProvider.getInstance).toHaveBeenCalledWith({
       entityRef: { kind: 'Component', namespace: 'default', name: 'svc' },
+      fullJobNames: ['pipeline'],
+      instanceName: undefined,
       credentials,
     });
   });

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildLogsAction.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createGetBuildLogsAction.ts
@@ -80,6 +80,13 @@ the relevant failure message rather than processing the entire output.
             .describe(
               'Full name of the Jenkins job, e.g. "my-folder/my-pipeline" or "my-folder/my-pipeline/main".',
             ),
+          instanceName: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              'Configured Jenkins instance that owns the job. Defaults to the entity default when omitted.',
+            ),
           buildNumber: z
             .number()
             .int()
@@ -108,6 +115,8 @@ the relevant failure message rather than processing the entire output.
 
       const jenkinsInfo = await jenkinsInfoProvider.getInstance({
         entityRef,
+        fullJobNames: [input.jobFullName],
+        instanceName: input.instanceName,
         credentials,
       });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createListBuildsAction.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createListBuildsAction.test.ts
@@ -97,6 +97,7 @@ describe('createListBuildsAction', () => {
     );
     expect(result.output.builds).toHaveLength(1);
     expect(result.output.builds[0]).toMatchObject({
+      instanceName: 'default',
       name: 'my-folder/my-pipeline',
       status: 'SUCCESS',
       inQueue: false,
@@ -106,6 +107,42 @@ describe('createListBuildsAction', () => {
         building: false,
       },
     });
+  });
+
+  it('returns identical job names from different Jenkins instances separately', async () => {
+    mockJenkinsInfoProvider.getInstances = jest.fn().mockResolvedValue([
+      {
+        instanceName: 'prod',
+        baseUrl: 'http://jenkins-prod',
+        fullJobNames: ['my-folder/my-pipeline'],
+        projectCountLimit: 50,
+      },
+      {
+        instanceName: 'dev',
+        baseUrl: 'http://jenkins-dev',
+        fullJobNames: ['my-folder/my-pipeline'],
+        projectCountLimit: 50,
+      },
+    ]);
+    const registration = mockActionsRegistry.register.mock.calls[0][0];
+
+    const result = await registration.action({
+      input: { name: 'my-service' },
+      credentials: mockCredentials.user(),
+      logger: mockServices.logger.mock(),
+    });
+
+    expect(mockJenkinsApi.getProjects).toHaveBeenCalledTimes(2);
+    expect(result.output.builds).toEqual([
+      expect.objectContaining({
+        instanceName: 'prod',
+        name: 'my-folder/my-pipeline',
+      }),
+      expect.objectContaining({
+        instanceName: 'dev',
+        name: 'my-folder/my-pipeline',
+      }),
+    ]);
   });
 
   it('applies default kind and namespace when not provided', async () => {

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createListBuildsAction.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createListBuildsAction.ts
@@ -18,6 +18,7 @@ import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { JenkinsInfoProvider } from '../service/jenkinsInfoProvider';
 import { JenkinsApiImpl } from '../service/jenkinsApi';
+import { getJenkinsInstances } from '../service/getJenkinsInstances';
 
 /**
  * Registers the `jenkins:list-builds` action with the ActionsRegistryService.
@@ -89,6 +90,9 @@ For re-triggering a build use \`jenkins:trigger-build\`.
           builds: z
             .array(
               z.object({
+                instanceName: z
+                  .string()
+                  .describe('The configured Jenkins instance for this job.'),
                 name: z.string().describe('The full name of the Jenkins job.'),
                 displayName: z
                   .string()
@@ -146,33 +150,41 @@ For re-triggering a build use \`jenkins:trigger-build\`.
         `Listing Jenkins builds for entity ${stringifyEntityRef(entityRef)}`,
       );
 
-      const jenkinsInfo = await jenkinsInfoProvider.getInstance({
+      const jenkinsInstances = await getJenkinsInstances(jenkinsInfoProvider, {
         entityRef,
         credentials,
       });
 
       const branches = input.branch ? [input.branch] : undefined;
-      const projects = await jenkinsApi.getProjects(jenkinsInfo, branches);
+      const projectsByInstance = await Promise.all(
+        jenkinsInstances.map(async jenkinsInfo => ({
+          instanceName: jenkinsInfo.instanceName,
+          projects: await jenkinsApi.getProjects(jenkinsInfo, branches),
+        })),
+      );
 
       return {
         output: {
-          builds: projects.map(p => ({
-            name: p.fullName,
-            displayName: p.fullDisplayName,
-            status: p.status,
-            inQueue: p.inQueue,
-            lastBuild: p.lastBuild
-              ? {
-                  number: p.lastBuild.number,
-                  url: p.lastBuild.url,
-                  result: p.lastBuild.result ?? null,
-                  building: p.lastBuild.building,
-                  timestamp: p.lastBuild.timestamp,
-                  duration: p.lastBuild.duration,
-                  displayName: p.lastBuild.displayName,
-                }
-              : null,
-          })),
+          builds: projectsByInstance.flatMap(({ instanceName, projects }) =>
+            projects.map(p => ({
+              instanceName,
+              name: p.fullName,
+              displayName: p.fullDisplayName,
+              status: p.status,
+              inQueue: p.inQueue,
+              lastBuild: p.lastBuild
+                ? {
+                    number: p.lastBuild.number,
+                    url: p.lastBuild.url,
+                    result: p.lastBuild.result ?? null,
+                    building: p.lastBuild.building,
+                    timestamp: p.lastBuild.timestamp,
+                    duration: p.lastBuild.duration,
+                    displayName: p.lastBuild.displayName,
+                  }
+                : null,
+            })),
+          ),
         },
       };
     },

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createTriggerBuildAction.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createTriggerBuildAction.test.ts
@@ -66,6 +66,7 @@ describe('createTriggerBuildAction', () => {
         kind: 'Component',
         namespace: 'default',
         jobFullName: 'my-folder/my-pipeline/main',
+        instanceName: 'prod',
         buildNumber: 42,
       },
       credentials,
@@ -79,6 +80,16 @@ describe('createTriggerBuildAction', () => {
       'component:default/my-service',
       { credentials },
     );
+    expect(mockJenkinsInfoProvider.getInstance).toHaveBeenCalledWith({
+      entityRef: {
+        kind: 'Component',
+        namespace: 'default',
+        name: 'my-service',
+      },
+      fullJobNames: ['my-folder/my-pipeline/main'],
+      instanceName: 'prod',
+      credentials,
+    });
     expect(result.output.status).toBe(201);
   });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/actions/createTriggerBuildAction.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/actions/createTriggerBuildAction.ts
@@ -88,6 +88,13 @@ retries during incident response or debugging.
             .describe(
               'Full name of the Jenkins job to trigger, e.g. "my-folder/my-pipeline/main".',
             ),
+          instanceName: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              'Configured Jenkins instance that owns the job. Defaults to the entity default when omitted.',
+            ),
           buildNumber: z
             .number()
             .int()
@@ -118,6 +125,7 @@ retries during incident response or debugging.
       const jenkinsInfo = await jenkinsInfoProvider.getInstance({
         entityRef,
         fullJobNames: [input.jobFullName],
+        instanceName: input.instanceName,
         credentials,
       });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import http, { Server } from 'http';
+import { AddressInfo } from 'net';
+import { ConfigReader } from '@backstage/config';
+import { mockServices } from '@backstage/backend-test-utils';
+import { JenkinsApiImpl } from './jenkinsApi';
+import { JenkinsBuilder, JenkinsEnvironment } from './JenkinsBuilder';
+import { JenkinsInfoProvider } from './jenkinsInfoProvider';
+
+function httpGet(url: string): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, response => {
+        let body = '';
+        response.on('data', chunk => {
+          body += chunk;
+        });
+        response.on('end', () => {
+          resolve({
+            status: response.statusCode ?? 0,
+            body: JSON.parse(body),
+          });
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+class TestJenkinsBuilder extends JenkinsBuilder {
+  constructor(
+    env: JenkinsEnvironment,
+    private readonly jenkinsApi: JenkinsApiImpl,
+  ) {
+    super(env);
+  }
+
+  protected override createJenkinsApi(): JenkinsApiImpl {
+    return this.jenkinsApi;
+  }
+}
+
+describe('JenkinsBuilder', () => {
+  let server: Server | undefined;
+  let provider: jest.Mocked<JenkinsInfoProvider>;
+  let jenkinsApi: jest.Mocked<Pick<JenkinsApiImpl, 'getProjects' | 'getBuild'>>;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close(error => (error ? reject(error) : resolve()));
+      });
+      server = undefined;
+    }
+  });
+
+  async function startServer(): Promise<string> {
+    const httpAuth = mockServices.httpAuth.mock();
+    httpAuth.credentials.mockResolvedValue(
+      await mockServices.auth().getOwnServiceCredentials(),
+    );
+
+    const builder = new TestJenkinsBuilder(
+      {
+        permissions: mockServices.permissions(),
+        config: new ConfigReader({ jenkins: {} }),
+        logger: mockServices.logger.mock(),
+        jenkinsInfoProvider: provider,
+        discovery: mockServices.discovery(),
+        auth: mockServices.auth(),
+        httpAuth,
+      },
+      jenkinsApi as unknown as JenkinsApiImpl,
+    );
+    const { router } = await builder.build();
+    const app = express().use(router);
+
+    return new Promise(resolve => {
+      server = app.listen(0, () => {
+        const { port } = server?.address() as AddressInfo;
+        resolve(`http://localhost:${port}`);
+      });
+    });
+  }
+
+  beforeEach(() => {
+    provider = {
+      getInstance: jest.fn().mockResolvedValue({
+        instanceName: 'dev',
+        baseUrl: 'http://jenkins-dev',
+        fullJobNames: ['folder/shared-job'],
+        projectCountLimit: 50,
+      }),
+      getInstances: jest.fn().mockResolvedValue([
+        {
+          instanceName: 'prod',
+          baseUrl: 'http://jenkins-prod',
+          fullJobNames: ['folder/shared-job'],
+          projectCountLimit: 50,
+        },
+        {
+          instanceName: 'dev',
+          baseUrl: 'http://jenkins-dev',
+          fullJobNames: ['folder/shared-job'],
+          projectCountLimit: 50,
+        },
+      ]),
+    };
+    jenkinsApi = {
+      getProjects: jest.fn().mockResolvedValue([
+        {
+          fullName: 'folder/shared-job',
+          fullDisplayName: 'folder » shared-job',
+          displayName: 'shared-job',
+          inQueue: false,
+          status: 'SUCCESS',
+          lastBuild: null,
+        },
+      ]),
+      getBuild: jest.fn().mockResolvedValue({ number: 12 }),
+    };
+  });
+
+  it('returns identical job names once per Jenkins instance', async () => {
+    const baseUrl = await startServer();
+
+    const response = await httpGet(
+      `${baseUrl}/v1/entity/default/Component/my-service/projects`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      projects: [
+        expect.objectContaining({
+          instanceName: 'prod',
+          fullName: 'folder/shared-job',
+        }),
+        expect.objectContaining({
+          instanceName: 'dev',
+          fullName: 'folder/shared-job',
+        }),
+      ],
+    });
+    expect(jenkinsApi.getProjects).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses instanceName when resolving a job with a duplicate full name', async () => {
+    const baseUrl = await startServer();
+
+    const response = await httpGet(
+      `${baseUrl}/v1/entity/default/Component/my-service/job/${encodeURIComponent(
+        'folder/shared-job',
+      )}/12?instanceName=dev`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(provider.getInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fullJobNames: ['folder/shared-job'],
+        instanceName: 'dev',
+      }),
+    );
+    expect(jenkinsApi.getBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceName: 'dev' }),
+      ['folder', 'shared-job'],
+      12,
+    );
+  });
+});

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/JenkinsBuilder.ts
@@ -17,6 +17,7 @@
 import express from 'express';
 import Router from 'express-promise-router';
 import { JenkinsInfoProvider } from './jenkinsInfoProvider';
+import { getJenkinsInstances } from './getJenkinsInstances';
 import { JenkinsApiImpl } from './jenkinsApi';
 import {
   PermissionEvaluator,
@@ -104,7 +105,7 @@ export class JenkinsBuilder {
         : undefined;
     }
 
-    const jenkinsApi = new JenkinsApiImpl(permissionEvaluator);
+    const jenkinsApi = this.createJenkinsApi(permissionEvaluator);
 
     const router = Router();
     router.use(express.json());
@@ -114,6 +115,10 @@ export class JenkinsBuilder {
       async (request, response) => {
         const { namespace, kind, name } = request.params;
         const branch = request.query.branch;
+        const instanceName = this.getInstanceNameQuery(request, response);
+        if (instanceName === null) {
+          return;
+        }
         let branches: string[] | undefined;
 
         if (branch === undefined) {
@@ -130,33 +135,51 @@ export class JenkinsBuilder {
           return;
         }
 
-        const jenkinsInfo = await jenkinsInfoProvider.getInstance({
-          entityRef: {
-            kind,
-            namespace,
-            name,
+        const jenkinsInstances = await getJenkinsInstances(
+          jenkinsInfoProvider,
+          {
+            entityRef: {
+              kind,
+              namespace,
+              name,
+            },
+            credentials: await httpAuth.credentials(request),
+            instanceName,
           },
-          credentials: await httpAuth.credentials(request),
+        );
+
+        const projectsByInstance = await Promise.all(
+          jenkinsInstances.map(async jenkinsInfo => {
+            try {
+              const projects = await jenkinsApi.getProjects(
+                jenkinsInfo,
+                branches,
+              );
+
+              return projects.map(project => ({
+                ...project,
+                instanceName: jenkinsInfo.instanceName,
+              }));
+            } catch (error) {
+              const errorDetails =
+                error instanceof AggregateError ? error.errors : error;
+
+              // Promise.any can return an AggregateError with the unhelpful
+              // message "All promises were rejected", so include its causes.
+              throw new Error(
+                `Unable to fetch projects from Jenkins instance '${
+                  jenkinsInfo.instanceName
+                }', for ${jenkinsInfo.fullJobNames}: ${stringifyError(
+                  errorDetails,
+                )}`,
+              );
+            }
+          }),
+        );
+
+        response.json({
+          projects: projectsByInstance.flat(),
         });
-
-        try {
-          const projects = await jenkinsApi.getProjects(jenkinsInfo, branches);
-
-          response.json({
-            projects: projects,
-          });
-        } catch (err) {
-          // Promise.any, used in the getProjects call returns an Aggregate error message with a useless error message 'AggregateError: All promises were rejected'
-          // extract useful information ourselves
-          if (err.errors) {
-            throw new Error(
-              `Unable to fetch projects, for ${
-                jenkinsInfo.fullJobNames
-              }: ${stringifyError(err.errors)}`,
-            );
-          }
-          throw err;
-        }
       },
     );
 
@@ -165,6 +188,10 @@ export class JenkinsBuilder {
       async (request, response) => {
         const { namespace, kind, name, jobFullName, buildNumber } =
           request.params;
+        const instanceName = this.getInstanceNameQuery(request, response);
+        if (instanceName === null) {
+          return;
+        }
         const jobs = this.jobFullNameParamToJobs(jobFullName);
 
         const jenkinsInfo = await jenkinsInfoProvider.getInstance({
@@ -174,6 +201,7 @@ export class JenkinsBuilder {
             name,
           },
           fullJobNames: [jobFullName],
+          instanceName,
           credentials: await httpAuth.credentials(request),
         });
 
@@ -193,6 +221,10 @@ export class JenkinsBuilder {
       '/v1/entity/:namespace/:kind/:name/job/:jobFullName',
       async (request, response) => {
         const { namespace, kind, name, jobFullName } = request.params;
+        const instanceName = this.getInstanceNameQuery(request, response);
+        if (instanceName === null) {
+          return;
+        }
         const jobs = this.jobFullNameParamToJobs(jobFullName);
 
         const jenkinsInfo = await jenkinsInfoProvider.getInstance({
@@ -202,6 +234,7 @@ export class JenkinsBuilder {
             name,
           },
           fullJobNames: [jobFullName],
+          instanceName,
           credentials: await httpAuth.credentials(request),
         });
 
@@ -218,6 +251,10 @@ export class JenkinsBuilder {
       async (request, response) => {
         const { namespace, kind, name, jobFullName, buildNumber } =
           request.params;
+        const instanceName = this.getInstanceNameQuery(request, response);
+        if (instanceName === null) {
+          return;
+        }
         const jobs = this.jobFullNameParamToJobs(jobFullName);
 
         const jenkinsInfo = await jenkinsInfoProvider.getInstance({
@@ -227,6 +264,7 @@ export class JenkinsBuilder {
             name,
           },
           fullJobNames: [jobFullName],
+          instanceName,
           credentials: await httpAuth.credentials(request),
         });
 
@@ -249,6 +287,10 @@ export class JenkinsBuilder {
       async (request, response) => {
         const { namespace, kind, name, jobFullName, buildNumber } =
           request.params;
+        const instanceName = this.getInstanceNameQuery(request, response);
+        if (instanceName === null) {
+          return;
+        }
         const jobs = this.jobFullNameParamToJobs(jobFullName);
 
         const jenkinsInfo = await jenkinsInfoProvider.getInstance({
@@ -258,6 +300,7 @@ export class JenkinsBuilder {
             name,
           },
           fullJobNames: [jobFullName],
+          instanceName,
           credentials: await httpAuth.credentials(request),
         });
 
@@ -279,5 +322,29 @@ export class JenkinsBuilder {
   private jobFullNameParamToJobs(jobFullName: string): string[] {
     // jobFullName may contain a list of job names separated by '/'
     return jobFullName.split('/').map((s: string) => encodeURIComponent(s));
+  }
+
+  protected createJenkinsApi(
+    permissionEvaluator?: PermissionEvaluator,
+  ): JenkinsApiImpl {
+    return new JenkinsApiImpl(permissionEvaluator);
+  }
+
+  private getInstanceNameQuery(
+    request: express.Request,
+    response: express.Response,
+  ): string | undefined | null {
+    const instanceName = request.query.instanceName;
+    if (instanceName === undefined) {
+      return instanceName;
+    }
+    if (typeof instanceName === 'string' && instanceName.length > 0) {
+      return instanceName;
+    }
+
+    response
+      .status(400)
+      .send('Something was unexpected about the instanceName queryString');
+    return null;
   }
 }

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/getJenkinsInstances.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/getJenkinsInstances.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  JenkinsInfo,
+  JenkinsInfoProvider,
+  JenkinsInfoProviderOptions,
+} from './jenkinsInfoProvider';
+
+export type JenkinsInstanceInfo = JenkinsInfo & { instanceName: string };
+
+/**
+ * Uses the plural provider API when available and falls back to the legacy
+ * single-instance API for custom providers.
+ */
+export async function getJenkinsInstances(
+  provider: JenkinsInfoProvider,
+  options: JenkinsInfoProviderOptions,
+): Promise<JenkinsInstanceInfo[]> {
+  let instances: JenkinsInfo[];
+  if (options.instanceName) {
+    instances = [await provider.getInstance(options)];
+  } else if (provider.getInstances) {
+    instances = await provider.getInstances(options);
+  } else {
+    instances = [await provider.getInstance(options)];
+  }
+
+  return instances.map(instance => ({
+    ...instance,
+    instanceName: instance.instanceName ?? options.instanceName ?? 'default',
+  }));
+}

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/index.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/index.ts
@@ -21,6 +21,7 @@ export {
 export type {
   JenkinsInfo,
   JenkinsInfoProvider,
+  JenkinsInfoProviderOptions,
   JenkinsInstanceConfig,
 } from './jenkinsInfoProvider';
 export * from './JenkinsBuilder';

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.test.ts
@@ -235,6 +235,7 @@ describe('DefaultJenkinsInfoProvider', () => {
       }),
     );
     expect(info).toStrictEqual({
+      instanceName: 'default',
       baseUrl: 'https://jenkins.example.com',
       crumbIssuer: undefined,
       headers: {
@@ -244,6 +245,86 @@ describe('DefaultJenkinsInfoProvider', () => {
       },
       fullJobNames: ['teamA/artistLookup-build'],
       projectCountLimit: 50,
+    });
+  });
+
+  it('resolves identical job names independently for multiple instances', async () => {
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: {
+        name: 'bar',
+        annotations: {
+          'jenkins.io/job-full-name':
+            'prod:teamA/shared-build, dev:teamA/shared-build, teamA/default-build',
+        },
+      },
+    };
+    const provider = configureProvider(
+      {
+        jenkins: {
+          instances: [
+            {
+              name: 'default',
+              baseUrl: 'https://jenkins-default.example.com',
+              username: 'backstage-bot',
+              apiKey: 'default-token',
+            },
+            {
+              name: 'prod',
+              baseUrl: 'https://jenkins-prod.example.com',
+              username: 'backstage-bot',
+              apiKey: 'prod-token',
+            },
+            {
+              name: 'dev',
+              baseUrl: 'https://jenkins-dev.example.com',
+              username: 'backstage-bot',
+              apiKey: 'dev-token',
+            },
+          ],
+        },
+      },
+      entity,
+    );
+
+    const instances = await provider.getInstances({ entityRef });
+
+    expect(instances).toHaveLength(3);
+    expect(instances).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          instanceName: 'prod',
+          baseUrl: 'https://jenkins-prod.example.com',
+          fullJobNames: ['teamA/shared-build'],
+        }),
+        expect.objectContaining({
+          instanceName: 'dev',
+          baseUrl: 'https://jenkins-dev.example.com',
+          fullJobNames: ['teamA/shared-build'],
+        }),
+        expect.objectContaining({
+          instanceName: 'default',
+          baseUrl: 'https://jenkins-default.example.com',
+          fullJobNames: ['teamA/default-build'],
+        }),
+      ]),
+    );
+
+    mockCatalog.getEntityByRef.mockReturnValueOnce(Promise.resolve(entity));
+    await expect(
+      provider.getInstance({ entityRef, instanceName: 'dev' }),
+    ).resolves.toMatchObject({
+      instanceName: 'dev',
+      baseUrl: 'https://jenkins-dev.example.com',
+      fullJobNames: ['teamA/shared-build'],
+    });
+
+    mockCatalog.getEntityByRef.mockReturnValueOnce(Promise.resolve(entity));
+    await expect(provider.getInstance({ entityRef })).resolves.toMatchObject({
+      instanceName: 'default',
+      baseUrl: 'https://jenkins-default.example.com',
+      fullJobNames: ['teamA/default-build'],
     });
   });
 

--- a/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
+++ b/workspaces/jenkins/plugins/jenkins-backend/src/service/jenkinsInfoProvider.ts
@@ -30,24 +30,43 @@ import {
 import { Config } from '@backstage/config';
 
 /** @public */
-export interface JenkinsInfoProvider {
-  getInstance(options: {
-    /**
-     * The entity to get the info about.
-     */
-    entityRef: CompoundEntityRef;
-    /**
-     * Specific job(s) to get. This is only passed in when we know the job name(s) we are interested in.
-     */
-    fullJobNames?: string[];
+export interface JenkinsInfoProviderOptions {
+  /**
+   * The entity to get the info about.
+   */
+  entityRef: CompoundEntityRef;
+  /**
+   * Specific job(s) to get. This is only passed in when we know the job name(s) we are interested in.
+   */
+  fullJobNames?: string[];
+  /**
+   * The configured Jenkins instance that owns the requested job.
+   */
+  instanceName?: string;
 
-    credentials?: BackstageCredentials;
-    logger?: LoggerService;
-  }): Promise<JenkinsInfo>;
+  credentials?: BackstageCredentials;
+  logger?: LoggerService;
+}
+
+/** @public */
+export interface JenkinsInfoProvider {
+  getInstance(options: JenkinsInfoProviderOptions): Promise<JenkinsInfo>;
+
+  /**
+   * Gets all Jenkins instances referenced by an entity.
+   *
+   * This method is optional to preserve compatibility with custom providers
+   * that only support a single instance.
+   */
+  getInstances?(
+    options: JenkinsInfoProviderOptions,
+  ): Promise<Array<JenkinsInfo & { instanceName: string }>>;
 }
 
 /** @public */
 export interface JenkinsInfo {
+  /** The configured name of the Jenkins instance. */
+  instanceName?: string;
   baseUrl: string;
   headers?: Record<string, string | string[]>;
   fullJobNames: string[];
@@ -224,13 +243,45 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
     );
   }
 
-  async getInstance(opt: {
-    entityRef: CompoundEntityRef;
-    fullJobNames?: string[];
-    credentials?: BackstageCredentials;
-  }): Promise<JenkinsInfo> {
-    const DEFAULT_LIMITATION_OF_PROJECTS = 50;
+  async getInstance(opt: JenkinsInfoProviderOptions): Promise<JenkinsInfo> {
+    const { entity, jobsByInstance } = await this.getEntityAndJobs(opt);
+    let instanceName = opt.instanceName;
+    if (!instanceName && jobsByInstance.size === 1) {
+      instanceName = jobsByInstance.keys().next().value;
+    } else if (!instanceName && jobsByInstance.has('default')) {
+      instanceName = 'default';
+    }
+    const fullJobNames = instanceName
+      ? jobsByInstance.get(instanceName)
+      : undefined;
 
+    if (!instanceName || !fullJobNames) {
+      const requestedInstance = opt.instanceName
+        ? `Jenkins instance '${opt.instanceName}'`
+        : 'a default Jenkins instance';
+      throw new Error(
+        `Couldn't find ${requestedInstance} in the Jenkins annotations on entity with name: ${stringifyEntityRef(
+          opt.entityRef,
+        )}`,
+      );
+    }
+
+    return this.getJenkinsInfo(entity, instanceName, fullJobNames);
+  }
+
+  async getInstances(
+    opt: JenkinsInfoProviderOptions,
+  ): Promise<Array<JenkinsInfo & { instanceName: string }>> {
+    const { entity, jobsByInstance } = await this.getEntityAndJobs(opt);
+
+    return Array.from(jobsByInstance, ([instanceName, fullJobNames]) =>
+      this.getJenkinsInfo(entity, instanceName, fullJobNames),
+    );
+  }
+
+  private async getEntityAndJobs(
+    opt: JenkinsInfoProviderOptions,
+  ): Promise<{ entity: Entity; jobsByInstance: Map<string, string[]> }> {
     const credentials =
       opt.credentials ?? (await this.auth.getOwnServiceCredentials());
 
@@ -254,58 +305,54 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
       );
     }
 
-    // Group job names by their Jenkins instances.
-    const jobsByInstance = jenkinsAndJobNames.reduce(
-      (acc: Record<string, string[]>, name) => {
-        const splitIndex = name.indexOf(':');
+    const jobsByInstance = new Map<string, string[]>();
+    for (const annotationValue of jenkinsAndJobNames) {
+      const name = annotationValue.trim();
+      if (!name) {
+        continue;
+      }
 
-        const { default: defaultJobs = [] } = acc;
+      const splitIndex = name.indexOf(':');
+      const instanceName =
+        splitIndex === -1 ? 'default' : name.substring(0, splitIndex).trim();
+      const jobName =
+        splitIndex === -1 ? name : name.substring(splitIndex + 1).trim();
 
-        // No instance specified, default
-        if (splitIndex === -1) {
-          acc.default = [...defaultJobs, name];
-        } else {
-          const instanceName = name.substring(0, splitIndex);
-          const jobName = name.substring(splitIndex + 1);
+      if (!instanceName || !jobName) {
+        throw new Error(
+          `Invalid Jenkins annotation value '${annotationValue}' on entity with name: ${stringifyEntityRef(
+            opt.entityRef,
+          )}`,
+        );
+      }
 
-          acc[instanceName] = [...(acc[instanceName] || []), jobName];
-        }
-
-        return acc;
-      },
-      {},
-    );
-
-    // Ensure that all jobs belong to a single Jenkins instance.
-    const instancesFound: string[] = Object.keys(jobsByInstance);
-    if (instancesFound.length > 1) {
-      throw new Error(
-        `More than one Jenkins instance found: (${instancesFound}) ` +
-          `on entity with name: ${stringifyEntityRef(opt.entityRef)}. ` +
-          `Please use the same instance for all jobs.`,
-      );
+      jobsByInstance.set(instanceName, [
+        ...(jobsByInstance.get(instanceName) ?? []),
+        jobName,
+      ]);
     }
 
-    const jenkinsName: string = instancesFound.pop() ?? 'default';
-    const fullJobNames = jobsByInstance[jenkinsName];
+    return { entity, jobsByInstance };
+  }
 
-    // lookup baseURL + creds from config
-    const instanceConfig = this.config.getInstanceConfig(jenkinsName);
-
-    // override baseURL if config has override set to true
+  private getJenkinsInfo(
+    entity: Entity,
+    instanceName: string,
+    fullJobNames: string[],
+  ): JenkinsInfo & { instanceName: string } {
+    const DEFAULT_LIMITATION_OF_PROJECTS = 50;
+    const instanceConfig = this.config.getInstanceConfig(instanceName);
     const overrideUrlValue =
       DefaultJenkinsInfoProvider.getEntityOverrideURL(entity);
-    if (
+    const useOverrideUrl =
       instanceConfig.allowedBaseUrlOverrideRegex &&
       overrideUrlValue &&
       DefaultJenkinsInfoProvider.verifyUrlMatchesRegex(
         overrideUrlValue,
         instanceConfig.allowedBaseUrlOverrideRegex,
         this.logger,
-      )
-    ) {
-      instanceConfig.baseUrl = overrideUrlValue;
-    }
+      );
+    const baseUrl = useOverrideUrl ? overrideUrlValue : instanceConfig.baseUrl;
 
     const creds = Buffer.from(
       `${instanceConfig.username}:${instanceConfig.apiKey}`,
@@ -313,7 +360,8 @@ export class DefaultJenkinsInfoProvider implements JenkinsInfoProvider {
     ).toString('base64');
 
     return {
-      baseUrl: instanceConfig.baseUrl,
+      instanceName,
+      baseUrl,
       headers: {
         Authorization: `Basic ${creds}`,
         ...instanceConfig.extraRequestHeaders,

--- a/workspaces/jenkins/plugins/jenkins/README.md
+++ b/workspaces/jenkins/plugins/jenkins/README.md
@@ -93,7 +93,8 @@ metadata:
   description: 'a description'
   annotations:
     jenkins.io/github-folder: 'folder-name/project-name' # deprecated
-    jenkins.io/job-full-name: 'folder-name/project-name,folder-name/project-name' # use this instead
+    # Unprefixed jobs use the default instance; prefixed jobs use that named instance.
+    jenkins.io/job-full-name: 'folder-name/project-name,production:folder-name/project-name'
 
 spec:
   type: service
@@ -111,6 +112,9 @@ spec:
 - View all runs inside a folder
 - Last build status for specified branch
 - View summary of a build
+- View and operate jobs from multiple Jenkins instances on the same entity
+
+The projects table includes the Jenkins instance name. The same job full name can appear on multiple instances; build details, run history, console logs, and retries are resolved using both the instance name and job full name.
 
 ## Limitations
 

--- a/workspaces/jenkins/plugins/jenkins/report.api.md
+++ b/workspaces/jenkins/plugins/jenkins/report.api.md
@@ -49,12 +49,14 @@ export interface JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<Build>;
   // Warning: (ae-forgotten-export) The symbol "BuildConsoleText" needs to be exported by the entry point index.d.ts
   getBuildConsoleText(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<BuildConsoleText>;
   // Warning: (ae-forgotten-export) The symbol "Job" needs to be exported by the entry point index.d.ts
   //
@@ -62,6 +64,7 @@ export interface JenkinsApi {
   getJobBuilds(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
+    instanceName?: string;
   }): Promise<Job>;
   getProjects(options: {
     entity: CompoundEntityRef;
@@ -74,6 +77,7 @@ export interface JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<void>;
 }
 
@@ -92,17 +96,20 @@ export class JenkinsClient implements JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<Build>;
   // (undocumented)
   getBuildConsoleText(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<BuildConsoleText>;
   // (undocumented)
   getJobBuilds(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
+    instanceName?: string;
   }): Promise<Job>;
   // (undocumented)
   getProjects(options: {
@@ -116,6 +123,7 @@ export class JenkinsClient implements JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<void>;
 }
 
@@ -154,6 +162,8 @@ export interface Project {
   fullName: string;
   // (undocumented)
   inQueue: string;
+  // (undocumented)
+  instanceName?: string;
   // (undocumented)
   lastBuild: Build;
   // (undocumented)

--- a/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.test.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
+import { JenkinsClient } from './JenkinsApi';
+
+describe('JenkinsClient', () => {
+  const baseUrl = 'http://backstage.example.com/api/jenkins';
+  const entity = {
+    kind: 'Component',
+    namespace: 'default',
+    name: 'my-service',
+  };
+  let discoveryApi: jest.Mocked<Pick<DiscoveryApi, 'getBaseUrl'>>;
+  let fetchApi: jest.Mocked<Pick<FetchApi, 'fetch'>>;
+  let client: JenkinsClient;
+
+  beforeEach(() => {
+    discoveryApi = {
+      getBaseUrl: jest.fn().mockResolvedValue(baseUrl),
+    };
+    fetchApi = {
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as Response),
+    };
+    client = new JenkinsClient({
+      discoveryApi: discoveryApi as unknown as DiscoveryApi,
+      fetchApi: fetchApi as unknown as FetchApi,
+    });
+  });
+
+  it('keeps identical job names associated with their source instance', async () => {
+    const project = {
+      fullName: 'folder/shared-job',
+      fullDisplayName: 'folder » shared-job',
+      displayName: 'shared-job',
+      inQueue: false,
+      status: 'SUCCESS',
+      lastBuild: { number: 12 },
+    };
+    fetchApi.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        projects: [
+          { ...project, instanceName: 'prod' },
+          { ...project, instanceName: 'dev' },
+        ],
+      }),
+    } as Response);
+
+    const projects = await client.getProjects({ entity, filter: {} });
+    await projects[1].onRestartClick();
+
+    expect(projects.map(p => [p.instanceName, p.fullName])).toEqual([
+      ['prod', 'folder/shared-job'],
+      ['dev', 'folder/shared-job'],
+    ]);
+    expect(fetchApi.fetch.mock.calls[1][0].toString()).toBe(
+      `${baseUrl}/v1/entity/default/Component/my-service/job/folder%2Fshared-job/12?instanceName=dev`,
+    );
+    expect(fetchApi.fetch.mock.calls[1][1]).toEqual({ method: 'POST' });
+  });
+
+  it('passes instanceName to build, history, and console requests', async () => {
+    await client.getBuild({
+      entity,
+      jobFullName: 'folder/shared-job',
+      buildNumber: '12',
+      instanceName: 'prod',
+    });
+    await client.getJobBuilds({
+      entity,
+      jobFullName: 'folder/shared-job',
+      instanceName: 'prod',
+    });
+    await client.getBuildConsoleText({
+      entity,
+      jobFullName: 'folder/shared-job',
+      buildNumber: '12',
+      instanceName: 'prod',
+    });
+
+    expect(fetchApi.fetch.mock.calls.map(call => call[0].toString())).toEqual([
+      `${baseUrl}/v1/entity/default/Component/my-service/job/folder%2Fshared-job/12?instanceName=prod`,
+      `${baseUrl}/v1/entity/default/Component/my-service/job/folder%2Fshared-job?instanceName=prod`,
+      `${baseUrl}/v1/entity/default/Component/my-service/job/folder%2Fshared-job/12/consoleText?instanceName=prod`,
+    ]);
+  });
+});

--- a/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/api/JenkinsApi.ts
@@ -90,6 +90,7 @@ export interface Project {
   fullName: string;
   inQueue: string;
   // added by us
+  instanceName?: string;
   status: string; // == inQueue ? 'queued' : lastBuild.building ? 'running' : lastBuild.result,
   onRestartClick: () => Promise<void>; // TODO rename to handle.* ? also, should this be on lastBuild?
 }
@@ -117,25 +118,27 @@ export interface JenkinsApi {
   /**
    * Get a single build.
    *
-   * This takes an entity to support selecting between multiple jenkins instances.
-   *
-   * TODO: abstract jobFullName (so we could support differentiating between the same named job on multiple instances).
+   * This takes an entity and instance name to support selecting between
+   * multiple Jenkins instances.
    */
   getBuild(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<Build>;
 
   getJobBuilds(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
+    instanceName?: string;
   }): Promise<Job>;
 
   retry(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<void>;
 
   /**
@@ -145,6 +148,7 @@ export interface JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<BuildConsoleText>;
 }
 
@@ -179,11 +183,13 @@ export class JenkinsClient implements JenkinsApi {
     return (
       (await response.json()).projects?.map((p: Project) => ({
         ...p,
+        instanceName: p.instanceName ?? 'default',
         onRestartClick: () => {
           return this.retry({
             entity,
             jobFullName: p.fullName,
             buildNumber: String(p.lastBuild.number),
+            instanceName: p.instanceName ?? 'default',
           });
         },
       })) || []
@@ -194,15 +200,19 @@ export class JenkinsClient implements JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<Build> {
-    const { entity, jobFullName, buildNumber } = options;
-    const url = `${await this.discoveryApi.getBaseUrl(
-      'jenkins',
-    )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
-      entity.kind,
-    )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
-      jobFullName,
-    )}/${encodeURIComponent(buildNumber)}`;
+    const { entity, jobFullName, buildNumber, instanceName } = options;
+    const url = new URL(
+      `${await this.discoveryApi.getBaseUrl(
+        'jenkins',
+      )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
+        entity.kind,
+      )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
+        jobFullName,
+      )}/${encodeURIComponent(buildNumber)}`,
+    );
+    this.appendInstanceName(url, instanceName);
 
     const response = await this.fetchApi.fetch(url);
 
@@ -213,15 +223,19 @@ export class JenkinsClient implements JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<void> {
-    const { entity, jobFullName, buildNumber } = options;
-    const url = `${await this.discoveryApi.getBaseUrl(
-      'jenkins',
-    )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
-      entity.kind,
-    )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
-      jobFullName,
-    )}/${encodeURIComponent(buildNumber)}`;
+    const { entity, jobFullName, buildNumber, instanceName } = options;
+    const url = new URL(
+      `${await this.discoveryApi.getBaseUrl(
+        'jenkins',
+      )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
+        entity.kind,
+      )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
+        jobFullName,
+      )}/${encodeURIComponent(buildNumber)}`,
+    );
+    this.appendInstanceName(url, instanceName);
 
     const response = await this.fetchApi.fetch(url, { method: 'POST' });
 
@@ -233,15 +247,19 @@ export class JenkinsClient implements JenkinsApi {
   async getJobBuilds(options: {
     entity: CompoundEntityRef;
     jobFullName: string;
+    instanceName?: string;
   }): Promise<Job> {
-    const { entity, jobFullName } = options;
-    const url = `${await this.discoveryApi.getBaseUrl(
-      'jenkins',
-    )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
-      entity.kind,
-    )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
-      jobFullName,
-    )}`;
+    const { entity, jobFullName, instanceName } = options;
+    const url = new URL(
+      `${await this.discoveryApi.getBaseUrl(
+        'jenkins',
+      )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
+        entity.kind,
+      )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
+        jobFullName,
+      )}`,
+    );
+    this.appendInstanceName(url, instanceName);
 
     const response = await this.fetchApi.fetch(url);
 
@@ -252,18 +270,28 @@ export class JenkinsClient implements JenkinsApi {
     entity: CompoundEntityRef;
     jobFullName: string;
     buildNumber: string;
+    instanceName?: string;
   }): Promise<BuildConsoleText> {
-    const { entity, jobFullName, buildNumber } = options;
-    const url = `${await this.discoveryApi.getBaseUrl(
-      'jenkins',
-    )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
-      entity.kind,
-    )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
-      jobFullName,
-    )}/${encodeURIComponent(buildNumber)}/consoleText`;
+    const { entity, jobFullName, buildNumber, instanceName } = options;
+    const url = new URL(
+      `${await this.discoveryApi.getBaseUrl(
+        'jenkins',
+      )}/v1/entity/${encodeURIComponent(entity.namespace)}/${encodeURIComponent(
+        entity.kind,
+      )}/${encodeURIComponent(entity.name)}/job/${encodeURIComponent(
+        jobFullName,
+      )}/${encodeURIComponent(buildNumber)}/consoleText`,
+    );
+    this.appendInstanceName(url, instanceName);
 
     const response = await this.fetchApi.fetch(url);
 
     return await response.json();
+  }
+
+  private appendInstanceName(url: URL, instanceName?: string): void {
+    if (instanceName) {
+      url.searchParams.set('instanceName', instanceName);
+    }
   }
 }

--- a/workspaces/jenkins/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
+++ b/workspaces/jenkins/plugins/jenkins/src/components/BuildWithStepsPage/BuildWithStepsPage.tsx
@@ -29,6 +29,7 @@ import { useBuildWithSteps } from '../useBuildWithSteps';
 
 import { Breadcrumbs, Content, Link } from '@backstage/core-components';
 import { useRouteRefParams } from '@backstage/core-plugin-api';
+import { useSearchParams } from 'react-router-dom';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -46,9 +47,15 @@ const useStyles = makeStyles(theme => ({
 const BuildWithStepsView = () => {
   // TODO: Add a test that react-router decodes this (even though `generatePath` doesn't encode it for you!)
   const { jobFullName, buildNumber } = useRouteRefParams(buildRouteRef);
+  const [searchParams] = useSearchParams();
+  const instanceName = searchParams.get('instanceName') ?? undefined;
   const classes = useStyles();
 
-  const [{ value }] = useBuildWithSteps({ jobFullName, buildNumber });
+  const [{ value }] = useBuildWithSteps({
+    jobFullName,
+    buildNumber,
+    instanceName,
+  });
 
   return (
     <div className={classes.root}>

--- a/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.test.tsx
+++ b/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/CITable.test.tsx
@@ -39,7 +39,14 @@ const entity = {
 const jenkinsApi: Partial<JenkinsApi> = {
   getProjects: () =>
     Promise.resolve([
-      { lastBuild: { timestamp: 0, status: 'success', url: 'foo' } },
+      {
+        instanceName: 'dev',
+        fullName: 'folder/shared-job',
+        fullDisplayName: 'folder » shared-job',
+        displayName: 'shared-job',
+        status: 'success',
+        lastBuild: { timestamp: 0, status: 'success', url: 'foo', number: 12 },
+      },
     ] as Project[]),
 };
 
@@ -86,5 +93,28 @@ describe('<CITable />', () => {
       );
       expect(getByText('My custom title!')).toBeVisible();
     });
+  });
+
+  it('keeps the Jenkins instance in build detail links', async () => {
+    const { findByRole } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [jenkinsApiRef, jenkinsApi],
+          [toastApiRef, {}],
+        ]}
+      >
+        <EntityProvider entity={entity}>
+          <CITable />
+        </EntityProvider>
+      </TestApiProvider>,
+      mountedRoutes,
+    );
+
+    expect(
+      await findByRole('link', { name: 'folder » shared-job' }),
+    ).toHaveAttribute(
+      'href',
+      '/builds/folder%2Fshared-job/12?instanceName=dev',
+    );
   });
 });

--- a/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/columns.tsx
+++ b/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/columns.tsx
@@ -114,13 +114,16 @@ export const columnFactories = Object.freeze({
             );
           }
 
+          const buildLink = routeLink({
+            jobFullName: encodeURIComponent(row.fullName),
+            buildNumber: String(row.lastBuild?.number),
+          });
+          const instanceQuery = row.instanceName
+            ? `?instanceName=${encodeURIComponent(row.instanceName)}`
+            : '';
+
           return (
-            <Link
-              to={routeLink({
-                jobFullName: encodeURIComponent(row.fullName),
-                buildNumber: String(row.lastBuild?.number),
-              })}
-            >
+            <Link to={`${buildLink}${instanceQuery}`}>
               {row.fullDisplayName}
             </Link>
           );
@@ -128,6 +131,13 @@ export const columnFactories = Object.freeze({
 
         return <LinkWrapper />;
       },
+    };
+  },
+
+  createInstanceColumn(): TableColumn<Project> {
+    return {
+      title: 'Instance',
+      field: 'instanceName',
     };
   },
 
@@ -223,6 +233,12 @@ export const columnFactories = Object.freeze({
 
           const toastApi = useApi(toastApiRef);
           const jobRunsLink = useRouteRef(jobRunsRouteRef);
+          const runsLink = jobRunsLink({
+            jobFullName: encodeURIComponent(row.fullName || ''),
+          });
+          const instanceQuery = row.instanceName
+            ? `?instanceName=${encodeURIComponent(row.instanceName)}`
+            : '';
 
           const onRebuild = async () => {
             if (row.onRestartClick) {
@@ -264,11 +280,7 @@ export const columnFactories = Object.freeze({
                   </IconButton>
                 </Tooltip>
               )}
-              <Link
-                to={jobRunsLink({
-                  jobFullName: encodeURIComponent(row.fullName || ''),
-                })}
-              >
+              <Link to={`${runsLink}${instanceQuery}`}>
                 <Tooltip title="View Runs">
                   <IconButton>
                     <HistoryIcon />

--- a/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/presets.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/components/BuildsPage/lib/CITable/presets.ts
@@ -21,6 +21,7 @@ import { TableColumn } from '@backstage/core-components';
 export const defaultCITableColumns: TableColumn<Project>[] = [
   columnFactories.createTimestampColumn(),
   columnFactories.createSourceColumn(),
+  columnFactories.createInstanceColumn(),
   columnFactories.createBuildColumn(),
   columnFactories.createTestColumn(),
   columnFactories.createStatusColumn(),

--- a/workspaces/jenkins/plugins/jenkins/src/components/JobRunsTable/JobRunsTable.tsx
+++ b/workspaces/jenkins/plugins/jenkins/src/components/JobRunsTable/JobRunsTable.tsx
@@ -25,6 +25,7 @@ import { JenkinsRunStatus } from './../BuildsPage/lib/Status';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import { jobRunsRouteRef } from '../../plugin';
 import { useRouteRefParams } from '@backstage/core-plugin-api';
+import { useSearchParams } from 'react-router-dom';
 
 const generatedColumns: TableColumn[] = [
   {
@@ -177,7 +178,12 @@ export const JobRunsTableView = ({
 
 export const JobRunsTable = () => {
   const { jobFullName } = useRouteRefParams(jobRunsRouteRef);
-  const [tableProps, { setPage, setPageSize }] = useJobRuns(jobFullName);
+  const [searchParams] = useSearchParams();
+  const instanceName = searchParams.get('instanceName') ?? undefined;
+  const [tableProps, { setPage, setPageSize }] = useJobRuns(
+    jobFullName,
+    instanceName,
+  );
 
   return (
     <JobRunsTableView

--- a/workspaces/jenkins/plugins/jenkins/src/components/useBuildWithSteps.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/components/useBuildWithSteps.ts
@@ -31,9 +31,11 @@ const INTERVAL_AMOUNT = 1500;
 export function useBuildWithSteps({
   jobFullName,
   buildNumber,
+  instanceName,
 }: {
   jobFullName: string;
   buildNumber: string;
+  instanceName?: string;
 }) {
   const api = useApi(jenkinsApiRef);
   const errorApi = useApi(errorApiRef);
@@ -42,12 +44,17 @@ export function useBuildWithSteps({
   const getBuildWithSteps = useCallback(async () => {
     try {
       const entityName = await getCompoundEntityRef(entity);
-      return api.getBuild({ entity: entityName, jobFullName, buildNumber });
+      return api.getBuild({
+        entity: entityName,
+        jobFullName,
+        buildNumber,
+        instanceName,
+      });
     } catch (e) {
       errorApi.post(e);
       return Promise.reject(e);
     }
-  }, [buildNumber, jobFullName, entity, api, errorApi]);
+  }, [buildNumber, jobFullName, instanceName, entity, api, errorApi]);
 
   const { loading, value, retry } = useAsyncRetry(
     () => getBuildWithSteps(),

--- a/workspaces/jenkins/plugins/jenkins/src/components/useBuilds.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/components/useBuilds.ts
@@ -45,9 +45,18 @@ export function useBuilds({ branch }: { branch?: string } = {}) {
     errorType: ErrorType;
   }>();
 
-  const restartBuild = async (jobFullName: string, buildNumber: string) => {
+  const restartBuild = async (
+    jobFullName: string,
+    buildNumber: string,
+    instanceName?: string,
+  ) => {
     try {
-      await api.retry({ entity: entityName, jobFullName, buildNumber });
+      await api.retry({
+        entity: entityName,
+        jobFullName,
+        buildNumber,
+        instanceName,
+      });
     } catch (e) {
       errorApi.post(e);
     }

--- a/workspaces/jenkins/plugins/jenkins/src/components/useJobRuns.ts
+++ b/workspaces/jenkins/plugins/jenkins/src/components/useJobRuns.ts
@@ -25,7 +25,7 @@ export enum ErrorType {
   NOT_FOUND,
 }
 
-export function useJobRuns(jobFullName: string) {
+export function useJobRuns(jobFullName: string, instanceName?: string) {
   const { entity } = useEntity();
   const api = useApi(jenkinsApiRef);
   const errorApi = useApi(errorApiRef);
@@ -43,6 +43,7 @@ export function useJobRuns(jobFullName: string) {
       const jobBuilds = await api.getJobBuilds({
         entity: getCompoundEntityRef(entity),
         jobFullName,
+        instanceName,
       });
       return jobBuilds;
     } catch (e) {
@@ -52,7 +53,7 @@ export function useJobRuns(jobFullName: string) {
       setError({ message: e.message, errorType });
       throw e;
     }
-  }, [api, errorApi, entity]);
+  }, [api, errorApi, entity, instanceName, jobFullName]);
 
   return [
     {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This allows a single catalog entity to reference jobs from multiple named Jenkins instances.

Jobs are scoped by both instance name and full job name, so identically named jobs on different instances do not collide. Unprefixed jobs continue to resolve through the `default` instance, preserving existing single-instance behavior.

The originating instance is retained when listing builds, opening build details, viewing history and logs, or retrying a build.

Closes #10301

<img width="1024" height="667" alt="image" src="https://github.com/user-attachments/assets/c16d83a8-8f11-4616-bce9-64a0eddd78c9" />


### Validation

- Backend tests: 40 passed
- Frontend tests: 5 passed
- Type checking, linting, formatting, and API report validation passed
- Manually validated two named instances containing the same full job name

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))