### PR TITLE
azure-devops: Support non-PAT credentials in wiki search collator

### DIFF
--- a/workspaces/azure-devops/.changeset/support-non-pat-credentials.md
+++ b/workspaces/azure-devops/.changeset/support-non-pat-credentials.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-search-backend-module-azure-devops': minor
+---
+
+Added support for non-PAT credentials (service principals, managed identities) via `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`. The `token` config field is now deprecated in favor of `integrations.azure`. The `baseUrl` config field is now optional, defaulting to `https://dev.azure.com`.

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/README.md
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/README.md
@@ -16,24 +16,50 @@ In the root directory of your Backstage project:
 yarn add --cwd packages/backend @backstage-community/plugin-search-backend-module-azure-devops
 ```
 
-Add the necessary configuration for this plugin to your `app-config.yaml`:
+### Authentication
+
+This plugin supports all credential types provided by `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`, including:
+
+- **Personal Access Tokens (PATs)**
+- **Service Principals (client credentials)**
+- **Managed Identities**
+
+Credentials are configured under `integrations.azure` in your `app-config.yaml`. This is the same configuration used by other Azure DevOps plugins in the Backstage ecosystem.
 
 ```yaml
 # app-config.yaml
 
-# multiple wikis
-azureDevOpsWikiCollator:
-  baseUrl: https://my-azure-instance.com # The URL of your Azure DevOps instance. Required
-  token: ${AZURE_TOKEN} # The PAT used to authenticate to the Azure DevOps REST API. Required.
-  wikis:
-    - wikiIdentifier: Wiki-Identifier.wiki # The identifier of the wiki. This can be found by looking at the URL of the wiki in ADO. It is typically something like '{nameOfWiki}.wiki'. Required.
-      organization: MyOrganization # The name of the organization the wiki is contained in. Required.
-      project: MyProject # The name of the project the wiki is contained in. Required.
-      titleSuffix: ' - My Suffix' # A string to append to the title of articles to make them easier to identify as search results from the wiki. Optional
-    - wikiIdentifier: Wiki-Identifier2.wiki
-      organization: MyOrganization
-      project: MyProject
-      titleSuffix: ' - Suffix 2'
+integrations:
+  azure:
+    - host: dev.azure.com
+      credentials:
+        - personalAccessToken: ${AZURE_TOKEN}
+```
+
+For service principal or managed identity configuration, see the [Backstage Azure integration documentation](https://backstage.io/docs/integrations/azure/locations).
+
+### Collator configuration
+
+Add the wiki collator configuration to your `app-config.yaml`:
+
+```yaml
+# app-config.yaml
+
+search:
+  collators:
+    azureDevOpsWikiCollator:
+      # baseUrl is optional, defaults to https://dev.azure.com
+      # Only needed for Azure DevOps Server (on-premises) instances
+      # baseUrl: https://ado.mycompany.com
+      wikis:
+        - wikiIdentifier: Wiki-Identifier.wiki # The identifier of the wiki found in the ADO URL. Required.
+          organization: MyOrganization # The name of the organization the wiki is in. Required.
+          project: MyProject # The name of the project the wiki is in. Required.
+          titleSuffix: ' - My Suffix' # A string to append to article titles in search results. Optional.
+        - wikiIdentifier: Wiki-Identifier2.wiki
+          organization: MyOrganization
+          project: MyProject
+          titleSuffix: ' - Suffix 2'
 ```
 
 Add the plugin to your backend:
@@ -53,6 +79,28 @@ Add the plugin to your backend:
 From here, the collator will begin indexing all articles in the wiki into search. Once the indexing is done, the articles and their content will be searchable via the Backstage search feature.
 
 If there are any errors with indexing the articles, they will be reported in the Backstage logs.
+
+### Deprecated: Direct token configuration
+
+The previous configuration style using a `token` field directly in the collator config is deprecated and will be removed in a future release. If you are currently using this configuration:
+
+```yaml
+# app-config.yaml — DEPRECATED
+
+search:
+  collators:
+    azureDevOpsWikiCollator:
+      baseUrl: https://dev.azure.com
+      token: ${AZURE_TOKEN} # Deprecated — use integrations.azure instead
+      wikis:
+        - wikiIdentifier: Wiki-Identifier.wiki
+          organization: MyOrganization
+          project: MyProject
+```
+
+Please migrate to the `integrations.azure` configuration shown above. The `token` field still works for backward compatibility, but you will see a deprecation warning in your logs.
+
+> **Note:** Microsoft is [retiring Global PATs in Azure DevOps Services on December 1, 2026](https://devblogs.microsoft.com/devops/retirement-of-global-personal-access-tokens-in-azure-devops/). If you are using a Global PAT, you should migrate to organization-scoped PATs or Entra ID credentials (service principal or managed identity) before that date.
 
 ## Previously maintained by
 

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/config.d.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/config.d.ts
@@ -28,14 +28,21 @@ export interface Config {
          */
         schedule?: SchedulerServiceTaskScheduleDefinitionConfig;
         /**
-         * URL of your Azure Devops instances; required
+         * URL of your Azure DevOps instance. Defaults to `https://dev.azure.com` if not provided.
          */
