### PR TITLE
Fix Renovate opening react-router-dom v7 PRs via OSV vulnerability alerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -114,6 +114,7 @@
       "description": "Block react-router v7 — Backstage does not yet support it. Vulnerability alerts disabled since the security fix is available on the v6 line",
       "matchPackageNames": ["react-router", "react-router-dom"],
       "allowedVersions": "<7.0.0",
+      "ignoreCves": ["CVE-2026-53668"],
       "vulnerabilityAlerts": {
         "enabled": false
       }

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -61,7 +61,7 @@ Vulnerability alerts are enabled globally via two independent mechanisms:
 - **`vulnerabilityAlerts`** — responds to GitHub Dependabot alerts. Can be disabled per package using `vulnerabilityAlerts.enabled: false` in a package rule.
 - **`osvVulnerabilityAlerts`** — queries the [OSV database](https://osv.dev) directly. This is a global boolean with no per-package toggle and bypasses `allowedVersions` constraints.
 
-For packages with version pins (like `react-router`), disabling `vulnerabilityAlerts` alone is not sufficient — `osvVulnerabilityAlerts` will still create PRs that upgrade past the allowed version range. To fully suppress a vulnerability for a pinned package, add the CVE to `ignoreCves` in the package rule alongside `vulnerabilityAlerts.enabled: false`.
+For packages with version pins (like `react-router`), disabling `vulnerabilityAlerts` alone is not sufficient — `osvVulnerabilityAlerts` will still create PRs that upgrade past the allowed version range. To stop Renovate from creating remediation PRs for a pinned package, add the CVE to `ignoreCves` in the package rule alongside `vulnerabilityAlerts.enabled: false`. This only affects Renovate's PR behavior; GitHub/Dependabot alerts may still remain visible in the repository Security UI.
 
 ## Modifying the Configuration
 

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -56,7 +56,12 @@ Lock file maintenance PRs are disabled. Each workspace has its own `yarn.lock`, 
 
 ### Vulnerability Alerts
 
-Vulnerability alerts are enabled globally. For packages with version pins (like `react-router`), vulnerability alerts are explicitly disabled when the security fix is available on the pinned version line — otherwise Renovate would create PRs to upgrade past the allowed version range.
+Vulnerability alerts are enabled globally via two independent mechanisms:
+
+- **`vulnerabilityAlerts`** — responds to GitHub Dependabot alerts. Can be disabled per package using `vulnerabilityAlerts.enabled: false` in a package rule.
+- **`osvVulnerabilityAlerts`** — queries the [OSV database](https://osv.dev) directly. This is a global boolean with no per-package toggle and bypasses `allowedVersions` constraints.
+
+For packages with version pins (like `react-router`), disabling `vulnerabilityAlerts` alone is not sufficient — `osvVulnerabilityAlerts` will still create PRs that upgrade past the allowed version range. To fully suppress a vulnerability for a pinned package, add the CVE to `ignoreCves` in the package rule alongside `vulnerabilityAlerts.enabled: false`.
 
 ## Modifying the Configuration
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ignore CVE-2026-53668 for `react-router` and `react-router-dom` in the Renovate config.

The existing package rule blocks v7 updates and disables `vulnerabilityAlerts`, but
`osvVulnerabilityAlerts` (enabled globally) is a separate system that queries the OSV
database directly and bypasses both `allowedVersions` and the `vulnerabilityAlerts`
package rule. This caused Renovate to keep opening PRs like #10934.

Adding `ignoreCves` suppresses the CVE from both alert sources. We'll upgrade to
react-router v7 once the upstream Backstage framework completes its migration.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))