### PR TITLE
graphiql migration from MUI to BUI

### DIFF
--- a/workspaces/graphiql/.changeset/migrate-graphiql-browser-to-bui.md
+++ b/workspaces/graphiql/.changeset/migrate-graphiql-browser-to-bui.md
@@ -3,3 +3,5 @@
 ---
 
 Migrated `GraphiQLBrowser` and `GraphiQLPage` from Material-UI to Backstage UI (`@backstage/ui`). Tabs, typography, and the endpoint switcher now use BUI's `Tabs`/`TabList`/`Tab`/`TabPanel` and `Text` components. `@material-ui/core` is still a dependency for the `GraphiQLIcon` component, which relies on MUI's `SvgIcon` type as required by existing Backstage icon APIs.
+
+**Note for consuming apps:** import `@backstage/ui/css/styles.css` in your app entry point if it is not already included.

--- a/workspaces/graphiql/.changeset/migrate-graphiql-browser-to-bui.md
+++ b/workspaces/graphiql/.changeset/migrate-graphiql-browser-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-graphiql': minor
+---
+
+Migrated `GraphiQLBrowser` and `GraphiQLPage` from Material-UI to Backstage UI (`@backstage/ui`). Tabs, typography, and the endpoint switcher now use BUI's `Tabs`/`TabList`/`Tab`/`TabPanel` and `Text` components. `@material-ui/core` is still a dependency for the `GraphiQLIcon` component, which relies on MUI's `SvgIcon` type as required by existing Backstage icon APIs.

--- a/workspaces/graphiql/plugins/graphiql/package.json
+++ b/workspaces/graphiql/plugins/graphiql/package.json
@@ -57,6 +57,7 @@
     "@backstage/core-components": "backstage:^",
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
+    "@backstage/ui": "backstage:^",
     "@material-ui/core": "^4.12.2",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "graphiql": "^3.0.6",

--- a/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.module.css
+++ b/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.module.css
@@ -1,0 +1,20 @@
+@layer components {
+  .root {
+    height: 100%;
+    display: flex;
+    flex-flow: column nowrap;
+  }
+
+  .tabs {
+    background: var(--bui-bg-surface-1);
+    border-bottom: 1px solid var(--bui-border);
+  }
+
+  .graphiQlWrapper {
+    flex: 1;
+  }
+
+  .graphiQlWrapper :global(.graphiql-container) {
+    box-sizing: initial;
+  }
+}

--- a/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
+++ b/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLBrowser/GraphiQLBrowser.tsx
@@ -15,38 +15,16 @@
  */
 
 import { lazy, useState, Suspense } from 'react';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import { makeStyles } from '@material-ui/core/styles';
+import { Tabs, TabList, Tab, TabPanel, Text } from '@backstage/ui';
 import 'graphiql/graphiql.css';
 import { StorageBucket } from '../../lib/storage';
 import { GraphQLEndpoint } from '../../lib/api';
 import { Progress } from '@backstage/core-components';