-        baseUrl: string;
+        baseUrl?: string;
         /**
-         * Personal Access Token to authenticate to the Azure DevOps instance; required
+         * Personal Access Token to authenticate to the Azure DevOps instance.
+         *
+         * @deprecated Use `integrations.azure` in your app-config.yaml to configure
+         * Azure DevOps credentials instead. This supports PATs, service principals,
+         * and managed identities via `DefaultAzureDevOpsCredentialsProvider`.
+         * If both `token` and `integrations.azure` credentials are present, the
+         * `token` value takes precedence for backward compatibility.
+         * This field will be removed in a future release.
          * @visibility secret
          */
-        token: string;
+        token?: string;
         /**
          * Array of one or more wikis to collate
          */

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
@@ -33,6 +33,7 @@
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",
     "@backstage/errors": "backstage:^",
+    "@backstage/integration": "backstage:^",
     "@backstage/plugin-search-backend-node": "backstage:^",
     "@backstage/plugin-search-common": "backstage:^",
     "axios": "^1.4.0",

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.test.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.test.ts
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import { ConfigReader } from '@backstage/config';
+import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
+import { AzureDevOpsWikiArticleCollatorFactory } from './AzureDevOpsWikiArticleCollatorFactory';
+
+const mockFetchResponse = (body: object, headers?: Record<string, string>) => {
+  return {
+    ok: true,
+    json: async () => body,
+    headers: new Headers(headers),
+  } as Response;
+};
+
+describe('AzureDevOpsWikiArticleCollatorFactory', () => {
+  const logger = mockServices.logger.mock();
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('fromConfig', () => {
+    it('should read all config values from app-config', () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              baseUrl: 'https://ado.mycompany.com',
+              token: 'my-pat',
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                  titleSuffix: ' - Wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+      });
+
+      expect(factory.type).toBe('azure-devops-wiki-article');
+    });
+
+    it('should accept config without baseUrl or token when credentials provider is given', () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn(),
+      };
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      expect(factory.type).toBe('azure-devops-wiki-article');
+    });
+  });
+
+  describe('execute', () => {
+    it('should log deprecation warning when token is configured', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              baseUrl: 'https://dev.azure.com',
+              token: 'my-pat',
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 1, path: '/Page' }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            id: 1,
+            path: '/Page',
+            content: 'Content',
+            remoteUrl: 'https://dev.azure.com/my-org/my-project/_wiki/1/Page',
+            gitItemPath: '/Page.md',
+            isNonConformant: false,
+            isParentPage: false,
+            order: 0,
+            subPages: [],
+            url: '',
+          }),
+        );
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('deprecated'),
+      );
+    });
+
+    it('should not log deprecation warning when using credentials provider', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer token' },
+          token: 'token',
+          type: 'bearer',
+        }),
+      };
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 1, path: '/Page' }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            id: 1,
+            path: '/Page',
+            content: 'Content',
+            remoteUrl: 'https://dev.azure.com/my-org/my-project/_wiki/1/Page',
+            gitItemPath: '/Page.md',
+            isNonConformant: false,
+            isParentPage: false,
+            order: 0,
+            subPages: [],
+            url: '',
+          }),
+        );
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(documents).toHaveLength(1);
+      expect(documents[0]).toEqual({
+        title: 'Page',
+        location: 'https://dev.azure.com/my-org/my-project/_wiki/1/Page',
+        text: 'Content',
+      });
+    });
+
+    it('should error when no wikis are configured', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              token: 'my-pat',
+            },
+          },
+        },
+      });
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(documents).toHaveLength(0);
+      expect(logger.error).toHaveBeenCalledWith(
+        'No wikis configured in your app-config.yaml',
+      );
+    });
+
+    it('should error when no token and no credentials provider', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(documents).toHaveLength(0);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('No credentials available'),
+      );
+    });
+
+    it('should default baseUrl to https://dev.azure.com', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              wikis: [
+                {
+                  organization: 'my-org',
+                  project: 'my-project',
+                  wikiIdentifier: 'my-wiki.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer token' },
+          token: 'token',
+          type: 'bearer',
+        }),
+      };
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 1, path: '/Page' }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            id: 1,
+            path: '/Page',
+            content: 'Content',
+            remoteUrl: 'https://dev.azure.com/my-org/my-project/_wiki/1/Page',
+            gitItemPath: '/Page.md',
+            isNonConformant: false,
+            isParentPage: false,
+            order: 0,
+            subPages: [],
+            url: '',
+          }),
+        );
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('https://dev.azure.com/my-org/my-project'),
+        expect.any(Object),
+      );
+    });
+
+    it('should index multiple wikis from different organizations', async () => {
+      const config = new ConfigReader({
+        search: {
+          collators: {
+            azureDevOpsWikiCollator: {
+              wikis: [
+                {
+                  organization: 'org-a',
+                  project: 'proj-a',
+                  wikiIdentifier: 'wiki-a.wiki',
+                  titleSuffix: ' - Org A',
+                },
+                {
+                  organization: 'org-b',
+                  project: 'proj-b',
+                  wikiIdentifier: 'wiki-b.wiki',
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer token' },
+          token: 'token',
+          type: 'bearer',
+        }),
+      };
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 1, path: '/Page-A' }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 2, path: '/Page-B' }] }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            id: 1,
+            path: '/Page-A',
+            content: 'Content A',
+            remoteUrl: 'https://dev.azure.com/org-a/proj-a/_wiki/1/Page-A',
+            gitItemPath: '/Page-A.md',
+            isNonConformant: false,
+            isParentPage: false,
+            order: 0,
+            subPages: [],
+            url: '',
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            id: 2,
+            path: '/Page-B',
+            content: 'Content B',
+            remoteUrl: 'https://dev.azure.com/org-b/proj-b/_wiki/2/Page-B',
+            gitItemPath: '/Page-B.md',
+            isNonConformant: false,
+            isParentPage: false,
+            order: 0,
+            subPages: [],
+            url: '',
+          }),
+        );
+
+      const factory = AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      const collator = await factory.getCollator();
+      const documents: any[] = [];
+      for await (const doc of collator) {
+        documents.push(doc);
+      }
+
+      expect(documents).toHaveLength(2);
+      expect(documents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            title: 'Page-A - Org A',
+            text: 'Content A',
+          }),
+          expect.objectContaining({
+            title: 'Page-B',
+            text: 'Content B',
+          }),
+        ]),
+      );
+
+      expect(mockCredentialsProvider.getCredentials).toHaveBeenCalledWith({
+        url: 'https://dev.azure.com/org-a',
+      });
+      expect(mockCredentialsProvider.getCredentials).toHaveBeenCalledWith({
+        url: 'https://dev.azure.com/org-b',
+      });
+    });
+  });
+});

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
@@ -45,7 +45,10 @@ export class AzureDevOpsWikiArticleCollatorFactory
   public readonly type: string = 'azure-devops-wiki-article';
 
   private constructor(options: WikiArticleCollatorFactoryOptions) {
-    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    this.baseUrl = (options.baseUrl?.trim() || DEFAULT_BASE_URL).replace(
+      /\/+$/,
+      '',
+    );
     this.token = options.token;
     this.credentialsProvider = options.credentialsProvider;
     this.logger = options.logger;

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
@@ -16,6 +16,7 @@
 
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
 import { Readable } from 'stream';
 import {
   DocumentCollatorFactory,
@@ -23,6 +24,7 @@ import {
 } from '@backstage/plugin-search-common';
 import {
   CONFIG_SECTION_NAME,
+  DEFAULT_BASE_URL,
   WikiArticleCollatorFactoryOptions,
   WikiArticleCollatorOptions,
   WikiPage,
@@ -32,15 +34,20 @@ import { AzureDevOpsWikiReader } from './AzureDevOpsWikiReader';
 export class AzureDevOpsWikiArticleCollatorFactory
   implements DocumentCollatorFactory
 {
-  private readonly baseUrl: string | undefined;
+  private readonly baseUrl: string;
   private readonly logger: LoggerService;
+  private readonly credentialsProvider?: AzureDevOpsCredentialsProvider;
+  /**
+   * @deprecated Use `credentialsProvider` instead.
+   */
   private readonly token: string | undefined;
   private readonly wikis: WikiArticleCollatorOptions[] | undefined;
   public readonly type: string = 'azure-devops-wiki-article';
 
   private constructor(options: WikiArticleCollatorFactoryOptions) {
-    this.baseUrl = options.baseUrl;
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
     this.token = options.token;
+    this.credentialsProvider = options.credentialsProvider;
     this.logger = options.logger;
     this.wikis = options.wikis;
   }
@@ -81,6 +88,16 @@ export class AzureDevOpsWikiArticleCollatorFactory
       return;
     }
 
+    if (this.token) {
+      this.logger.warn(
+        `The 'token' configuration for ${CONFIG_SECTION_NAME} is deprecated. ` +
+          "Configure credentials under 'integrations.azure' in your app-config.yaml instead. " +
+          'This supports PATs, service principals, and managed identities. ' +
+          'The token field will be removed in a future release. ' +
+          'See https://backstage.io/docs/integrations/azure/locations for details.',
+      );
+    }
+
     const articles: (IndexableDocument | null)[] =
       await this.readAllArticlesFromAllWikis();
 
@@ -99,16 +116,18 @@ export class AzureDevOpsWikiArticleCollatorFactory
       this.logger.error(`No wikis configured in your app-config.yaml`);
       return false;
     }
+
+    if (!this.token && !this.credentialsProvider) {
+      this.logger.error(
+        `No credentials available: configure 'integrations.azure' in your app-config.yaml ` +
+          `or provide a '${CONFIG_SECTION_NAME}.token' (deprecated). ` +
+          'See https://backstage.io/docs/integrations/azure/locations for details.',
+      );
+      return false;
+    }
+
     if (
       [
-        this.validateSingleConfigurationOptionExists(
-          this.baseUrl,
-          `${CONFIG_SECTION_NAME}.baseUrl`,
-        ),
-        this.validateSingleConfigurationOptionExists(
-          this.token,
-          `${CONFIG_SECTION_NAME}.token`,
-        ),
         ...this.wikis.flatMap((wiki, index) => {
           return [
             this.validateSingleConfigurationOptionExists(
@@ -152,15 +171,16 @@ export class AzureDevOpsWikiArticleCollatorFactory
   private async readAllArticlesFromSingleWiki(
     wiki: WikiArticleCollatorOptions,
   ): Promise<(IndexableDocument | null)[]> {
-    const reader = new AzureDevOpsWikiReader(
-      this.baseUrl as string,
-      wiki.organization as string,
-      wiki.project as string,
-      this.token as string,
-      wiki.wikiIdentifier as string,
-      this.logger,
-      wiki.titleSuffix,
-    );
+    const reader = new AzureDevOpsWikiReader({
+      baseUrl: this.baseUrl,
+      organization: wiki.organization as string,
+      project: wiki.project as string,
+      wikiIdentifier: wiki.wikiIdentifier as string,
+      logger: this.logger,
+      titleSuffix: wiki.titleSuffix,
+      token: this.token,
+      credentialsProvider: this.credentialsProvider,
+    });
 
     const listOfAllArticles = await reader.getListOfAllWikiPages();
     this.logger.info(

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiArticleCollatorFactory.ts
@@ -45,7 +45,7 @@ export class AzureDevOpsWikiArticleCollatorFactory
   public readonly type: string = 'azure-devops-wiki-article';
 
   private constructor(options: WikiArticleCollatorFactoryOptions) {
-    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
+    this.baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
     this.token = options.token;
     this.credentialsProvider = options.credentialsProvider;
     this.logger = options.logger;

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
+import { AzureDevOpsWikiReader } from './AzureDevOpsWikiReader';
+
+const mockFetchResponse = (body: object, headers?: Record<string, string>) => {
+  return {
+    ok: true,
+    json: async () => body,
+    headers: new Headers(headers),
+  } as Response;
+};
+
+describe('AzureDevOpsWikiReader', () => {
+  const logger = mockServices.logger.mock();
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(mockFetchResponse({ value: [] }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('with legacy PAT token', () => {
+    it('should use Basic auth with the provided token', async () => {
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        token: 'my-pat-token',
+      });
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          id: 1,
+          path: '/Test-Page',
+          content: 'Hello world',
+          remoteUrl:
+            'https://dev.azure.com/my-org/my-project/_wiki/wikis/my-wiki.wiki/1/Test-Page',
+          gitItemPath: '/Test-Page.md',
+          isNonConformant: false,
+          isParentPage: false,
+          order: 0,
+          subPages: [],
+          url: 'https://dev.azure.com/my-org/my-project/_apis/wiki/wikis/my-wiki.wiki/pages/1',
+        }),
+      );
+
+      await reader.readSingleWikiPage(1);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://dev.azure.com/my-org/my-project/_apis/wiki/wikis/my-wiki.wiki//pages/1?includeContent=true',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Basic ${btoa(':my-pat-token')}`,
+          }),
+        }),
+      );
+    });
+
+    it('should prefer token over credentials provider when both are present', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer service-principal-token' },
+          token: 'service-principal-token',
+          type: 'bearer',
+        }),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        token: 'my-pat-token',
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          id: 1,
+          path: '/Test',
+          content: '',
+          remoteUrl: '',
+          gitItemPath: '',
+          isNonConformant: false,
+          isParentPage: false,
+          order: 0,
+          subPages: [],
+          url: '',
+        }),
+      );
+
+      await reader.readSingleWikiPage(1);
+
+      expect(mockCredentialsProvider.getCredentials).not.toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Basic ${btoa(':my-pat-token')}`,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('with credentials provider', () => {
+    it('should use Bearer auth from credentials provider', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer my-bearer-token' },
+          token: 'my-bearer-token',
+          type: 'bearer',
+        }),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          id: 1,
+          path: '/Test',
+          content: '',
+          remoteUrl: '',
+          gitItemPath: '',
+          isNonConformant: false,
+          isParentPage: false,
+          order: 0,
+          subPages: [],
+          url: '',
+        }),
+      );
+
+      await reader.readSingleWikiPage(1);
+
+      expect(mockCredentialsProvider.getCredentials).toHaveBeenCalledWith({
+        url: 'https://dev.azure.com/my-org',
+      });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer my-bearer-token',
+          }),
+        }),
+      );
+    });
+
+    it('should use PAT auth from credentials provider', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Basic cGF0LWZyb20taW50ZWdyYXRpb24=' },
+          token: 'pat-from-integration',
+          type: 'pat',
+        }),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          id: 1,
+          path: '/Test',
+          content: '',
+          remoteUrl: '',
+          gitItemPath: '',
+          isNonConformant: false,
+          isParentPage: false,
+          order: 0,
+          subPages: [],
+          url: '',
+        }),
+      );
+
+      await reader.readSingleWikiPage(1);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Basic cGF0LWZyb20taW50ZWdyYXRpb24=',
+          }),
+        }),
+      );
+    });
+
+    it('should throw when credentials provider returns undefined', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      await expect(reader.readSingleWikiPage(1)).rejects.toThrow(
+        'No credentials found for Azure DevOps organization at https://dev.azure.com/my-org',
+      );
+    });
+
+    it('should build correct org URL for credentials lookup with custom baseUrl', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer token' },
+          token: 'token',
+          type: 'bearer',
+        }),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://ado.mycompany.com',
+        organization: 'internal-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          id: 1,
+          path: '/Test',
+          content: '',
+          remoteUrl: '',
+          gitItemPath: '',
+          isNonConformant: false,
+          isParentPage: false,
+          order: 0,
+          subPages: [],
+          url: '',
+        }),
+      );
+
+      await reader.readSingleWikiPage(1);
+
+      expect(mockCredentialsProvider.getCredentials).toHaveBeenCalledWith({
+        url: 'https://ado.mycompany.com/internal-org',
+      });
+    });
+  });
+
+  describe('getListOfAllWikiPages', () => {
+    it('should paginate through wiki pages using continuation token', async () => {
+      const mockCredentialsProvider: AzureDevOpsCredentialsProvider = {
+        getCredentials: jest.fn().mockResolvedValue({
+          headers: { Authorization: 'Bearer token' },
+          token: 'token',
+          type: 'bearer',
+        }),
+      };
+
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+        credentialsProvider: mockCredentialsProvider,
+      });
+
+      fetchSpy
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            { value: [{ id: 1, path: '/Page-1' }] },
+            { 'x-ms-continuationtoken': 'continue-token' },
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({ value: [{ id: 2, path: '/Page-2' }] }),
+        );
+
+      const pages = await reader.getListOfAllWikiPages();
+
+      expect(pages).toHaveLength(2);
+      expect(pages[0]).toEqual({ id: 1, path: '/Page-1' });
+      expect(pages[1]).toEqual({ id: 2, path: '/Page-2' });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when neither token nor credentials provider is configured', async () => {
+      const reader = new AzureDevOpsWikiReader({
+        baseUrl: 'https://dev.azure.com',
+        organization: 'my-org',
+        project: 'my-project',
+        wikiIdentifier: 'my-wiki.wiki',
+        logger,
+      });
+
+      await expect(reader.readSingleWikiPage(1)).rejects.toThrow(
+        'No authentication configured',
+      );
+    });
+  });
+});

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
@@ -74,7 +74,9 @@ describe('AzureDevOpsWikiReader', () => {
         'https://dev.azure.com/my-org/my-project/_apis/wiki/wikis/my-wiki.wiki//pages/1?includeContent=true',
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: `Basic ${btoa(':my-pat-token')}`,
+            Authorization: `Basic ${Buffer.from(':my-pat-token').toString(
+              'base64',
+            )}`,
           }),
         }),
       );
@@ -121,7 +123,9 @@ describe('AzureDevOpsWikiReader', () => {
         expect.any(String),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Authorization: `Basic ${btoa(':my-pat-token')}`,
+            Authorization: `Basic ${Buffer.from(':my-pat-token').toString(
+              'base64',
+            )}`,
           }),
         }),
       );

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.test.ts
@@ -71,7 +71,7 @@ describe('AzureDevOpsWikiReader', () => {
       await reader.readSingleWikiPage(1);
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://dev.azure.com/my-org/my-project/_apis/wiki/wikis/my-wiki.wiki//pages/1?includeContent=true',
+        'https://dev.azure.com/my-org/my-project/_apis/wiki/wikis/my-wiki.wiki/pages/1?includeContent=true',
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: `Basic ${Buffer.from(':my-pat-token').toString(

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
@@ -101,7 +101,7 @@ export class AzureDevOpsWikiReader {
   readSingleWikiPage = async (id: number): Promise<WikiPage> => {
     let rawPageContent;
     try {
-      const pageResponse = await this.fetch(`/pages/${id}?includeContent=true`);
+      const pageResponse = await this.fetch(`pages/${id}?includeContent=true`);
 
       rawPageContent = await pageResponse.json();
       return rawPageContent;

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
@@ -17,10 +17,9 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
 import { WikiPageDetail, WikiPage } from '../types';
-import { buildBaseUrl, fetchWithRetry } from '../utils';
+import { buildBaseUrl, convertStringToBase64, fetchWithRetry } from '../utils';
 
-/** @public */
-export interface AzureDevOpsWikiReaderOptions {
+interface AzureDevOpsWikiReaderOptions {
   baseUrl: string;
   organization: string;
   project: string;
@@ -116,7 +115,7 @@ export class AzureDevOpsWikiReader {
 
   private async getAuthHeaders(): Promise<Record<string, string>> {
     if (this.token) {
-      const credentials = btoa(`:${this.token}`);
+      const credentials = convertStringToBase64(`:${this.token}`);
       return { Authorization: `Basic ${credentials}` };
     }
 
@@ -142,7 +141,7 @@ export class AzureDevOpsWikiReader {
     );
   }
 
-  fetch: typeof fetchWithRetry = async (url, options) => {
+  private fetch: typeof fetchWithRetry = async (url, options) => {
     const authHeaders = await this.getAuthHeaders();
 
     return fetchWithRetry(

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/collator/AzureDevOpsWikiReader.ts
@@ -15,29 +15,45 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
 import { WikiPageDetail, WikiPage } from '../types';
 import { buildBaseUrl, fetchWithRetry } from '../utils';
 
+/** @public */
+export interface AzureDevOpsWikiReaderOptions {
+  baseUrl: string;
+  organization: string;
+  project: string;
+  wikiIdentifier: string;
+  logger: LoggerService;
+  titleSuffix?: string;
+  /**
+   * @deprecated Use `credentialsProvider` instead. This field will be removed
+   * in a future release.
+   */
+  token?: string;
+  credentialsProvider?: AzureDevOpsCredentialsProvider;
+}
+
 export class AzureDevOpsWikiReader {
   private readonly logger: LoggerService;
+  private readonly baseUrl: string;
   private readonly organization: string;
   private readonly project: string;
   private readonly wikiIdentifier: string;
+  private readonly token?: string;
+  private readonly credentialsProvider?: AzureDevOpsCredentialsProvider;
   public titleSuffix?: string;
-  constructor(
-    private readonly baseUrl: string,
-    organization: string,
-    project: string,
-    private readonly token: string,
-    wikiIdentifier: string,
-    logger: LoggerService,
-    titleSuffix?: string,
-  ) {
-    this.logger = logger;
-    this.titleSuffix = titleSuffix;
-    this.organization = organization;
-    this.project = project;
-    this.wikiIdentifier = wikiIdentifier;
+
+  constructor(options: AzureDevOpsWikiReaderOptions) {
+    this.baseUrl = options.baseUrl;
+    this.organization = options.organization;
+    this.project = options.project;
+    this.wikiIdentifier = options.wikiIdentifier;
+    this.logger = options.logger;
+    this.titleSuffix = options.titleSuffix;
+    this.token = options.token;
+    this.credentialsProvider = options.credentialsProvider;
   }
 
   getListOfAllWikiPages = async () => {
@@ -98,8 +114,36 @@ export class AzureDevOpsWikiReader {
     }
   };
 
+  private async getAuthHeaders(): Promise<Record<string, string>> {
+    if (this.token) {
+      const credentials = btoa(`:${this.token}`);
+      return { Authorization: `Basic ${credentials}` };
+    }
+
+    if (this.credentialsProvider) {
+      const orgUrl = `${this.baseUrl}/${this.organization}`;
+      const credentials = await this.credentialsProvider.getCredentials({
+        url: orgUrl,
+      });
+
+      if (credentials) {
+        return credentials.headers;
+      }
+
+      throw new Error(
+        `No credentials found for Azure DevOps organization at ${orgUrl}. ` +
+          "Check your 'integrations.azure' configuration in app-config.yaml. " +
+          'See https://backstage.io/docs/integrations/azure/locations for details.',
+      );
+    }
+
+    throw new Error(
+      'No authentication configured. Provide either a token or credentials provider.',
+    );
+  }
+
   fetch: typeof fetchWithRetry = async (url, options) => {
-    const credentials = btoa(`:${this.token}`);
+    const authHeaders = await this.getAuthHeaders();
 
     return fetchWithRetry(
       `${buildBaseUrl(
@@ -110,7 +154,7 @@ export class AzureDevOpsWikiReader {
       )}/${url}`,
       {
         ...options,
-        headers: { ...options?.headers, Authorization: `Basic ${credentials}` },
+        headers: { ...options?.headers, ...authHeaders },
       },
     );
   };

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/module.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/module.ts
@@ -18,6 +18,10 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
+import {
+  DefaultAzureDevOpsCredentialsProvider,
+  ScmIntegrations,
+} from '@backstage/integration';
 import { AzureDevOpsWikiArticleCollatorFactory } from './collator';
 import { readScheduleConfigOptions } from './config';
 
@@ -34,12 +38,17 @@ export const searchModuleAzureDevOps = createBackendModule({
         indexRegistry: searchIndexRegistryExtensionPoint,
       },
       async init({ config, scheduler, logger, indexRegistry }) {
+        const integrations = ScmIntegrations.fromConfig(config);
+        const credentialsProvider =
+          DefaultAzureDevOpsCredentialsProvider.fromIntegrations(integrations);
+
         indexRegistry.addCollator({
           schedule: scheduler.createScheduledTaskRunner(
             readScheduleConfigOptions(config),
           ),
           factory: AzureDevOpsWikiArticleCollatorFactory.fromConfig(config, {
             logger,
+            credentialsProvider,
           }),
         });
       },

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/types.ts
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/src/types.ts
@@ -15,8 +15,11 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { AzureDevOpsCredentialsProvider } from '@backstage/integration';
 
 export const CONFIG_SECTION_NAME = 'search.collators.azureDevOpsWikiCollator';
+
+export const DEFAULT_BASE_URL = 'https://dev.azure.com';
 
 export type WikiArticleCollatorOptions = {
   organization?: string;
@@ -27,7 +30,12 @@ export type WikiArticleCollatorOptions = {
 
 export type WikiArticleCollatorFactoryOptions = {
   baseUrl?: string;
+  /**
+   * @deprecated Use `integrations.azure` in your app-config.yaml instead.
+   * This field will be removed in a future release.
+   */
   token?: string;
+  credentialsProvider?: AzureDevOpsCredentialsProvider;
   wikis?: WikiArticleCollatorOptions[];
   logger: LoggerService;
 };

--- a/workspaces/azure-devops/yarn.lock
+++ b/workspaces/azure-devops/yarn.lock
@@ -2249,6 +2249,7 @@ __metadata:
     "@backstage/cli": "backstage:^"
     "@backstage/config": "backstage:^"
     "@backstage/errors": "backstage:^"
+    "@backstage/integration": "backstage:^"
     "@backstage/plugin-search-backend-node": "backstage:^"
     "@backstage/plugin-search-common": "backstage:^"
     axios: "npm:^1.4.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added support for non-PAT credentials (service principals, managed identities) via `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`. The `token` config field is now deprecated in favor of `integrations.azure`. The `baseUrl` config field is now optional, defaulting to `https://dev.azure.com`.

Closes #10884

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))