### PR TITLE
Version Packages (adr)

### DIFF
--- a/workspaces/adr/.changeset/fix-adr-image-dotted-repo-name.md
+++ b/workspaces/adr/.changeset/fix-adr-image-dotted-repo-name.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-adr-backend': patch
----
-
-Fixed images failing to load when the source repository name contains dots, such as Azure DevOps repositories where the file path is passed as a query parameter.

--- a/workspaces/adr/plugins/adr-backend/CHANGELOG.md
+++ b/workspaces/adr/plugins/adr-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-adr-backend
 
+## 0.25.1
+
+### Patch Changes
+
+- 1cf5dae: Fixed images failing to load when the source repository name contains dots, such as Azure DevOps repositories where the file path is passed as a query parameter.
+
 ## 0.25.0
 
 ### Minor Changes

--- a/workspaces/adr/plugins/adr-backend/package.json
+++ b/workspaces/adr/plugins/adr-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage-community/plugin-adr-backend",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-adr-backend@0.25.1

### Patch Changes

-   1cf5dae: Fixed images failing to load when the source repository name contains dots, such as Azure DevOps repositories where the file path is passed as a query parameter.
