### PR TITLE
[plugins/multi-source-security-viewer] Fixes links to GitHub Actions plugin

### DIFF
--- a/workspaces/multi-source-security-viewer/.changeset/three-oranges-fetch.md
+++ b/workspaces/multi-source-security-viewer/.changeset/three-oranges-fetch.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-multi-source-security-viewer': patch
+---
+
+Updates broken docs links

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
@@ -12,7 +12,7 @@ This plugin enables you to visualize pipeline security information from multiple
    The supported CI's are:
 
 - [Jenkins](../../../jenkins/plugins/jenkins-backend/README.md)
-- [Github Actions](../../../github-actions/plugins/github-actions/README.md)
+- [Github Actions](../../../github/plugins/github-actions/README.md)
 - [Gitlab CI](https://github.com/immobiliare/backstage-plugin-gitlab?tab=readme-ov-file#setup)
 - [Azure Pipelines](../../../azure-devops/plugins/azure-devops/README.md)
 
@@ -109,7 +109,7 @@ If you choose to display the plugin when the annotation is present along with th
 3. Ensure your CI annotations are set:
 
 - [Jenkins](../../../jenkins/plugins/jenkins/README.md)
-- [Github Actions]([../../../github-actions/plugins/github-actions/README.md)
+- [Github Actions]([../../../github/plugins/github-actions/README.md)
 - [Gitlab CI](https://github.com/immobiliare/backstage-plugin-gitlab?tab=readme-ov-file#annotations)
 - [Azure Pipelines](../../../azure-devops/plugins/azure-devops/README.md)
 

--- a/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
+++ b/workspaces/multi-source-security-viewer/plugins/multi-source-security-viewer/README.md
@@ -109,7 +109,7 @@ If you choose to display the plugin when the annotation is present along with th
 3. Ensure your CI annotations are set:
 
 - [Jenkins](../../../jenkins/plugins/jenkins/README.md)
-- [Github Actions]([../../../github/plugins/github-actions/README.md)
+- [Github Actions](../../../github/plugins/github-actions/README.md)
 - [Gitlab CI](https://github.com/immobiliare/backstage-plugin-gitlab?tab=readme-ov-file#annotations)
 - [Azure Pipelines](../../../azure-devops/plugins/azure-devops/README.md)
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

The path to the `github-actions` plugins workspace have changed and this PR updates them to point to the correct place

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] Added or updated documentation
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
