### PR TITLE
feat(tekton): add missing 'unknown' vulnerability severity translation

### DIFF
--- a/workspaces/tekton/.changeset/add-unknown-vulnerability-severity.md
+++ b/workspaces/tekton/.changeset/add-unknown-vulnerability-severity.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-tekton': patch
+---
+
+Added missing translation for "unknown" vulnerability severity

--- a/workspaces/tekton/plugins/tekton/report-alpha.api.md
+++ b/workspaces/tekton/plugins/tekton/report-alpha.api.md
@@ -36,6 +36,7 @@ export const tektonTranslationRef: TranslationRef<
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.high': 'High';
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Medium';
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.low': 'Low';
+    readonly 'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Unknown';
     readonly 'pipelineRunList.tableHeaderTitle.name': 'NAME';
     readonly 'pipelineRunList.tableHeaderTitle.vulnerabilities': 'VULNERABILITIES';
     readonly 'pipelineRunList.tableHeaderTitle.status': 'STATUS';

--- a/workspaces/tekton/plugins/tekton/report-translations.api.md
+++ b/workspaces/tekton/plugins/tekton/report-translations.api.md
@@ -36,6 +36,7 @@ export const tektonTranslationRef: TranslationRef<
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.high': 'High';
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Medium';
     readonly 'pipelineRunList.vulnerabilitySeverityTitle.low': 'Low';
+    readonly 'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Unknown';
     readonly 'pipelineRunList.tableHeaderTitle.name': 'NAME';
     readonly 'pipelineRunList.tableHeaderTitle.vulnerabilities': 'VULNERABILITIES';
     readonly 'pipelineRunList.tableHeaderTitle.status': 'STATUS';

--- a/workspaces/tekton/plugins/tekton/src/translations/de.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/de.ts
@@ -57,6 +57,7 @@ const tektonTranslationDe = createTranslationMessages({
     'pipelineRunList.vulnerabilitySeverityTitle.high': 'Hoch',
     'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Mittel',
     'pipelineRunList.vulnerabilitySeverityTitle.low': 'Niedrig',
+    'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Unbekannt',
     'pipelineRunList.tableHeaderTitle.name': 'NAME',
     'pipelineRunList.tableHeaderTitle.vulnerabilities': 'SCHWACHSTELLEN',
     'pipelineRunList.tableHeaderTitle.status': 'STATUS',

--- a/workspaces/tekton/plugins/tekton/src/translations/es.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/es.ts
@@ -59,6 +59,7 @@ const tektonTranslationEs = createTranslationMessages({
     'pipelineRunList.vulnerabilitySeverityTitle.high': 'Alta',
     'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Media',
     'pipelineRunList.vulnerabilitySeverityTitle.low': 'Baja',
+    'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Desconocida',
     'pipelineRunList.tableHeaderTitle.name': 'NOMBRE',
     'pipelineRunList.tableHeaderTitle.vulnerabilities': 'VULNERABILIDADES',
     'pipelineRunList.tableHeaderTitle.status': 'ESTADO',

--- a/workspaces/tekton/plugins/tekton/src/translations/fr.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/fr.ts
@@ -58,6 +58,7 @@ const tektonTranslationFr = createTranslationMessages({
     'pipelineRunList.vulnerabilitySeverityTitle.high': 'Haut',
     'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Moyen',
     'pipelineRunList.vulnerabilitySeverityTitle.low': 'Faible',
+    'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Inconnu',
     'pipelineRunList.tableHeaderTitle.name': 'NOM',
     'pipelineRunList.tableHeaderTitle.vulnerabilities': 'VULNÉRABILITÉS',
     'pipelineRunList.tableHeaderTitle.status': 'STATUT',

--- a/workspaces/tekton/plugins/tekton/src/translations/it.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/it.ts
@@ -58,6 +58,7 @@ const tektonTranslationIt = createTranslationMessages({
     'pipelineRunList.vulnerabilitySeverityTitle.high': 'Alta',
     'pipelineRunList.vulnerabilitySeverityTitle.medium': 'Media',
     'pipelineRunList.vulnerabilitySeverityTitle.low': 'Bassa',
+    'pipelineRunList.vulnerabilitySeverityTitle.unknown': 'Sconosciuta',
     'pipelineRunList.tableHeaderTitle.name': 'NOME',
     'pipelineRunList.tableHeaderTitle.vulnerabilities': 'VULNERABILITÀ',
     'pipelineRunList.tableHeaderTitle.status': 'STATO',

--- a/workspaces/tekton/plugins/tekton/src/translations/ja.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/ja.ts
@@ -57,6 +57,7 @@ const tektonTranslationJa = createTranslationMessages({
     'pipelineRunList.vulnerabilitySeverityTitle.high': '高',
     'pipelineRunList.vulnerabilitySeverityTitle.medium': '中',
     'pipelineRunList.vulnerabilitySeverityTitle.low': '低',
+    'pipelineRunList.vulnerabilitySeverityTitle.unknown': '不明',
     'pipelineRunList.tableHeaderTitle.name': '名前',
     'pipelineRunList.tableHeaderTitle.vulnerabilities': '脆弱性',
     'pipelineRunList.tableHeaderTitle.status': '状態',

--- a/workspaces/tekton/plugins/tekton/src/translations/ref.ts
+++ b/workspaces/tekton/plugins/tekton/src/translations/ref.ts
@@ -65,6 +65,7 @@ export const tektonMessages = {
       high: 'High',
       medium: 'Medium',
       low: 'Low',
+      unknown: 'Unknown',
     },
     tableHeaderTitle: {
       name: 'NAME',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added the missing `unknown` translation key to `vulnerabilitySeverityTitle` in the Tekton plugin translation reference and all language files (de, es, fr, it, ja).

This was identified while writing Playwright e2e tests — the `unknown` vulnerability severity from scan results had no corresponding translation entry.

Related: https://issues.redhat.com/browse/RHDHBUGS-2607

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)