### PR TITLE
Revert "Fix Renovate opening react-router-dom v7 PRs via OSV vulnerability alerts"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -114,7 +114,6 @@
       "description": "Block react-router v7 — Backstage does not yet support it. Vulnerability alerts disabled since the security fix is available on the v6 line",
       "matchPackageNames": ["react-router", "react-router-dom"],
       "allowedVersions": "<7.0.0",
-      "ignoreCves": ["CVE-2026-53668"],
       "vulnerabilityAlerts": {
         "enabled": false
       }

--- a/docs/renovate.md
+++ b/docs/renovate.md
@@ -56,12 +56,7 @@ Lock file maintenance PRs are disabled. Each workspace has its own `yarn.lock`, 
 
 ### Vulnerability Alerts
 
-Vulnerability alerts are enabled globally via two independent mechanisms:
-
-- **`vulnerabilityAlerts`** — responds to GitHub Dependabot alerts. Can be disabled per package using `vulnerabilityAlerts.enabled: false` in a package rule.
-- **`osvVulnerabilityAlerts`** — queries the [OSV database](https://osv.dev) directly. This is a global boolean with no per-package toggle and bypasses `allowedVersions` constraints.
-
-For packages with version pins (like `react-router`), disabling `vulnerabilityAlerts` alone is not sufficient — `osvVulnerabilityAlerts` will still create PRs that upgrade past the allowed version range. To stop Renovate from creating remediation PRs for a pinned package, add the CVE to `ignoreCves` in the package rule alongside `vulnerabilityAlerts.enabled: false`. This only affects Renovate's PR behavior; GitHub/Dependabot alerts may still remain visible in the repository Security UI.
+Vulnerability alerts are enabled globally. For packages with version pins (like `react-router`), vulnerability alerts are explicitly disabled when the security fix is available on the pinned version line — otherwise Renovate would create PRs to upgrade past the allowed version range.
 
 ## Modifying the Configuration
 


### PR DESCRIPTION
Reverts backstage/community-plugins#10935 to fix https://github.com/backstage/community-plugins/issues/10950

`ignoreCves` is not a valid Renovate config option, and it appears that many of the PRs of concern were autoclosed prior to this PR being merged (i.e. https://github.com/backstage/community-plugins/pull/10929), so I believe that issue is resolved without this change.