+import styles from './GraphiQLBrowser.module.css';
 
 const GraphiQL = lazy(() =>
   import('graphiql').then(m => ({ default: m.GraphiQL })),
 );
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    height: '100%',
-    display: 'flex',
-    flexFlow: 'column nowrap',
-  },
-  tabs: {
-    background: theme.palette.background.paper,
-  },
-  graphiQlWrapper: {
-    flex: 1,
-    '@global': {
-      '.graphiql-container': {
-        boxSizing: 'initial',
-      },
-    },
-  },
-}));
 
 type GraphiQLBrowserProps = {
   endpoints: GraphQLEndpoint[];
@@ -55,38 +33,43 @@ type GraphiQLBrowserProps = {
 export const GraphiQLBrowser = (props: GraphiQLBrowserProps) => {
   const { endpoints } = props;
 
-  const classes = useStyles();
-  const [tabIndex, setTabIndex] = useState(0);
+  const [tabId, setTabId] = useState<string>('0');
 
   if (!endpoints.length) {
-    return <Typography variant="h4">No endpoints available</Typography>;
+    return <Text variant="title-large">No endpoints available</Text>;
   }
 
+  const tabIndex = Number(tabId);
   const { id, fetcher, plugins } = endpoints[tabIndex];
   const storage = StorageBucket.forLocalStorage(`plugin/graphiql/data/${id}`);
 
   return (
-    <div className={classes.root}>
+    <div className={styles.root}>
       <Suspense fallback={<Progress />}>
         <Tabs
-          classes={{ root: classes.tabs }}
-          value={tabIndex}
-          onChange={(_, value) => setTabIndex(value)}
-          indicatorColor="primary"
+          selectedKey={tabId}
+          onSelectionChange={key => setTabId(String(key))}
         >
-          {endpoints.map(({ title }, index) => (
-            <Tab key={index} label={title} value={index} />
+          <TabList className={styles.tabs}>
+            {endpoints.map(({ title }, index) => (
+              <Tab key={index} id={String(index)}>
+                {title}
+              </Tab>
+            ))}
+          </TabList>
+          {endpoints.map((_, index) => (
+            <TabPanel key={index} id={String(index)}>
+              <div className={styles.graphiQlWrapper}>
+                <GraphiQL
+                  key={index}
+                  fetcher={fetcher}
+                  storage={storage}
+                  plugins={plugins}
+                />
+              </div>
+            </TabPanel>
           ))}
         </Tabs>
-        <Divider />
-        <div className={classes.graphiQlWrapper}>
-          <GraphiQL
-            key={tabIndex}
-            fetcher={fetcher}
-            storage={storage}
-            plugins={plugins}
-          />
-        </div>
       </Suspense>
     </div>
   );

--- a/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.tsx
+++ b/workspaces/graphiql/plugins/graphiql/src/components/GraphiQLPage/GraphiQLPage.tsx
@@ -19,7 +19,7 @@ import useAsync from 'react-use/esm/useAsync';
 import 'graphiql/graphiql.css';
 import { graphQlBrowseApiRef } from '../../lib/api';
 import { GraphiQLBrowser } from '../GraphiQLBrowser';
-import Typography from '@material-ui/core/Typography';
+import { Text } from '@backstage/ui';
 import {
   Content,
   Header,
@@ -44,10 +44,10 @@ export const GraphiQLPage = () => {
   } else if (endpoints.error) {
     content = (
       <Content>
-        <Typography variant="h4" color="error">
+        <Text variant="title-large" color="danger">
           {/* TODO: provide a proper error component */}
           Failed to load GraphQL endpoints, {String(endpoints.error)}
-        </Typography>
+        </Text>
       </Content>
     );
   } else {

--- a/workspaces/graphiql/yarn.lock
+++ b/workspaces/graphiql/yarn.lock
@@ -372,6 +372,7 @@ __metadata:
     "@backstage/dev-utils": "backstage:^"
     "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/test-utils": "backstage:^"
+    "@backstage/ui": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
@@ -1526,7 +1527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.1":
+"@backstage/ui@backstage:^::backstage=1.54.5&npm=0.17.1, @backstage/ui@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/ui@npm:0.17.1"
   dependencies:


### PR DESCRIPTION
Migrated the GraphiQL plugin's browser and page components from Material UI (MUI) to Backstage UI (BUI) as part of the ongoing migration effort.

## What changed

- Replaced MUI `Tabs`/`Tab`/`Typography`/`Divider`/`makeStyles` with Backstage UI `Tabs`/`TabList`/`Tab`/`TabPanel`/`Text` in `GraphiQLBrowser` and `GraphiQLPage`
- Added a CSS module (`GraphiQLBrowser.module.css`) for the root layout, tab surface/divider styling, and the pre-existing `.graphiql-container` box-sizing override
- Endpoint tab switching still remounts the embedded `GraphiQL` instance per tab, preserving prior behavior
- Added `@backstage/ui` as a dependency
- Added a changeset for the package release note

## Not changed / known limitation

`@material-ui/core` remains a dependency. The public `GraphiQLIcon` export still uses MUI's `SvgIcon`/`SvgIconProps`, which several existing Backstage icon APIs (legacy `IconComponent`, the GraphiQL plugin icon type, and the current API report) still expect. Switching `GraphiQLIcon` to a native SVG would be a breaking change to its public prop signature and is out of scope for this PR.

## Verified

- `yarn tsc`
- `yarn workspace @backstage-community/plugin-graphiql lint`
- `yarn workspace @backstage-community/plugin-graphiql test` (16/16 passing)
- `yarn workspace @backstage-community/plugin-graphiql build`
- Manual visual check (agent-browser): header, all three endpoint tabs (GitHub/GitLab/Countries), active-tab styling, per-tab GraphiQL remount, and the custom plugin icon on the Countries endpoint

## Screenshots

After:

<img width="1280" height="633" alt="graphiql-state3" src="https://github.com/user-attachments/assets/709979d2-2fda-470d-a3b3-dafdae75e8f8" />

## ✔️ Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
