### PR TITLE
Version Packages (scaffolder-backend-module-regex)

### DIFF
--- a/workspaces/scaffolder-backend-module-regex/.changeset/version-bump-1-54-5.md
+++ b/workspaces/scaffolder-backend-module-regex/.changeset/version-bump-1-54-5.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-regex': minor
----
-
-Backstage version bump to v1.54.5

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-regex
 
+## 2.18.0
+
+### Minor Changes
+
+- fe687dc: Backstage version bump to v1.54.5
+
 ## 2.17.1
 
 ### Patch Changes

--- a/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
+++ b/workspaces/scaffolder-backend-module-regex/plugins/regex-actions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@backstage-community/plugin-scaffolder-backend-module-regex",
   "description": "The regex custom actions",
-  "version": "2.17.1",
+  "version": "2.18.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-scaffolder-backend-module-regex@2.18.0

### Minor Changes

-   fe687dc: Backstage version bump to v1.54.5
