### PR TITLE
grafana migration from MUI to BUI

### DIFF
--- a/workspaces/grafana/.changeset/grafana-mui-to-bui.md
+++ b/workspaces/grafana/.changeset/grafana-mui-to-bui.md
@@ -1,5 +1,5 @@
 ---
-'@backstage-community/plugin-grafana': minor
+'@backstage-community/plugin-grafana': major
 ---
 
-**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.
+Migrated from Material UI (MUI) to Backstage UI (BUI).

--- a/workspaces/grafana/.changeset/grafana-mui-to-bui.md
+++ b/workspaces/grafana/.changeset/grafana-mui-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-grafana': minor
+---
+
+**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

--- a/workspaces/grafana/plugins/grafana/knip-report.md
+++ b/workspaces/grafana/plugins/grafana/knip-report.md
@@ -4,6 +4,6 @@
 
 | Name                        | Location          | Severity |
 | :-------------------------- | :---------------- | :------- |
-| @testing-library/user-event | package.json:77:6 | error    |
-| @backstage/core-app-api     | package.json:71:6 | error    |
+| @testing-library/user-event | package.json:76:6 | error    |
+| @backstage/core-app-api     | package.json:70:6 | error    |
 

--- a/workspaces/grafana/plugins/grafana/package.json
+++ b/workspaces/grafana/plugins/grafana/package.json
@@ -55,8 +55,7 @@
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/frontend-plugin-api": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/core": "^4.12.2",
-    "@material-ui/lab": "4.0.0-alpha.61",
+    "@backstage/ui": "backstage:^",
     "cross-fetch": "^4.0.0",
     "jsep": "^1.3.8",
     "react-use": "^17.2.4"

--- a/workspaces/grafana/plugins/grafana/src/components/AlertsCard/AlertsCard.tsx
+++ b/workspaces/grafana/plugins/grafana/src/components/AlertsCard/AlertsCard.tsx
@@ -34,7 +34,7 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { grafanaApiRef, GrafanaApi } from '../../api';
 import useAsync from 'react-use/lib/useAsync';
-import { Alert } from '@material-ui/lab';
+import { Alert, Text } from '@backstage/ui';
 import { AlertsCardOpts, Alert as GrafanaAlert } from '../../types';
 import {
   GRAFANA_ANNOTATION_ALERT_LABEL_SELECTOR,
@@ -106,7 +106,11 @@ export const AlertsTable = ({
 
   return (
     <Table
-      title={opts.title || 'Alerts'}
+      title={
+        <Text as="h2" variant="title-medium" weight="bold">
+          {opts.title || 'Alerts'}
+        </Text>
+      }
       options={{
         paging: opts.paged ?? false,
         pageSize: opts.pageSize ?? 5,
@@ -153,13 +157,13 @@ const Alerts = ({ entity, opts }: { entity: Entity; opts: AlertsCardOpts }) => {
   }, [grafanaApi, selectorKey, hostId, Boolean(resolveError)]);
 
   if (resolveError) {
-    return <Alert severity="error">{resolveError.message}</Alert>;
+    return <Alert status="danger" title={resolveError.message} />;
   }
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <Alert status="danger" title={error.message} />;
   }
 
   return <AlertsTable alerts={value || []} opts={opts} />;
@@ -173,7 +177,7 @@ export const AlertsCard = (opts?: AlertsCardOpts) => {
     resolveUnifiedAlerting(grafanaApi, hostId);
 
   if (resolveError) {
-    return <Alert severity="error">{resolveError.message}</Alert>;
+    return <Alert status="danger" title={resolveError.message} />;
   }
 
   if (!unifiedAlertingEnabled && !isDashboardSelectorAvailable(entity)) {

--- a/workspaces/grafana/plugins/grafana/src/components/DashboardsCard/DashboardsCard.tsx
+++ b/workspaces/grafana/plugins/grafana/src/components/DashboardsCard/DashboardsCard.tsx
@@ -23,9 +23,7 @@ import {
 import { useApi } from '@backstage/core-plugin-api';
 import { grafanaApiRef } from '../../api';
 import useAsync from 'react-use/lib/useAsync';
-import Alert from '@material-ui/lab/Alert';
-import Tooltip from '@material-ui/core/Tooltip';
-import Typography from '@material-ui/core/Typography';
+import { Alert, Focusable, Text, Tooltip, TooltipTrigger } from '@backstage/ui';
 import { Dashboard, DashboardCardOpts } from '../../types';
 import {
   dashboardSelectorFromEntity,
@@ -65,13 +63,18 @@ export const DashboardsTable = ({
   ];
 
   const titleElm = (
-    <Tooltip
-      title={`Note: only dashboard with the "${dashboardSelectorFromEntity(
-        entity,
-      )}" selector are displayed.`}
-    >
-      <Typography variant="h5">{opts.title || 'Dashboards'}</Typography>
-    </Tooltip>
+    <TooltipTrigger>
+      <Focusable>
+        <Text as="h2" variant="title-medium" weight="bold">
+          {opts.title || 'Dashboards'}
+        </Text>
+      </Focusable>
+      <Tooltip>
+        {`Note: only dashboard with the "${dashboardSelectorFromEntity(
+          entity,
+        )}" selector are displayed.`}
+      </Tooltip>
+    </TooltipTrigger>
   );
 
   return (
@@ -114,7 +117,7 @@ const Dashboards = ({
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <Alert status="danger" title={error.message} />;
   }
 
   return (

--- a/workspaces/grafana/yarn.lock
+++ b/workspaces/grafana/yarn.lock
@@ -410,8 +410,7 @@ __metadata:
     "@backstage/frontend-test-utils": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@backstage/ui": "backstage:^"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
@@ -1681,7 +1680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.1":
+"@backstage/ui@backstage:^::backstage=1.54.5&npm=0.17.1, @backstage/ui@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/ui@npm:0.17.1"
   dependencies:


### PR DESCRIPTION
Migrated the `grafana` plugin from Material UI (MUI) to Backstage UI (BUI) as part of #7869.

**Changes:**

- Replaced `@material-ui/lab` `Alert` with `@backstage/ui` `Alert` (`severity="error"` → `status="danger"`) in `AlertsCard` and `DashboardsCard`
- Replaced MUI `Tooltip` + `Typography` on the Dashboards card title with BUI `TooltipTrigger` + `Tooltip` + `Text`
- Card titles now render via BUI `Text` in both cards, so the plugin no longer relies on the table's internal MUI `Typography` for headings
- Removed all `@material-ui/*` dependencies from `package.json` and added `@backstage/ui`

**Notes:**

- Heading typography and the Dashboards tooltip text are unchanged — both titles render at the same size and weight as before (`24px` / `700`).
- No behavioral changes: the Grafana API calls, alert/dashboard selector logic, and table columns are untouched.
- Existing tests pass unchanged (8 suites / 77 tests), and `yarn build:api-reports` produces no diff.

**Before:**

<img width="958" height="443" alt="grafana_dark_before" src="https://github.com/user-attachments/assets/f020f929-d98e-476b-8345-55e252b314f8" />
<img width="959" height="443" alt="grafana_light_before" src="https://github.com/user-attachments/assets/bf927622-de9b-43d1-b7e6-4c2ca31e2c94" />


**After:**

<img width="959" height="441" alt="grafana_light_after" src="https://github.com/user-attachments/assets/14d71923-ae39-480e-b891-1d58a7a87e57" />
<img width="959" height="443" alt="grafana_dark_after" src="https://github.com/user-attachments/assets/5e496a9c-6416-4e01-bb79-4407ba9fa877" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))