### PR TITLE
Update changesets action

### DIFF
--- a/.github/workflows/release_workspace.yml
+++ b/.github/workflows/release_workspace.yml
@@ -94,13 +94,17 @@ jobs:
       - name: Update Version Packages (${{ inputs.workspace }}) PR
         id: changesets-pr
         if: steps.release_check.outputs.needs_release != 'true' || inputs.force_release != true
-        uses: backstage/changesets-action@291bfc1f76d1dcfbf967f5810dc0423592eae09a # v2.3.1
+        uses: backstage/changesets-action@f24ad771fafcd1500864302d3143b9b95ceb4e15 # v3.0.0
         with:
           title: Version Packages (${{ inputs.workspace }})
           cwd: workspaces/${{ inputs.workspace }}
           version: yarn changeset version
           versionBranch: changesets-release/${{ inputs.workspace }}
-          skipRootChangelogUpdate: true
+          commit: |-
+            Version Packages
+
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+            Generated-by: changesets/action
         env:
           GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/release_workspace_version.yml
+++ b/.github/workflows/release_workspace_version.yml
@@ -110,13 +110,17 @@ jobs:
       - name: Update Version Packages (${{ needs.check-merged-pr.outputs.workspace_name }}) PR
         id: changesets-pr
         if: steps.release_check.outputs.needs_release != 'true'
-        uses: backstage/changesets-action@291bfc1f76d1dcfbf967f5810dc0423592eae09a # v2.3.1
+        uses: backstage/changesets-action@f24ad771fafcd1500864302d3143b9b95ceb4e15 # v3.0.0
         with:
           title: Version Packages (${{ needs.check-merged-pr.outputs.workspace_name }})
           cwd: workspaces/${{ needs.check-merged-pr.outputs.workspace_name }}
           version: yarn changeset version
           versionBranch: maintenance-changesets-release/${{ needs.check-merged-pr.outputs.workspace_name }}
-          skipRootChangelogUpdate: true
+          commit: |-
+            Version Packages
+
+            Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+            Generated-by: changesets/action
         env:
           GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Pin both workspace release workflows to the immutable commit behind `backstage/changesets-action` v3.0.0 and remove the obsolete `skipRootChangelogUpdate` input. The refreshed fork is based on upstream v1.9.0 and differs only by the `versionBranch` input required for independent workspace release PR branches.

Both workflows also provide a signed-off commit message so action-generated version commits satisfy this repository's DCO requirement, including prerelease mode.

The released commit was exercised end-to-end in a disposable nested Changesets workspace, verifying the custom branch, workspace-only file changes, generated PR body, and generated-commit DCO trailer.

Release: backstage/changesets-action@v3.0.0

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (Not applicable: workflow-only change)
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All your commits have a Signed-off-by line in the message.
