### PR TITLE
chore(scaffolder-relation-processor): drop outdated Backstage dependency resolutions

### DIFF
--- a/workspaces/scaffolder-relation-processor/.changeset/curly-jeans-pull.md
+++ b/workspaces/scaffolder-relation-processor/.changeset/curly-jeans-pull.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor': patch
+---
+
+Uses the Backstage 1.54.5 versions of the events and notifications packages instead of older pinned dependencies.

--- a/workspaces/scaffolder-relation-processor/package.json
+++ b/workspaces/scaffolder-relation-processor/package.json
@@ -58,11 +58,7 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "@backstage/plugin-events-node": "0.4.23",
-    "@backstage/plugin-signals-node": "0.2.2",
-    "@backstage/plugin-notifications-node": "0.2.27",
-    "@backstage/plugin-notifications-common": "0.2.3"
+    "@types/react-dom": "^18"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/workspaces/scaffolder-relation-processor/yarn.lock
+++ b/workspaces/scaffolder-relation-processor/yarn.lock
@@ -1987,7 +1987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.10.0, @backstage/backend-plugin-api@npm:^1.9.2":
+"@backstage/backend-plugin-api@npm:^1.10.0":
   version: 1.10.0
   resolution: "@backstage/backend-plugin-api@npm:1.10.0"
   dependencies:
@@ -2754,11 +2754,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.23":
-  version: 0.4.23
-  resolution: "@backstage/plugin-events-node@npm:0.4.23"
+"@backstage/plugin-events-node@npm:^0.4.25":
+  version: 0.4.25
+  resolution: "@backstage/plugin-events-node@npm:0.4.25"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.10.0"
     "@backstage/errors": "npm:^1.3.1"
     "@backstage/types": "npm:^1.2.2"
     "@types/content-type": "npm:^1.1.8"
@@ -2767,11 +2767,11 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     express: "npm:^4.22.0"
     uri-template: "npm:^2.0.0"
-  checksum: 10/3eef8215b0c51df85c3773bc39eb87bccb28b7e2b1dd4245e64eb7499a7648b2d9a93a76518e7cd416d017e01ab5147948e888993a050aaa13097e80b2280397
+  checksum: 10/95e6b043080860b058241bf9620ea9686097f14305c3fc0c502872791f1e3fd4bc0a990c96a0be8015c5202c40acad781e22e25729c36624473b3af44f16067d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-common@npm:0.2.3":
+"@backstage/plugin-notifications-common@npm:^0.2.3":
   version: 0.2.3
   resolution: "@backstage/plugin-notifications-common@npm:0.2.3"
   dependencies:
@@ -2781,13 +2781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@npm:0.2.27":
-  version: 0.2.27
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.27"
+"@backstage/plugin-notifications-node@npm:^0.2.29":
+  version: 0.2.29
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.29"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.2"
+    "@backstage/backend-plugin-api": "npm:^1.10.0"
     "@backstage/plugin-notifications-common": "npm:^0.2.3"
-  checksum: 10/f0ce5dc2c70c8f28e6aef50c6c8dd5cad96897a31739bd5af967980cafbb6728aaba6ac1340f8476444d4813773a854510571ca58229c7ef3ad6a781f1e24759
+  checksum: 10/65eacfe8804b409213d7033d7868ac02e00780119b681bf516179b9e78ca8f68ea94ec91af6d3646aecdc233e0255190462a1c98c4573da852a1bf921ff3eb44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes workspace-level pins for `@backstage/plugin-events-node`, `@backstage/plugin-signals-node`, `@backstage/plugin-notifications-node`, and `@backstage/plugin-notifications-common`. Those were holding older versions than the current Backstage 1.54.5 dependencies, which already match npm latest.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
