### PR TITLE
puppetdb migration from MUI to BUI

### DIFF
--- a/workspaces/puppetdb/.changeset/puppetdb-mui-to-bui.md
+++ b/workspaces/puppetdb/.changeset/puppetdb-mui-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-puppetdb': major
+---
+
+**BREAKING** Migrated from Material UI (MUI) to Backstage UI (BUI). This means that Backstage UI is now a requirement for this plugin, see the Backstage UI [installation documentation](https://ui.backstage.io/get-started/installation) for more details.

--- a/workspaces/puppetdb/plugins/puppetdb/package.json
+++ b/workspaces/puppetdb/plugins/puppetdb/package.json
@@ -47,7 +47,7 @@
     "@backstage/core-plugin-api": "backstage:^",
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-catalog-react": "backstage:^",
-    "@material-ui/core": "^4.12.2",
+    "@backstage/ui": "backstage:^",
     "@types/react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-use": "^17.2.4"
   },

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsEventsTable.module.css
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsEventsTable.module.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@layer components {
+  .empty {
+    padding: var(--bui-space-4);
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsEventsTable.tsx
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsEventsTable.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Typography from '@material-ui/core/Typography';
 import { puppetDbApiRef, PuppetDbReportEvent } from '../../api';
 import {
   ResponseErrorPanel,
@@ -22,20 +21,13 @@ import {
 } from '@backstage/core-components';
 import useAsync from 'react-use/esm/useAsync';
 import { useApi } from '@backstage/core-plugin-api';
-import { makeStyles } from '@material-ui/core/styles';
+import { Text } from '@backstage/ui';
 import { StatusField } from '../StatusField';
+import styles from './ReportDetailsEventsTable.module.css';
 
 type ReportEventsTableProps = {
   hash: string;
 };
-
-const useStyles = makeStyles(theme => ({
-  empty: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-}));
 
 /**
  * Component for displaying PuppetDB report events.
@@ -45,7 +37,6 @@ const useStyles = makeStyles(theme => ({
 export const ReportDetailsEventsTable = (props: ReportEventsTableProps) => {
   const { hash } = props;
   const puppetDbApi = useApi(puppetDbApiRef);
-  const classes = useStyles();
   const { value, loading, error } = useAsync(async () => {
     return puppetDbApi.getPuppetDbReportEvents(hash);
   }, [puppetDbApi, hash]);
@@ -61,9 +52,9 @@ export const ReportDetailsEventsTable = (props: ReportEventsTableProps) => {
       align: 'center',
       width: '300px',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {new Date(Date.parse(rowData.run_start_time)).toLocaleString()}
-        </Typography>
+        </Text>
       ),
     },
     {
@@ -72,43 +63,43 @@ export const ReportDetailsEventsTable = (props: ReportEventsTableProps) => {
       align: 'center',
       width: '300px',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {new Date(Date.parse(rowData.run_end_time)).toLocaleString()}
-        </Typography>
+        </Text>
       ),
     },
     {
       title: 'Containing Class',
       field: 'containing_class',
       render: rowData => (
-        <Typography noWrap title={rowData.file || ''}>
+        <Text truncate title={rowData.file || ''}>
           {rowData.containing_class}
-        </Typography>
+        </Text>
       ),
     },
     {
       title: 'Resource',
       field: 'resource_title',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {rowData.resource_type}[{rowData.resource_title}]
-        </Typography>
+        </Text>
       ),
     },
     {
       title: 'Property',
       field: 'property',
-      render: rowData => <Typography noWrap>{rowData.property}</Typography>,
+      render: rowData => <Text truncate>{rowData.property}</Text>,
     },
     {
       title: 'Old Value',
       field: 'old_value',
-      render: rowData => <Typography noWrap>{rowData.old_value}</Typography>,
+      render: rowData => <Text truncate>{rowData.old_value}</Text>,
     },
     {
       title: 'New Value',
       field: 'new_value',
-      render: rowData => <Typography noWrap>{rowData.new_value}</Typography>,
+      render: rowData => <Text truncate>{rowData.new_value}</Text>,
     },
     {
       title: 'Status',
@@ -131,9 +122,9 @@ export const ReportDetailsEventsTable = (props: ReportEventsTableProps) => {
         pageSizeOptions: [10],
       }}
       emptyContent={
-        <Typography color="textSecondary" className={classes.empty}>
+        <Text color="secondary" className={styles.empty}>
           No events
-        </Typography>
+        </Text>
       }
       title="Latest events"
       columns={columns}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsLogsTable.module.css
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsLogsTable.module.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@layer components {
+  .empty {
+    padding: var(--bui-space-4);
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsLogsTable.tsx
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsLogsTable.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Typography from '@material-ui/core/Typography';
 import { puppetDbApiRef, PuppetDbReportLog } from '../../api';
 import {
   ResponseErrorPanel,
@@ -23,28 +22,23 @@ import {
 } from '@backstage/core-components';
 import useAsync from 'react-use/esm/useAsync';
 import { useApi } from '@backstage/core-plugin-api';
-import { makeStyles } from '@material-ui/core/styles';
+import { Text } from '@backstage/ui';
+import styles from './ReportDetailsLogsTable.module.css';
 
 type ReportLogsTableProps = {
   hash: string;
 };
 
-const useStyles = makeStyles(theme => ({
-  empty: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  level_error: {
-    color: theme.palette.error.light,
-  },
-  level_warning: {
-    color: theme.palette.warning.light,
-  },
-  level_notice: {
-    color: theme.palette.info.light,
-  },
-}));
+const levelColor = (level: string) => {
+  switch (level) {
+    case 'error':
+      return 'danger' as const;
+    case 'warning':
+      return 'warning' as const;
+    default:
+      return 'info' as const;
+  }
+};
 
 /**
  * Component for displaying PuppetDB report logs.
@@ -54,7 +48,6 @@ const useStyles = makeStyles(theme => ({
 export const ReportDetailsLogsTable = (props: ReportLogsTableProps) => {
   const { hash } = props;
   const puppetDbApi = useApi(puppetDbApiRef);
-  const classes = useStyles();
   const { value, loading, error } = useAsync(async () => {
     return puppetDbApi.getPuppetDbReportLogs(hash);
   }, [puppetDbApi, hash]);
@@ -70,16 +63,9 @@ export const ReportDetailsLogsTable = (props: ReportLogsTableProps) => {
       align: 'center',
       width: '100px',
       render: rowData => (
-        <Typography
-          noWrap
-          className={
-            (rowData.level === 'warning' && classes.level_warning) ||
-            (rowData.level === 'error' && classes.level_error) ||
-            classes.level_notice
-          }
-        >
+        <Text truncate color={levelColor(rowData.level)}>
           {rowData.level.toLocaleUpperCase('en-US')}
-        </Typography>
+        </Text>
       ),
     },
     {
@@ -88,20 +74,20 @@ export const ReportDetailsLogsTable = (props: ReportLogsTableProps) => {
       align: 'center',
       width: '300px',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {new Date(Date.parse(rowData.time)).toLocaleString()}
-        </Typography>
+        </Text>
       ),
     },
     {
       title: 'Source',
       field: 'source',
-      render: rowData => <Typography noWrap>{rowData.source}</Typography>,
+      render: rowData => <Text truncate>{rowData.source}</Text>,
     },
     {
       title: 'Message',
       field: 'message',
-      render: rowData => <Typography noWrap>{rowData.message}</Typography>,
+      render: rowData => <Text truncate>{rowData.message}</Text>,
     },
   ];
 
@@ -119,9 +105,9 @@ export const ReportDetailsLogsTable = (props: ReportLogsTableProps) => {
         pageSizeOptions: [10],
       }}
       emptyContent={
-        <Typography color="textSecondary" className={classes.empty}>
+        <Text color="secondary" className={styles.empty}>
           No logs
-        </Typography>
+        </Text>
       }
       title="Latest logs"
       columns={columns}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.module.css
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.module.css
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@layer components {
+  .card {
+    position: relative;
+    overflow: visible;
+    margin-top: var(--bui-space-4);
+  }
+
+  .tabs {
+    border-bottom: 1px solid var(--bui-border);
+    background-color: var(--bui-bg-surface-0);
+    padding: 0 var(--bui-space-8);
+  }
+
+  .tab {
+    padding: var(--bui-space-4);
+    font-weight: var(--bui-font-weight-bold);
+    color: var(--bui-fg-secondary);
+    text-transform: uppercase;
+  }
+
+  .tab[data-selected] {
+    color: var(--bui-fg-primary);
+  }
+
+  .panel {
+    margin-left: var(--bui-space-4);
+    padding-top: var(--bui-space-4);
+    margin-top: var(--bui-space-2);
+    margin-bottom: var(--bui-space-2);
+  }
+}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.tsx
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportDetailsPage/ReportDetailsPage.tsx
@@ -16,38 +16,21 @@
 
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import { Breadcrumbs, Link } from '@backstage/core-components';
-import { makeStyles } from '@material-ui/core/styles';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { puppetDbRouteRef } from '../../routes';
-import { useState } from 'react';
-import Card from '@material-ui/core/Card';
-import CardContent from '@material-ui/core/CardContent';
-import Tab from '@material-ui/core/Tab';
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
-import Tabs from '@material-ui/core/Tabs';
+import {
+  Card,
+  CardBody,
+  Flex,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  Text,
+} from '@backstage/ui';
 import { ReportDetailsEventsTable } from './ReportDetailsEventsTable';
 import { ReportDetailsLogsTable } from './ReportDetailsLogsTable';
-
-const useStyles = makeStyles(theme => ({
-  cards: {
-    marginTop: theme.spacing(2),
-  },
-  tabs: {
-    borderBottom: `1px solid ${theme.palette.textVerySubtle}`,
-    backgroundColor: theme.palette.background.default,
-    padding: theme.spacing(0, 4),
-  },
-  default: {
-    padding: theme.spacing(2),
-    fontWeight: theme.typography.fontWeightBold,
-    color: theme.palette.text.secondary,
-    textTransform: 'uppercase',
-  },
-  selected: {
-    color: theme.palette.text.primary,
-  },
-}));
+import styles from './ReportDetailsPage.module.css';
 
 /**
  * Component for displaying the details of a PuppetDB report.
@@ -56,49 +39,40 @@ const useStyles = makeStyles(theme => ({
  */
 export const ReportDetailsPage = () => {
   const { hash = '' } = useParams();
-  const classes = useStyles();
-  const [tabIndex, setTabIndex] = useState(0);
   const reportsRouteLink = useRouteRef(puppetDbRouteRef);
-  const tabs = [
-    { id: 'events', label: 'Events' },
-    { id: 'logs', label: 'Logs' },
-  ];
-  const safeTabIndex = tabIndex > tabs.length - 1 ? 0 : tabIndex;
 
   return (
-    <div>
+    <Flex direction="column">
       <Breadcrumbs aria-label="breadcrumb">
         <Link component={RouterLink} to={reportsRouteLink()}>
           PuppetDB Reports
         </Link>
-        <Typography noWrap>{hash}</Typography>
+        <Text truncate>{hash}</Text>
       </Breadcrumbs>
-      <Card
-        style={{ position: 'relative', overflow: 'visible' }}
-        className={classes.cards}
-      >
-        <CardContent>
-          <Tabs
-            indicatorColor="primary"
-            onChange={(_, index) => setTabIndex(index)}
-            value={safeTabIndex}
-          >
-            {tabs.map((tab, index) => (
-              <Tab
-                className={classes.default}
-                label={tab.label}
-                key={tab.id}
-                value={index}
-                classes={{ selected: classes.selected }}
-              />
-            ))}
+      <Card className={styles.card}>
+        <CardBody>
+          <Tabs>
+            <TabList className={styles.tabs}>
+              <Tab id="events" className={styles.tab}>
+                Events
+              </Tab>
+              <Tab id="logs" className={styles.tab}>
+                Logs
+              </Tab>
+            </TabList>
+            <TabPanel id="events">
+              <Flex direction="column" className={styles.panel}>
+                <ReportDetailsEventsTable hash={hash} />
+              </Flex>
+            </TabPanel>
+            <TabPanel id="logs">
+              <Flex direction="column" className={styles.panel}>
+                <ReportDetailsLogsTable hash={hash} />
+              </Flex>
+            </TabPanel>
           </Tabs>
-          <Box ml={2} pt={2} my={1} display="flex" flexDirection="column">
-            {safeTabIndex === 0 && <ReportDetailsEventsTable hash={hash} />}
-            {safeTabIndex === 1 && <ReportDetailsLogsTable hash={hash} />}
-          </Box>
-        </CardContent>
+        </CardBody>
       </Card>
-    </div>
+    </Flex>
   );
 };

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportsPage/ReportsTable.module.css
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportsPage/ReportsTable.module.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@layer components {
+  .empty {
+    padding: var(--bui-space-4);
+    display: flex;
+    justify-content: center;
+  }
+}

--- a/workspaces/puppetdb/plugins/puppetdb/src/components/ReportsPage/ReportsTable.tsx
+++ b/workspaces/puppetdb/plugins/puppetdb/src/components/ReportsPage/ReportsTable.tsx
@@ -22,23 +22,15 @@ import {
   TableColumn,
 } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
-import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
+import { Text } from '@backstage/ui';
 import { Link as RouterLink } from 'react-router-dom';
 import { puppetDbReportRouteRef } from '../../routes';
 import { StatusField } from '../StatusField';
+import styles from './ReportsTable.module.css';
 
 type ReportsTableProps = {
   certName: string;
 };
-
-const useStyles = makeStyles(theme => ({
-  empty: {
-    padding: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-}));
 
 /**
  * Component for displaying a table of PuppetDB reports for a given node.
@@ -49,7 +41,6 @@ export const ReportsTable = (props: ReportsTableProps) => {
   const { certName } = props;
   const puppetDbApi = useApi(puppetDbApiRef);
   const reportsRouteLink = useRouteRef(puppetDbReportRouteRef);
-  const classes = useStyles();
 
   const { value, loading, error } = useAsync(async () => {
     return puppetDbApi.getPuppetDbNodeReports(certName);
@@ -69,11 +60,11 @@ export const ReportsTable = (props: ReportsTableProps) => {
           to={reportsRouteLink({ hash: rowData.hash! })}
         >
           {rowData.configuration_version !== '' ? (
-            <Typography noWrap>{rowData.configuration_version}</Typography>
+            <Text truncate>{rowData.configuration_version}</Text>
           ) : (
-            <Typography noWrap>
+            <Text truncate>
               <em>(N/A)</em>
-            </Typography>
+            </Text>
           )}
         </Link>
       ),
@@ -84,9 +75,9 @@ export const ReportsTable = (props: ReportsTableProps) => {
       align: 'center',
       width: '300px',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {new Date(Date.parse(rowData.start_time)).toLocaleString()}
-        </Typography>
+        </Text>
       ),
     },
     {
@@ -95,9 +86,9 @@ export const ReportsTable = (props: ReportsTableProps) => {
       align: 'center',
       width: '300px',
       render: rowData => (
-        <Typography noWrap>
+        <Text truncate>
           {new Date(Date.parse(rowData.end_time)).toLocaleString()}
-        </Typography>
+        </Text>
       ),
     },
     {
@@ -109,12 +100,12 @@ export const ReportsTable = (props: ReportsTableProps) => {
         const end_date = new Date(Date.parse(rowData.end_time));
         const duration = new Date(end_date.getTime() - start_date.getTime());
         return (
-          <Typography noWrap>
+          <Text truncate>
             {duration.getUTCHours().toString().padStart(2, '0')}:
             {duration.getUTCMinutes().toString().padStart(2, '0')}:
             {duration.getUTCSeconds().toString().padStart(2, '0')}.
             {duration.getUTCMilliseconds().toString().padStart(4, '0')}
-          </Typography>
+          </Text>
         );
       },
     },
@@ -127,11 +118,7 @@ export const ReportsTable = (props: ReportsTableProps) => {
       field: 'noop',
       align: 'center',
       render: rowData =>
-        rowData.noop ? (
-          <Typography>NOOP</Typography>
-        ) : (
-          <Typography>NO-NOOP</Typography>
-        ),
+        rowData.noop ? <Text>NOOP</Text> : <Text>NO-NOOP</Text>,
     },
     {
       title: 'Status',
@@ -155,9 +142,9 @@ export const ReportsTable = (props: ReportsTableProps) => {
         pageSizeOptions: [10],
       }}
       emptyContent={
-        <Typography color="textSecondary" className={classes.empty}>
+        <Text color="secondary" className={styles.empty}>
           No reports
-        </Typography>
+        </Text>
       }
       title={`Latest PuppetDB reports from node ${certName}`}
       columns={columns}

--- a/workspaces/puppetdb/yarn.lock
+++ b/workspaces/puppetdb/yarn.lock
@@ -365,7 +365,7 @@ __metadata:
     "@backstage/errors": "backstage:^"
     "@backstage/plugin-catalog-react": "backstage:^"
     "@backstage/test-utils": "backstage:^"
-    "@material-ui/core": "npm:^4.12.2"
+    "@backstage/ui": "backstage:^"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^15.0.0"
@@ -1513,7 +1513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.17.1":
+"@backstage/ui@backstage:^::backstage=1.54.5&npm=0.17.1, @backstage/ui@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/ui@npm:0.17.1"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated the PuppetDB plugin from Material UI (MUI) to Backstage UI (BUI).

This updates the report tables and report details tabs to use Backstage UI components and CSS modules, while preserving the existing user-facing layout and behavior.

### Screenshots

#### Before

<img width="959" height="444" alt="puppetdb_dark_before" src="https://github.com/user-attachments/assets/96632e03-8354-4d05-ab0a-e7dcb066ee34" />
<img width="959" height="438" alt="puppetdb_light_before" src="https://github.com/user-attachments/assets/1d59e87d-663a-4b08-bd7c-1ed4e4c50b5c" />


#### After

<img width="959" height="437" alt="puppetdb_light_after" src="https://github.com/user-attachments/assets/6b6751d0-6f07-496c-84e1-2579482933c9" />
<img width="959" height="442" alt="puppetdb_dark_after" src="https://github.com/user-attachments/assets/80300b20-afdd-4814-9aea-b9d900672baa" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))