### PR TITLE
feat(airbrake): migrate frontend plugin from MUI to Backstage UI

### DIFF
--- a/workspaces/airbrake/.changeset/quiet-cameras-invite.md
+++ b/workspaces/airbrake/.changeset/quiet-cameras-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-airbrake': major
+---
+
+Migrated from Material-UI (MUI) to Backstage UI (BUI)

--- a/workspaces/airbrake/plugins/airbrake/dev/components/ApiBar/ApiBar.module.css
+++ b/workspaces/airbrake/plugins/airbrake/dev/components/ApiBar/ApiBar.module.css
@@ -1,0 +1,7 @@
+@layer components {
+  .root {
+    display: flex;
+    gap: var(--bui-space-4);
+    flex-wrap: wrap;
+  }
+}

--- a/workspaces/airbrake/plugins/airbrake/dev/components/ApiBar/ApiBar.tsx
+++ b/workspaces/airbrake/plugins/airbrake/dev/components/ApiBar/ApiBar.tsx
@@ -13,40 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import TextField from '@material-ui/core/TextField';
-import { makeStyles } from '@material-ui/core/styles';
+import { TextField } from '@backstage/ui';
 import { Context } from '../ContextProvider';
-
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: 'flex',
-    gap: '1em',
-    flexWrap: 'wrap',
-  },
-  label: {
-    color: `${theme.palette.common.white} !important`,
-  },
-  outline: {
-    color: `${theme.palette.common.white} !important`,
-    borderColor: `${theme.palette.common.white} !important`,
-  },
-}));
+import styles from './ApiBar.module.css';
 
 export const ApiBar = () => {
-  const classes = useStyles();
-
   return (
     <Context.Consumer>
       {value => (
-        <div className={classes.root}>
+        <div className={styles.root}>
           <TextField
+            id="project-id"
             label="Project ID"
-            variant="outlined"
-            defaultValue={value.projectId}
-            InputLabelProps={{ classes: { root: classes.label } }}
-            InputProps={{ classes: { notchedOutline: classes.outline } }}
-            onChange={e =>
-              value.setProjectId?.(parseInt(e.target.value, 10) || undefined)
+            defaultValue={value.projectId?.toString()}
+            onChange={newValue =>
+              value.setProjectId?.(parseInt(newValue, 10) || undefined)
             }
           />
         </div>

--- a/workspaces/airbrake/plugins/airbrake/dev/index.tsx
+++ b/workspaces/airbrake/plugins/airbrake/dev/index.tsx
@@ -30,6 +30,11 @@ import CloudOffIcon from '@material-ui/icons/CloudOff';
 import CloudIcon from '@material-ui/icons/Cloud';
 import { Context, ContextProvider } from './components/ContextProvider';
 
+// The dev harness bootstraps a standalone app, so it needs the BUI styles
+// even though this package is a frontend-plugin.
+// eslint-disable-next-line @backstage/no-ui-css-imports-in-non-frontend
+import '@backstage/ui/css/styles.css';
+
 createDevApp()
   .registerPlugin(airbrakePlugin)
   .addPage({

--- a/workspaces/airbrake/plugins/airbrake/package.json
+++ b/workspaces/airbrake/plugins/airbrake/package.json
@@ -44,6 +44,7 @@
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
     "@backstage/test-utils": "backstage:^",
+    "@backstage/ui": "backstage:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",

--- a/workspaces/airbrake/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.module.css
+++ b/workspaces/airbrake/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.module.css
@@ -1,0 +1,5 @@
+@layer components {
+  .multilineText {
+    white-space: pre-wrap;
+  }
+}

--- a/workspaces/airbrake/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.tsx
+++ b/workspaces/airbrake/plugins/airbrake/src/components/EntityAirbrakeWidget/EntityAirbrakeWidget.tsx
@@ -22,23 +22,14 @@ import {
   Progress,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
+import { Flex, Text } from '@backstage/ui';
 import useAsync from 'react-use/esm/useAsync';
 import { airbrakeApiRef } from '../../api';
 import { MissingAnnotationEmptyState } from '@backstage/plugin-catalog-react';
 import { AIRBRAKE_PROJECT_ID_ANNOTATION, useProjectId } from '../useProjectId';
-
-const useStyles = makeStyles({
-  multilineText: {
-    whiteSpace: 'pre-wrap',
-  },
-});
+import styles from './EntityAirbrakeWidget.module.css';
 
 export const EntityAirbrakeWidget = ({ entity }: { entity: Entity }) => {
-  const classes = useStyles();
-
   const projectId = useProjectId(entity);
   const airbrakeApi = useApi(airbrakeApiRef);
 
@@ -60,19 +51,19 @@ export const EntityAirbrakeWidget = ({ entity }: { entity: Entity }) => {
     return <Progress />;
   } else if (value) {
     return (
-      <Grid container spacing={3} direction="column">
+      <Flex direction="column" gap="6">
         {value.groups?.map(group => (
-          <Grid item key={group.id}>
+          <div key={group.id}>
             {group.errors?.map((groupError, i) => (
               <InfoCard title={groupError.type} key={i}>
-                <Typography variant="body1" className={classes.multilineText}>
+                <Text variant="body-medium" className={styles.multilineText}>
                   {groupError.message}
-                </Typography>
+                </Text>
               </InfoCard>
             ))}
-          </Grid>
+          </div>
         ))}
-      </Grid>
+      </Flex>
     );
   }
 

--- a/workspaces/airbrake/yarn.lock
+++ b/workspaces/airbrake/yarn.lock
@@ -2011,6 +2011,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
+    "@backstage/ui": "backstage:^"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@testing-library/jest-dom": "npm:^6.0.0"
@@ -3414,7 +3415,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.1":
+"@backstage/ui@backstage:^::backstage=1.54.5&npm=0.17.1, @backstage/ui@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/ui@npm:0.17.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Changes**

- `EntityAirbrakeWidget`: replaced MUI `Grid` with BUI `Flex` and `Typography` with BUI `Text`; moved `makeStyles` rules into a CSS module.
- Dev harness `ApiBar`: replaced the MUI `TextField` with the BUI `TextField`; dropped the `makeStyles` overrides that were only there to force white text/border on the header, and moved the layout rules into a CSS module.
- Added `@backstage/ui` as a dependency and imported the BUI stylesheet in the dev harness (with the standard eslint-disable used by other migrated workspaces, since this is a `frontend-plugin` package).

Surrounding components (`InfoCard`, `EmptyState`, `Progress`) still come from `@backstage/core-components`, so the rendered output is intentionally near-identical.

<img width="789" height="443" alt="image" src="https://github.com/user-attachments/assets/6c91b473-8492-47f2-913f-4e6da65c40f6" />


- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
