### PR TITLE
Version Packages (azure-devops)

### DIFF
--- a/workspaces/azure-devops/.changeset/dotnet-prerequisites-docs.md
+++ b/workspaces/azure-devops/.changeset/dotnet-prerequisites-docs.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-scaffolder-backend-module-dotnet': patch
----
-
-Added prerequisites section to README documenting the .NET SDK requirement

--- a/workspaces/azure-devops/.changeset/support-non-pat-credentials.md
+++ b/workspaces/azure-devops/.changeset/support-non-pat-credentials.md
@@ -1,5 +1,0 @@
----
-'@backstage-community/plugin-search-backend-module-azure-devops': minor
----
-
-Added support for non-PAT credentials (service principals, managed identities) via `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`. The `token` config field is now deprecated in favor of `integrations.azure`. The `baseUrl` config field is now optional, defaulting to `https://dev.azure.com`.

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-scaffolder-backend-module-dotnet
 
+## 0.17.1
+
+### Patch Changes
+
+- 60a4083: Added prerequisites section to README documenting the .NET SDK requirement
+
 ## 0.17.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/package.json
+++ b/workspaces/azure-devops/plugins/scaffolder-backend-module-dotnet/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.17.0",
+  "version": "0.17.1",
   "license": "Apache-2.0",
   "name": "@backstage-community/plugin-scaffolder-backend-module-dotnet",
   "description": "The azure-devops module for @backstage/plugin-scaffolder-backend",

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage-community/plugin-search-backend-module-azure-devops
 
+## 0.10.0
+
+### Minor Changes
+
+- 4fcd1ca: Added support for non-PAT credentials (service principals, managed identities) via `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`. The `token` config field is now deprecated in favor of `integrations.azure`. The `baseUrl` config field is now optional, defaulting to `https://dev.azure.com`.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
+++ b/workspaces/azure-devops/plugins/search-backend-module-azure-devops/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.0",
+  "version": "0.10.0",
   "license": "Apache-2.0",
   "name": "@backstage-community/plugin-search-backend-module-azure-devops",
   "description": "The azure-devops backend module for the search plugin.",


### PR DESCRIPTION
# Releases

## @backstage-community/plugin-search-backend-module-azure-devops@0.10.0

### Minor Changes

-   4fcd1ca: Added support for non-PAT credentials (service principals, managed identities) via `DefaultAzureDevOpsCredentialsProvider` from `@backstage/integration`. The `token` config field is now deprecated in favor of `integrations.azure`. The `baseUrl` config field is now optional, defaulting to `https://dev.azure.com`.

## @backstage-community/plugin-scaffolder-backend-module-dotnet@0.17.1

### Patch Changes

-   60a4083: Added prerequisites section to README documenting the .NET SDK requirement
